### PR TITLE
fix: improve cursor display in TextInput and SecretInput

### DIFF
--- a/src/cli/tui/components/Cursor.tsx
+++ b/src/cli/tui/components/Cursor.tsx
@@ -2,11 +2,18 @@ import { Text } from 'ink';
 import { useEffect, useState } from 'react';
 
 interface CursorProps {
+  /** Character to display at cursor position (default: space) */
+  char?: string;
   /** Blink interval in milliseconds (default: 500) */
   interval?: number;
 }
 
-export function Cursor({ interval = 500 }: CursorProps) {
+/**
+ * Blinking cursor that highlights the character at cursor position.
+ * When visible, shows the character with inverted colors (white bg, black text).
+ * When hidden, shows the character normally.
+ */
+export function Cursor({ char = ' ', interval = 500 }: CursorProps) {
   const [visible, setVisible] = useState(true);
 
   useEffect(() => {
@@ -14,5 +21,13 @@ export function Cursor({ interval = 500 }: CursorProps) {
     return () => clearInterval(timer);
   }, [interval]);
 
-  return <Text color="white">{visible ? '▋' : ' '}</Text>;
+  if (visible) {
+    return (
+      <Text backgroundColor="white" color="black">
+        {char}
+      </Text>
+    );
+  }
+
+  return <Text>{char}</Text>;
 }


### PR DESCRIPTION
- Update Cursor component to overlay character with inverted colors instead of inserting a block character that shifts text
- Support multi-line display for long pasted text (e.g., API keys)
- Cursor now properly shows on the correct line when editing

## Description

<!-- Provide a detailed description of the changes in this PR -->

## Related Issues



## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm test`
- [ ] I ran `npm run typecheck`
- [ ] I ran `npm run lint`

## Checklist

- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
