### PR TITLE
add memory disclaimer, that it is not connected automatically

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13308,24 +13308,6 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",

--- a/src/cli/tui/screens/memory/AddMemoryFlow.tsx
+++ b/src/cli/tui/screens/memory/AddMemoryFlow.tsx
@@ -3,6 +3,7 @@ import { useCreateMemory, useExistingMemoryNames } from '../../hooks/useCreateMe
 import { AddSuccessScreen } from '../add/AddSuccessScreen';
 import { AddMemoryScreen } from './AddMemoryScreen';
 import type { AddMemoryConfig } from './types';
+import { Text } from 'ink';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 type FlowState =
@@ -64,6 +65,12 @@ export function AddMemoryFlow({ isInteractive = true, onExit, onBack }: AddMemor
         isInteractive={isInteractive}
         message={`Added memory: ${flow.memoryName}`}
         detail="Memory added to project in `agentcore/agentcore.json`."
+        summary={
+          <Text color="yellow">
+            Note: Once you deploy, the memory resource will be created in your account, but it is not automatically
+            connected to your agent. You must configure your agent code to use this memory.
+          </Text>
+        }
         onAddAnother={onBack}
         onExit={onExit}
       />


### PR DESCRIPTION
## Description

add a memory disclaimer that says memory is not connect to agent by default and you need to connect it to your agent code 

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:all`
- [ ] I ran `npm run typecheck`
- [ ] I ran `npm run lint`

## Checklist

- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
