### PR TITLE
fix: standardize error messages for missing agents

### DIFF
--- a/src/cli/commands/dev/command.tsx
+++ b/src/cli/commands/dev/command.tsx
@@ -77,7 +77,7 @@ export const registerDev = (program: Command) => {
       }
 
       if (!project.agents || project.agents.length === 0) {
-        render(<FatalError message="No agents defined in project." suggestedCommand="agentcore create" />);
+        render(<FatalError message="No agents defined in project." suggestedCommand="agentcore add agent" />);
         process.exit(1);
       }
 

--- a/src/cli/tui/screens/attach/AttachFlow.tsx
+++ b/src/cli/tui/screens/attach/AttachFlow.tsx
@@ -162,8 +162,8 @@ export function AttachFlow(props: { onExit: () => void }) {
   if (agents.length === 0) {
     return (
       <ErrorPrompt
-        message="No agents in project"
-        detail="Add an agent first using the 'add' command."
+        message="No agents in project."
+        detail="Run 'agentcore add agent' first."
         onBack={props.onExit}
         onExit={props.onExit}
       />


### PR DESCRIPTION
## Description

Standardizes error messages when users run commands that require agents before any agents exist in the project.

### Problem
Error messaging was inconsistent across commands when a project exists but has no agents:
- add before create → "No agentcore project found. Run agentcore create first." ✓
- attach before adding agents → "No agents in project. Add an agent first using the 'add' command." ✗
- dev before adding agents → Suggested agentcore create instead of agentcore add agent ✗

### Solution
Updated error messages to follow the consistent "Run X first" pattern used elsewhere in the CLI.

### Changes
| File | Before | After |
|------|--------|-------|
| AttachFlow.tsx | "Add an agent first using the 'add' command." | "Run 'agentcore add agent' first." |
| dev/command.tsx | Suggests agentcore create | Suggests agentcore add agent |

### Testing
- [x] Build passes
- [x] Lint passes
- [x] Error messages now consistent with "Run X first" pattern