### PR TITLE
fix: handle plain JSON responses in deployed invoke

### DIFF
--- a/src/assets/python/openaiagents/base/main.py
+++ b/src/assets/python/openaiagents/base/main.py
@@ -49,7 +49,7 @@ async def invoke(payload, context):
     result = await main(prompt)
 
     # Return result
-    yield {"result": result.final_output}
+    return {"result": result.final_output}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Fixes #48 

Fix blank responses when invoking deployed agents that return plain JSON instead of SSE format.

The CLI's invokeAgentRuntimeStreaming was only handling SSE-formatted responses (data: ...). When runtimes return plain JSON (e.g., {"result": "..."} from OpenAI Agents SDK), the response was silently dropped.

Added extractResult fallback to handle non-SSE responses, matching the existing behavior in local dev invoke.

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran npm test
- [ ] I ran npm run typecheck
- [ ] I ran npm run lint

Manual testing:
- Deployed Project08 (OpenAI Agents) with return {"result": ...}
- Ran agentcore-cli invoke - response now displays correctly
- Previously showed blank response, now shows agent output

## Checklist

- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published