### PR TITLE
fix: add CLI dependency checks to create command

### DIFF
--- a/src/cli/commands/create/types.ts
+++ b/src/cli/commands/create/types.ts
@@ -21,4 +21,5 @@ export interface CreateResult {
   error?: string;
   dryRun?: boolean;
   wouldCreate?: string[];
+  warnings?: string[];
 }

--- a/src/cli/external-requirements/__tests__/checks.test.ts
+++ b/src/cli/external-requirements/__tests__/checks.test.ts
@@ -1,0 +1,132 @@
+import { checkCreateDependencies } from '../checks';
+import { describe, expect, it } from 'vitest';
+
+describe('checkCreateDependencies', () => {
+  describe('result structure', () => {
+    it('returns proper structure with all fields', async () => {
+      const result = await checkCreateDependencies();
+
+      expect(result).toHaveProperty('passed');
+      expect(result).toHaveProperty('checks');
+      expect(result).toHaveProperty('errors');
+      expect(result).toHaveProperty('warnings');
+      expect(Array.isArray(result.checks)).toBe(true);
+      expect(Array.isArray(result.errors)).toBe(true);
+      expect(Array.isArray(result.warnings)).toBe(true);
+    });
+
+    it('always checks npm and aws when no language specified', async () => {
+      const result = await checkCreateDependencies();
+
+      const binaries = result.checks.map(c => c.binary);
+      expect(binaries).toContain('npm');
+      expect(binaries).toContain('aws');
+      expect(binaries).not.toContain('uv');
+    });
+
+    it('checks uv only for Python language', async () => {
+      const result = await checkCreateDependencies({ language: 'Python' });
+
+      const binaries = result.checks.map(c => c.binary);
+      expect(binaries).toContain('uv');
+      expect(binaries).toContain('npm');
+      expect(binaries).toContain('aws');
+    });
+
+    it('does not check uv for TypeScript language', async () => {
+      const result = await checkCreateDependencies({ language: 'TypeScript' });
+
+      const binaries = result.checks.map(c => c.binary);
+      expect(binaries).not.toContain('uv');
+      expect(binaries).toContain('npm');
+      expect(binaries).toContain('aws');
+    });
+  });
+
+  describe('severity levels', () => {
+    it('marks npm as error severity', async () => {
+      const result = await checkCreateDependencies();
+
+      const npmCheck = result.checks.find(c => c.binary === 'npm');
+      expect(npmCheck?.severity).toBe('error');
+    });
+
+    it('marks aws as warn severity', async () => {
+      const result = await checkCreateDependencies();
+
+      const awsCheck = result.checks.find(c => c.binary === 'aws');
+      expect(awsCheck?.severity).toBe('warn');
+    });
+
+    it('marks uv as error severity for Python', async () => {
+      const result = await checkCreateDependencies({ language: 'Python' });
+
+      const uvCheck = result.checks.find(c => c.binary === 'uv');
+      expect(uvCheck?.severity).toBe('error');
+    });
+  });
+
+  describe('install hints', () => {
+    it('provides install hints for all checked tools', async () => {
+      const result = await checkCreateDependencies({ language: 'Python' });
+
+      for (const check of result.checks) {
+        expect(check.installHint).toBeDefined();
+        expect(check.installHint!.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('npm hint mentions nodejs.org', async () => {
+      const result = await checkCreateDependencies();
+
+      const npmCheck = result.checks.find(c => c.binary === 'npm');
+      expect(npmCheck?.installHint).toContain('nodejs.org');
+    });
+
+    it('aws hint mentions aws.amazon.com', async () => {
+      const result = await checkCreateDependencies();
+
+      const awsCheck = result.checks.find(c => c.binary === 'aws');
+      expect(awsCheck?.installHint).toContain('aws.amazon.com');
+    });
+
+    it('uv hint mentions astral-sh/uv', async () => {
+      const result = await checkCreateDependencies({ language: 'Python' });
+
+      const uvCheck = result.checks.find(c => c.binary === 'uv');
+      expect(uvCheck?.installHint).toContain('astral-sh/uv');
+    });
+  });
+
+  describe('passed logic', () => {
+    it('passed is true when no error-severity tools are missing', async () => {
+      // Assuming npm is installed in the test environment
+      const result = await checkCreateDependencies();
+
+      // If npm is available, passed should be true (aws missing is just a warning)
+      if (result.checks.find(c => c.binary === 'npm')?.available) {
+        expect(result.passed).toBe(true);
+      }
+    });
+
+    it('errors array only contains error-severity failures', async () => {
+      const result = await checkCreateDependencies();
+
+      // If there are errors, they should all be about error-severity tools (npm, uv)
+      for (const error of result.errors) {
+        expect(error).toMatch(/'(npm|uv)'/);
+      }
+    });
+
+    it('warnings array only contains warn-severity failures', async () => {
+      const result = await checkCreateDependencies();
+
+      // If aws is missing, it should be in warnings, not errors
+      const awsCheck = result.checks.find(c => c.binary === 'aws');
+      if (awsCheck && !awsCheck.available) {
+        expect(result.warnings.some(w => w.includes('aws'))).toBe(true);
+        expect(result.errors.some(e => e.includes('aws'))).toBe(false);
+      }
+    });
+  });
+});

--- a/src/cli/external-requirements/index.ts
+++ b/src/cli/external-requirements/index.ts
@@ -14,6 +14,11 @@ export {
   formatVersionError,
   requiresUv,
   checkDependencyVersions,
+  checkCreateDependencies,
   type VersionCheckResult,
   type DependencyCheckResult,
+  type CheckSeverity,
+  type CliToolCheck,
+  type CliToolsCheckResult,
+  type CheckCreateDependenciesOptions,
 } from './checks';


### PR DESCRIPTION
Add upfront checks for required CLI tools before project creation:
- npm: required for CDK (error if missing)
- uv: required for Python projects only (error if missing)
- aws: optional, needed for deployment (warn only)

This prevents confusing failures later in the create process when required tools are not available.

Changes:
- Add checkCreateDependencies() function with cross-platform binary detection
- Integrate checks into createProject() and createProjectWithAgent()
- Add warnings field to CreateResult for JSON output mode
- Add comprehensive tests for the new functionality

## Description
<!-- Provide a detailed description of the changes in this PR -->

## Related Issues
<!-- Link to related issues using #issue-number format -->

## Documentation PR
<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change
<!-- Check all that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm test`
- [ ] I ran `npm run typecheck`
- [ ] I ran `npm run lint`

## Checklist
- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
