### PR TITLE
fix: bump CrewAI minimum Python to 3.11

### DIFF
--- a/src/assets/python/crewai/base/pyproject.toml
+++ b/src/assets/python/crewai/base/pyproject.toml
@@ -7,7 +7,7 @@ name = "{{ name }}"
 version = "0.1.0"
 description = "AgentCore Runtime Application using CrewAI SDK"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "opentelemetry-distro",
     "opentelemetry-exporter-otlp",


### PR DESCRIPTION
## Description

Bump CrewAI template minimum Python version from 3.10 to 3.11.

CrewAI depends on onnxruntime which dropped Python 3.10 wheels in recent versions. This causes uv sync to fail during agentcore create for CrewAI projects:

error: Distribution `onnxruntime==1.24.1` can't be installed because it doesn't have a source distribution or wheel for the current platform

hint: You're using CPython 3.10 (`cp310`), but `onnxruntime` (v1.24.1) only has wheels with the following Python implementation tags: `cp311`, `cp312`, `cp313`, `cp314`


## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran npm run test:all
- [ ] I ran npm run typecheck
- [ ] I ran npm run lint

Manual testing:
- Created new CrewAI project with agentcore create
- Verified uv sync completes successfully
- Ran agentcore dev and invoked agent successfully

## Checklist

- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.