### PR TITLE
fix: pyproject mcp to have otel

### DIFF
--- a/src/assets/mcp/python/pyproject.toml
+++ b/src/assets/mcp/python/pyproject.toml
@@ -11,6 +11,8 @@ requires-python = ">=3.10"
 dependencies = [
     "mcp[cli] >= 1.2.0",
     "httpx >= 0.27.0",
+    "opentelemetry-distro",
+    "opentelemetry-exporter-otlp",
 ]
 
 [project.scripts]


### PR DESCRIPTION
fix pyproject mcp to have otel