### PR TITLE
fix: align help text descriptions after project creation

### DIFF
--- a/src/cli/commands/create/command.tsx
+++ b/src/cli/commands/create/command.tsx
@@ -34,9 +34,14 @@ function printCreateSummary(
   console.log(`  ${projectName}/`);
   if (agentName) {
     const frameworkLabel = framework ?? 'agent';
-    console.log(`    app/${agentName}/  ${dim}${language} agent (${frameworkLabel})${reset}`);
+    const agentPath = `app/${agentName}/`;
+    const agentcorePath = 'agentcore/';
+    const maxPathLen = Math.max(agentPath.length, agentcorePath.length);
+    console.log(`    ${agentPath.padEnd(maxPathLen)}  ${dim}${language} agent (${frameworkLabel})${reset}`);
+    console.log(`    ${agentcorePath.padEnd(maxPathLen)}  ${dim}Config and CDK project${reset}`);
+  } else {
+    console.log(`    agentcore/  ${dim}Config and CDK project${reset}`);
   }
-  console.log(`    agentcore/           ${dim}Config and CDK project${reset}`);
   console.log('');
 
   // Success and next steps

--- a/src/cli/tui/screens/create/CreateScreen.tsx
+++ b/src/cli/tui/screens/create/CreateScreen.tsx
@@ -46,9 +46,14 @@ function buildExitMessage(projectName: string, steps: Step[], agentConfig: AddAg
   if (agentConfig?.agentType === 'create') {
     const frameworkOption = FRAMEWORK_OPTIONS.find(o => o.id === agentConfig.framework);
     const frameworkLabel = frameworkOption?.title ?? agentConfig.framework;
-    lines.push(`    app/${agentConfig.name}/  \x1b[2m${agentConfig.language} agent (${frameworkLabel})\x1b[0m`);
+    const agentPath = `app/${agentConfig.name}/`;
+    const agentcorePath = 'agentcore/';
+    const maxPathLen = Math.max(agentPath.length, agentcorePath.length);
+    lines.push(`    ${agentPath.padEnd(maxPathLen)}  \x1b[2m${agentConfig.language} agent (${frameworkLabel})\x1b[0m`);
+    lines.push(`    ${agentcorePath.padEnd(maxPathLen)}  \x1b[2mConfig and CDK project\x1b[0m`);
+  } else {
+    lines.push(`    agentcore/  \x1b[2mConfig and CDK project\x1b[0m`);
   }
-  lines.push(`    agentcore/           \x1b[2mConfig and CDK project\x1b[0m`);
   lines.push('');
 
   // Success message
@@ -103,15 +108,19 @@ function CreatedSummary({ projectName, agentConfig }: { projectName: string; age
     return option?.title ?? framework;
   };
 
+  const agentPath = agentConfig?.agentType === 'create' ? `app/${agentConfig.name}/` : null;
+  const agentcorePath = 'agentcore/';
+  const maxPathLen = agentPath ? Math.max(agentPath.length, agentcorePath.length) : agentcorePath.length;
+
   return (
     <Box flexDirection="column" marginTop={1}>
       <Text dimColor>Created:</Text>
       <Box flexDirection="column" marginLeft={2}>
         <Text>{projectName}/</Text>
-        {agentConfig?.agentType === 'create' && (
+        {agentConfig?.agentType === 'create' && agentPath && (
           <Box marginLeft={2}>
             <Text>
-              app/{agentConfig.name}/
+              {agentPath.padEnd(maxPathLen)}
               <Text dimColor>
                 {'  '}
                 {agentConfig.language} agent ({getFrameworkLabel(agentConfig.framework)})
@@ -121,7 +130,8 @@ function CreatedSummary({ projectName, agentConfig }: { projectName: string; age
         )}
         <Box marginLeft={2}>
           <Text>
-            agentcore/<Text dimColor>{'         '}Config and CDK project</Text>
+            {agentcorePath.padEnd(maxPathLen)}
+            <Text dimColor>{'  '}Config and CDK project</Text>
           </Text>
         </Box>
       </Box>


### PR DESCRIPTION
Fixes #166

## Description

<img width="1084" height="264" alt="image" src="https://github.com/user-attachments/assets/d39a8c33-ef73-4a55-8692-8578ad47446e" />

There was an alignment issue before after create. This commit fixes that alignment. 

Before:     
```                          
  app/MyAgent17WithPizzazz/  Python agent (OpenAI Agents)           
  agentcore/           Config and CDK project                                                                                                        
```
                                                                                                                                                     
  After:                                                                                                                                             
```
  app/MyAgent17WithPizzazz/  Python agent (OpenAI Agents)                                                                                            
  agentcore/                 Config and CDK project                                
```
Uses `padEnd()` to dynamically align descriptions based on the longest path. 


## Related Issues

https://github.com/aws/agentcore-cli/issues/166

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Check all that apply -->

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:all`
- [ ] I ran `npm run typecheck`
- [ ] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
