### PR TITLE
fix: skip framework/language prompts in BYOC flow

### DIFF
--- a/src/cli/tui/screens/agent/types.ts
+++ b/src/cli/tui/screens/agent/types.ts
@@ -20,7 +20,8 @@ export type AgentType = 'create' | 'byo';
  * - language → framework → modelProvider → [apiKey] → memory → confirm
  *
  * BYO path (agentType = 'byo'):
- * - codeLocation → language → framework → modelProvider → [apiKey] → confirm
+ * - codeLocation → modelProvider → [apiKey] → confirm
+ * (language/framework not needed for BYO - user's code already has these)
  *
  * Note: apiKey step only appears for non-Bedrock model providers
  */


### PR DESCRIPTION
Fixes #178

## Description

 - Remove framework and language selection steps from BYOC (Bring Your Own Code) flow                                                              
 - These prompts are unnecessary since user's code already has framework/language baked in
 - Show all model providers for BYO (instead of filtering by framework)

## Related Issues

https://github.com/aws/agentcore-cli/issues/178

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Check all that apply -->

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [X] I ran `npm run test:all`
- [ ] I ran `npm run typecheck`
- [ ] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
