### PR TITLE
fix: enhance status command with ResourceGraph visualization

### DIFF
--- a/src/cli/tui/components/index.ts
+++ b/src/cli/tui/components/index.ts
@@ -24,6 +24,6 @@ export { TextInput } from './TextInput';
 export { TwoColumn } from './TwoColumn';
 export { WizardSelect, WizardMultiSelect } from './WizardSelect';
 export { AwsTargetConfigUI, getAwsConfigHelpText } from './AwsTargetConfigUI';
-export { ResourceGraph } from './ResourceGraph';
+export { ResourceGraph, type AgentStatusInfo } from './ResourceGraph';
 export { LogLink } from './LogLink';
 export { ScrollableText } from './ScrollableText';


### PR DESCRIPTION
## Description

Enhance the `agentcore status` command to show the same ResourceGraph visualization used in plan, with runtime status shown inline next to agents, plus deployed resource details (ARNs, memory IDs).
                                                                                                                                                           
  Changes:                                                  
  - Replace two-column layout with ResourceGraph showing agent tree structure
  - Show inline runtime status badges (e.g., [READY], [ACTIVE], [error])
  - Display agent runtime ARNs and memory IDs under each agent
  - Fetch all agent statuses upfront instead of on-demand
  - Add Ctrl+R shortcut to refresh runtime status
  - Load MCP spec to show gateways and tools in the graph
  - Hide stale ARN info when status fetch errors (e.g., after destroy)
  - Show MCP resources section only when gateways/runtimes/lambdas exist

## Related Issues

Bug bash issue

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Check all that apply -->

- [X] Bug fix
- [X] New feature
- [X] Breaking change
- [X] Documentation update
- [X] Other (please describe):

## Testing

How have you tested the change?

- [X] I ran `npm test`
- [X] I ran `npm run typecheck`
- [X] I ran `npm run lint`

## Checklist

- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
