### PR TITLE
fix: improve API key not found error message

### DIFF
--- a/src/assets/python/autogen/base/model/load.py
+++ b/src/assets/python/autogen/base/model/load.py
@@ -46,7 +46,7 @@ def _get_api_key() -> str:
         api_key = os.getenv(IDENTITY_ENV_VAR)
         if not api_key:
             raise RuntimeError(
-                f"{IDENTITY_ENV_VAR} not found. Run via 'agentcore dev' to load agentcore/.env"
+                f"{IDENTITY_ENV_VAR} not found. Add {IDENTITY_ENV_VAR}=your-key to .env.local"
             )
         return api_key
     return _agentcore_identity_api_key_provider()
@@ -83,7 +83,7 @@ def _get_api_key() -> str:
         api_key = os.getenv(IDENTITY_ENV_VAR)
         if not api_key:
             raise RuntimeError(
-                f"{IDENTITY_ENV_VAR} not found. Run via 'agentcore dev' to load agentcore/.env"
+                f"{IDENTITY_ENV_VAR} not found. Add {IDENTITY_ENV_VAR}=your-key to .env.local"
             )
         return api_key
     return _agentcore_identity_api_key_provider()
@@ -120,7 +120,7 @@ def _get_api_key() -> str:
         api_key = os.getenv(IDENTITY_ENV_VAR)
         if not api_key:
             raise RuntimeError(
-                f"{IDENTITY_ENV_VAR} not found. Run via 'agentcore dev' to load agentcore/.env"
+                f"{IDENTITY_ENV_VAR} not found. Add {IDENTITY_ENV_VAR}=your-key to .env.local"
             )
         return api_key
     return _agentcore_identity_api_key_provider()

--- a/src/assets/python/crewai/base/model/load.py
+++ b/src/assets/python/crewai/base/model/load.py
@@ -34,7 +34,7 @@ def _get_api_key() -> str:
         api_key = os.getenv(IDENTITY_ENV_VAR)
         if not api_key:
             raise RuntimeError(
-                f"{IDENTITY_ENV_VAR} not found. Run via 'agentcore dev' to load agentcore/.env"
+                f"{IDENTITY_ENV_VAR} not found. Add {IDENTITY_ENV_VAR}=your-key to .env.local"
             )
         return api_key
     return _agentcore_identity_api_key_provider()
@@ -72,7 +72,7 @@ def _get_api_key() -> str:
         api_key = os.getenv(IDENTITY_ENV_VAR)
         if not api_key:
             raise RuntimeError(
-                f"{IDENTITY_ENV_VAR} not found. Run via 'agentcore dev' to load agentcore/.env"
+                f"{IDENTITY_ENV_VAR} not found. Add {IDENTITY_ENV_VAR}=your-key to .env.local"
             )
         return api_key
     return _agentcore_identity_api_key_provider()
@@ -109,7 +109,7 @@ def _get_api_key() -> str:
         api_key = os.getenv(IDENTITY_ENV_VAR)
         if not api_key:
             raise RuntimeError(
-                f"{IDENTITY_ENV_VAR} not found. Run via 'agentcore dev' to load agentcore/.env"
+                f"{IDENTITY_ENV_VAR} not found. Add {IDENTITY_ENV_VAR}=your-key to .env.local"
             )
         return api_key
     return _agentcore_identity_api_key_provider()

--- a/src/assets/python/googleadk/base/model/load.py
+++ b/src/assets/python/googleadk/base/model/load.py
@@ -20,7 +20,7 @@ def _get_api_key() -> str:
         api_key = os.getenv(IDENTITY_ENV_VAR)
         if not api_key:
             raise RuntimeError(
-                f"{IDENTITY_ENV_VAR} not found. Run via 'agentcore dev' to load agentcore/.env"
+                f"{IDENTITY_ENV_VAR} not found. Add {IDENTITY_ENV_VAR}=your-key to .env.local"
             )
         return api_key
     return _agentcore_identity_api_key_provider()

--- a/src/assets/python/langchain_langgraph/base/model/load.py
+++ b/src/assets/python/langchain_langgraph/base/model/load.py
@@ -34,7 +34,7 @@ def _get_api_key() -> str:
         api_key = os.getenv(IDENTITY_ENV_VAR)
         if not api_key:
             raise RuntimeError(
-                f"{IDENTITY_ENV_VAR} not found. Run via 'agentcore dev' to load agentcore/.env"
+                f"{IDENTITY_ENV_VAR} not found. Add {IDENTITY_ENV_VAR}=your-key to .env.local"
             )
         return api_key
     return _agentcore_identity_api_key_provider()
@@ -71,7 +71,7 @@ def _get_api_key() -> str:
         api_key = os.getenv(IDENTITY_ENV_VAR)
         if not api_key:
             raise RuntimeError(
-                f"{IDENTITY_ENV_VAR} not found. Run via 'agentcore dev' to load agentcore/.env"
+                f"{IDENTITY_ENV_VAR} not found. Add {IDENTITY_ENV_VAR}=your-key to .env.local"
             )
         return api_key
     return _agentcore_identity_api_key_provider()
@@ -108,7 +108,7 @@ def _get_api_key() -> str:
         api_key = os.getenv(IDENTITY_ENV_VAR)
         if not api_key:
             raise RuntimeError(
-                f"{IDENTITY_ENV_VAR} not found. Run via 'agentcore dev' to load agentcore/.env"
+                f"{IDENTITY_ENV_VAR} not found. Add {IDENTITY_ENV_VAR}=your-key to .env.local"
             )
         return api_key
     return _agentcore_identity_api_key_provider()

--- a/src/assets/python/openaiagents/base/model/load.py
+++ b/src/assets/python/openaiagents/base/model/load.py
@@ -20,7 +20,7 @@ def _get_api_key() -> str:
         api_key = os.getenv(IDENTITY_ENV_VAR)
         if not api_key:
             raise RuntimeError(
-                f"{IDENTITY_ENV_VAR} not found. Run via 'agentcore dev' to load agentcore/.env"
+                f"{IDENTITY_ENV_VAR} not found. Add {IDENTITY_ENV_VAR}=your-key to .env.local"
             )
         return api_key
     return _agentcore_identity_api_key_provider()

--- a/src/assets/python/strands/base/model/load.py
+++ b/src/assets/python/strands/base/model/load.py
@@ -31,7 +31,7 @@ def _get_api_key() -> str:
         api_key = os.getenv(IDENTITY_ENV_VAR)
         if not api_key:
             raise RuntimeError(
-                f"{IDENTITY_ENV_VAR} not found. Run via 'agentcore dev' to load agentcore/.env"
+                f"{IDENTITY_ENV_VAR} not found. Add {IDENTITY_ENV_VAR}=your-key to .env.local"
             )
         return api_key
     return _agentcore_identity_api_key_provider()
@@ -70,7 +70,7 @@ def _get_api_key() -> str:
         api_key = os.getenv(IDENTITY_ENV_VAR)
         if not api_key:
             raise RuntimeError(
-                f"{IDENTITY_ENV_VAR} not found. Run via 'agentcore dev' to load agentcore/.env"
+                f"{IDENTITY_ENV_VAR} not found. Add {IDENTITY_ENV_VAR}=your-key to .env.local"
             )
         return api_key
     return _agentcore_identity_api_key_provider()
@@ -108,7 +108,7 @@ def _get_api_key() -> str:
         api_key = os.getenv(IDENTITY_ENV_VAR)
         if not api_key:
             raise RuntimeError(
-                f"{IDENTITY_ENV_VAR} not found. Run via 'agentcore dev' to load agentcore/.env"
+                f"{IDENTITY_ENV_VAR} not found. Add {IDENTITY_ENV_VAR}=your-key to .env.local"
             )
         return api_key
     return _agentcore_identity_api_key_provider()


### PR DESCRIPTION
## Description
Improved the error message when an API key is not found for non-Bedrock providers (Gemini, OpenAI, Anthropic).

Before:
```
AGENTCORE_IDENTITY_GEMINI not found. Run via 'agentcore dev' to load agentcore/.env
```

After:
```
AGENTCORE_IDENTITY_GEMINI not found. Add AGENTCORE_IDENTITY_GEMINI=your-key to .env.local
```

This gives users clear, actionable guidance on how to fix the issue.

## Related Issues
<!-- Link to related issues using #issue-number format -->

## Documentation PR
N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran npm test
- [x] I ran npm run typecheck
- [x] I ran npm run lint

Manual testing:
- Ran agentcore dev without Gemini API key → error now shows actionable fix

## Checklist
- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.