### PR TITLE
fix: update deploy UI to add a publishing assets step before deploying

### DIFF
--- a/src/cli/tui/components/DeployStatus.tsx
+++ b/src/cli/tui/components/DeployStatus.tsx
@@ -168,7 +168,7 @@ export function DeployStatus({ messages, isComplete, hasError }: DeployStatusPro
 
   return (
     <Box flexDirection="column" borderStyle="round" borderColor="gray" paddingX={1} minWidth={50}>
-      <GradientText text="Deploy to AWS" />
+      <GradientText text="Deploying to AWS" />
       {progress && (
         <Box marginTop={1}>
           <ProgressBar current={progress.current} total={progress.total} />

--- a/src/cli/tui/screens/deploy/DeployScreen.tsx
+++ b/src/cli/tui/screens/deploy/DeployScreen.tsx
@@ -47,6 +47,7 @@ export function DeployScreen({ isInteractive, onExit, autoConfirm, onNavigate, p
     hasTokenExpiredError,
     hasCredentialsError,
     isComplete,
+    hasStartedCfn,
     logFilePath,
     missingCredentials,
     startDeploy,
@@ -176,8 +177,8 @@ export function DeployScreen({ isInteractive, onExit, autoConfirm, onNavigate, p
 
   const targetDisplay = context?.awsTargets.map(t => `${t.region}:${t.account}`).join(', ');
 
-  // Show deploy status box during deploy phase (replaces "Deploy to AWS" step)
-  const showDeployStatus = phase === 'deploying' || isComplete;
+  // Show deploy status box once CloudFormation has started (after asset publishing)
+  const showDeployStatus = hasStartedCfn || isComplete;
 
   // Filter out "Deploy to AWS" step when deploy status box is showing
   const displaySteps = showDeployStatus ? steps.filter(s => s.label !== 'Deploy to AWS') : steps;


### PR DESCRIPTION
## Description

Improves the deploy UI to show clearer progress during the two distinct phases of deployment:                                                              
                  
  1. Asset publishing phase: Added a new "Publish assets" step that shows while CDK uploads Lambda code bundles and other assets to S3/ECR. Previously, users saw "Preparing deployment" with no indication of what was happening.
  2. CloudFormation deployment phase: Once CloudFormation starts creating resources, the "Publish assets" step completes and the "Deploying to AWS" box appears with the progress bar and resource status lines.

  This provides better visibility into the deployment process, especially during the asset publishing phase which can take significant time for projects with large Lambda functions or multiple assets.

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [X] I ran `npm test`
- [X] I ran `npm run typecheck`
- [X] I ran `npm run lint`

## Checklist

- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
