### PR TITLE
make invoke text scrollable after finishes

### DIFF
--- a/src/cli/tui/screens/invoke/InvokeScreen.tsx
+++ b/src/cli/tui/screens/invoke/InvokeScreen.tsx
@@ -173,7 +173,7 @@ export function InvokeScreen({
               content={assistantMessage.content}
               color="green"
               isStreaming={phase === 'invoking'}
-              isActive={mode === 'chat'}
+              isActive={mode === 'chat' || mode === 'input'}
             />
           </Box>
         )}


### PR DESCRIPTION
## Description

after the invoke response finishes streaming it goes back into input mode. And that means input must be scrollable as well. 

Small fix

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:all`
- [ ] I ran `npm run typecheck`
- [ ] I ran `npm run lint`

## Checklist

- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
