### PR TITLE
fix: change create flow for better UX. now exits out after create

### DIFF
--- a/src/cli/cloudformation/__tests__/outputs.test.ts
+++ b/src/cli/cloudformation/__tests__/outputs.test.ts
@@ -11,9 +11,15 @@ describe('buildDeployedState', () => {
       },
     };
 
-    const result = buildDeployedState('default', 'TestStack', agents, undefined, 'arn:aws:kms:us-east-1:123456789012:key/abc-123');
+    const result = buildDeployedState(
+      'default',
+      'TestStack',
+      agents,
+      undefined,
+      'arn:aws:kms:us-east-1:123456789012:key/abc-123'
+    );
 
-    expect(result.targets.default.resources?.identityKmsKeyArn).toBe('arn:aws:kms:us-east-1:123456789012:key/abc-123');
+    expect(result.targets.default?.resources?.identityKmsKeyArn).toBe('arn:aws:kms:us-east-1:123456789012:key/abc-123');
   });
 
   it('omits identityKmsKeyArn when not provided', () => {
@@ -27,7 +33,7 @@ describe('buildDeployedState', () => {
 
     const result = buildDeployedState('default', 'TestStack', agents);
 
-    expect(result.targets.default.resources?.identityKmsKeyArn).toBeUndefined();
+    expect(result.targets.default?.resources?.identityKmsKeyArn).toBeUndefined();
   });
 
   it('preserves existing state while adding new target with kmsKeyArn', () => {
@@ -42,9 +48,15 @@ describe('buildDeployedState', () => {
       },
     };
 
-    const result = buildDeployedState('dev', 'DevStack', {}, existingState, 'arn:aws:kms:us-east-1:123456789012:key/dev-key');
+    const result = buildDeployedState(
+      'dev',
+      'DevStack',
+      {},
+      existingState,
+      'arn:aws:kms:us-east-1:123456789012:key/dev-key'
+    );
 
-    expect(result.targets.prod.resources?.stackName).toBe('ProdStack');
-    expect(result.targets.dev.resources?.identityKmsKeyArn).toBe('arn:aws:kms:us-east-1:123456789012:key/dev-key');
+    expect(result.targets.prod?.resources?.stackName).toBe('ProdStack');
+    expect(result.targets.dev?.resources?.identityKmsKeyArn).toBe('arn:aws:kms:us-east-1:123456789012:key/dev-key');
   });
 });

--- a/src/cli/commands/deploy/actions.ts
+++ b/src/cli/commands/deploy/actions.ts
@@ -131,7 +131,7 @@ export async function handleDeploy(options: ValidatedDeployOptions): Promise<Dep
       startStep('Set up API key providers');
       const identityResult = await setupApiKeyProviders({
         projectSpec: context.projectSpec,
-        configBaseDir: configIO.baseDir,
+        configBaseDir: configIO.getConfigRoot(),
         region: target.region,
         enableKmsEncryption: true,
       });

--- a/src/cli/commands/package/action.ts
+++ b/src/cli/commands/package/action.ts
@@ -60,13 +60,15 @@ export async function handlePackage(context: PackageContext): Promise<PackageRes
   }
 
   // Filter only CodeZip artifacts
-  const packableAgents = agentsToPackage.filter((a): a is CodeZipAgent => {
-    if (!isCodeZipAgent(a)) {
-      skipped.push(a.name);
-      return false;
+  const packableAgents: CodeZipAgent[] = [];
+  for (const agent of agentsToPackage) {
+    const agentName = agent.name;
+    if (isCodeZipAgent(agent)) {
+      packableAgents.push(agent);
+    } else {
+      skipped.push(agentName);
     }
-    return true;
-  });
+  }
 
   if (packableAgents.length === 0) {
     return { success: true, results: [], skipped };

--- a/src/cli/tui/App.tsx
+++ b/src/cli/tui/App.tsx
@@ -20,8 +20,8 @@ import { StatusScreen } from './screens/status/StatusScreen';
 import { UpdateScreen } from './screens/update';
 import { ValidateScreen } from './screens/validate';
 import { type CommandMeta, getCommandsForUI } from './utils/commands';
-import React, { useState } from 'react';
 import { useApp } from 'ink';
+import React, { useState } from 'react';
 
 // Capture cwd once at app initialization
 const cwd = getWorkingDirectory();
@@ -49,13 +49,14 @@ type Route =
 function AppContent() {
   const { exit } = useApp();
   // Start on help screen if project exists (show commands), otherwise home (show Quick Start)
-  const initialRoute: Route = projectExists() ? { name: 'help' } : { name: 'home' };
+  const inProject = projectExists();
+  const initialRoute: Route = inProject ? { name: 'help' } : { name: 'home' };
   const [route, setRoute] = useState<Route>(initialRoute);
   const [helpNotice, setHelpNotice] = useState<React.ReactNode | null>(null);
 
-  // Get commands from commander program
+  // Get commands from commander program (hide 'create' when in project)
   const program = createProgram();
-  const commands = getCommandsForUI(program);
+  const commands = getCommandsForUI(program, { inProject });
 
   const onSelectCommand = (id: string) => {
     const cmd = commands.find(c => c.id === id);

--- a/src/cli/tui/screens/create/CreateScreen.tsx
+++ b/src/cli/tui/screens/create/CreateScreen.tsx
@@ -178,8 +178,7 @@ export function CreateScreen({ cwd, isInteractive, onExit, onNavigate }: CreateS
     </Box>
   );
 
-  const helpText =
-    allSuccess && isInteractive ? HELP_TEXT.NAVIGATE_SELECT : flow.hasError || allSuccess ? HELP_TEXT.EXIT : undefined;
+  const helpText = flow.hasError || allSuccess ? HELP_TEXT.EXIT : undefined;
 
   return (
     <Screen title="AgentCore Create" onExit={onExit} headerContent={headerContent} helpText={helpText}>
@@ -187,22 +186,37 @@ export function CreateScreen({ cwd, isInteractive, onExit, onNavigate }: CreateS
       {allSuccess && flow.outputDir && (
         <Box marginTop={1} flexDirection="column">
           <CreatedSummary projectName={flow.projectName} agentConfig={flow.addAgentConfig} />
-          {isInteractive && (
-            <Box marginTop={1}>
-              <Text dimColor>cd {flow.projectName}</Text>
+          {isInteractive ? (
+            <Box marginTop={1} flexDirection="column">
+              <Text color="green">Project created successfully!</Text>
+              <Box marginTop={1} flexDirection="column">
+                <Text>To continue, exit and navigate to your new project:</Text>
+                <Box marginLeft={2} marginTop={1} flexDirection="column">
+                  <Text>
+                    <Text color="cyan">1.</Text> Press <Text color="cyan">Esc</Text> to exit
+                  </Text>
+                  <Text>
+                    <Text color="cyan">2.</Text> Run <Text color="cyan">cd {flow.projectName}</Text>
+                  </Text>
+                  <Text>
+                    <Text color="cyan">3.</Text> Run <Text color="cyan">agentcore</Text> to continue
+                  </Text>
+                </Box>
+              </Box>
             </Box>
+          ) : (
+            <NextSteps
+              steps={getCreateNextSteps(flow.addAgentConfig !== null)}
+              isInteractive={isInteractive}
+              onSelect={step => {
+                if (onNavigate) {
+                  onNavigate({ command: step.command as NextCommand, workingDir: projectRoot });
+                }
+              }}
+              onBack={onExit}
+              isActive={allSuccess}
+            />
           )}
-          <NextSteps
-            steps={getCreateNextSteps(flow.addAgentConfig !== null)}
-            isInteractive={isInteractive}
-            onSelect={step => {
-              if (onNavigate) {
-                onNavigate({ command: step.command as NextCommand, workingDir: projectRoot });
-              }
-            }}
-            onBack={onExit}
-            isActive={allSuccess}
-          />
         </Box>
       )}
       {flow.hasError && (

--- a/src/cli/tui/screens/home/HomeScreen.tsx
+++ b/src/cli/tui/screens/home/HomeScreen.tsx
@@ -1,26 +1,36 @@
 import { findConfigRoot } from '../../../../lib';
 import { Cursor, ScreenLayout } from '../../components';
 import { buildLogo, useLayout } from '../../context';
-import { HINTS, QUICK_START } from '../../copy';
+import { HINTS } from '../../copy';
 import { Box, Text, useApp, useInput } from 'ink';
 import React from 'react';
+
+function NoProjectMessage() {
+  return (
+    <Box marginTop={1} flexDirection="column">
+      <Text color="yellow">No AgentCore project found in this directory.</Text>
+      <Box marginTop={1} flexDirection="column">
+        <Text dimColor>You can:</Text>
+        <Box marginLeft={2} flexDirection="column">
+          <Text>
+            <Text color="cyan">create</Text>
+            <Text dimColor> - Create a new AgentCore project here</Text>
+          </Text>
+          <Text dimColor>or cd into an existing project directory</Text>
+        </Box>
+      </Box>
+    </Box>
+  );
+}
 
 function QuickStart() {
   return (
     <Box marginTop={1} flexDirection="column">
-      <Text bold color="cyan">
-        Quick Start
-      </Text>
-      <Box marginTop={1} flexDirection="column">
-        <Text>
-          <Text color="cyan">create</Text>
-          <Text dimColor> {QUICK_START.create}</Text>
-        </Text>
-      </Box>
+      <NoProjectMessage />
       <Box marginTop={1}>
         <Text>
           <Text color="cyan">⚑ </Text>
-          <Text dimColor>Run create to get started</Text>
+          <Text dimColor>Press Enter to create a new project</Text>
         </Text>
       </Box>
     </Box>
@@ -31,8 +41,8 @@ function hasProject(): boolean {
   return findConfigRoot() !== null;
 }
 
-// Quick start takes 8 lines: margin(1) + header(1) + margin(1) + 3 items + margin(1) + tip(1)
-const QUICK_START_LINES = 8;
+// Quick start takes 9 lines for the "no project" message plus tip
+const QUICK_START_LINES = 9;
 
 interface HomeScreenProps {
   cwd: string;

--- a/src/cli/tui/utils/commands.ts
+++ b/src/cli/tui/utils/commands.ts
@@ -13,9 +13,25 @@ export interface CommandMeta {
  */
 const HIDDEN_FROM_TUI = ['update', 'package'] as const;
 
-export function getCommandsForUI(program: Command): CommandMeta[] {
+/**
+ * Commands hidden from TUI when inside an existing project.
+ * 'create' is hidden because users should use 'add' instead.
+ */
+const HIDDEN_WHEN_IN_PROJECT = ['create'] as const;
+
+interface GetCommandsOptions {
+  /** Whether user is currently inside an AgentCore project */
+  inProject?: boolean;
+}
+
+export function getCommandsForUI(program: Command, options: GetCommandsOptions = {}): CommandMeta[] {
+  const { inProject = false } = options;
+
   return program.commands
     .filter(cmd => !HIDDEN_FROM_TUI.includes(cmd.name() as (typeof HIDDEN_FROM_TUI)[number]))
+    .filter(
+      cmd => !inProject || !HIDDEN_WHEN_IN_PROJECT.includes(cmd.name() as (typeof HIDDEN_WHEN_IN_PROJECT)[number])
+    )
     .map(cmd => ({
       id: cmd.name(),
       title: cmd.name(),


### PR DESCRIPTION
## Description

UX change alignment. detects if we are in a project or not. 
1. if in agentcore project -- do not let users "create" so the TUI doesn't even show that command.
2. if outside a project -- either create project or cd into one 
``` 
No AgentCore project found in this directory.

  You can:
    create - Create a new AgentCore project here
    or cd into an existing project directory

```

Once the user creates a new project:
```
Created:
    Testing2/
      agentcore/         Config and CDK project

  Project created successfully!

 To continue, exit and navigate to your new project:

    1. Press Esc to exit
    2. Run cd Testing2
    3. Run agentcore to continue
```

+ other unrelated typecheck fixes

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Check all that apply -->

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [X] I ran `npm test`
- [X] I ran `npm run typecheck`
- [X] I ran `npm run lint`

## Checklist

- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
