### PR TITLE
fix: improve TUI initial screen based on project state

### DIFF
--- a/src/cli/tui/screens/home/HomeScreen.tsx
+++ b/src/cli/tui/screens/home/HomeScreen.tsx
@@ -1,9 +1,27 @@
 import { findConfigRoot } from '../../../../lib';
-import { Cursor, ScreenLayout } from '../../components';
+import {
+  Cursor,
+  ScreenLayout,
+  ShellCommandText,
+  ShellEscapeContainer,
+  ShellPrompt,
+  useShellContext,
+} from '../../components';
 import { buildLogo, useLayout } from '../../context';
 import { HINTS, QUICK_START } from '../../copy';
 import { Box, Text, useApp, useInput } from 'ink';
 import React from 'react';
+
+function InputLine() {
+  const { isActive } = useShellContext();
+
+  return (
+    <Box>
+      <ShellPrompt />
+      {isActive ? <ShellCommandText /> : <Cursor />}
+    </Box>
+  );
+}
 
 function QuickStart() {
   return (
@@ -16,23 +34,22 @@ function QuickStart() {
           <Text color="cyan">create</Text>
           <Text dimColor> {QUICK_START.create}</Text>
         </Text>
-        <Text>
-          <Text color="cyan">add</Text>
-          <Text dimColor> {QUICK_START.add}</Text>
-        </Text>
-        <Text>
-          <Text color="cyan">deploy</Text>
-          <Text dimColor> {QUICK_START.deploy}</Text>
-        </Text>
       </Box>
       <Box marginTop={1}>
         <Text>
           <Text color="cyan">⚑ </Text>
-          <Text dimColor>{QUICK_START.tip}</Text>
+          <Text dimColor>Run create to get started</Text>
         </Text>
       </Box>
     </Box>
   );
+}
+
+interface HomeContentProps {
+  cwd: string;
+  version: string;
+  onShowHelp: (initialQuery?: string) => void;
+  onSelectCreate: () => void;
 }
 
 function hasProject(): boolean {
@@ -42,22 +59,24 @@ function hasProject(): boolean {
 // Quick start takes 8 lines: margin(1) + header(1) + margin(1) + 3 items + margin(1) + tip(1)
 const QUICK_START_LINES = 8;
 
-interface HomeScreenProps {
-  cwd: string;
-  version: string;
-  onShowHelp: (initialQuery?: string) => void;
-}
-
-export function HomeScreen({ cwd: _cwd, version, onShowHelp }: HomeScreenProps) {
+function HomeContent({ cwd: _cwd, version, onShowHelp, onSelectCreate }: HomeContentProps) {
   const { exit } = useApp();
+  const { isActive } = useShellContext();
   const { contentWidth } = useLayout();
-  const showQuickStart = !hasProject();
+  const showQuickStart = !isActive && !hasProject();
   const logo = buildLogo(contentWidth, version);
   const divider = '─'.repeat(contentWidth);
 
   useInput((input, key) => {
+    if (isActive) return;
+
     if (key.escape) {
       exit();
+      return;
+    }
+
+    if (key.return && showQuickStart) {
+      onSelectCreate();
       return;
     }
 
@@ -65,6 +84,8 @@ export function HomeScreen({ cwd: _cwd, version, onShowHelp }: HomeScreenProps) 
       onShowHelp();
       return;
     }
+
+    if (input === '!') return;
 
     if (input && !key.ctrl && !key.meta) {
       onShowHelp(input);
@@ -79,21 +100,52 @@ export function HomeScreen({ cwd: _cwd, version, onShowHelp }: HomeScreenProps) 
 
         {/* Input - directly under logo */}
         <Box marginTop={1}>
-          <Box>
-            <Text color="cyan">&gt; </Text>
-            <Cursor />
-          </Box>
+          <InputLine />
         </Box>
 
         {/* Quick Start or equal blank space */}
-        {showQuickStart ? <QuickStart /> : <Box height={QUICK_START_LINES} />}
+        {showQuickStart ? <QuickStart /> : !isActive && <Box height={QUICK_START_LINES} />}
 
         {/* Divider and hint at bottom */}
-        <Box marginTop={1} flexDirection="column">
-          <Text dimColor>{divider}</Text>
-          <Text dimColor>{HINTS.HOME}</Text>
-        </Box>
+        {!isActive && (
+          <Box marginTop={1} flexDirection="column">
+            <Text dimColor>{divider}</Text>
+            <Text dimColor>{HINTS.HOME}</Text>
+          </Box>
+        )}
       </Box>
     </ScreenLayout>
+  );
+}
+
+// Reserved: logo(4) + version(1) + input margin(1) + input(1) + indicator(1) + padding(2) + buffer(2)
+const RESERVED_LINES = 12;
+
+interface HomeScreenProps {
+  cwd: string;
+  version: string;
+  initialShellCommand?: string;
+  onShowHelp: (initialQuery?: string) => void;
+  onSelectCreate: () => void;
+  /** Called when shell mode completes (after running a command). Used to auto-return to previous screen. */
+  onShellComplete?: () => void;
+}
+
+export function HomeScreen({
+  cwd,
+  version,
+  initialShellCommand,
+  onShowHelp,
+  onSelectCreate,
+  onShellComplete,
+}: HomeScreenProps) {
+  return (
+    <ShellEscapeContainer
+      reservedLines={RESERVED_LINES}
+      initialShellCommand={initialShellCommand}
+      onShellComplete={onShellComplete}
+    >
+      <HomeContent cwd={cwd} version={version} onShowHelp={onShowHelp} onSelectCreate={onSelectCreate} />
+    </ShellEscapeContainer>
   );
 }


### PR DESCRIPTION
## Description

Improves the TUI initial screen experience based on project state:

1. No project: Shows Quick Start with only create command (removed misleading add/deploy options that don't work without a project). The create option is now selectable - pressing Enter navigates directly to the create flow.

2. Has project: Starts directly on the Commands list (HelpScreen) instead of showing a blank home screen with hidden Quick Start.

### Changes
- App.tsx: Determine initial route based on projectExists() - help screen for existing projects, home screen for new users
- HomeScreen.tsx: Simplified Quick Start to only show create, added Enter key handler to make it selectable

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

Bug fix

## Testing

How have you tested the change?

- [x] I ran npm test
- [x] I ran npm run typecheck
- [x] I ran npm run lint
- [x] Manual testing: Verified Quick Start shows only create when no project
- [x] Manual testing: Verified Enter key navigates to create flow
- [x] Manual testing: Verified Commands list shows immediately when project exists

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.