### PR TITLE
Simplify uv dependency check to availability-only

### DIFF
--- a/src/cli/external-requirements/checks.ts
+++ b/src/cli/external-requirements/checks.ts
@@ -3,7 +3,7 @@
  */
 import { checkSubprocess, isWindows, runSubprocessCapture } from '../../lib';
 import type { AgentCoreProjectSpec, TargetLanguage } from '../../schema';
-import { NODE_MIN_VERSION, UV_MIN_VERSION, formatSemVer, parseSemVer, semVerGte } from './versions';
+import { NODE_MIN_VERSION, formatSemVer, parseSemVer, semVerGte } from './versions';
 
 /**
  * Result of a version check.
@@ -21,15 +21,6 @@ export interface VersionCheckResult {
  */
 function parseNodeVersion(output: string): string | null {
   const match = /v?(\d+\.\d+\.\d+)/.exec(output.trim());
-  return match?.[1] ?? null;
-}
-
-/**
- * Extract version from `uv --version` output.
- * Expected format: "uv 0.9.2" or "uv 0.9.2 (abc123 2024-01-01)"
- */
-function parseUvVersion(output: string): string | null {
-  const match = /uv\s+(\d+\.\d+\.\d+)/.exec(output.trim());
   return match?.[1] ?? null;
 }
 
@@ -63,32 +54,19 @@ export async function checkNodeVersion(): Promise<VersionCheckResult> {
 }
 
 /**
- * Check that uv meets minimum version requirement.
+ * Check that uv is available in PATH.
  */
 export async function checkUvVersion(): Promise<VersionCheckResult> {
-  const required = formatSemVer(UV_MIN_VERSION);
-
   const result = await runSubprocessCapture('uv', ['--version']);
   if (result.code !== 0) {
-    return { satisfied: false, current: null, required, binary: 'uv' };
+    return { satisfied: false, current: null, required: 'any', binary: 'uv' };
   }
 
-  const versionStr = parseUvVersion(result.stdout);
-  if (!versionStr) {
-    return { satisfied: false, current: null, required, binary: 'uv' };
-  }
+  // Extract version for display in preflight logs
+  const match = /uv\s+(\d+\.\d+\.\d+)/.exec(result.stdout.trim());
+  const current = match?.[1] ?? 'unknown';
 
-  const current = parseSemVer(versionStr);
-  if (!current) {
-    return { satisfied: false, current: versionStr, required, binary: 'uv' };
-  }
-
-  return {
-    satisfied: semVerGte(current, UV_MIN_VERSION),
-    current: versionStr,
-    required,
-    binary: 'uv',
-  };
+  return { satisfied: true, current, required: 'any', binary: 'uv' };
 }
 
 /**
@@ -97,7 +75,7 @@ export async function checkUvVersion(): Promise<VersionCheckResult> {
 export function formatVersionError(result: VersionCheckResult): string {
   if (result.current === null) {
     if (result.binary === 'uv') {
-      return `'${result.binary}' not found. Install uv >= ${result.required} from https://github.com/astral-sh/uv#installation`;
+      return `'uv' not found. Install from https://github.com/astral-sh/uv#installation`;
     }
     return `'${result.binary}' not found. Install ${result.binary} >= ${result.required}`;
   }
@@ -124,7 +102,7 @@ export interface DependencyCheckResult {
 /**
  * Check that required dependency versions are met.
  * - Node >= 18 is always required for CDK synth
- * - uv >= 0.9.2 is required when there are Python CodeZip agents
+ * - uv is required when there are Python CodeZip agents
  */
 export async function checkDependencyVersions(projectSpec: AgentCoreProjectSpec): Promise<DependencyCheckResult> {
   const errors: string[] = [];

--- a/src/cli/external-requirements/index.ts
+++ b/src/cli/external-requirements/index.ts
@@ -1,12 +1,4 @@
-export {
-  parseSemVer,
-  compareSemVer,
-  semVerGte,
-  formatSemVer,
-  NODE_MIN_VERSION,
-  UV_MIN_VERSION,
-  type SemVer,
-} from './versions';
+export { parseSemVer, compareSemVer, semVerGte, formatSemVer, NODE_MIN_VERSION, type SemVer } from './versions';
 
 export {
   checkNodeVersion,

--- a/src/cli/external-requirements/versions.ts
+++ b/src/cli/external-requirements/versions.ts
@@ -59,6 +59,3 @@ export function formatSemVer(v: SemVer): string {
 
 /** Minimum Node.js version required for CDK synth (ES2022 target) */
 export const NODE_MIN_VERSION: SemVer = { major: 18, minor: 0, patch: 0 };
-
-/** Minimum uv version required for Python CodeZip packaging */
-export const UV_MIN_VERSION: SemVer = { major: 0, minor: 9, patch: 2 };

--- a/src/cli/operations/deploy/index.ts
+++ b/src/cli/operations/deploy/index.ts
@@ -36,7 +36,6 @@ export {
   semVerGte,
   formatSemVer,
   NODE_MIN_VERSION,
-  UV_MIN_VERSION,
   type DependencyCheckResult,
   type SemVer,
   type VersionCheckResult,

--- a/src/cli/tui/hooks/useCdkPreflight.ts
+++ b/src/cli/tui/hooks/useCdkPreflight.ts
@@ -266,7 +266,7 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
           return;
         }
 
-        // Step: Check dependencies (Node >= 18, uv >= 0.9.2 for Python CodeZip)
+        // Step: Check dependencies (Node >= 18, uv for Python CodeZip)
         updateStep(STEP_DEPS, { status: 'running' });
         logger.startStep('Check dependencies');
         try {


### PR DESCRIPTION
## Description

Simplify the UV dependency check in the deploy preflight to only verify that `uv` is installed (available in PATH), removing the semver comparison against `UV_MIN_VERSION` (0.9.2). The project creation flow already does a simple availability check — the deploy preflight should be consistent.

**Changes:**
- Remove `UV_MIN_VERSION` constant from `versions.ts`
- Simplify `checkUvVersion()` in `checks.ts` to check availability only (still extracts version string for preflight log display)
- Update `formatVersionError()` uv-not-found message to not reference a minimum version
- Remove `UV_MIN_VERSION` from re-exports in `index.ts` and `deploy/index.ts`
- Update comments in `useCdkPreflight.ts`
Fixex #96 

## Related Issues

N/A

## Documentation PR

N/A — no user-facing documentation references the minimum uv version.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe): Simplification / cleanup — removes unnecessary version pinning

## Testing

How have you tested the change?

- [x] I ran `npm test`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`

All 14 existing tests in `src/cli/external-requirements/__tests__/checks.test.ts` pass. TypeScript compiles cleanly with `--noEmit`.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.