### PR TITLE
fix: show 'add' option when no agent created

### DIFF
--- a/src/cli/tui/screens/create/CreateScreen.tsx
+++ b/src/cli/tui/screens/create/CreateScreen.tsx
@@ -10,7 +10,7 @@ import { useCreateFlow } from './useCreateFlow';
 import { Box, Text } from 'ink';
 import { join } from 'path';
 
-type NextCommand = 'dev' | 'deploy';
+type NextCommand = 'dev' | 'deploy' | 'add';
 
 interface NavigateParams {
   command: NextCommand;
@@ -26,10 +26,15 @@ interface CreateScreenProps {
 }
 
 /** Next steps shown after successful project creation */
-const CREATE_NEXT_STEPS: NextStep[] = [
-  { command: 'dev', label: 'Run agent locally' },
-  { command: 'deploy', label: 'Deploy to AWS' },
-];
+function getCreateNextSteps(hasAgent: boolean): NextStep[] {
+  if (hasAgent) {
+    return [
+      { command: 'dev', label: 'Run agent locally' },
+      { command: 'deploy', label: 'Deploy to AWS' },
+    ];
+  }
+  return [{ command: 'add', label: 'Add an agent' }];
+}
 
 const CREATE_PROMPT_ITEMS = [
   { id: 'yes', title: 'Yes, add an agent' },
@@ -188,7 +193,7 @@ export function CreateScreen({ cwd, isInteractive, onExit, onNavigate }: CreateS
             </Box>
           )}
           <NextSteps
-            steps={CREATE_NEXT_STEPS}
+            steps={getCreateNextSteps(flow.addAgentConfig !== null)}
             isInteractive={isInteractive}
             onSelect={step => {
               if (onNavigate) {


### PR DESCRIPTION
## Description
When a user creates a new project but chooses "No, I'll do it later" when asked to add an agent, the next steps screen now shows "add" as the primary option instead of "dev" and "deploy".
This makes sense because:
- dev requires an agent to run locally
- deploy requires an agent to deploy

The user must add an agent first, so we guide them to that action.

## Related Issues
<!-- Link to related issues using #issue-number format -->

## Documentation PR
<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran npm test
- [x] I ran npm run typecheck
- [x] I ran npm run lint

Manual testing:
1. Run TUI → select "create" → enter project name → select "No, I'll do it later"
2. Verify next steps shows "add" and "return" (not "dev" or "deploy")

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.