### PR TITLE
fix: make JWT allowedAudience optional 

### DIFF
--- a/src/cli/commands/add/actions.ts
+++ b/src/cli/commands/add/actions.ts
@@ -199,10 +199,12 @@ function buildGatewayConfig(options: ValidatedAddGatewayOptions): AddGatewayConf
   if (options.authorizerType === 'CUSTOM_JWT' && options.discoveryUrl) {
     config.jwtConfig = {
       discoveryUrl: options.discoveryUrl,
-      allowedAudience: options
-        .allowedAudience!.split(',')
-        .map(s => s.trim())
-        .filter(Boolean),
+      allowedAudience: options.allowedAudience
+        ? options.allowedAudience
+            .split(',')
+            .map(s => s.trim())
+            .filter(Boolean)
+        : [],
       allowedClients: options
         .allowedClients!.split(',')
         .map(s => s.trim())

--- a/src/cli/commands/add/validate.ts
+++ b/src/cli/commands/add/validate.ts
@@ -126,17 +126,7 @@ export function validateAddGatewayOptions(options: AddGatewayOptions): Validatio
       return { valid: false, error: `Discovery URL must end with ${OIDC_WELL_KNOWN_SUFFIX}` };
     }
 
-    if (!options.allowedAudience) {
-      return { valid: false, error: '--allowed-audience is required for CUSTOM_JWT authorizer' };
-    }
-
-    const audiences = options.allowedAudience
-      .split(',')
-      .map(s => s.trim())
-      .filter(Boolean);
-    if (audiences.length === 0) {
-      return { valid: false, error: 'At least one audience value is required' };
-    }
+    // allowedAudience is optional - empty means no audience validation
 
     if (!options.allowedClients) {
       return { valid: false, error: '--allowed-clients is required for CUSTOM_JWT authorizer' };

--- a/src/cli/tui/screens/mcp/AddGatewayScreen.tsx
+++ b/src/cli/tui/screens/mcp/AddGatewayScreen.tsx
@@ -244,10 +244,11 @@ function JwtConfigInput({ subStep, onDiscoveryUrl, onAudience, onClients, onCanc
         {subStep === 1 && (
           <TextInput
             prompt="Allowed Audience (comma-separated, e.g., 7abc123def456)"
+            placeholder="press Enter for none"
             initialValue=""
             onSubmit={onAudience}
             onCancel={onCancel}
-            customValidation={value => validateCommaSeparatedList(value, 'audience')}
+            allowEmpty
           />
         )}
         {subStep === 2 && (

--- a/src/schema/schemas/mcp.ts
+++ b/src/schema/schemas/mcp.ts
@@ -40,8 +40,8 @@ const OidcDiscoveryUrlSchema = z
 export const CustomJwtAuthorizerConfigSchema = z.object({
   /** OIDC discovery URL (e.g., https://cognito-idp.{region}.amazonaws.com/{userPoolId}/.well-known/openid-configuration) */
   discoveryUrl: OidcDiscoveryUrlSchema,
-  /** List of allowed audiences (typically client IDs) */
-  allowedAudience: z.array(z.string().min(1)).min(1),
+  /** List of allowed audiences (typically client IDs). Empty array means no audience validation. */
+  allowedAudience: z.array(z.string().min(1)),
   /** List of allowed client IDs */
   allowedClients: z.array(z.string().min(1)).min(1),
 });


### PR DESCRIPTION
## Description

Makes `allowedAudience` optional in the JWT authorizer flow. Users can now press Enter to skip the audience field (no audience validation).

- Adds placeholder text "press Enter for none" in the audience input field

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran npm test
- [x] I ran npm run typecheck
- [x] I ran npm run lint

Manual testing:
- Verified TUI flow allows empty audience (press Enter)
- Verified CLI --allowed-audience flag is now optional
- Verified wider panel displays discovery URLs without garbled text

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.