### PR TITLE
fix: use project-scoped credential naming consistently

### DIFF
--- a/src/assets/cdk/bin/cdk.ts
+++ b/src/assets/cdk/bin/cdk.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { AgentCoreStack } from '../lib/cdk-stack';
-import { ConfigIO, type AgentCoreMcpSpec, type AwsDeploymentTarget } from '@aws/agentcore-l3-cdk-constructs';
+import { ConfigIO, type AwsDeploymentTarget } from '@aws/agentcore-l3-cdk-constructs';
 import { App, type Environment } from 'aws-cdk-lib';
 import * as path from 'path';
 
@@ -23,12 +23,6 @@ async function main() {
   const spec = await configIO.readProjectSpec();
   const targets = await configIO.readAWSDeploymentTargets();
 
-  // Read MCP spec if it exists (stored separately in mcp.json)
-  let mcpSpec: AgentCoreMcpSpec | undefined;
-  if (configIO.configExists('mcp')) {
-    mcpSpec = await configIO.readMcpSpec();
-  }
-
   if (targets.length === 0) {
     throw new Error('No deployment targets configured. Please define targets in agentcore/aws-targets.json');
   }
@@ -41,7 +35,6 @@ async function main() {
 
     new AgentCoreStack(app, stackName, {
       spec,
-      mcpSpec,
       env,
       description: `AgentCore stack for ${spec.name} deployed to ${target.name} (${target.region})`,
       tags: {

--- a/src/assets/cdk/lib/cdk-stack.ts
+++ b/src/assets/cdk/lib/cdk-stack.ts
@@ -1,9 +1,4 @@
-import {
-  AgentCoreApplication,
-  AgentCoreMcp,
-  type AgentCoreProjectSpec,
-  type AgentCoreMcpSpec,
-} from '@aws/agentcore-l3-cdk-constructs';
+import { AgentCoreApplication, type AgentCoreProjectSpec } from '@aws/agentcore-l3-cdk-constructs';
 import { CfnOutput, Stack, type StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 
@@ -12,12 +7,6 @@ export interface AgentCoreStackProps extends StackProps {
    * The AgentCore project specification containing agents, memories, and credentials.
    */
   spec: AgentCoreProjectSpec;
-
-  /**
-   * Optional MCP specification for gateways and runtime tools.
-   * MCP is stored separately in mcp.json.
-   */
-  mcpSpec?: AgentCoreMcpSpec;
 }
 
 /**
@@ -30,27 +19,15 @@ export class AgentCoreStack extends Stack {
   /** The AgentCore application containing all agent environments */
   public readonly application: AgentCoreApplication;
 
-  /** The MCP construct if MCP is configured */
-  public readonly mcp?: AgentCoreMcp;
-
   constructor(scope: Construct, id: string, props: AgentCoreStackProps) {
     super(scope, id, props);
 
-    const { spec, mcpSpec } = props;
+    const { spec } = props;
 
     // Create AgentCoreApplication with all agents
     this.application = new AgentCoreApplication(this, 'Application', {
       spec,
     });
-
-    // Instantiate AgentCoreMcp if MCP spec is provided
-    if (mcpSpec) {
-      this.mcp = new AgentCoreMcp(this, 'Mcp', {
-        projectName: spec.name,
-        mcpSpec,
-        agentCoreApplication: this.application,
-      });
-    }
 
     // Stack-level output
     new CfnOutput(this, 'StackNameOutput', {

--- a/src/cli/templates/types.ts
+++ b/src/cli/templates/types.ts
@@ -1,6 +1,14 @@
 import type { ModelProvider, SDKFramework, TargetLanguage } from '../../schema';
 
 /**
+ * Identity provider info for template rendering.
+ */
+export interface IdentityProviderRenderConfig {
+  name: string;
+  envVarName: string;
+}
+
+/**
  * Configuration needed by template renderers.
  * This is separate from the v2 Agent schema which only stores runtime config.
  */
@@ -11,4 +19,6 @@ export interface AgentRenderConfig {
   modelProvider: ModelProvider;
   hasMemory: boolean;
   hasIdentity: boolean;
+  /** Identity providers for template rendering (maps to credentials in schema) */
+  identityProviders: IdentityProviderRenderConfig[];
 }

--- a/src/cli/tui/screens/create/useCreateFlow.ts
+++ b/src/cli/tui/screens/create/useCreateFlow.ts
@@ -295,7 +295,8 @@ export function useCreateFlow(cwd: string): CreateFlowState {
                 };
 
                 logger.logSubStep(`Framework: ${generateConfig.sdk}`);
-                const renderConfig = mapGenerateConfigToRenderConfig(generateConfig);
+                // Pass actual project name for credential naming in templates
+                const renderConfig = mapGenerateConfigToRenderConfig(generateConfig, projectName);
                 const renderer = createRenderer(renderConfig);
                 logger.logSubStep('Rendering agent template...');
                 await renderer.render({ outputDir: projectRoot });
@@ -317,7 +318,9 @@ export function useCreateFlow(cwd: string): CreateFlowState {
               // Write API key to agentcore/.env for non-Bedrock providers
               if (addAgentConfig.apiKey && addAgentConfig.modelProvider !== 'Bedrock') {
                 logger.logSubStep('Writing API key to .env...');
-                const envVarName = computeDefaultCredentialEnvVarName(addAgentConfig.modelProvider);
+                // Use project-scoped credential name: {projectName}{modelProvider}
+                const credentialName = `${projectName}${addAgentConfig.modelProvider}`;
+                const envVarName = computeDefaultCredentialEnvVarName(credentialName);
                 await setEnvVar(envVarName, addAgentConfig.apiKey, configBaseDir);
               }
             });

--- a/src/cli/tui/screens/generate/useGenerateFlow.ts
+++ b/src/cli/tui/screens/generate/useGenerateFlow.ts
@@ -1,4 +1,4 @@
-import { APP_DIR } from '../../../../lib';
+import { APP_DIR, ConfigIO } from '../../../../lib';
 import { getErrorMessage } from '../../../errors';
 import { type PythonSetupResult, setupPythonProject } from '../../../operations';
 import { mapGenerateConfigToRenderConfig, writeAgentToProject } from '../../../operations/agent/generate';
@@ -64,7 +64,12 @@ export function useGenerateFlow(): GenerateFlowState {
       // Step 0: Generate project files and update project config
       updateStep(0, { status: 'running' });
       try {
-        const renderConfig = mapGenerateConfigToRenderConfig(config);
+        // Read project spec to get the actual project name for credential naming
+        const configIO = new ConfigIO({ baseDir: project.configRoot });
+        const projectSpec = await configIO.readProjectSpec();
+
+        // Pass actual project name for credential naming in templates
+        const renderConfig = mapGenerateConfigToRenderConfig(config, projectSpec.name);
         const renderer = createRenderer(renderConfig);
         await renderer.render({ outputDir: project.projectRoot });
         await writeAgentToProject(config);

--- a/src/cli/tui/screens/identity/AddIdentityFlow.tsx
+++ b/src/cli/tui/screens/identity/AddIdentityFlow.tsx
@@ -19,7 +19,7 @@ interface AddIdentityFlowProps {
 
 export function AddIdentityFlow({ isInteractive = true, onExit, onBack }: AddIdentityFlowProps) {
   const { createIdentity, reset: resetCreate } = useCreateIdentity();
-  const { identityNames: existingNames } = useExistingIdentityNames();
+  const { names: existingNames } = useExistingIdentityNames();
   const [flow, setFlow] = useState<FlowState>({ name: 'create-wizard' });
 
   // In non-interactive mode, exit after success

--- a/src/cli/tui/screens/identity/AddIdentityScreen.tsx
+++ b/src/cli/tui/screens/identity/AddIdentityScreen.tsx
@@ -71,7 +71,6 @@ export function AddIdentityScreen({ onComplete, onExit, existingIdentityNames }:
             onSubmit={wizard.setName}
             onCancel={() => wizard.goBack()}
             schema={CredentialNameSchema}
-            customValidation={value => !existingIdentityNames.includes(value) || 'Credential name already exists'}
           />
         )}
 


### PR DESCRIPTION
## Description

 Fixes credential naming inconsistency introduced during the schema refactor (#108).                                                                                                                                         
   
  After the schema changes moved from agent-scoped to project-scoped credentials, the credential naming became inconsistent across different parts of the codebase:                                                           
                                                            
  - agentcore.json correctly stored credentials as {projectName}{modelProvider} (e.g., MyTestingAnthropic)
  - .env files incorrectly stored keys as AGENTCORE_CREDENTIAL_{modelProvider} (e.g., AGENTCORE_CREDENTIAL_ANTHROPIC)
  - Generated template code expected the project-scoped name but received the wrong env var

  This caused runtime errors like:
  Error: AGENTCORE_CREDENTIAL_MYPROJECTANTHROPIC not found in environment

  Changes:
  - write-agent-to-project.ts: Use actual project name from config for credential naming instead of agent name
  - schema-mapper.ts: Add optional actualProjectName parameter to mapGenerateConfigToRenderConfig()
  - useCreateFlow.ts, useGenerateFlow.ts, useAddAgent.ts: Pass project name to render config
  - add/actions.ts, create/action.ts: Use project-scoped credential names for env vars
  - create-identity.ts: Allow updating existing credentials (for add identity flow when credential already exists in config)
  - types.ts: Add IdentityProviderRenderConfig for template rendering
  - AddIdentityFlow.tsx: Fix destructuring bug (names vs identityNames)
  - AddIdentityScreen.tsx: Allow adding credentials that already exist in config (to set API key)
  - Remove AgentCoreMcp from CDK assets (no longer exported from L3 constructs)

## Manual testing:
  - agentcore create with Anthropic provider - verified credential in agentcore.json and env var in .env.local match
  - agentcore dev with Anthropic provider agent - verified agent starts without credential errors
  - agentcore add identity standalone - verified can add/update credentials that already exist in config

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Check all that apply -->

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:all`
- [ ] I ran `npm run typecheck`
- [ ] I ran `npm run lint`

## Checklist

- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
