### PR TITLE
fix: use session.id in Google ADK template to fix session not found error

### DIFF
--- a/src/assets/python/googleadk/base/main.py
+++ b/src/assets/python/googleadk/base/main.py
@@ -54,7 +54,7 @@ async def call_agent_async(query, user_id, session_id):
     content = types.Content(role="user", parts=[types.Part(text=query)])
     session, runner = await setup_session_and_runner(user_id, session_id)
     events = runner.run_async(
-        user_id=user_id, session_id=session_id, new_message=content
+        user_id=user_id, session_id=session.id, new_message=content
     )
 
     final_response = None


### PR DESCRIPTION
## Description

Fixes `"Session not found: None"` error in Google ADK template.

The `InMemorySessionService.create_session()` may return a session with a different ID than the one passed in. The `runner.run_async()` call was using the input session_id parameter instead of `session.id` from the created session object, causing the runner to fail to find the session.

Changed from:
```
events = runner.run_async(
    user_id=user_id, session_id=session_id, new_message=content
)
```


To:
```
events = runner.run_async(
    user_id=user_id, session_id=session.id, new_message=content
)
```

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

Tested by running agentcore-cli dev on a Google ADK project - agent now responds successfully instead of throwing "Session not found: None" error.

- [ ] I ran npm test
- [ ] I ran npm run typecheck
- [ ] I ran npm run lint

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published


---


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.