### PR TITLE
Rename CLI command from agentcore-cli to agentcore

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ Note: CDK L3 constructs are in a separate package `@aws/agentcore-l3-cdk-constru
 
 ## Vended CDK Project
 
-When users run `agentcore-cli create`, we vend a CDK project at `agentcore/cdk/` that:
+When users run `agentcore create`, we vend a CDK project at `agentcore/cdk/` that:
 
 - Imports `@aws/agentcore-l3-cdk-constructs` for L3 constructs
 - Reads schema files and synthesizes CloudFormation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ npm link @aws/agentcore-l3-cdk-constructs
 
 ```bash
 cd /tmp && mkdir test-project && cd test-project
-agentcore-cli create
+agentcore create
 ```
 
 2. Link local CDK package in vended CDK:

--- a/README.md
+++ b/README.md
@@ -37,23 +37,23 @@ Use the terminal UI to walk through all commands interactively, or run each comm
 
 ```bash
 # Launch terminal UI
-agentcore-cli
+agentcore
 
 # Create a new project (wizard guides you through agent setup)
-agentcore-cli create
+agentcore create
 cd my-project
 
 # Test locally
-agentcore-cli dev
+agentcore dev
 
 # In another terminal:
-agentcore-cli invoke
+agentcore invoke
 
 # Deploy to AWS
-agentcore-cli deploy
+agentcore deploy
 
 # Invoke deployed agent
-agentcore-cli invoke --stream
+agentcore invoke --stream
 ```
 
 ## Supported Frameworks
@@ -144,14 +144,14 @@ Projects use JSON schema files in the `agentcore/` directory:
 
 ```bash
 # Interactive mode
-agentcore-cli invoke
+agentcore invoke
 
 # With prompt and streaming
-agentcore-cli invoke "What can you do?" --stream
+agentcore invoke "What can you do?" --stream
 
 # Session management
-agentcore-cli invoke --session-id <id>   # Continue conversation
-agentcore-cli invoke --new-session       # Start fresh
+agentcore invoke --session-id <id>   # Continue conversation
+agentcore invoke --new-session       # Start fresh
 ```
 
 ## Documentation

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -10,13 +10,13 @@ Create a new AgentCore project.
 
 ```bash
 # Interactive wizard
-agentcore-cli create
+agentcore create
 
 # Fully non-interactive with defaults
-agentcore-cli create --name MyProject --defaults
+agentcore create --name MyProject --defaults
 
 # Custom configuration
-agentcore-cli create \
+agentcore create \
   --name MyProject \
   --framework Strands \
   --model-provider Bedrock \
@@ -24,10 +24,10 @@ agentcore-cli create \
   --output-dir ./projects
 
 # Skip agent creation
-agentcore-cli create --name MyProject --no-agent
+agentcore create --name MyProject --no-agent
 
 # Preview without creating
-agentcore-cli create --name MyProject --defaults --dry-run
+agentcore create --name MyProject --defaults --dry-run
 ```
 
 | Flag                   | Description                                                                        |
@@ -51,10 +51,10 @@ agentcore-cli create --name MyProject --defaults --dry-run
 Deploy infrastructure to AWS.
 
 ```bash
-agentcore-cli deploy
-agentcore-cli deploy --target production
-agentcore-cli deploy -y --progress        # Auto-confirm with progress
-agentcore-cli deploy -v --json            # Verbose JSON output
+agentcore deploy
+agentcore deploy --target production
+agentcore deploy -y --progress        # Auto-confirm with progress
+agentcore deploy -v --json            # Verbose JSON output
 ```
 
 | Flag              | Description           |
@@ -70,8 +70,8 @@ agentcore-cli deploy -v --json            # Verbose JSON output
 Tear down deployed resources.
 
 ```bash
-agentcore-cli destroy
-agentcore-cli destroy --target dev -y     # Auto-confirm
+agentcore destroy
+agentcore destroy --target dev -y     # Auto-confirm
 ```
 
 | Flag              | Description       |
@@ -85,9 +85,9 @@ agentcore-cli destroy --target dev -y     # Auto-confirm
 Check deployment status.
 
 ```bash
-agentcore-cli status
-agentcore-cli status --agent MyAgent
-agentcore-cli status --target production
+agentcore status
+agentcore status --agent MyAgent
+agentcore status --target production
 ```
 
 | Flag                      | Description         |
@@ -101,8 +101,8 @@ agentcore-cli status --target production
 Validate configuration files.
 
 ```bash
-agentcore-cli validate
-agentcore-cli validate -d ./my-project
+agentcore validate
+agentcore validate -d ./my-project
 ```
 
 | Flag                     | Description       |
@@ -119,14 +119,14 @@ Add an agent to the project.
 
 ```bash
 # Create new agent from template
-agentcore-cli add agent \
+agentcore add agent \
   --name MyAgent \
   --framework Strands \
   --model-provider Bedrock \
   --memory shortTerm
 
 # Bring your own code
-agentcore-cli add agent \
+agentcore add agent \
   --name MyAgent \
   --type byo \
   --code-location ./my-agent \
@@ -154,7 +154,7 @@ agentcore-cli add agent \
 Add a memory resource.
 
 ```bash
-agentcore-cli add memory \
+agentcore add memory \
   --name SharedMemory \
   --strategies SEMANTIC,SUMMARIZATION \
   --expiry 30 \
@@ -177,7 +177,7 @@ agentcore-cli add memory \
 Add an identity provider (API key).
 
 ```bash
-agentcore-cli add identity \
+agentcore add identity \
   --name OpenAI \
   --type ApiKeyCredentialProvider \
   --api-key sk-... \
@@ -198,7 +198,7 @@ agentcore-cli add identity \
 Add an MCP tool.
 
 ```bash
-agentcore-cli add mcp-tool \
+agentcore add mcp-tool \
   --name MyTool \
   --language Python \
   --exposure mcp-runtime \
@@ -219,7 +219,7 @@ agentcore-cli add mcp-tool \
 Add a deployment target.
 
 ```bash
-agentcore-cli add target \
+agentcore add target \
   --name production \
   --account 123456789012 \
   --region us-west-2 \
@@ -240,16 +240,16 @@ Connect resources to agents.
 
 ```bash
 # Agent-to-agent
-agentcore-cli add bind agent --source CallerAgent --target HelperAgent
+agentcore add bind agent --source CallerAgent --target HelperAgent
 
 # Memory
-agentcore-cli add bind memory --agent MyAgent --memory SharedMemory --access read
+agentcore add bind memory --agent MyAgent --memory SharedMemory --access read
 
 # Identity
-agentcore-cli add bind identity --agent MyAgent --identity OpenAI
+agentcore add bind identity --agent MyAgent --identity OpenAI
 
 # MCP runtime
-agentcore-cli add bind mcp-runtime --agent MyAgent --runtime MyTool
+agentcore add bind mcp-runtime --agent MyAgent --runtime MyTool
 ```
 
 ### remove
@@ -257,15 +257,15 @@ agentcore-cli add bind mcp-runtime --agent MyAgent --runtime MyTool
 Remove resources from project.
 
 ```bash
-agentcore-cli remove agent --name MyAgent --force
-agentcore-cli remove memory --name SharedMemory
-agentcore-cli remove mcp-tool --name MyTool
-agentcore-cli remove identity --name OpenAI
-agentcore-cli remove target --name dev
+agentcore remove agent --name MyAgent --force
+agentcore remove memory --name SharedMemory
+agentcore remove mcp-tool --name MyTool
+agentcore remove identity --name OpenAI
+agentcore remove target --name dev
 
 # Reset everything
-agentcore-cli remove all --force
-agentcore-cli remove all --dry-run  # Preview
+agentcore remove all --force
+agentcore remove all --dry-run  # Preview
 ```
 
 | Flag            | Description               |
@@ -284,10 +284,10 @@ agentcore-cli remove all --dry-run  # Preview
 Start local development server.
 
 ```bash
-agentcore-cli dev
-agentcore-cli dev --agent MyAgent --port 3000
-agentcore-cli dev --logs                      # Non-interactive
-agentcore-cli dev --invoke "Hello" --stream   # Direct invoke
+agentcore dev
+agentcore dev --agent MyAgent --port 3000
+agentcore dev --logs                      # Non-interactive
+agentcore dev --invoke "Hello" --stream   # Direct invoke
 ```
 
 | Flag                    | Description                     |
@@ -303,12 +303,12 @@ agentcore-cli dev --invoke "Hello" --stream   # Direct invoke
 Invoke local or deployed agents.
 
 ```bash
-agentcore-cli invoke "What can you do?"
-agentcore-cli invoke --prompt "Hello" --stream
-agentcore-cli invoke --agent MyAgent --target production
-agentcore-cli invoke --session-id abc123      # Continue session
-agentcore-cli invoke --new-session            # Fresh session
-agentcore-cli invoke --json                   # JSON output
+agentcore invoke "What can you do?"
+agentcore invoke --prompt "Hello" --stream
+agentcore invoke --agent MyAgent --target production
+agentcore invoke --session-id abc123      # Continue session
+agentcore invoke --new-session            # Fresh session
+agentcore invoke --json                   # JSON output
 ```
 
 | Flag                | Description               |
@@ -330,9 +330,9 @@ agentcore-cli invoke --json                   # JSON output
 Package agent artifacts without deploying.
 
 ```bash
-agentcore-cli package
-agentcore-cli package --agent MyAgent
-agentcore-cli package -d ./my-project
+agentcore package
+agentcore package --agent MyAgent
+agentcore package -d ./my-project
 ```
 
 | Flag                     | Description            |
@@ -345,8 +345,8 @@ agentcore-cli package -d ./my-project
 Display project resource tree.
 
 ```bash
-agentcore-cli outline
-agentcore-cli outline agent MyAgent
+agentcore outline
+agentcore outline agent MyAgent
 ```
 
 ### update
@@ -354,8 +354,8 @@ agentcore-cli outline agent MyAgent
 Check for CLI updates.
 
 ```bash
-agentcore-cli update           # Check and install
-agentcore-cli update --check   # Check only
+agentcore update           # Check and install
+agentcore update --check   # Check only
 ```
 
 | Flag          | Description              |
@@ -370,18 +370,18 @@ agentcore-cli update --check   # Check only
 
 ```bash
 # Validate and deploy with auto-confirm
-agentcore-cli validate
-agentcore-cli deploy --target production -y --json
+agentcore validate
+agentcore deploy --target production -y --json
 ```
 
 ### Scripted Project Setup
 
 ```bash
-agentcore-cli create --name MyProject --defaults
+agentcore create --name MyProject --defaults
 cd MyProject
-agentcore-cli add memory --name SharedMemory --strategies SEMANTIC --owner MyProject
-agentcore-cli add target --name dev --account 123456789012 --region us-west-2
-agentcore-cli deploy --target dev -y
+agentcore add memory --name SharedMemory --strategies SEMANTIC --owner MyProject
+agentcore add target --name dev --account 123456789012 --region us-west-2
+agentcore deploy --target dev -y
 ```
 
 ### JSON Output for Automation
@@ -389,6 +389,6 @@ agentcore-cli deploy --target dev -y
 All commands with `--json` output structured data:
 
 ```bash
-agentcore-cli status --json | jq '.agents[0].runtimeArn'
-agentcore-cli invoke "Hello" --json | jq '.response'
+agentcore status --json | jq '.agents[0].runtimeArn'
+agentcore invoke "Hello" --json | jq '.response'
 ```

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -6,16 +6,16 @@ The `dev` command runs your agent locally for testing before deployment.
 
 ```bash
 # Start dev server (auto-selects agent if only one)
-agentcore-cli dev
+agentcore dev
 
 # Specify agent
-agentcore-cli dev --agent MyAgent
+agentcore dev --agent MyAgent
 
 # Custom port
-agentcore-cli dev --port 3000
+agentcore dev --port 3000
 
 # Non-interactive mode (logs to stdout)
-agentcore-cli dev --logs
+agentcore dev --logs
 ```
 
 ## Invoking Local Agents
@@ -24,16 +24,16 @@ With the dev server running, open another terminal:
 
 ```bash
 # Interactive chat
-agentcore-cli invoke
+agentcore invoke
 
 # Single prompt
-agentcore-cli invoke "What can you do?"
+agentcore invoke "What can you do?"
 
 # With streaming
-agentcore-cli invoke "Tell me a story" --stream
+agentcore invoke "Tell me a story" --stream
 
 # Direct invoke to running server
-agentcore-cli dev --invoke "Hello" --stream
+agentcore dev --invoke "Hello" --stream
 ```
 
 ## Environment Setup
@@ -74,7 +74,7 @@ agentcore/.cli/logs/
 
 ```bash
 # Dev server with stdout logging
-agentcore-cli dev --logs
+agentcore dev --logs
 ```
 
 ### Common Issues
@@ -82,7 +82,7 @@ agentcore-cli dev --logs
 **Port already in use:**
 
 ```bash
-agentcore-cli dev --port 8081
+agentcore dev --port 8081
 ```
 
 **Missing dependencies:**

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -7,7 +7,7 @@ MCP (Model Context Protocol) tools extend agent capabilities.
 Deploy tools as AgentCore Runtimes bound directly to agents.
 
 ```bash
-agentcore-cli add mcp-tool --exposure mcp-runtime
+agentcore add mcp-tool --exposure mcp-runtime
 ```
 
 ### mcp.json Configuration
@@ -49,7 +49,7 @@ agentcore-cli add mcp-tool --exposure mcp-runtime
 After creating an MCP runtime tool, bind it to agents:
 
 ```bash
-agentcore-cli add bind mcp-runtime --agent MyAgent --runtime MyTool
+agentcore add bind mcp-runtime --agent MyAgent --runtime MyTool
 ```
 
 This adds a reference in `agentcore.json`:

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -5,13 +5,13 @@ AgentCore Memory provides persistent context for agents across conversations.
 ## Adding Memory
 
 ```bash
-agentcore-cli add memory
+agentcore add memory
 ```
 
 Or with options:
 
 ```bash
-agentcore-cli add memory \
+agentcore add memory \
   --name SharedMemory \
   --strategies SEMANTIC,SUMMARIZATION \
   --expiry 30 \
@@ -117,10 +117,10 @@ To share memory between agents:
 
 ```bash
 # Create memory owned by AgentA
-agentcore-cli add memory --name SharedMemory --owner AgentA
+agentcore add memory --name SharedMemory --owner AgentA
 
 # Bind to AgentB with read access
-agentcore-cli add bind memory --agent AgentB --memory SharedMemory --access read
+agentcore add bind memory --agent AgentB --memory SharedMemory --access read
 ```
 
 ## Removal Policy

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
-    "agentcore-cli": "dist/cli/index.mjs"
+    "agentcore": "dist/cli/index.mjs"
   },
   "exports": {
     ".": {

--- a/src/cli/commands/update/command.tsx
+++ b/src/cli/commands/update/command.tsx
@@ -37,7 +37,9 @@ export const registerUpdate = (program: Command) => {
             render(<Text color="green">Successfully updated to {result.latestVersion}</Text>);
             break;
           case 'update-failed':
-            render(<Text color="red">Failed to install update. Try running: npm install -g agentcore-cli@latest</Text>);
+            render(
+              <Text color="red">Failed to install update. Try running: npm install -g @aws/agentcore-cli@latest</Text>
+            );
             process.exit(1);
             break;
         }


### PR DESCRIPTION
## Description

change the cli command from `agentcore-cli` to `agentcore`

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:all`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`

## Checklist

- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
