### PR TITLE
fix: change quit keybinding from 'q' to Ctrl+Q

### DIFF
--- a/src/cli/tui/components/FullScreenLogView.tsx
+++ b/src/cli/tui/components/FullScreenLogView.tsx
@@ -38,7 +38,7 @@ export function FullScreenLogView({ logs, logFilePath, onExit }: FullScreenLogVi
   }, [scrollUpOffset, maxScrollPos]);
 
   useInput((input, key) => {
-    if (key.escape || input === 'q' || input === 'l') {
+    if (key.escape || (key.ctrl && input === 'q') || input === 'l') {
       onExit();
       return;
     }

--- a/src/cli/tui/components/HelpText.tsx
+++ b/src/cli/tui/components/HelpText.tsx
@@ -20,5 +20,5 @@ export function HelpText({ text }: HelpTextProps) {
  * Standard exit help text.
  */
 export function ExitHelpText() {
-  return <HelpText text="Press ESC or 'q' to exit" />;
+  return <HelpText text="Press ESC or Ctrl+Q to exit" />;
 }

--- a/src/cli/tui/components/PromptScreen.tsx
+++ b/src/cli/tui/components/PromptScreen.tsx
@@ -13,7 +13,7 @@ interface PromptScreenProps {
   onConfirm?: () => void;
   /** Called when secondary/back action is triggered (Enter or 'b') */
   onBack?: () => void;
-  /** Called when exit is triggered (Escape or 'q' or 'n') */
+  /** Called when exit is triggered (Escape or Ctrl+Q or 'n') */
   onExit?: () => void;
   /** Panel border color (default: undefined, no color) */
   borderColor?: string;
@@ -49,7 +49,7 @@ export function PromptScreen({
     if (!inputEnabled) {
       return;
     }
-    if (key.escape || input === 'q' || input === 'n') {
+    if (key.escape || (key.ctrl && input === 'q') || input === 'n') {
       onExit?.();
       return;
     }
@@ -120,7 +120,7 @@ export function ErrorPrompt({
   onExit?: () => void;
 }) {
   useInput((input, key) => {
-    if (key.escape || input === 'q' || input === 'n') {
+    if (key.escape || (key.ctrl && input === 'q') || input === 'n') {
       onExit?.();
       return;
     }

--- a/src/cli/tui/components/Screen.tsx
+++ b/src/cli/tui/components/Screen.tsx
@@ -20,7 +20,7 @@ interface ScreenProps {
  * Standard screen wrapper that provides:
  * - ScreenLayout with responsive padding
  * - ScreenHeader with title
- * - Exit handling (Escape / 'q')
+ * - Exit handling (Escape / Ctrl+Q)
  * - Help text at the bottom
  */
 export function Screen({ title, color, onExit, helpText, headerContent, footerContent, children }: ScreenProps) {

--- a/src/cli/tui/components/SelectScreen.tsx
+++ b/src/cli/tui/components/SelectScreen.tsx
@@ -18,7 +18,7 @@ interface SelectScreenProps<T extends SelectableItem> {
   items: T[];
   /** Called when an item is selected */
   onSelect: (item: T, index: number) => void;
-  /** Called when exiting (Escape or 'q') */
+  /** Called when exiting (Escape or Ctrl+Q) */
   onExit: () => void;
   /** Whether navigation is active (default: true) */
   isActive?: boolean;

--- a/src/cli/tui/hooks/useExitHandler.ts
+++ b/src/cli/tui/hooks/useExitHandler.ts
@@ -1,7 +1,7 @@
 import { useInput } from 'ink';
 
 /**
- * Hook that handles the standard exit keys (Escape, 'q').
+ * Hook that handles the standard exit keys (Escape, Ctrl+Q).
  * Should be used at the top level of screens that need exit handling.
  *
  * @param onExit - Callback to invoke when exit is requested
@@ -10,7 +10,7 @@ import { useInput } from 'ink';
 export function useExitHandler(onExit: () => void, enabled = true): void {
   useInput(
     (input, key) => {
-      if (key.escape || input === 'q') {
+      if (key.escape || (key.ctrl && input === 'q')) {
         onExit();
       }
     },

--- a/src/cli/tui/hooks/useListNavigation.ts
+++ b/src/cli/tui/hooks/useListNavigation.ts
@@ -85,7 +85,7 @@ export function useListNavigation<T>({
   useInput(
     (input, key) => {
       // Handle exit
-      if (key.escape || input === 'q') {
+      if (key.escape || (key.ctrl && input === 'q')) {
         onExit?.();
         return;
       }

--- a/src/cli/tui/screens/dev/DevScreen.tsx
+++ b/src/cli/tui/screens/dev/DevScreen.tsx
@@ -231,7 +231,7 @@ export function DevScreen(props: DevScreenProps) {
     (input, key) => {
       // Agent selection mode
       if (mode === 'select-agent') {
-        if (key.escape || input === 'q') {
+        if (key.escape || (key.ctrl && input === 'q')) {
           props.onBack();
           return;
         }
@@ -253,8 +253,8 @@ export function DevScreen(props: DevScreenProps) {
 
       // In chat mode
       if (mode === 'chat') {
-        // Esc or q to quit (but skip if we just cancelled from input mode)
-        if (key.escape || input === 'q' || (key.ctrl && input === 'c')) {
+        // Esc or Ctrl+Q to quit (but skip if we just cancelled from input mode)
+        if (key.escape || (key.ctrl && input === 'q') || (key.ctrl && input === 'c')) {
           if (justCancelledRef.current) {
             // Skip this escape - it's from the input cancel
             justCancelledRef.current = false;

--- a/src/cli/tui/screens/invoke/InvokeScreen.tsx
+++ b/src/cli/tui/screens/invoke/InvokeScreen.tsx
@@ -59,7 +59,7 @@ export function InvokeScreen({
   useInput((input, key) => {
     if (phase === 'loading' || phase === 'error' || !config) return;
 
-    if (key.escape || input === 'q') {
+    if (key.escape || (key.ctrl && input === 'q')) {
       if (mode === 'input') {
         setMode('chat');
       } else if (mode === 'chat' && config.agents.length > 1) {

--- a/src/cli/tui/screens/outline/OutlineScreen.tsx
+++ b/src/cli/tui/screens/outline/OutlineScreen.tsx
@@ -73,7 +73,7 @@ export function OutlineScreen({ isInteractive: _isInteractive, onExit }: Outline
       }
       if (key.escape) setMode('select-scope');
     } else if (mode === 'view') {
-      if (key.escape || input === 'q') setMode('select-scope');
+      if (key.escape || (key.ctrl && input === 'q')) setMode('select-scope');
     }
   });
 


### PR DESCRIPTION
## Description

Changes the quit keybinding from q to Ctrl+Q across all screens to prevent accidental exits when typing prompts containing the letter 'q'.

Affected screens:
- DevScreen (agent selection and chat modes)
- InvokeScreen
- OutlineScreen
- PromptScreen
- FullScreenLogView

## Related Issues
<!-- Link to related issues using #issue-number format -->

## Documentation PR
<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran npm test
- [x] I ran npm run typecheck
- [ ] I ran npm run lint

Manually tested by typing prompts containing 'q' in dev and invoke screens - no longer exits unexpectedly.

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.