### PR TITLE
fix: BYO agent wizard back navigation

### DIFF
--- a/src/cli/tui/components/Screen.tsx
+++ b/src/cli/tui/components/Screen.tsx
@@ -14,6 +14,8 @@ interface ScreenProps {
   /** Optional content to display above the help text at the bottom */
   footerContent?: ReactNode;
   children: ReactNode;
+  /** Whether Escape key triggers onExit (default: true). Set to false when sub-components handle their own back navigation. */
+  exitEnabled?: boolean;
 }
 
 /**
@@ -23,8 +25,17 @@ interface ScreenProps {
  * - Exit handling (Escape / Ctrl+Q)
  * - Help text at the bottom
  */
-export function Screen({ title, color, onExit, helpText, headerContent, footerContent, children }: ScreenProps) {
-  useExitHandler(onExit);
+export function Screen({
+  title,
+  color,
+  onExit,
+  helpText,
+  headerContent,
+  footerContent,
+  children,
+  exitEnabled = true,
+}: ScreenProps) {
+  useExitHandler(onExit, exitEnabled);
 
   const displayHelpText = helpText ?? HELP_TEXT.EXIT;
 

--- a/src/cli/tui/screens/agent/AddAgentScreen.tsx
+++ b/src/cli/tui/screens/agent/AddAgentScreen.tsx
@@ -356,8 +356,16 @@ export function AddAgentScreen({ existingAgentNames, onComplete, onExit }: AddAg
   }
 
   // BYO path
+  // Disable Screen's exit handler when not on first step (sub-components handle back navigation)
+  const byoExitEnabled = byoCurrentIndex === 0;
   return (
-    <Screen title="Add Agent" onExit={onExit} helpText={getHelpText()} headerContent={renderStepIndicator()}>
+    <Screen
+      title="Add Agent"
+      onExit={onExit}
+      helpText={getHelpText()}
+      headerContent={renderStepIndicator()}
+      exitEnabled={byoExitEnabled}
+    >
       <Panel>
         {byoStep === 'codeLocation' && (
           <CodeLocationInput


### PR DESCRIPTION
## Description

Fixes back navigation in the BYO (Bring Your Own) agent wizard. Previously, pressing Esc on sub-steps (language, framework, etc.) would exit the entire Add Agent screen and return to the main menu. Now it correctly navigates back to the previous step.

The issue was that the Screen component's useExitHandler was capturing Esc before the sub-component's useListNavigation could handle it. Added an exitEnabled prop to Screen to disable the global exit handler when sub-components need to handle their own back navigation.

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran npm test
- [x] I ran npm run typecheck
- [x] I ran npm run lint

Manual testing:
1. agentcore-cli add agent
2. Enter name → Enter
3. Select "Bring my own code" → Enter
4. Enter code location → Enter
5. On language step, press Esc → Now goes back to code location step ✓

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.