### PR TITLE
fix: convert Windows .exe console scripts to Linux for cross-platform…

### DIFF
--- a/src/lib/packaging/python.ts
+++ b/src/lib/packaging/python.ts
@@ -3,6 +3,8 @@ import { UV_INSTALL_HINT, getArtifactZipName } from '../constants';
 import { runSubprocessCapture, runSubprocessCaptureSync } from '../utils/subprocess';
 import { PackagingError } from './errors';
 import {
+  convertWindowsScriptsToLinux,
+  convertWindowsScriptsToLinuxSync,
   copySourceTree,
   copySourceTreeSync,
   createZipFromDir,
@@ -110,6 +112,8 @@ export class PythonCodeZipPackager implements RuntimePackager {
 
       if (result.code === 0) {
         await copySourceTree(srcDir, stagingDir);
+        // Convert Windows .exe scripts to Linux shell scripts for cross-platform deployment
+        await convertWindowsScriptsToLinux(stagingDir);
         return stagingDir;
       } else {
         const platformIssue = detectUnavailablePlatform(result);
@@ -219,6 +223,8 @@ export class PythonCodeZipPackagerSync implements CodeZipPackager {
 
       if (result.code === 0) {
         copySourceTreeSync(srcDir, stagingDir);
+        // Convert Windows .exe scripts to Linux shell scripts for cross-platform deployment
+        convertWindowsScriptsToLinuxSync(stagingDir);
         return stagingDir;
       } else {
         const platformIssue = detectUnavailablePlatform(result);


### PR DESCRIPTION
## Description
When packaging Python dependencies on Windows for Linux targets (AWS Lambda/AgentCore), uv generates .exe console scripts based on the host OS rather than the target platform. This causes deployment failures with errors like 'OpenTelemetry instrumentation executable not found'.

This fix adds post-processing to convert known Windows .exe scripts (opentelemetry-instrument, opentelemetry-bootstrap) to Linux-compatible shell scripts after uv pip install completes. Similar PR has been merged to L3 constructs package. 

## Related Issues
N/A

## Documentation PR
N/A

## Type of Change
<!-- Check all that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm test`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`

## Checklist
- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
