### PR TITLE
fix OpenAI/Anthropic not selected, reset selectedIndex every step in …

### DIFF
--- a/src/cli/tui/hooks/useListNavigation.ts
+++ b/src/cli/tui/hooks/useListNavigation.ts
@@ -1,5 +1,5 @@
 import { useInput } from 'ink';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 interface UseListNavigationOptions<T> {
   /** The list of items to navigate */
@@ -18,6 +18,8 @@ interface UseListNavigationOptions<T> {
   onHotkeySelect?: (item: T, index: number) => void;
   /** Optional function to check if an item is disabled */
   isDisabled?: (item: T) => boolean;
+  /** Optional key to reset selection when changed */
+  resetKey?: string | number;
 }
 
 interface UseListNavigationResult {
@@ -58,6 +60,7 @@ export function useListNavigation<T>({
   getHotkeys,
   onHotkeySelect,
   isDisabled,
+  resetKey,
 }: UseListNavigationOptions<T>): UseListNavigationResult {
   // Initialize with first enabled index (parent should ensure data is loaded before mounting)
   const [selectedIndex, setSelectedIndex] = useState(() => {
@@ -65,6 +68,14 @@ export function useListNavigation<T>({
     const idx = items.findIndex(item => !isDisabled(item));
     return idx >= 0 ? idx : 0;
   });
+
+  // Reset selection when resetKey changes
+  useEffect(() => {
+    if (resetKey !== undefined) {
+      const idx = isDisabled ? items.findIndex(item => !isDisabled(item)) : 0;
+      setSelectedIndex(idx >= 0 ? idx : 0);
+    }
+  }, [resetKey]);
 
   // Find next non-disabled index in given direction
   const findNextIndex = (current: number, direction: 1 | -1): number => {

--- a/src/cli/tui/screens/generate/GenerateWizardUI.tsx
+++ b/src/cli/tui/screens/generate/GenerateWizardUI.tsx
@@ -87,6 +87,7 @@ export function GenerateWizardUI({ wizard, onBack, onConfirm, isActive }: Genera
     onExit: onBack,
     isActive: isActive && isSelectStep,
     isDisabled: item => item.disabled ?? false,
+    resetKey: wizard.step,
   });
 
   // Handle confirm step input


### PR DESCRIPTION
…wizard

## Description
Each step in the wizard flow was sharing the same selectedIndex so if i selected OpenAI frameworks (index 5) then the next screen would have index 5. So if i selected OpenAI Agents, then went to model that only has one (index 0) then 5 is out of bounds and does not show up. 

This CR resets the index at each step to 0. This is more natural and always has a default selected value

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:all`
- [ ] I ran `npm run typecheck`
- [ ] I ran `npm run lint`

## Checklist

- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
