### PR TITLE
add deploy as selection option after add success

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13308,24 +13308,6 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",

--- a/src/cli/tui/App.tsx
+++ b/src/cli/tui/App.tsx
@@ -139,7 +139,7 @@ function AppContent() {
   }
 
   if (route.name === 'add') {
-    return <AddFlow isInteractive={true} onExit={() => setRoute({ name: 'help' })} />;
+    return <AddFlow isInteractive={true} onExit={() => setRoute({ name: 'help' })} onDeploy={() => setRoute({ name: 'deploy' })} />;
   }
 
   if (route.name === 'remove') {

--- a/src/cli/tui/screens/add/AddFlow.tsx
+++ b/src/cli/tui/screens/add/AddFlow.tsx
@@ -88,6 +88,8 @@ interface AddFlowProps {
   /** Whether running in interactive TUI mode (from App.tsx) vs CLI mode */
   isInteractive: boolean;
   onExit: () => void;
+  /** Called when user selects deploy from success screen */
+  onDeploy?: () => void;
 }
 
 export function AddFlow(props: AddFlowProps) {
@@ -206,6 +208,7 @@ export function AddFlow(props: AddFlowProps) {
         onComplete={handleAddAgent}
         onExit={props.onExit}
         onBack={() => setFlow({ name: 'select' })}
+        onDeploy={props.onDeploy}
       />
     );
   }
@@ -222,6 +225,7 @@ export function AddFlow(props: AddFlowProps) {
         onAddAnother={() => {
           void refreshAgents().then(() => setFlow({ name: 'select' }));
         }}
+        onDeploy={props.onDeploy}
         onExit={props.onExit}
       />
     );
@@ -239,6 +243,7 @@ export function AddFlow(props: AddFlowProps) {
         onAddAnother={() => {
           void refreshAgents().then(() => setFlow({ name: 'select' }));
         }}
+        onDeploy={props.onDeploy}
         onExit={props.onExit}
       />
     );
@@ -252,6 +257,7 @@ export function AddFlow(props: AddFlowProps) {
         availableAgents={agents}
         onExit={props.onExit}
         onBack={() => setFlow({ name: 'select' })}
+        onDeploy={props.onDeploy}
       />
     );
   }
@@ -264,6 +270,7 @@ export function AddFlow(props: AddFlowProps) {
         existingAgents={agents}
         onExit={props.onExit}
         onBack={() => setFlow({ name: 'select' })}
+        onDeploy={props.onDeploy}
       />
     );
   }
@@ -275,6 +282,7 @@ export function AddFlow(props: AddFlowProps) {
         isInteractive={props.isInteractive}
         onBack={() => setFlow({ name: 'select' })}
         onExit={props.onExit}
+        onDeploy={props.onDeploy}
       />
     );
   }
@@ -291,6 +299,7 @@ export function AddFlow(props: AddFlowProps) {
         availableAgents={agents}
         onExit={props.onExit}
         onBack={() => setFlow({ name: 'select' })}
+        onDeploy={props.onDeploy}
       />
     );
   }
@@ -316,6 +325,7 @@ export function AddFlow(props: AddFlowProps) {
         onAddAnother={() => {
           void refreshTargets().then(() => setFlow({ name: 'select' }));
         }}
+        onDeploy={props.onDeploy}
         onExit={props.onExit}
       />
     );

--- a/src/cli/tui/screens/add/AddSuccessScreen.tsx
+++ b/src/cli/tui/screens/add/AddSuccessScreen.tsx
@@ -3,7 +3,10 @@ import { Box, Text } from 'ink';
 import type { ReactNode } from 'react';
 import React from 'react';
 
-const ADD_SUCCESS_STEPS: NextStep[] = [{ command: 'add', label: 'Add another resource' }];
+const ADD_SUCCESS_STEPS: NextStep[] = [
+  { command: 'deploy', label: 'Deploy to AWS' },
+  { command: 'add', label: 'Add another resource' },
+];
 
 interface AddSuccessScreenProps {
   /** Whether running in interactive TUI mode */
@@ -20,6 +23,8 @@ interface AddSuccessScreenProps {
   loadingMessage?: string;
   /** Called when "Add another resource" is selected */
   onAddAnother: () => void;
+  /** Called when "Deploy" is selected */
+  onDeploy?: () => void;
   /** Called when "return" is selected to go back to main menu, or in non-interactive exit */
   onExit: () => void;
 }
@@ -32,11 +37,14 @@ export function AddSuccessScreen({
   loading,
   loadingMessage,
   onAddAnother,
+  onDeploy,
   onExit,
 }: AddSuccessScreenProps) {
   const handleSelect = (step: NextStep) => {
     if (step.command === 'add') {
       onAddAnother();
+    } else if (step.command === 'deploy') {
+      onDeploy?.();
     }
   };
 

--- a/src/cli/tui/screens/agent/AddAgentFlow.tsx
+++ b/src/cli/tui/screens/agent/AddAgentFlow.tsx
@@ -28,6 +28,8 @@ interface AddAgentFlowProps {
   onComplete: (config: AddAgentConfig) => void;
   onExit: () => void;
   onBack: () => void;
+  /** Called when user selects deploy from success screen */
+  onDeploy?: () => void;
 }
 
 const MODE_OPTIONS: SelectableItem[] = [
@@ -41,6 +43,7 @@ export function AddAgentFlow({
   onComplete,
   onExit,
   onBack,
+  onDeploy,
 }: AddAgentFlowProps) {
   const [flow, setFlow] = useState<FlowState>({ name: 'mode-select' });
 
@@ -310,6 +313,7 @@ export function AddAgentFlow({
         message={`Added remote tool: ${flow.toolName}`}
         detail={`Agent "${flow.sourceAgent}" can now invoke agent "${flow.targetAgent}" as a remote tool.`}
         onAddAnother={onBack}
+        onDeploy={onDeploy}
         onExit={onExit}
       />
     );

--- a/src/cli/tui/screens/identity/AddIdentityFlow.tsx
+++ b/src/cli/tui/screens/identity/AddIdentityFlow.tsx
@@ -15,9 +15,11 @@ interface AddIdentityFlowProps {
   isInteractive?: boolean;
   onExit: () => void;
   onBack: () => void;
+  /** Called when user selects deploy from success screen */
+  onDeploy?: () => void;
 }
 
-export function AddIdentityFlow({ isInteractive = true, onExit, onBack }: AddIdentityFlowProps) {
+export function AddIdentityFlow({ isInteractive = true, onExit, onBack, onDeploy }: AddIdentityFlowProps) {
   const { createIdentity, reset: resetCreate } = useCreateIdentity();
   const { names: existingNames } = useExistingIdentityNames();
   const [flow, setFlow] = useState<FlowState>({ name: 'create-wizard' });
@@ -57,6 +59,7 @@ export function AddIdentityFlow({ isInteractive = true, onExit, onBack }: AddIde
         message={`Added credential: ${flow.identityName}`}
         detail="Credential added to project in `agentcore/agentcore.json`. API key stored in `agentcore/.env`."
         onAddAnother={onBack}
+        onDeploy={onDeploy}
         onExit={onExit}
       />
     );

--- a/src/cli/tui/screens/mcp/AddGatewayFlow.tsx
+++ b/src/cli/tui/screens/mcp/AddGatewayFlow.tsx
@@ -34,6 +34,8 @@ interface AddGatewayFlowProps {
   availableAgents: string[];
   onExit: () => void;
   onBack: () => void;
+  /** Called when user selects deploy from success screen */
+  onDeploy?: () => void;
 }
 
 const MODE_OPTIONS: SelectableItem[] = [
@@ -41,7 +43,7 @@ const MODE_OPTIONS: SelectableItem[] = [
   { id: 'bind', title: 'Bind existing gateway', description: 'Attach an existing gateway to an agent' },
 ];
 
-export function AddGatewayFlow({ isInteractive = true, availableAgents, onExit, onBack }: AddGatewayFlowProps) {
+export function AddGatewayFlow({ isInteractive = true, availableAgents, onExit, onBack, onDeploy }: AddGatewayFlowProps) {
   const { createGateway, reset: resetCreate } = useCreateGateway();
   const { gateways: existingGateways, refresh: refreshGateways } = useExistingGateways();
   const [flow, setFlow] = useState<FlowState>({ name: 'mode-select' });
@@ -332,6 +334,7 @@ export function AddGatewayFlow({ isInteractive = true, availableAgents, onExit, 
         onAddAnother={() => {
           void refreshGateways().then(() => onBack());
         }}
+        onDeploy={onDeploy}
         onExit={onExit}
       />
     );
@@ -345,6 +348,7 @@ export function AddGatewayFlow({ isInteractive = true, availableAgents, onExit, 
         message={`Bound gateway: ${flow.gatewayName}`}
         detail={`Agent "${flow.targetAgent}" now uses gateway "${flow.gatewayName}".`}
         onAddAnother={onBack}
+        onDeploy={onDeploy}
         onExit={onExit}
       />
     );

--- a/src/cli/tui/screens/mcp/AddMcpToolFlow.tsx
+++ b/src/cli/tui/screens/mcp/AddMcpToolFlow.tsx
@@ -26,6 +26,8 @@ interface AddMcpToolFlowProps {
   existingAgents: string[];
   onExit: () => void;
   onBack: () => void;
+  /** Called when user selects deploy from success screen */
+  onDeploy?: () => void;
 }
 
 const MODE_OPTIONS: SelectableItem[] = [
@@ -33,7 +35,7 @@ const MODE_OPTIONS: SelectableItem[] = [
   { id: 'bind', title: 'Bind existing MCP runtime', description: 'Add an agent to an existing MCP runtime' },
 ];
 
-export function AddMcpToolFlow({ isInteractive = true, existingAgents, onExit, onBack }: AddMcpToolFlowProps) {
+export function AddMcpToolFlow({ isInteractive = true, existingAgents, onExit, onBack, onDeploy }: AddMcpToolFlowProps) {
   const { createTool, reset: resetCreate } = useCreateMcpTool();
   const { gateways: existingGateways } = useExistingGateways();
   const { toolNames: existingToolNames } = useExistingToolNames();
@@ -254,6 +256,7 @@ export function AddMcpToolFlow({ isInteractive = true, existingAgents, onExit, o
         loading={flow.loading}
         loadingMessage={flow.loadingMessage}
         onAddAnother={onBack}
+        onDeploy={onDeploy}
         onExit={onExit}
       />
     );
@@ -267,6 +270,7 @@ export function AddMcpToolFlow({ isInteractive = true, existingAgents, onExit, o
         message={`Bound agent to MCP runtime`}
         detail={`Agent "${flow.targetAgent}" is now bound to MCP runtime "${flow.mcpRuntimeName}".`}
         onAddAnother={onBack}
+        onDeploy={onDeploy}
         onExit={onExit}
       />
     );

--- a/src/cli/tui/screens/memory/AddMemoryFlow.tsx
+++ b/src/cli/tui/screens/memory/AddMemoryFlow.tsx
@@ -15,6 +15,8 @@ interface AddMemoryFlowProps {
   isInteractive?: boolean;
   onExit: () => void;
   onBack: () => void;
+  /** Called when user selects deploy from success screen */
+  onDeploy?: () => void;
 }
 
 const MODE_OPTIONS: SelectableItem[] = [
@@ -27,7 +29,7 @@ const ACCESS_OPTIONS: SelectableItem[] = [
   { id: 'readwrite', title: 'Read/Write', description: 'Agent can read and write to memory' },
 ];
 
-export function AddMemoryFlow({ isInteractive = true, onExit, onBack }: AddMemoryFlowProps) {
+export function AddMemoryFlow({ isInteractive = true, onExit, onBack, onDeploy }: AddMemoryFlowProps) {
   const { createMemory, reset: resetCreate } = useCreateMemory();
   const { names: existingNames } = useExistingMemoryNames();
   const [flow, setFlow] = useState<FlowState>({ name: 'create-wizard' });
@@ -65,6 +67,7 @@ export function AddMemoryFlow({ isInteractive = true, onExit, onBack }: AddMemor
         message={`Added memory: ${flow.memoryName}`}
         detail="Memory added to project in `agentcore/agentcore.json`."
         onAddAnother={onBack}
+        onDeploy={onDeploy}
         onExit={onExit}
       />
     );


### PR DESCRIPTION
## Description
adding deploy as an option after a user adds a resource. This suggestion was from alrichey

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:all`
- [ ] I ran `npm run typecheck`
- [ ] I ran `npm run lint`

## Checklist

- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
