### PR TITLE
add memory not available in dev warning

### DIFF
--- a/src/cli/tui/hooks/useDevServer.ts
+++ b/src/cli/tui/hooks/useDevServer.ts
@@ -235,5 +235,6 @@ export function useDevServer(options: { workingDir: string; port: number; agentN
     restart,
     stop,
     logFilePath: loggerRef.current?.getRelativeLogPath(),
+    hasMemory: (project?.memories?.length ?? 0) > 0,
   };
 }

--- a/src/cli/tui/screens/dev/DevScreen.tsx
+++ b/src/cli/tui/screens/dev/DevScreen.tsx
@@ -157,6 +157,7 @@ export function DevScreen(props: DevScreenProps) {
     restart,
     stop,
     logFilePath,
+    hasMemory,
   } = useDevServer({
     workingDir,
     port: props.port ?? 8080,
@@ -367,6 +368,11 @@ export function DevScreen(props: DevScreenProps) {
         </Box>
       )}
       {logFilePath && <LogLink filePath={logFilePath} />}
+      {hasMemory && (
+        <Text color="yellow">
+          AgentCore memory is not available when running locally. To test memory, deploy and use invoke.
+        </Text>
+      )}
     </Box>
   );
 


### PR DESCRIPTION
## Description
If the user has memory and they are using dev, there is a warning saying "AgentCore memory is not available when running locally. To test memory, deploy and use invoke." 

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:all`
- [ ] I ran `npm run typecheck`
- [ ] I ran `npm run lint`

## Checklist

- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
