### PR TITLE
fix: prevent selecting disabled language options

### DIFF
--- a/src/cli/tui/screens/agent/AddAgentScreen.tsx
+++ b/src/cli/tui/screens/agent/AddAgentScreen.tsx
@@ -221,6 +221,7 @@ export function AddAgentScreen({ existingAgentNames, onComplete, onExit }: AddAg
     },
     onExit: handleByoBack,
     isActive: isByoPath && byoStep === 'language',
+    isDisabled: item => item.disabled ?? false,
   });
 
   const frameworkNav = useListNavigation({

--- a/src/cli/tui/screens/generate/GenerateWizardUI.tsx
+++ b/src/cli/tui/screens/generate/GenerateWizardUI.tsx
@@ -86,6 +86,7 @@ export function GenerateWizardUI({ wizard, onBack, onConfirm, isActive }: Genera
     onSelect: handleSelect,
     onExit: onBack,
     isActive: isActive && isSelectStep,
+    isDisabled: item => item.disabled ?? false,
   });
 
   // Handle confirm step input


### PR DESCRIPTION
## Description

Fix disabled language options (e.g., "TypeScript - coming soon") being selectable in the TUI.

Added isDisabled callback to useListNavigation in both the add agent and create flows to properly prevent selection of disabled items.

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran npm test
- [ ] I ran npm run typecheck
- [x] I ran npm run lint

Manual testing:
- Ran agentcore-cli create and verified TypeScript option cannot be selected
- Ran agentcore-cli add agent and verified TypeScript option cannot be selected
- Confirmed Python selection still works normally

## Checklist

- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.