### PR TITLE
docs: update README and add CLI reference documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # @aws/agentcore-cli
 
-CLI tool for Amazon Bedrock AgentCore. Create, deploy, and manage agentic applications on AWS.
+CLI tool for Amazon Bedrock AgentCore. Create, develop, and deploy agentic applications on AWS.
+
+## Prerequisites
+
+- **Node.js** 18.x or later
+- **AWS CLI** configured with credentials
+- **uv** for Python agents ([install](https://docs.astral.sh/uv/getting-started/installation/))
+- **AWS CDK** bootstrapped: `npx cdk bootstrap aws://ACCOUNT_ID/REGION`
 
 ## Installation
 
@@ -11,43 +18,134 @@ npm install -g @aws/agentcore-cli
 ## Quick Start
 
 ```bash
-# Create a new project
+# Create a new project (wizard guides you through agent setup)
 agentcore-cli create
+cd my-project
+
+# Test locally
+agentcore-cli dev
+# In another terminal:
+agentcore-cli invoke
 
 # Deploy to AWS
 agentcore-cli deploy
 
-# Check status
-agentcore-cli status
-
-# Invoke an agent
-agentcore-cli invoke
+# Invoke deployed agent
+agentcore-cli invoke --stream
 ```
+
+## Supported Frameworks
+
+| Framework           | Notes                         |
+| ------------------- | ----------------------------- |
+| Strands             | AWS-native, streaming support |
+| LangChain/LangGraph | Graph-based workflows         |
+| AutoGen             | Multi-agent conversations     |
+| CrewAI              | Role-based agent teams        |
+| Google ADK          | Gemini only                   |
+| OpenAI Agents       | OpenAI only                   |
+
+## Supported Model Providers
+
+| Provider       | API Key Required          | Default Model              |
+| -------------- | ------------------------- | -------------------------- |
+| Amazon Bedrock | No (uses AWS credentials) | Claude Sonnet 4.5          |
+| Anthropic      | Yes                       | claude-sonnet-4-5-20250929 |
+| Google Gemini  | Yes                       | gemini-2.0-flash           |
+| OpenAI         | Yes                       | gpt-4o                     |
 
 ## Commands
 
-| Command  | Description                    |
-| -------- | ------------------------------ |
-| `create` | Create a new AgentCore project |
-| `deploy` | Deploy infrastructure to AWS   |
-| `status` | Check deployment status        |
-| `invoke` | Invoke a deployed agent        |
-| `dev`    | Start local development server |
-| `add`    | Add agents, memory, identity   |
-| `remove` | Remove resources               |
-| `plan`   | Preview infrastructure changes |
+### Project Lifecycle
+
+| Command    | Description                    |
+| ---------- | ------------------------------ |
+| `create`   | Create a new AgentCore project |
+| `validate` | Validate configuration files   |
+| `plan`     | Preview infrastructure changes |
+| `deploy`   | Deploy infrastructure to AWS   |
+| `status`   | Check deployment status        |
+| `destroy`  | Tear down deployed resources   |
+
+### Resource Management
+
+| Command  | Description                                       |
+| -------- | ------------------------------------------------- |
+| `add`    | Add agents, memory, identity, MCP tools, gateways |
+| `remove` | Remove resources from project                     |
+| `attach` | Connect resources to agents                       |
+
+### Development
+
+| Command   | Description                               |
+| --------- | ----------------------------------------- |
+| `dev`     | Start local development server            |
+| `invoke`  | Invoke local or deployed agents           |
+| `package` | Package agent artifacts without deploying |
+
+### Utilities
+
+| Command   | Description                   |
+| --------- | ----------------------------- |
+| `outline` | Display project resource tree |
+| `edit`    | Interactive schema editor     |
+| `update`  | Check for CLI updates         |
+
+## Project Structure
+
+```
+my-project/
+├── agentcore/
+│   ├── agentcore.json      # Agent specifications
+│   ├── aws-targets.json    # Deployment targets
+│   ├── mcp.json            # MCP gateway/tool config
+│   └── cdk/                # CDK infrastructure
+├── app/                    # Agent code
+└── .env.local              # API keys (gitignored)
+```
 
 ## Configuration
 
 Projects use JSON schema files in the `agentcore/` directory:
 
-- `agentcore.json` - Agent specifications
-- `aws-targets.json` - Deployment targets
-- `mcp.json` - MCP gateway configuration
+- `agentcore.json` - Agent specifications, memory, identity, remote tools
+- `aws-targets.json` - Deployment targets (account, region)
+- `mcp.json` - MCP gateway and tool definitions
+- `deployed-state.json` - Runtime state (auto-managed)
+
+## Primitives
+
+- **Memory** - Semantic, summarization, and user preference strategies
+- **Identity** - Secure API key management via Secrets Manager
+- **MCP Gateway** - HTTP endpoints exposing tools to agents
+- **MCP Runtime Tools** - Direct agent-to-tool connections
+- **Agent-to-Agent** - Agents invoking other agents as tools
+
+## Invoking Agents
+
+```bash
+# Interactive mode
+agentcore-cli invoke
+
+# With prompt and streaming
+agentcore-cli invoke "What can you do?" --stream
+
+# Session management
+agentcore-cli invoke --session-id <id>   # Continue conversation
+agentcore-cli invoke --new-session       # Start fresh
+```
+
+## Documentation
+
+- [CLI Commands Reference](docs/commands.md) - Full command reference for scripting and CI/CD
+- [Configuration](docs/configuration.md) - Schema reference for config files
+- [MCP Tools](docs/mcp-tools.md) - MCP runtime vs gateway modes
+- [Memory](docs/memory.md) - Memory strategies and sharing
+- [Local Development](docs/local-development.md) - Dev server and debugging
 
 ## Library Usage
 
-The CLI also exports utilities for programmatic use:
+The CLI exports utilities for programmatic use:
 
 ```typescript
 import { type AgentEnvSpec, ConfigIO } from '@aws/agentcore-cli';
@@ -58,7 +156,7 @@ const spec = await configIO.readProjectSpec();
 
 ## Related Package
 
-- `@aws/agentcore-l3-cdk-constructs` - CDK constructs used by vended projects
+- `@aws/agentcore-l3-cdk-constructs` - CDK constructs for standalone infrastructure-as-code usage
 
 ## Security
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,473 @@
+# CLI Commands Reference
+
+All commands support non-interactive (scriptable) usage with flags. Use `--json` for machine-readable output.
+
+## Project Lifecycle
+
+### create
+
+Create a new AgentCore project.
+
+```bash
+# Interactive wizard
+agentcore-cli create
+
+# Fully non-interactive with defaults
+agentcore-cli create --name MyProject --defaults
+
+# Custom configuration
+agentcore-cli create \
+  --name MyProject \
+  --framework Strands \
+  --model-provider Bedrock \
+  --memory shortTerm \
+  --output-dir ./projects
+
+# Skip agent creation
+agentcore-cli create --name MyProject --no-agent
+
+# Preview without creating
+agentcore-cli create --name MyProject --defaults --dry-run
+```
+
+| Flag                   | Description                                                                        |
+| ---------------------- | ---------------------------------------------------------------------------------- |
+| `--name <name>`        | Project name (alphanumeric, max 23 chars)                                          |
+| `--defaults`           | Use defaults (Python, Strands, Bedrock, no memory)                                 |
+| `--no-agent`           | Skip agent creation                                                                |
+| `--language <lang>`    | `Python` or `TypeScript`                                                           |
+| `--framework <fw>`     | `Strands`, `LangChain_LangGraph`, `AutoGen`, `CrewAI`, `GoogleADK`, `OpenAIAgents` |
+| `--model-provider <p>` | `Bedrock`, `Anthropic`, `OpenAI`, `Gemini`                                         |
+| `--api-key <key>`      | API key for non-Bedrock providers                                                  |
+| `--memory <opt>`       | `none`, `shortTerm`, `longAndShortTerm`                                            |
+| `--output-dir <dir>`   | Output directory                                                                   |
+| `--skip-git`           | Skip git initialization                                                            |
+| `--skip-python-setup`  | Skip venv setup                                                                    |
+| `--dry-run`            | Preview without creating                                                           |
+| `--json`               | JSON output                                                                        |
+
+### plan
+
+Preview infrastructure changes before deploying.
+
+```bash
+agentcore-cli plan
+agentcore-cli plan --target production
+agentcore-cli plan --target dev --deploy  # Plan then deploy
+agentcore-cli plan -y --json              # Auto-confirm, JSON output
+```
+
+| Flag              | Description                  |
+| ----------------- | ---------------------------- |
+| `--target <name>` | Deployment target            |
+| `-y, --yes`       | Auto-confirm prompts         |
+| `--deploy`        | Deploy after successful plan |
+| `--json`          | JSON output                  |
+
+### deploy
+
+Deploy infrastructure to AWS.
+
+```bash
+agentcore-cli deploy
+agentcore-cli deploy --target production
+agentcore-cli deploy -y --progress        # Auto-confirm with progress
+agentcore-cli deploy -v --json            # Verbose JSON output
+```
+
+| Flag              | Description           |
+| ----------------- | --------------------- |
+| `--target <name>` | Deployment target     |
+| `-y, --yes`       | Auto-confirm prompts  |
+| `--progress`      | Real-time progress    |
+| `-v, --verbose`   | Resource-level events |
+| `--json`          | JSON output           |
+
+### destroy
+
+Tear down deployed resources.
+
+```bash
+agentcore-cli destroy
+agentcore-cli destroy --target dev -y     # Auto-confirm
+```
+
+| Flag              | Description       |
+| ----------------- | ----------------- |
+| `--target <name>` | Target to destroy |
+| `-y, --yes`       | Skip confirmation |
+| `--json`          | JSON output       |
+
+### status
+
+Check deployment status.
+
+```bash
+agentcore-cli status
+agentcore-cli status --agent MyAgent
+agentcore-cli status --target production
+```
+
+| Flag                      | Description         |
+| ------------------------- | ------------------- |
+| `--agent <name>`          | Specific agent      |
+| `--agent-runtime-id <id>` | Specific runtime ID |
+| `--target <name>`         | Deployment target   |
+
+### validate
+
+Validate configuration files.
+
+```bash
+agentcore-cli validate
+agentcore-cli validate -d ./my-project
+```
+
+| Flag                     | Description       |
+| ------------------------ | ----------------- |
+| `-d, --directory <path>` | Project directory |
+
+---
+
+## Resource Management
+
+### add agent
+
+Add an agent to the project.
+
+```bash
+# Create new agent from template
+agentcore-cli add agent \
+  --name MyAgent \
+  --framework Strands \
+  --model-provider Bedrock \
+  --memory shortTerm
+
+# Bring your own code
+agentcore-cli add agent \
+  --name MyAgent \
+  --type byo \
+  --code-location ./my-agent \
+  --entrypoint main.py \
+  --language Python \
+  --framework Strands \
+  --model-provider Bedrock
+```
+
+| Flag                     | Description                           |
+| ------------------------ | ------------------------------------- |
+| `--name <name>`          | Agent name                            |
+| `--type <type>`          | `create` (default) or `byo`           |
+| `--language <lang>`      | `Python`, `TypeScript`, `Other` (BYO) |
+| `--framework <fw>`       | Agent framework                       |
+| `--model-provider <p>`   | Model provider                        |
+| `--api-key <key>`        | API key for non-Bedrock               |
+| `--memory <opt>`         | Memory option (create only)           |
+| `--code-location <path>` | Code path (BYO only)                  |
+| `--entrypoint <file>`    | Entry file (BYO only)                 |
+| `--json`                 | JSON output                           |
+
+### add memory
+
+Add a memory resource.
+
+```bash
+agentcore-cli add memory \
+  --name SharedMemory \
+  --strategies SEMANTIC,SUMMARIZATION \
+  --expiry 30 \
+  --owner MyAgent \
+  --users AgentA,AgentB
+```
+
+| Flag                   | Description                                                               |
+| ---------------------- | ------------------------------------------------------------------------- |
+| `--name <name>`        | Memory name                                                               |
+| `--description <desc>` | Description                                                               |
+| `--strategies <types>` | Comma-separated: `SEMANTIC`, `SUMMARIZATION`, `USER_PREFERENCE`, `CUSTOM` |
+| `--expiry <days>`      | Event expiry (default: 30)                                                |
+| `--owner <agent>`      | Owning agent                                                              |
+| `--users <agents>`     | Comma-separated users                                                     |
+| `--json`               | JSON output                                                               |
+
+### add identity
+
+Add an identity provider (API key).
+
+```bash
+agentcore-cli add identity \
+  --name OpenAI \
+  --type ApiKeyCredentialProvider \
+  --api-key sk-... \
+  --owner MyAgent
+```
+
+| Flag               | Description                |
+| ------------------ | -------------------------- |
+| `--name <name>`    | Identity name              |
+| `--type <type>`    | `ApiKeyCredentialProvider` |
+| `--api-key <key>`  | API key value              |
+| `--owner <agent>`  | Owning agent               |
+| `--users <agents>` | Comma-separated users      |
+| `--json`           | JSON output                |
+
+### add gateway
+
+Add an MCP gateway.
+
+```bash
+# Basic gateway
+agentcore-cli add gateway \
+  --name main-gateway \
+  --agents MyAgent
+
+# With JWT authorization
+agentcore-cli add gateway \
+  --name secure-gateway \
+  --authorizer-type CUSTOM_JWT \
+  --discovery-url "https://cognito-idp.us-west-2.amazonaws.com/xxx/.well-known/openid-configuration" \
+  --allowed-audience client-id \
+  --allowed-clients client-id
+```
+
+| Flag                        | Description                          |
+| --------------------------- | ------------------------------------ |
+| `--name <name>`             | Gateway name                         |
+| `--description <desc>`      | Description                          |
+| `--authorizer-type <type>`  | `NONE` (default) or `CUSTOM_JWT`     |
+| `--discovery-url <url>`     | OIDC discovery URL (for JWT)         |
+| `--allowed-audience <vals>` | Comma-separated audiences (for JWT)  |
+| `--allowed-clients <vals>`  | Comma-separated client IDs (for JWT) |
+| `--agents <names>`          | Comma-separated agents to attach     |
+| `--json`                    | JSON output                          |
+
+### add mcp-tool
+
+Add an MCP tool.
+
+```bash
+# Direct runtime tool
+agentcore-cli add mcp-tool \
+  --name MyTool \
+  --language Python \
+  --exposure mcp-runtime \
+  --agents MyAgent
+
+# Behind gateway
+agentcore-cli add mcp-tool \
+  --name MyTool \
+  --language Python \
+  --exposure behind-gateway \
+  --gateway main-gateway \
+  --host Lambda
+```
+
+| Flag                   | Description                                         |
+| ---------------------- | --------------------------------------------------- |
+| `--name <name>`        | Tool name                                           |
+| `--description <desc>` | Description                                         |
+| `--language <lang>`    | `Python` or `TypeScript`                            |
+| `--exposure <mode>`    | `mcp-runtime` or `behind-gateway`                   |
+| `--agents <names>`     | Agents (for mcp-runtime)                            |
+| `--gateway <name>`     | Gateway (for behind-gateway)                        |
+| `--host <host>`        | `Lambda` or `AgentCoreRuntime` (for behind-gateway) |
+| `--json`               | JSON output                                         |
+
+### add target
+
+Add a deployment target.
+
+```bash
+agentcore-cli add target \
+  --name production \
+  --account 123456789012 \
+  --region us-west-2 \
+  --description "Production environment"
+```
+
+| Flag                   | Description    |
+| ---------------------- | -------------- |
+| `--name <name>`        | Target name    |
+| `--account <id>`       | AWS account ID |
+| `--region <region>`    | AWS region     |
+| `--description <desc>` | Description    |
+| `--json`               | JSON output    |
+
+### attach
+
+Connect resources to agents.
+
+```bash
+# Agent-to-agent
+agentcore-cli attach agent --source CallerAgent --target HelperAgent
+
+# Memory
+agentcore-cli attach memory --agent MyAgent --memory SharedMemory --access read
+
+# Identity
+agentcore-cli attach identity --agent MyAgent --identity OpenAI
+
+# MCP runtime
+agentcore-cli attach mcp-runtime --agent MyAgent --runtime MyTool
+
+# Gateway
+agentcore-cli attach gateway --agent MyAgent --gateway main-gateway
+```
+
+### remove
+
+Remove resources from project.
+
+```bash
+agentcore-cli remove agent --name MyAgent --force
+agentcore-cli remove memory --name SharedMemory
+agentcore-cli remove gateway --name main-gateway
+agentcore-cli remove mcp-tool --name MyTool
+agentcore-cli remove identity --name OpenAI
+agentcore-cli remove target --name dev
+
+# Reset everything
+agentcore-cli remove all --force
+agentcore-cli remove all --dry-run  # Preview
+```
+
+| Flag            | Description               |
+| --------------- | ------------------------- |
+| `--name <name>` | Resource name             |
+| `--force`       | Skip confirmation         |
+| `--dry-run`     | Preview (remove all only) |
+| `--json`        | JSON output               |
+
+---
+
+## Development
+
+### dev
+
+Start local development server.
+
+```bash
+agentcore-cli dev
+agentcore-cli dev --agent MyAgent --port 3000
+agentcore-cli dev --logs                      # Non-interactive
+agentcore-cli dev --invoke "Hello" --stream   # Direct invoke
+```
+
+| Flag                    | Description                     |
+| ----------------------- | ------------------------------- |
+| `-p, --port <port>`     | Port (default: 8080)            |
+| `-a, --agent <name>`    | Agent to run                    |
+| `-i, --invoke <prompt>` | Invoke running server           |
+| `-s, --stream`          | Stream response (with --invoke) |
+| `-l, --logs`            | Non-interactive stdout logging  |
+
+### invoke
+
+Invoke local or deployed agents.
+
+```bash
+agentcore-cli invoke "What can you do?"
+agentcore-cli invoke --prompt "Hello" --stream
+agentcore-cli invoke --agent MyAgent --target production
+agentcore-cli invoke --session-id abc123      # Continue session
+agentcore-cli invoke --new-session            # Fresh session
+agentcore-cli invoke --json                   # JSON output
+```
+
+| Flag                | Description               |
+| ------------------- | ------------------------- |
+| `--prompt <text>`   | Prompt text               |
+| `--agent <name>`    | Specific agent            |
+| `--target <name>`   | Deployment target         |
+| `--session-id <id>` | Continue specific session |
+| `--new-session`     | Start fresh session       |
+| `--stream`          | Stream response           |
+| `--json`            | JSON output               |
+
+### stop-session
+
+Stop an active runtime session.
+
+```bash
+agentcore-cli stop-session
+agentcore-cli stop-session --agent MyAgent --session-id abc123
+```
+
+| Flag                | Description       |
+| ------------------- | ----------------- |
+| `--agent <name>`    | Specific agent    |
+| `--target <name>`   | Deployment target |
+| `--session-id <id>` | Session to stop   |
+
+---
+
+## Utilities
+
+### package
+
+Package agent artifacts without deploying.
+
+```bash
+agentcore-cli package
+agentcore-cli package --agent MyAgent
+agentcore-cli package -d ./my-project
+```
+
+| Flag                     | Description            |
+| ------------------------ | ---------------------- |
+| `-d, --directory <path>` | Project directory      |
+| `-a, --agent <name>`     | Package specific agent |
+
+### outline
+
+Display project resource tree.
+
+```bash
+agentcore-cli outline
+agentcore-cli outline agent MyAgent
+```
+
+### update
+
+Check for CLI updates.
+
+```bash
+agentcore-cli update           # Check and install
+agentcore-cli update --check   # Check only
+```
+
+| Flag          | Description              |
+| ------------- | ------------------------ |
+| `-c, --check` | Check without installing |
+
+---
+
+## Common Patterns
+
+### CI/CD Pipeline
+
+```bash
+# Validate, plan, and deploy with auto-confirm
+agentcore-cli validate
+agentcore-cli plan --target production -y --json
+agentcore-cli deploy --target production -y --json
+```
+
+### Scripted Project Setup
+
+```bash
+agentcore-cli create --name MyProject --defaults
+cd MyProject
+agentcore-cli add memory --name SharedMemory --strategies SEMANTIC --owner MyProject
+agentcore-cli add target --name dev --account 123456789012 --region us-west-2
+agentcore-cli deploy --target dev -y
+```
+
+### JSON Output for Automation
+
+All commands with `--json` output structured data:
+
+```bash
+agentcore-cli status --json | jq '.agents[0].runtimeArn'
+agentcore-cli invoke "Hello" --json | jq '.response'
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,239 @@
+# Configuration Reference
+
+AgentCore projects use JSON configuration files in the `agentcore/` directory.
+
+## Files Overview
+
+| File                  | Purpose                                     |
+| --------------------- | ------------------------------------------- |
+| `agentcore.json`      | Project and agent definitions               |
+| `aws-targets.json`    | Deployment targets                          |
+| `mcp.json`            | MCP gateways and runtime tools              |
+| `deployed-state.json` | Runtime state (auto-managed, do not edit)   |
+| `.env.local`          | API keys for local development (gitignored) |
+
+---
+
+## agentcore.json
+
+Main project configuration containing agents and their capabilities.
+
+```json
+{
+  "name": "MyProject",
+  "version": "0.1",
+  "description": "Project description",
+  "agents": [...]
+}
+```
+
+### Project Fields
+
+| Field               | Required | Description                                                 |
+| ------------------- | -------- | ----------------------------------------------------------- |
+| `name`              | Yes      | Project name (1-23 chars, alphanumeric, starts with letter) |
+| `version`           | Yes      | Schema version (currently `"0.1"`)                          |
+| `description`       | Yes      | Project description                                         |
+| `agents`            | Yes      | Array of agent specifications                               |
+| `identityKmsKeyArn` | No       | KMS key ARN for encrypting identity credentials             |
+
+### Agent Specification
+
+```json
+{
+  "name": "MyAgent",
+  "id": "my-agent-001",
+  "sdkFramework": "Strands",
+  "targetLanguage": "Python",
+  "modelProvider": "Bedrock",
+  "runtime": {...},
+  "mcpProviders": [],
+  "memoryProviders": [],
+  "identityProviders": [],
+  "remoteTools": []
+}
+```
+
+| Field               | Required | Description                                                                        |
+| ------------------- | -------- | ---------------------------------------------------------------------------------- |
+| `name`              | Yes      | Agent name (1-64 chars, alphanumeric)                                              |
+| `id`                | Yes      | Unique identifier                                                                  |
+| `sdkFramework`      | Yes      | `Strands`, `LangChain_LangGraph`, `AutoGen`, `CrewAI`, `GoogleADK`, `OpenAIAgents` |
+| `targetLanguage`    | Yes      | `Python` or `TypeScript`                                                           |
+| `modelProvider`     | Yes      | `Bedrock`, `Anthropic`, `OpenAI`, `Gemini`                                         |
+| `runtime`           | Yes      | Runtime configuration                                                              |
+| `mcpProviders`      | Yes      | MCP gateway references                                                             |
+| `memoryProviders`   | Yes      | Memory configurations                                                              |
+| `identityProviders` | Yes      | Identity/API key configurations                                                    |
+| `remoteTools`       | Yes      | Agent-to-agent and MCP runtime references                                          |
+
+### Runtime Configuration
+
+```json
+{
+  "artifact": "CodeZip",
+  "name": "MyAgentRuntime",
+  "pythonVersion": "PYTHON_3_12",
+  "entrypoint": "main.py",
+  "codeLocation": "app/MyAgent/",
+  "networkMode": "PUBLIC"
+}
+```
+
+| Field           | Required | Description                                    |
+| --------------- | -------- | ---------------------------------------------- |
+| `artifact`      | Yes      | Always `"CodeZip"`                             |
+| `name`          | Yes      | Runtime name (1-23 chars)                      |
+| `pythonVersion` | Yes      | `PYTHON_3_12` or `PYTHON_3_13`                 |
+| `entrypoint`    | Yes      | Python file (e.g., `main.py` or `main.py:app`) |
+| `codeLocation`  | Yes      | Directory containing agent code                |
+| `networkMode`   | No       | `PUBLIC` (default) or `PRIVATE`                |
+
+### Memory Provider
+
+Owned memory (agent creates and manages):
+
+```json
+{
+  "type": "AgentCoreMemory",
+  "relation": "own",
+  "name": "MyMemory",
+  "description": "Agent memory",
+  "envVarName": "AGENTCORE_MEMORY_MYMEMORY",
+  "config": {
+    "eventExpiryDuration": 30,
+    "memoryStrategies": [{ "type": "SEMANTIC" }, { "type": "SUMMARIZATION" }]
+  }
+}
+```
+
+Referenced memory (agent uses another agent's memory):
+
+```json
+{
+  "type": "AgentCoreMemory",
+  "relation": "use",
+  "name": "SharedMemory",
+  "description": "Reference to shared memory",
+  "envVarName": "AGENTCORE_MEMORY_SHARED",
+  "access": "readwrite"
+}
+```
+
+| Field        | Required | Description                               |
+| ------------ | -------- | ----------------------------------------- |
+| `type`       | Yes      | Always `"AgentCoreMemory"`                |
+| `relation`   | Yes      | `"own"` (creates) or `"use"` (references) |
+| `name`       | Yes      | Memory name                               |
+| `envVarName` | Yes      | Environment variable for memory ID        |
+| `config`     | Own only | Memory configuration                      |
+| `access`     | Use only | `"read"` or `"readwrite"`                 |
+
+### Identity Provider
+
+```json
+{
+  "type": "AgentCoreIdentity",
+  "variant": "ApiKeyCredentialProvider",
+  "relation": "own",
+  "name": "OpenAI",
+  "description": "OpenAI API key",
+  "envVarName": "AGENTCORE_IDENTITY_OPENAI"
+}
+```
+
+| Field        | Required | Description                         |
+| ------------ | -------- | ----------------------------------- |
+| `type`       | Yes      | Always `"AgentCoreIdentity"`        |
+| `variant`    | Yes      | Always `"ApiKeyCredentialProvider"` |
+| `relation`   | Yes      | `"own"` or `"use"`                  |
+| `name`       | Yes      | Identity name                       |
+| `envVarName` | Yes      | Environment variable for API key    |
+
+### Remote Tools
+
+Agent-to-agent invocation:
+
+```json
+{
+  "type": "AgentCoreAgentInvocation",
+  "name": "CallHelper",
+  "description": "Invoke helper agent",
+  "targetAgentName": "HelperAgent",
+  "envVarName": "AGENTCORE_AGENT_HELPER_ARN"
+}
+```
+
+MCP runtime reference:
+
+```json
+{
+  "type": "AgentCoreMcpRuntime",
+  "name": "MyMcpTool",
+  "description": "MCP runtime tool",
+  "mcpRuntimeName": "DirectTool",
+  "envVarName": "AGENTCORE_MCPRUNTIME_DIRECTTOOL_URL"
+}
+```
+
+---
+
+## aws-targets.json
+
+Array of deployment targets.
+
+```json
+[
+  {
+    "name": "default",
+    "description": "Production (us-west-2)",
+    "account": "123456789012",
+    "region": "us-west-2"
+  },
+  {
+    "name": "dev",
+    "description": "Development (us-east-1)",
+    "account": "123456789012",
+    "region": "us-east-1"
+  }
+]
+```
+
+| Field         | Required | Description                             |
+| ------------- | -------- | --------------------------------------- |
+| `name`        | Yes      | Target name (used with `--target` flag) |
+| `description` | No       | Target description                      |
+| `account`     | Yes      | AWS account ID (12 digits)              |
+| `region`      | Yes      | AWS region                              |
+
+### Supported Regions
+
+See [AgentCore Regions](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/agentcore-regions.html) for the
+current list.
+
+---
+
+## mcp.json
+
+MCP gateway and runtime tool definitions. See [MCP Tools](./mcp-tools.md) for details.
+
+```json
+{
+  "agentCoreGateways": [...],
+  "mcpRuntimeTools": [...]
+}
+```
+
+---
+
+## .env.local
+
+API keys for local development. This file is gitignored.
+
+```bash
+AGENTCORE_IDENTITY_OPENAI=sk-...
+AGENTCORE_IDENTITY_ANTHROPIC=sk-ant-...
+AGENTCORE_IDENTITY_GEMINI=AI...
+```
+
+The environment variable names must match the `envVarName` in your identity providers.

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,0 +1,113 @@
+# Local Development
+
+The `dev` command runs your agent locally for testing before deployment.
+
+## Starting the Dev Server
+
+```bash
+# Start dev server (auto-selects agent if only one)
+agentcore-cli dev
+
+# Specify agent
+agentcore-cli dev --agent MyAgent
+
+# Custom port
+agentcore-cli dev --port 3000
+
+# Non-interactive mode (logs to stdout)
+agentcore-cli dev --logs
+```
+
+## Invoking Local Agents
+
+With the dev server running, open another terminal:
+
+```bash
+# Interactive chat
+agentcore-cli invoke
+
+# Single prompt
+agentcore-cli invoke "What can you do?"
+
+# With streaming
+agentcore-cli invoke "Tell me a story" --stream
+
+# Direct invoke to running server
+agentcore-cli dev --invoke "Hello" --stream
+```
+
+## Environment Setup
+
+### Python Virtual Environment
+
+The dev server automatically:
+
+1. Creates `.venv` if it doesn't exist
+2. Runs `uv sync` to install dependencies from `pyproject.toml`
+3. Starts uvicorn with your agent
+
+### API Keys
+
+For non-Bedrock providers, add keys to `agentcore/.env.local`:
+
+```bash
+AGENTCORE_IDENTITY_OPENAI=sk-...
+AGENTCORE_IDENTITY_ANTHROPIC=sk-ant-...
+AGENTCORE_IDENTITY_GEMINI=AI...
+```
+
+The variable names must match `envVarName` in your identity providers.
+
+## Debugging
+
+### Log Files
+
+Logs are written to `agentcore/.cli/logs/`:
+
+```
+agentcore/.cli/logs/
+├── dev/           # Dev server logs
+└── invoke/        # Invocation logs with request/response
+```
+
+### Verbose Output
+
+```bash
+# Dev server with stdout logging
+agentcore-cli dev --logs
+```
+
+### Common Issues
+
+**Port already in use:**
+
+```bash
+agentcore-cli dev --port 8081
+```
+
+**Missing dependencies:**
+
+```bash
+cd app/MyAgent
+uv sync
+```
+
+**API key not found:** Check that `.env.local` has the correct variable name matching your identity provider's
+`envVarName`.
+
+## Hot Reload
+
+The dev server watches for file changes and automatically reloads. Edit your agent code and the changes take effect
+immediately.
+
+## Dev vs Deployed Behavior
+
+| Aspect     | Local Dev     | Deployed                 |
+| ---------- | ------------- | ------------------------ |
+| API Keys   | `.env.local`  | AWS Secrets Manager      |
+| Memory     | Not available | AgentCore Memory service |
+| MCP Tools  | Local server  | AgentCore Runtime/Lambda |
+| Networking | localhost     | VPC/Public               |
+
+Memory and MCP tools require deployment to test fully. For local testing, you can mock these dependencies in your agent
+code.

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1,0 +1,221 @@
+# MCP Tools
+
+MCP (Model Context Protocol) tools extend agent capabilities. AgentCore supports two deployment modes.
+
+## Deployment Modes
+
+| Mode               | Description                     | Use Case                               |
+| ------------------ | ------------------------------- | -------------------------------------- |
+| **MCP Runtime**    | Direct agent-to-tool connection | Simple setups, single agent            |
+| **Behind Gateway** | Tools exposed via HTTP gateway  | Shared tools, JWT auth, Lambda hosting |
+
+## MCP Runtime Tools
+
+Deploy tools as AgentCore Runtimes bound directly to agents.
+
+```bash
+agentcore-cli add mcp-tool --exposure mcp-runtime
+```
+
+### mcp.json Configuration
+
+```json
+{
+  "agentCoreGateways": [],
+  "mcpRuntimeTools": [
+    {
+      "name": "MyTool",
+      "toolDefinition": {
+        "name": "MyTool",
+        "description": "Tool description",
+        "inputSchema": { "type": "object" }
+      },
+      "compute": {
+        "host": "AgentCoreRuntime",
+        "implementation": {
+          "language": "Python",
+          "path": "app/mcp/MyTool",
+          "handler": "server.py:main"
+        },
+        "runtime": {
+          "artifact": "CodeZip",
+          "pythonVersion": "PYTHON_3_12",
+          "name": "MyTool",
+          "entrypoint": "server.py:main",
+          "codeLocation": "app/mcp/MyTool",
+          "networkMode": "PUBLIC"
+        }
+      }
+    }
+  ]
+}
+```
+
+### Binding to Agents
+
+After creating an MCP runtime tool, attach it to agents:
+
+```bash
+agentcore-cli attach mcp-runtime --agent MyAgent --runtime MyTool
+```
+
+This adds a reference in `agentcore.json`:
+
+```json
+{
+  "remoteTools": [
+    {
+      "type": "AgentCoreMcpRuntime",
+      "mcpRuntimeName": "MyTool",
+      "envVarName": "AGENTCORE_MCPRUNTIME_MYTOOL_URL",
+      "name": "MyToolRef",
+      "description": "MCP runtime reference"
+    }
+  ]
+}
+```
+
+---
+
+## Gateway Tools
+
+Deploy tools behind an MCP Gateway with optional JWT authorization.
+
+```bash
+agentcore-cli add gateway
+agentcore-cli add mcp-tool --exposure behind-gateway
+```
+
+### Gateway Configuration
+
+```json
+{
+  "agentCoreGateways": [
+    {
+      "name": "main-gateway",
+      "description": "Primary tool gateway",
+      "authorizerType": "NONE",
+      "targets": [
+        {
+          "name": "MyTarget",
+          "targetType": "lambda",
+          "toolDefinitions": [
+            {
+              "name": "lookup_ip",
+              "description": "Look up IP geolocation",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "ip_address": { "type": "string" }
+                },
+                "required": ["ip_address"]
+              }
+            }
+          ],
+          "compute": {
+            "host": "Lambda",
+            "implementation": {
+              "language": "Python",
+              "path": "app/mcp/tools",
+              "handler": "handler.lambda_handler"
+            },
+            "pythonVersion": "PYTHON_3_12"
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Compute Hosts
+
+| Host               | Languages          | Notes                      |
+| ------------------ | ------------------ | -------------------------- |
+| `Lambda`           | Python, TypeScript | Serverless, scales to zero |
+| `AgentCoreRuntime` | Python only        | Always-on, lower latency   |
+
+### JWT Authorization
+
+For authenticated gateways:
+
+```json
+{
+  "name": "secure-gateway",
+  "authorizerType": "CUSTOM_JWT",
+  "authorizerConfiguration": {
+    "customJwtAuthorizer": {
+      "discoveryUrl": "https://cognito-idp.us-west-2.amazonaws.com/us-west-2_xxx/.well-known/openid-configuration",
+      "allowedAudience": ["client-id-1"],
+      "allowedClients": ["client-id-1"]
+    }
+  },
+  "targets": [...]
+}
+```
+
+| Field             | Description                                                                 |
+| ----------------- | --------------------------------------------------------------------------- |
+| `discoveryUrl`    | OIDC discovery endpoint (must end with `/.well-known/openid-configuration`) |
+| `allowedAudience` | Valid JWT audience values                                                   |
+| `allowedClients`  | Valid JWT client IDs                                                        |
+
+### Attaching Gateway to Agent
+
+```bash
+agentcore-cli attach gateway --agent MyAgent --gateway main-gateway
+```
+
+This adds an MCP provider in `agentcore.json`:
+
+```json
+{
+  "mcpProviders": [
+    {
+      "type": "AgentCoreGateway",
+      "name": "MainTools",
+      "description": "Primary tool gateway",
+      "gatewayName": "main-gateway",
+      "envVarName": "AGENTCORE_GATEWAY_MAIN"
+    }
+  ]
+}
+```
+
+---
+
+## Tool Definition Schema
+
+Both modes use the same tool definition format:
+
+```json
+{
+  "name": "tool_name",
+  "description": "What the tool does",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "param1": { "type": "string", "description": "Parameter description" },
+      "param2": { "type": "integer" }
+    },
+    "required": ["param1"]
+  }
+}
+```
+
+---
+
+## When to Use Each Mode
+
+**Use MCP Runtime when:**
+
+- Single agent needs the tool
+- Low latency is important
+- Simple setup preferred
+
+**Use Gateway when:**
+
+- Multiple agents share tools
+- JWT authentication required
+- Want Lambda's scale-to-zero
+- TypeScript tools needed

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -1,0 +1,155 @@
+# Memory
+
+AgentCore Memory provides persistent context for agents across conversations.
+
+## Adding Memory
+
+```bash
+agentcore-cli add memory
+```
+
+Or with options:
+
+```bash
+agentcore-cli add memory \
+  --name SharedMemory \
+  --strategies SEMANTIC,SUMMARIZATION \
+  --expiry 30 \
+  --owner MyAgent
+```
+
+## Memory Strategies
+
+| Strategy          | Description                                         |
+| ----------------- | --------------------------------------------------- |
+| `SEMANTIC`        | Vector-based similarity search for relevant context |
+| `SUMMARIZATION`   | Compressed conversation history                     |
+| `USER_PREFERENCE` | Store user-specific preferences and settings        |
+| `CUSTOM`          | Custom strategy implementation                      |
+
+You can combine multiple strategies:
+
+```json
+{
+  "memoryStrategies": [{ "type": "SEMANTIC" }, { "type": "SUMMARIZATION" }, { "type": "USER_PREFERENCE" }]
+}
+```
+
+### Strategy Options
+
+Each strategy can have optional configuration:
+
+```json
+{
+  "type": "SEMANTIC",
+  "name": "custom_semantic",
+  "description": "Custom semantic memory",
+  "namespaces": ["/users/facts", "/users/preferences"]
+}
+```
+
+| Field         | Required | Description                                     |
+| ------------- | -------- | ----------------------------------------------- |
+| `type`        | Yes      | Strategy type                                   |
+| `name`        | No       | Custom name (defaults to `<memoryName>-<type>`) |
+| `description` | No       | Strategy description                            |
+| `namespaces`  | No       | Array of namespace paths for scoping            |
+
+## Event Expiry
+
+Memory events expire after a configurable duration (7-365 days, default 30):
+
+```json
+{
+  "config": {
+    "eventExpiryDuration": 90,
+    "memoryStrategies": [...]
+  }
+}
+```
+
+## Ownership Model
+
+### Owned Memory
+
+The agent creates and manages the memory resource:
+
+```json
+{
+  "type": "AgentCoreMemory",
+  "relation": "own",
+  "name": "MyMemory",
+  "description": "Agent's private memory",
+  "envVarName": "AGENTCORE_MEMORY_MYMEMORY",
+  "config": {
+    "eventExpiryDuration": 30,
+    "memoryStrategies": [{ "type": "SEMANTIC" }]
+  }
+}
+```
+
+### Referenced Memory
+
+The agent uses another agent's memory:
+
+```json
+{
+  "type": "AgentCoreMemory",
+  "relation": "use",
+  "name": "SharedMemory",
+  "description": "Reference to shared memory",
+  "envVarName": "AGENTCORE_MEMORY_SHARED",
+  "access": "read"
+}
+```
+
+| Access Level | Description                      |
+| ------------ | -------------------------------- |
+| `read`       | Can retrieve from memory         |
+| `readwrite`  | Can retrieve and store (default) |
+
+## Sharing Memory
+
+To share memory between agents:
+
+1. One agent owns the memory (`relation: "own"`)
+2. Other agents reference it (`relation: "use"`)
+
+```bash
+# Create memory owned by AgentA
+agentcore-cli add memory --name SharedMemory --owner AgentA
+
+# Attach to AgentB with read access
+agentcore-cli attach memory --agent AgentB --memory SharedMemory --access read
+```
+
+## Removal Policy
+
+When removing an agent that owns memory:
+
+| Policy     | Behavior                                        |
+| ---------- | ----------------------------------------------- |
+| `cascade`  | Delete memory and clean up references (default) |
+| `restrict` | Prevent removal if other agents use the memory  |
+
+```json
+{
+  "relation": "own",
+  "removalPolicy": "restrict",
+  ...
+}
+```
+
+## Using Memory in Code
+
+The memory ID is available via environment variable:
+
+```python
+import os
+from bedrock_agentcore.memory import AgentCoreMemory
+
+memory_id = os.getenv("AGENTCORE_MEMORY_MYMEMORY")
+memory = AgentCoreMemory(memory_id=memory_id)
+```
+
+For Strands agents, memory is integrated via session manager - see the generated `memory/session.py` file.


### PR DESCRIPTION
### Description

Updates the README with fixes and adds comprehensive documentation in the docs/ folder for CLI usage, configuration schemas, and feature guides.

### Changes

README.md
- Fixed Quick Start section (removed non-existent --with-agent flag)
- Added --stream flag to invoke examples
- Added Default Model column to Supported Model Providers table
- Added package command to Commands table
- Added new "Invoking Agents" section with session management examples

docs/commands.md (new)
- Complete CLI command reference for non-interactive/scriptable usage
- All commands with full flag documentation and examples
- CI/CD and automation patterns with --json output

docs/configuration.md (new)
- Schema reference for agentcore.json, aws-targets.json, mcp.json
- Field descriptions and validation rules
- Examples for agents, memory, identity, and remote tools

docs/mcp-tools.md (new)
- MCP Runtime vs Gateway deployment modes
- Compute host options (Lambda vs AgentCoreRuntime)
- JWT authorization configuration
- When to use each mode

docs/memory.md (new)
- Memory strategies (SEMANTIC, SUMMARIZATION, USER_PREFERENCE, CUSTOM)
- Ownership model (own vs use)
- Sharing memory between agents
- Event expiry and removal policies

docs/local-development.md (new)
- Dev server usage and flags
- Environment setup and API keys
- Debugging and log locations
- Dev vs deployed behavior differences