### PR TITLE
fix: wait for agents to load before rendering add wizards

### DIFF
--- a/src/cli/tui/screens/add/AddFlow.tsx
+++ b/src/cli/tui/screens/add/AddFlow.tsx
@@ -363,6 +363,10 @@ export function AddFlow(props: AddFlowProps) {
   }
 
   if (flow.name === 'identity-wizard') {
+    // Wait for agents to load before rendering wizard
+    if (agents.length === 0) {
+      return null;
+    }
     return (
       <AddIdentityScreen
         existingIdentityNames={identityNames}

--- a/src/cli/tui/screens/memory/AddMemoryFlow.tsx
+++ b/src/cli/tui/screens/memory/AddMemoryFlow.tsx
@@ -44,6 +44,10 @@ export function AddMemoryFlow({ isInteractive = true, onExit, onBack }: AddMemor
   );
 
   if (flow.name === 'wizard') {
+    // Wait for agents to load before rendering wizard
+    if (agents.length === 0) {
+      return null;
+    }
     return (
       <AddMemoryScreen
         existingMemoryNames={existingNames}


### PR DESCRIPTION
## Description

Fix race condition where add memory/identity wizards would fail with `Owner agent "" not found error`.

The wizards were rendering before the `async useAvailableAgentsForMemory` hook finished loading agents. When there's a single agent, the wizard auto-selects it - but since agents were empty at init time, `ownerAgent` defaulted to empty string.

Added guard to wait for agents to load before rendering the wizard screens.

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran npm test
- [x] I ran npm run typecheck
- [ ] I ran npm run lint

Manual testing:
- Created new project with single agent
- Ran agentcore-cli add → Memory
- Wizard now works correctly (previously failed with empty owner agent error)

## Checklist

- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.