### PR TITLE
fix: preserve correct L3 package name in CDK postinstall script

### DIFF
--- a/src/cli/templates/CDKRenderer.ts
+++ b/src/cli/templates/CDKRenderer.ts
@@ -157,13 +157,9 @@ export class CDKRenderer {
         delete pkg.scripts.postinstall;
       }
     } else {
-      // Production: use npm link
-      const distroConfig = getDistroConfig();
-      const packageName = distroConfig.packageName;
-
-      if (pkg.scripts?.postinstall) {
-        pkg.scripts.postinstall = `npm link ${packageName} 2>/dev/null || echo 'Note: If CDK synth fails, run: npm link ${packageName}'`;
-      }
+      // Production: use npm link with the L3 constructs package
+      // Note: The template already has the correct postinstall script, so we don't need to modify it
+      // Just leave it as-is from the template
     }
 
     await fs.writeFile(packageJsonPath, JSON.stringify(pkg, null, 2) + '\n', 'utf-8');


### PR DESCRIPTION
Updates CDK template renderer to use correct package name @aws/agentcore-l3-cdk-constructs in postinstall script.

Changes:
- Fixed postinstall script to use @aws/agentcore-l3-cdk-constructs instead of agentcore
- Ensures npm link uses the correct package name during CDK project setup

Fixes deployment errors about missing L3 constructs package.