### PR TITLE
fix: resolve eslint errors in PackageScreen and python packager

### DIFF
--- a/src/cli/tui/screens/package/PackageScreen.tsx
+++ b/src/cli/tui/screens/package/PackageScreen.tsx
@@ -104,7 +104,7 @@ export function PackageScreen({ isInteractive: _isInteractive, onExit }: Package
             newSteps[i] = {
               label: agent.name,
               status: 'warn',
-              warn: `Skipped: ${agent.runtime.artifact} not supported`,
+              warn: `Skipped: ${String(agent.runtime.artifact)} not supported`,
             };
             skipped.push(agent.name);
             setState(prev => ({ ...prev, steps: [...newSteps], skipped }));

--- a/src/lib/packaging/python.ts
+++ b/src/lib/packaging/python.ts
@@ -29,7 +29,7 @@ const PLATFORM_CANDIDATES = ['aarch64-manylinux2014', 'aarch64-manylinux_2_28', 
 export class PythonCodeZipPackager implements RuntimePackager {
   async pack(spec: AgentEnvSpec, options: PackageOptions = {}): Promise<ArtifactResult> {
     this.validateSpec(spec);
-    const runtime = spec.runtime as CodeZipRuntime;
+    const runtime = spec.runtime;
 
     // Use agentName from options or fall back to spec.name for artifact naming
     const agentName = options.agentName ?? spec.name;


### PR DESCRIPTION
## Description

- Wrap agent.runtime.artifact in String() to fix template literal type error
- Remove unnecessary type assertion in PythonCodeZipPackager

## Type of Change

<!-- Check all that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm test`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`

## Checklist

- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
