### PR TITLE
feat: smart credential detection for multi-agent projects

### DIFF
--- a/src/cli/commands/add/__tests__/multi-agent-credentials.test.ts
+++ b/src/cli/commands/add/__tests__/multi-agent-credentials.test.ts
@@ -1,0 +1,281 @@
+/* eslint-disable security/detect-non-literal-fs-filename */
+import { runCLI } from '../../../../test-utils/index.js';
+import { randomUUID } from 'node:crypto';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+/**
+ * Integration tests for multi-agent credential behavior (Option C).
+ *
+ * Tests the smart credential detection:
+ * - Same API key → reuse existing project-scoped credential
+ * - Different API key → create agent-scoped credential
+ * - Remove agent → clean up agent-scoped credentials
+ */
+describe('multi-agent credential behavior', () => {
+  let testDir: string;
+  let projectDir: string;
+  const projectName = 'MultiAgentProj';
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `agentcore-multi-agent-cred-${randomUUID()}`);
+    await mkdir(testDir, { recursive: true });
+
+    // Create project without agent
+    const result = await runCLI(['create', '--name', projectName, '--no-agent'], testDir);
+    if (result.exitCode !== 0) {
+      throw new Error(`Failed to create project: ${result.stdout} ${result.stderr}`);
+    }
+    projectDir = join(testDir, projectName);
+  });
+
+  afterAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  async function readProjectSpec() {
+    const content = await readFile(join(projectDir, 'agentcore/agentcore.json'), 'utf-8');
+    return JSON.parse(content);
+  }
+
+  async function readEnvLocal() {
+    try {
+      return await readFile(join(projectDir, 'agentcore/.env.local'), 'utf-8');
+    } catch {
+      return '';
+    }
+  }
+
+  describe('credential reuse with same API key', () => {
+    it('first agent creates project-scoped credential', async () => {
+      const result = await runCLI(
+        [
+          'add',
+          'agent',
+          '--name',
+          'Agent1',
+          '--language',
+          'Python',
+          '--framework',
+          'Strands',
+          '--model-provider',
+          'Gemini',
+          '--api-key',
+          'KEY1',
+          '--memory',
+          'none',
+          '--json',
+        ],
+        projectDir
+      );
+
+      expect(result.exitCode, `stdout: ${result.stdout}, stderr: ${result.stderr}`).toBe(0);
+
+      const spec = await readProjectSpec();
+      expect(spec.credentials).toHaveLength(1);
+      expect(spec.credentials[0].name).toBe(`${projectName}Gemini`);
+
+      const env = await readEnvLocal();
+      expect(env).toContain('AGENTCORE_CREDENTIAL_MULTIAGENTPROJGEMINI=');
+      expect(env).toContain('KEY1');
+    });
+
+    it('second agent with same key reuses credential (no duplicate)', async () => {
+      const result = await runCLI(
+        [
+          'add',
+          'agent',
+          '--name',
+          'Agent2',
+          '--language',
+          'Python',
+          '--framework',
+          'Strands',
+          '--model-provider',
+          'Gemini',
+          '--api-key',
+          'KEY1',
+          '--memory',
+          'none',
+          '--json',
+        ],
+        projectDir
+      );
+
+      expect(result.exitCode, `stdout: ${result.stdout}, stderr: ${result.stderr}`).toBe(0);
+
+      const spec = await readProjectSpec();
+      // Should still have only 1 credential (reused)
+      expect(spec.credentials).toHaveLength(1);
+      expect(spec.credentials[0].name).toBe(`${projectName}Gemini`);
+
+      // Should have 2 agents
+      expect(spec.agents).toHaveLength(2);
+    });
+  });
+
+  describe('agent-scoped credential with different API key', () => {
+    it('third agent with different key creates agent-scoped credential', async () => {
+      const result = await runCLI(
+        [
+          'add',
+          'agent',
+          '--name',
+          'Agent3',
+          '--language',
+          'Python',
+          '--framework',
+          'Strands',
+          '--model-provider',
+          'Gemini',
+          '--api-key',
+          'KEY2',
+          '--memory',
+          'none',
+          '--json',
+        ],
+        projectDir
+      );
+
+      expect(result.exitCode, `stdout: ${result.stdout}, stderr: ${result.stderr}`).toBe(0);
+
+      const spec = await readProjectSpec();
+      // Should now have 2 credentials
+      expect(spec.credentials).toHaveLength(2);
+
+      const credNames = spec.credentials.map((c: { name: string }) => c.name);
+      expect(credNames).toContain(`${projectName}Gemini`);
+      expect(credNames).toContain(`${projectName}Agent3Gemini`);
+
+      // Should have 3 agents
+      expect(spec.agents).toHaveLength(3);
+
+      // .env.local should have both keys
+      const env = await readEnvLocal();
+      expect(env).toContain('AGENTCORE_CREDENTIAL_MULTIAGENTPROJGEMINI=');
+      expect(env).toContain('KEY1');
+      expect(env).toContain('AGENTCORE_CREDENTIAL_MULTIAGENTPROJAGENT3GEMINI=');
+      expect(env).toContain('KEY2');
+
+      // Generated code should reference correct credentials
+      const agent1Code = await readFile(join(projectDir, 'app/Agent1/model/load.py'), 'utf-8');
+      expect(agent1Code).toContain(`IDENTITY_PROVIDER_NAME = "${projectName}Gemini"`);
+
+      const agent3Code = await readFile(join(projectDir, 'app/Agent3/model/load.py'), 'utf-8');
+      expect(agent3Code).toContain(`IDENTITY_PROVIDER_NAME = "${projectName}Agent3Gemini"`);
+    });
+  });
+
+  describe('credential cleanup on agent removal', () => {
+    it('removing agent with agent-scoped credential cleans up credential', async () => {
+      const result = await runCLI(['remove', 'agent', '--name', 'Agent3', '--json'], projectDir);
+
+      expect(result.exitCode, `stdout: ${result.stdout}, stderr: ${result.stderr}`).toBe(0);
+
+      const spec = await readProjectSpec();
+      // Should be back to 1 credential (agent-scoped removed)
+      expect(spec.credentials).toHaveLength(1);
+      expect(spec.credentials[0].name).toBe(`${projectName}Gemini`);
+
+      // Should have 2 agents
+      expect(spec.agents).toHaveLength(2);
+    });
+
+    it('removing agent with shared credential does NOT remove credential', async () => {
+      // Remove Agent2 (uses shared project-scoped credential)
+      const result = await runCLI(['remove', 'agent', '--name', 'Agent2', '--json'], projectDir);
+
+      expect(result.exitCode, `stdout: ${result.stdout}, stderr: ${result.stderr}`).toBe(0);
+
+      const spec = await readProjectSpec();
+      // Credential should still exist (shared with Agent1)
+      expect(spec.credentials).toHaveLength(1);
+      expect(spec.credentials[0].name).toBe(`${projectName}Gemini`);
+
+      // Should have 1 agent
+      expect(spec.agents).toHaveLength(1);
+    });
+  });
+
+  describe('BYO (bring-your-own) agent path', () => {
+    it('BYO agent with same key reuses credential', async () => {
+      // Create a code directory for BYO agent
+      const byoDir = join(projectDir, 'app/ByoAgent');
+      await mkdir(byoDir, { recursive: true });
+      await writeFile(join(byoDir, 'main.py'), '# BYO agent');
+
+      const result = await runCLI(
+        [
+          'add',
+          'agent',
+          '--name',
+          'ByoAgent',
+          '--type',
+          'byo',
+          '--language',
+          'Python',
+          '--framework',
+          'Strands',
+          '--code-location',
+          'app/ByoAgent/',
+          '--model-provider',
+          'Gemini',
+          '--api-key',
+          'KEY1',
+          '--json',
+        ],
+        projectDir
+      );
+
+      expect(result.exitCode, `stdout: ${result.stdout}, stderr: ${result.stderr}`).toBe(0);
+
+      const spec = await readProjectSpec();
+      // Should still have only 1 credential (reused)
+      expect(spec.credentials).toHaveLength(1);
+      expect(spec.credentials[0].name).toBe(`${projectName}Gemini`);
+
+      // Should have 2 agents now
+      expect(spec.agents).toHaveLength(2);
+    });
+
+    it('BYO agent with different key creates agent-scoped credential', async () => {
+      const byoDir2 = join(projectDir, 'app/ByoAgent2');
+      await mkdir(byoDir2, { recursive: true });
+      await writeFile(join(byoDir2, 'main.py'), '# BYO agent 2');
+
+      const result = await runCLI(
+        [
+          'add',
+          'agent',
+          '--name',
+          'ByoAgent2',
+          '--type',
+          'byo',
+          '--language',
+          'Python',
+          '--framework',
+          'Strands',
+          '--code-location',
+          'app/ByoAgent2/',
+          '--model-provider',
+          'Gemini',
+          '--api-key',
+          'DIFFERENT_KEY',
+          '--json',
+        ],
+        projectDir
+      );
+
+      expect(result.exitCode, `stdout: ${result.stdout}, stderr: ${result.stderr}`).toBe(0);
+
+      const spec = await readProjectSpec();
+      // Should have 2 credentials now
+      expect(spec.credentials).toHaveLength(2);
+      const credNames = spec.credentials.map((c: { name: string }) => c.name);
+      expect(credNames).toContain(`${projectName}Gemini`);
+      expect(credNames).toContain(`${projectName}ByoAgent2Gemini`);
+    });
+  });
+});

--- a/src/cli/commands/add/__tests__/multi-agent-credentials.test.ts
+++ b/src/cli/commands/add/__tests__/multi-agent-credentials.test.ts
@@ -168,31 +168,31 @@ describe('multi-agent credential behavior', () => {
     });
   });
 
-  describe('credential cleanup on agent removal', () => {
-    it('removing agent with agent-scoped credential cleans up credential', async () => {
+  describe('credential persistence on agent removal', () => {
+    it('removing agent preserves agent-scoped credential for reuse', async () => {
       const result = await runCLI(['remove', 'agent', '--name', 'Agent3', '--json'], projectDir);
 
       expect(result.exitCode, `stdout: ${result.stdout}, stderr: ${result.stderr}`).toBe(0);
 
       const spec = await readProjectSpec();
-      // Should be back to 1 credential (agent-scoped removed)
-      expect(spec.credentials).toHaveLength(1);
-      expect(spec.credentials[0].name).toBe(`${projectName}Gemini`);
+      // Credentials preserved (both project-scoped and agent-scoped)
+      expect(spec.credentials).toHaveLength(2);
+      expect(spec.credentials.map((c: { name: string }) => c.name)).toContain(`${projectName}Gemini`);
+      expect(spec.credentials.map((c: { name: string }) => c.name)).toContain(`${projectName}Agent3Gemini`);
 
       // Should have 2 agents
       expect(spec.agents).toHaveLength(2);
     });
 
-    it('removing agent with shared credential does NOT remove credential', async () => {
+    it('removing agent with shared credential preserves credential', async () => {
       // Remove Agent2 (uses shared project-scoped credential)
       const result = await runCLI(['remove', 'agent', '--name', 'Agent2', '--json'], projectDir);
 
       expect(result.exitCode, `stdout: ${result.stdout}, stderr: ${result.stderr}`).toBe(0);
 
       const spec = await readProjectSpec();
-      // Credential should still exist (shared with Agent1)
-      expect(spec.credentials).toHaveLength(1);
-      expect(spec.credentials[0].name).toBe(`${projectName}Gemini`);
+      // Both credentials still exist
+      expect(spec.credentials).toHaveLength(2);
 
       // Should have 1 agent
       expect(spec.agents).toHaveLength(1);
@@ -205,6 +205,9 @@ describe('multi-agent credential behavior', () => {
       const byoDir = join(projectDir, 'app/ByoAgent');
       await mkdir(byoDir, { recursive: true });
       await writeFile(join(byoDir, 'main.py'), '# BYO agent');
+
+      const specBefore = await readProjectSpec();
+      const credCountBefore = specBefore.credentials.length;
 
       const result = await runCLI(
         [
@@ -232,18 +235,17 @@ describe('multi-agent credential behavior', () => {
       expect(result.exitCode, `stdout: ${result.stdout}, stderr: ${result.stderr}`).toBe(0);
 
       const spec = await readProjectSpec();
-      // Should still have only 1 credential (reused)
-      expect(spec.credentials).toHaveLength(1);
-      expect(spec.credentials[0].name).toBe(`${projectName}Gemini`);
-
-      // Should have 2 agents now
-      expect(spec.agents).toHaveLength(2);
+      // Should still have same number of credentials (reused)
+      expect(spec.credentials).toHaveLength(credCountBefore);
     });
 
     it('BYO agent with different key creates agent-scoped credential', async () => {
       const byoDir2 = join(projectDir, 'app/ByoAgent2');
       await mkdir(byoDir2, { recursive: true });
       await writeFile(join(byoDir2, 'main.py'), '# BYO agent 2');
+
+      const specBefore = await readProjectSpec();
+      const credCountBefore = specBefore.credentials.length;
 
       const result = await runCLI(
         [
@@ -271,10 +273,9 @@ describe('multi-agent credential behavior', () => {
       expect(result.exitCode, `stdout: ${result.stdout}, stderr: ${result.stderr}`).toBe(0);
 
       const spec = await readProjectSpec();
-      // Should have 2 credentials now
-      expect(spec.credentials).toHaveLength(2);
+      // Should have one more credential
+      expect(spec.credentials).toHaveLength(credCountBefore + 1);
       const credNames = spec.credentials.map((c: { name: string }) => c.name);
-      expect(credNames).toContain(`${projectName}Gemini`);
       expect(credNames).toContain(`${projectName}ByoAgent2Gemini`);
     });
   });

--- a/src/cli/commands/add/actions.ts
+++ b/src/cli/commands/add/actions.ts
@@ -17,11 +17,7 @@ import {
   mapModelProviderToIdentityProviders,
   writeAgentToProject,
 } from '../../operations/agent/generate';
-import {
-  computeDefaultCredentialEnvVarName,
-  createCredential,
-  resolveCredentialStrategy,
-} from '../../operations/identity/create-identity';
+import { createCredential, resolveCredentialStrategy } from '../../operations/identity/create-identity';
 import { createGatewayFromWizard, createToolFromWizard } from '../../operations/mcp/create-mcp';
 import { createMemory } from '../../operations/memory/create-memory';
 import { createRenderer } from '../../templates';

--- a/src/cli/commands/add/actions.ts
+++ b/src/cli/commands/add/actions.ts
@@ -14,9 +14,14 @@ import { setupPythonProject } from '../../operations';
 import {
   mapGenerateConfigToRenderConfig,
   mapModelProviderToCredentials,
+  mapModelProviderToIdentityProviders,
   writeAgentToProject,
 } from '../../operations/agent/generate';
-import { computeDefaultCredentialEnvVarName, createCredential } from '../../operations/identity/create-identity';
+import {
+  computeDefaultCredentialEnvVarName,
+  createCredential,
+  resolveCredentialStrategy,
+} from '../../operations/identity/create-identity';
 import { createGatewayFromWizard, createToolFromWizard } from '../../operations/mcp/create-mcp';
 import { createMemory } from '../../operations/memory/create-memory';
 import { createRenderer } from '../../templates';
@@ -115,22 +120,47 @@ async function handleCreatePath(options: ValidatedAddAgentOptions, configBaseDir
 
   const agentPath = join(projectRoot, APP_DIR, options.name);
 
-  // Pass actual project name for credential naming in templates
-  const renderConfig = mapGenerateConfigToRenderConfig(generateConfig, project.name);
+  // Resolve credential strategy FIRST to determine correct credential name
+  let identityProviders: ReturnType<typeof mapModelProviderToIdentityProviders> = [];
+  let strategy: Awaited<ReturnType<typeof resolveCredentialStrategy>> | undefined;
+
+  if (options.modelProvider !== 'Bedrock') {
+    strategy = await resolveCredentialStrategy(
+      project.name,
+      options.name,
+      options.modelProvider,
+      options.apiKey,
+      configBaseDir,
+      project.credentials
+    );
+
+    // Build identity providers with the correct credential name from strategy
+    identityProviders = [
+      {
+        name: strategy.credentialName,
+        envVarName: strategy.envVarName,
+      },
+    ];
+  }
+
+  // Render templates with correct identity provider
+  const renderConfig = mapGenerateConfigToRenderConfig(generateConfig, identityProviders);
   const renderer = createRenderer(renderConfig);
   await renderer.render({ outputDir: projectRoot });
 
-  await writeAgentToProject(generateConfig, { configBaseDir });
+  // Write agent to project config
+  if (strategy) {
+    await writeAgentToProject(generateConfig, { configBaseDir, credentialStrategy: strategy });
+
+    if (options.apiKey) {
+      await setEnvVar(strategy.envVarName, options.apiKey, configBaseDir);
+    }
+  } else {
+    await writeAgentToProject(generateConfig, { configBaseDir });
+  }
 
   if (options.language === 'Python') {
     await setupPythonProject({ projectDir: agentPath });
-  }
-
-  if (options.apiKey && options.modelProvider !== 'Bedrock') {
-    // Use project-scoped credential name: {projectName}{modelProvider}
-    const credentialName = `${project.name}${options.modelProvider}`;
-    const envVarName = computeDefaultCredentialEnvVarName(credentialName);
-    await setEnvVar(envVarName, options.apiKey, configBaseDir);
   }
 
   return { success: true, agentName: options.name, agentPath };
@@ -157,18 +187,31 @@ async function handleByoPath(
 
   project.agents.push(agent);
 
-  // Add credential for non-Bedrock providers
-  const credentials = mapModelProviderToCredentials(options.modelProvider, project.name);
-  project.credentials.push(...credentials);
+  // Handle credential creation with smart reuse detection
+  if (options.modelProvider !== 'Bedrock') {
+    const strategy = await resolveCredentialStrategy(
+      project.name,
+      options.name,
+      options.modelProvider,
+      options.apiKey,
+      configBaseDir,
+      project.credentials
+    );
+
+    if (!strategy.reuse) {
+      const credentials = mapModelProviderToCredentials(options.modelProvider, project.name);
+      if (credentials.length > 0) {
+        credentials[0].name = strategy.credentialName;
+        project.credentials.push(...credentials);
+      }
+    }
+
+    if (options.apiKey) {
+      await setEnvVar(strategy.envVarName, options.apiKey, configBaseDir);
+    }
+  }
 
   await configIO.writeProjectSpec(project);
-
-  if (options.apiKey && options.modelProvider !== 'Bedrock') {
-    // Use project-scoped credential name: {projectName}{modelProvider}
-    const credentialName = `${project.name}${options.modelProvider}`;
-    const envVarName = computeDefaultCredentialEnvVarName(credentialName);
-    await setEnvVar(envVarName, options.apiKey, configBaseDir);
-  }
 
   return { success: true, agentName: options.name };
 }

--- a/src/cli/commands/add/actions.ts
+++ b/src/cli/commands/add/actions.ts
@@ -201,7 +201,7 @@ async function handleByoPath(
     if (!strategy.reuse) {
       const credentials = mapModelProviderToCredentials(options.modelProvider, project.name);
       if (credentials.length > 0) {
-        credentials[0].name = strategy.credentialName;
+        credentials[0]!.name = strategy.credentialName;
         project.credentials.push(...credentials);
       }
     }

--- a/src/cli/operations/agent/generate/__tests__/write-agent-to-project.test.ts
+++ b/src/cli/operations/agent/generate/__tests__/write-agent-to-project.test.ts
@@ -1,0 +1,137 @@
+/* eslint-disable security/detect-non-literal-fs-filename */
+import type { GenerateConfig } from '../../../../tui/screens/generate/types.js';
+import type { CredentialStrategy } from '../../../identity/create-identity.js';
+import { randomUUID } from 'node:crypto';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+describe('writeAgentToProject with credentialStrategy', () => {
+  let testDir: string;
+  let configBaseDir: string;
+
+  const baseConfig: GenerateConfig = {
+    projectName: 'TestAgent',
+    sdk: 'Strands',
+    modelProvider: 'Gemini',
+    memory: 'none',
+    language: 'Python',
+  };
+
+  const baseProject = {
+    name: 'MyProject',
+    version: 1,
+    agents: [],
+    memories: [],
+    credentials: [],
+  };
+
+  beforeEach(async () => {
+    testDir = join(tmpdir(), `write-agent-test-${randomUUID()}`);
+    configBaseDir = join(testDir, 'agentcore');
+    await mkdir(configBaseDir, { recursive: true });
+    await writeFile(join(configBaseDir, 'agentcore.json'), JSON.stringify(baseProject, null, 2));
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  // Dynamic import to get fresh module after setup
+  async function getWriteAgentToProject() {
+    const mod = await import('../write-agent-to-project.js');
+    return mod.writeAgentToProject;
+  }
+
+  async function readProject() {
+    const { readFile } = await import('node:fs/promises');
+    const content = await readFile(join(configBaseDir, 'agentcore.json'), 'utf-8');
+    return JSON.parse(content);
+  }
+
+  describe('with credentialStrategy.reuse = true', () => {
+    it('does not add credential to project', async () => {
+      const writeAgentToProject = await getWriteAgentToProject();
+      const strategy: CredentialStrategy = {
+        reuse: true,
+        credentialName: 'MyProjectGemini',
+        envVarName: 'AGENTCORE_CREDENTIAL_MYPROJECTGEMINI',
+        isAgentScoped: false,
+      };
+
+      await writeAgentToProject(baseConfig, {
+        configBaseDir,
+        credentialStrategy: strategy,
+      });
+
+      const project = await readProject();
+      expect(project.credentials).toHaveLength(0);
+      expect(project.agents).toHaveLength(1);
+    });
+  });
+
+  describe('with credentialStrategy.reuse = false', () => {
+    it('adds credential with strategy.credentialName', async () => {
+      const writeAgentToProject = await getWriteAgentToProject();
+      const strategy: CredentialStrategy = {
+        reuse: false,
+        credentialName: 'MyProjectAgent2Gemini',
+        envVarName: 'AGENTCORE_CREDENTIAL_MYPROJECTAGENT2GEMINI',
+        isAgentScoped: true,
+      };
+
+      await writeAgentToProject(baseConfig, {
+        configBaseDir,
+        credentialStrategy: strategy,
+      });
+
+      const project = await readProject();
+      expect(project.credentials).toHaveLength(1);
+      expect(project.credentials[0].name).toBe('MyProjectAgent2Gemini');
+    });
+
+    it('adds project-scoped credential name', async () => {
+      const writeAgentToProject = await getWriteAgentToProject();
+      const strategy: CredentialStrategy = {
+        reuse: false,
+        credentialName: 'MyProjectGemini',
+        envVarName: 'AGENTCORE_CREDENTIAL_MYPROJECTGEMINI',
+        isAgentScoped: false,
+      };
+
+      await writeAgentToProject(baseConfig, {
+        configBaseDir,
+        credentialStrategy: strategy,
+      });
+
+      const project = await readProject();
+      expect(project.credentials[0].name).toBe('MyProjectGemini');
+    });
+  });
+
+  describe('without credentialStrategy (backward compatibility)', () => {
+    it('uses mapModelProviderToCredentials behavior', async () => {
+      const writeAgentToProject = await getWriteAgentToProject();
+
+      await writeAgentToProject(baseConfig, { configBaseDir });
+
+      const project = await readProject();
+      expect(project.credentials).toHaveLength(1);
+      expect(project.credentials[0].name).toBe('MyProjectGemini');
+    });
+
+    it('adds no credential for Bedrock', async () => {
+      const writeAgentToProject = await getWriteAgentToProject();
+      const bedrockConfig: GenerateConfig = {
+        ...baseConfig,
+        modelProvider: 'Bedrock',
+      };
+
+      await writeAgentToProject(bedrockConfig, { configBaseDir });
+
+      const project = await readProject();
+      expect(project.credentials).toHaveLength(0);
+    });
+  });
+});

--- a/src/cli/operations/agent/generate/index.ts
+++ b/src/cli/operations/agent/generate/index.ts
@@ -4,6 +4,7 @@ export {
   mapGenerateConfigToRenderConfig,
   mapGenerateInputToMemories,
   mapModelProviderToCredentials,
+  mapModelProviderToIdentityProviders,
   type GenerateConfigMappingResult,
 } from './schema-mapper';
 export { writeAgentToProject, type WriteAgentOptions } from './write-agent-to-project';

--- a/src/cli/operations/agent/generate/schema-mapper.ts
+++ b/src/cli/operations/agent/generate/schema-mapper.ts
@@ -151,7 +151,7 @@ function mapMemoryOptionToMemoryProviders(memory: MemoryOption, projectName: str
  * Maps model provider to identity providers for template rendering.
  * Bedrock uses IAM, so no identity provider is needed.
  */
-function mapModelProviderToIdentityProviders(
+export function mapModelProviderToIdentityProviders(
   modelProvider: ModelProvider,
   projectName: string
 ): IdentityProviderRenderConfig[] {
@@ -171,19 +171,20 @@ function mapModelProviderToIdentityProviders(
 /**
  * Maps GenerateConfig to AgentRenderConfig for template rendering.
  * @param config - Generate config (note: config.projectName is actually the agent name)
- * @param actualProjectName - Optional actual project name for credential naming (defaults to config.projectName)
+ * @param identityProviders - Identity providers to include (caller controls credential naming)
  */
-export function mapGenerateConfigToRenderConfig(config: GenerateConfig, actualProjectName?: string): AgentRenderConfig {
-  // Use actualProjectName for credential naming, fallback to config.projectName (agent name) for standalone generate
-  const projectNameForCredentials = actualProjectName ?? config.projectName;
+export function mapGenerateConfigToRenderConfig(
+  config: GenerateConfig,
+  identityProviders: IdentityProviderRenderConfig[]
+): AgentRenderConfig {
   return {
     name: config.projectName,
     sdkFramework: config.sdk,
     targetLanguage: config.language,
     modelProvider: config.modelProvider,
     hasMemory: config.memory !== 'none',
-    hasIdentity: config.modelProvider !== 'Bedrock',
+    hasIdentity: identityProviders.length > 0,
     memoryProviders: mapMemoryOptionToMemoryProviders(config.memory, config.projectName),
-    identityProviders: mapModelProviderToIdentityProviders(config.modelProvider, projectNameForCredentials),
+    identityProviders,
   };
 }

--- a/src/cli/operations/agent/generate/write-agent-to-project.ts
+++ b/src/cli/operations/agent/generate/write-agent-to-project.ts
@@ -47,7 +47,7 @@ export async function writeAgentToProject(config: GenerateConfig, options?: Writ
       if (!strategy.reuse) {
         const credentials = mapModelProviderToCredentials(config.modelProvider, project.name);
         if (credentials.length > 0) {
-          credentials[0].name = strategy.credentialName;
+          credentials[0]!.name = strategy.credentialName;
           project.credentials.push(...credentials);
         }
       }

--- a/src/cli/operations/agent/generate/write-agent-to-project.ts
+++ b/src/cli/operations/agent/generate/write-agent-to-project.ts
@@ -3,10 +3,12 @@ import type { AgentCoreProjectSpec } from '../../../../schema';
 import { SCHEMA_VERSION } from '../../../constants';
 import { AgentAlreadyExistsError } from '../../../errors';
 import type { GenerateConfig } from '../../../tui/screens/generate/types';
+import type { CredentialStrategy } from '../../identity/create-identity';
 import { mapGenerateConfigToAgent, mapGenerateInputToMemories, mapModelProviderToCredentials } from './schema-mapper';
 
 export interface WriteAgentOptions {
   configBaseDir?: string;
+  credentialStrategy?: CredentialStrategy;
 }
 
 /**
@@ -15,11 +17,12 @@ export interface WriteAgentOptions {
  * In v2 schema:
  * - Agent goes to project.agents[]
  * - Memory resources go to project.memories[]
- * - Credential resources go to project.credentials[]
+ * - Credential resources go to project.credentials[] (unless strategy.reuse)
  */
 export async function writeAgentToProject(config: GenerateConfig, options?: WriteAgentOptions): Promise<void> {
   const configBaseDir = options?.configBaseDir ?? requireConfigRoot();
   const configIO = new ConfigIO({ baseDir: configBaseDir });
+  const strategy = options?.credentialStrategy;
 
   // Map agent config to resources
   // Note: config.projectName is actually the agent name (GenerateConfig naming is confusing)
@@ -35,13 +38,24 @@ export async function writeAgentToProject(config: GenerateConfig, options?: Writ
       throw new AgentAlreadyExistsError(agentName);
     }
 
-    // Use actual project name for credential naming (not agent name)
-    const credentials = mapModelProviderToCredentials(config.modelProvider, project.name);
-
     // Add resources to project
     project.agents.push(agent);
     project.memories.push(...memories);
-    project.credentials.push(...credentials);
+
+    // Handle credentials based on strategy
+    if (strategy) {
+      if (!strategy.reuse) {
+        const credentials = mapModelProviderToCredentials(config.modelProvider, project.name);
+        if (credentials.length > 0) {
+          credentials[0].name = strategy.credentialName;
+          project.credentials.push(...credentials);
+        }
+      }
+    } else {
+      // Backward compatibility: no strategy provided
+      const credentials = mapModelProviderToCredentials(config.modelProvider, project.name);
+      project.credentials.push(...credentials);
+    }
 
     await configIO.writeProjectSpec(project);
   } else {

--- a/src/cli/operations/deploy/index.ts
+++ b/src/cli/operations/deploy/index.ts
@@ -18,6 +18,7 @@ export {
   setupApiKeyProviders,
   hasOwnedIdentityApiProviders,
   getMissingCredentials,
+  getAllCredentials,
   type SetupApiKeyProvidersOptions,
   type PreDeployIdentityResult,
   type ApiKeyProviderSetupResult,

--- a/src/cli/operations/identity/__tests__/resolve-credential-strategy.test.ts
+++ b/src/cli/operations/identity/__tests__/resolve-credential-strategy.test.ts
@@ -1,0 +1,188 @@
+import * as lib from '../../../../lib/index.js';
+import type { Credential } from '../../../../schema/index.js';
+import { resolveCredentialStrategy } from '../create-identity.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../../lib/index.js', async () => {
+  const actual = await vi.importActual('../../../../lib/index.js');
+  return {
+    ...actual,
+    getEnvVar: vi.fn(),
+  };
+});
+
+const mockGetEnvVar = vi.mocked(lib.getEnvVar);
+
+describe('resolveCredentialStrategy', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const projectName = 'MyProject';
+  const agentName = 'Agent1';
+  const configBaseDir = '/fake/path';
+
+  describe('early returns', () => {
+    it('returns reuse=true with empty credential for Bedrock provider', async () => {
+      const result = await resolveCredentialStrategy(projectName, agentName, 'Bedrock', 'some-key', configBaseDir, []);
+
+      expect(result).toEqual({
+        reuse: true,
+        credentialName: '',
+        envVarName: '',
+        isAgentScoped: false,
+      });
+      expect(mockGetEnvVar).not.toHaveBeenCalled();
+    });
+
+    it('returns reuse=true with empty credential when no API key provided', async () => {
+      const result = await resolveCredentialStrategy(projectName, agentName, 'Gemini', undefined, configBaseDir, []);
+
+      expect(result).toEqual({
+        reuse: true,
+        credentialName: '',
+        envVarName: '',
+        isAgentScoped: false,
+      });
+      expect(mockGetEnvVar).not.toHaveBeenCalled();
+    });
+
+    it('returns reuse=true with empty credential when API key is empty string', async () => {
+      const result = await resolveCredentialStrategy(projectName, agentName, 'Gemini', '', configBaseDir, []);
+
+      expect(result).toEqual({
+        reuse: true,
+        credentialName: '',
+        envVarName: '',
+        isAgentScoped: false,
+      });
+    });
+  });
+
+  describe('first agent (no existing credential)', () => {
+    it('creates project-scoped credential when no existing credentials', async () => {
+      const result = await resolveCredentialStrategy(projectName, agentName, 'Gemini', 'my-api-key', configBaseDir, []);
+
+      expect(result).toEqual({
+        reuse: false,
+        credentialName: 'MyProjectGemini',
+        envVarName: 'AGENTCORE_CREDENTIAL_MYPROJECTGEMINI',
+        isAgentScoped: false,
+      });
+      expect(mockGetEnvVar).not.toHaveBeenCalled();
+    });
+
+    it('creates project-scoped credential for OpenAI', async () => {
+      const result = await resolveCredentialStrategy(projectName, agentName, 'OpenAI', 'my-api-key', configBaseDir, []);
+
+      expect(result.credentialName).toBe('MyProjectOpenAI');
+      expect(result.envVarName).toBe('AGENTCORE_CREDENTIAL_MYPROJECTOPENAI');
+    });
+
+    it('creates project-scoped credential for Anthropic', async () => {
+      const result = await resolveCredentialStrategy(
+        projectName,
+        agentName,
+        'Anthropic',
+        'my-api-key',
+        configBaseDir,
+        []
+      );
+
+      expect(result.credentialName).toBe('MyProjectAnthropic');
+      expect(result.envVarName).toBe('AGENTCORE_CREDENTIAL_MYPROJECTANTHROPIC');
+    });
+  });
+
+  describe('credential exists - key comparison', () => {
+    const existingCredentials: Credential[] = [{ name: 'MyProjectGemini', type: 'ApiKey' }];
+
+    it('reuses credential when API keys match', async () => {
+      mockGetEnvVar.mockResolvedValue('same-key');
+
+      const result = await resolveCredentialStrategy(
+        projectName,
+        agentName,
+        'Gemini',
+        'same-key',
+        configBaseDir,
+        existingCredentials
+      );
+
+      expect(result).toEqual({
+        reuse: true,
+        credentialName: 'MyProjectGemini',
+        envVarName: 'AGENTCORE_CREDENTIAL_MYPROJECTGEMINI',
+        isAgentScoped: false,
+      });
+      expect(mockGetEnvVar).toHaveBeenCalledWith('AGENTCORE_CREDENTIAL_MYPROJECTGEMINI', configBaseDir);
+    });
+
+    it('creates agent-scoped credential when API keys differ', async () => {
+      mockGetEnvVar.mockResolvedValue('existing-key');
+
+      const result = await resolveCredentialStrategy(
+        projectName,
+        'Agent2',
+        'Gemini',
+        'different-key',
+        configBaseDir,
+        existingCredentials
+      );
+
+      expect(result).toEqual({
+        reuse: false,
+        credentialName: 'MyProjectAgent2Gemini',
+        envVarName: 'AGENTCORE_CREDENTIAL_MYPROJECTAGENT2GEMINI',
+        isAgentScoped: true,
+      });
+    });
+
+    it('creates project-scoped credential when existing key is undefined', async () => {
+      mockGetEnvVar.mockResolvedValue(undefined);
+
+      const result = await resolveCredentialStrategy(
+        projectName,
+        agentName,
+        'Gemini',
+        'new-key',
+        configBaseDir,
+        existingCredentials
+      );
+
+      expect(result).toEqual({
+        reuse: false,
+        credentialName: 'MyProjectGemini',
+        envVarName: 'AGENTCORE_CREDENTIAL_MYPROJECTGEMINI',
+        isAgentScoped: false,
+      });
+    });
+  });
+
+  describe('credential name format', () => {
+    it('concatenates project name, agent name, and provider correctly', async () => {
+      mockGetEnvVar.mockResolvedValue('old-key');
+
+      const result = await resolveCredentialStrategy('TestProject', 'MyAgent', 'OpenAI', 'new-key', configBaseDir, [
+        { name: 'TestProjectOpenAI', type: 'ApiKey' },
+      ]);
+
+      expect(result.credentialName).toBe('TestProjectMyAgentOpenAI');
+      expect(result.isAgentScoped).toBe(true);
+    });
+
+    it('handles project names with numbers', async () => {
+      const result = await resolveCredentialStrategy('Project123', 'Agent1', 'Gemini', 'key', configBaseDir, []);
+
+      expect(result.credentialName).toBe('Project123Gemini');
+    });
+  });
+
+  describe('env var name format', () => {
+    it('uppercases credential name in env var', async () => {
+      const result = await resolveCredentialStrategy('myproject', 'agent', 'Gemini', 'key', configBaseDir, []);
+
+      expect(result.envVarName).toBe('AGENTCORE_CREDENTIAL_MYPROJECTGEMINI');
+    });
+  });
+});

--- a/src/cli/operations/identity/__tests__/resolve-credential-strategy.test.ts
+++ b/src/cli/operations/identity/__tests__/resolve-credential-strategy.test.ts
@@ -95,7 +95,7 @@ describe('resolveCredentialStrategy', () => {
   });
 
   describe('credential exists - key comparison', () => {
-    const existingCredentials: Credential[] = [{ name: 'MyProjectGemini', type: 'ApiKey' }];
+    const existingCredentials: Credential[] = [{ name: 'MyProjectGemini', type: 'ApiKeyCredentialProvider' }];
 
     it('reuses credential when API keys match', async () => {
       mockGetEnvVar.mockResolvedValue('same-key');
@@ -164,7 +164,7 @@ describe('resolveCredentialStrategy', () => {
       mockGetEnvVar.mockResolvedValue('old-key');
 
       const result = await resolveCredentialStrategy('TestProject', 'MyAgent', 'OpenAI', 'new-key', configBaseDir, [
-        { name: 'TestProjectOpenAI', type: 'ApiKey' },
+        { name: 'TestProjectOpenAI', type: 'ApiKeyCredentialProvider' },
       ]);
 
       expect(result.credentialName).toBe('TestProjectMyAgentOpenAI');

--- a/src/cli/operations/identity/__tests__/resolve-credential-strategy.test.ts
+++ b/src/cli/operations/identity/__tests__/resolve-credential-strategy.test.ts
@@ -138,7 +138,7 @@ describe('resolveCredentialStrategy', () => {
       });
     });
 
-    it('creates project-scoped credential when existing key is undefined', async () => {
+    it('creates agent-scoped credential when no existing keys can be read', async () => {
       mockGetEnvVar.mockResolvedValue(undefined);
 
       const result = await resolveCredentialStrategy(
@@ -150,11 +150,103 @@ describe('resolveCredentialStrategy', () => {
         existingCredentials
       );
 
+      // Can't verify existing key matches, so create agent-scoped to be safe
       expect(result).toEqual({
         reuse: false,
+        credentialName: 'MyProjectAgent1Gemini',
+        envVarName: 'AGENTCORE_CREDENTIAL_MYPROJECTAGENT1GEMINI',
+        isAgentScoped: true,
+      });
+    });
+  });
+
+  describe('reuses agent-scoped credential when keys match', () => {
+    it('agent3 reuses agent2 credential when both use same secondary key', async () => {
+      // Scenario: agent1 uses mainKey (project-scoped), agent2 uses secondaryKey (agent-scoped)
+      // agent3 also uses secondaryKey - should reuse agent2's credential
+      const existingCredentials: Credential[] = [
+        { name: 'MyProjectGemini', type: 'ApiKeyCredentialProvider' },
+        { name: 'MyProjectAgent2Gemini', type: 'ApiKeyCredentialProvider' },
+      ];
+
+      mockGetEnvVar.mockImplementation((envVar: string) => {
+        if (envVar === 'AGENTCORE_CREDENTIAL_MYPROJECTGEMINI') return Promise.resolve('main-key');
+        if (envVar === 'AGENTCORE_CREDENTIAL_MYPROJECTAGENT2GEMINI') return Promise.resolve('secondary-key');
+        return Promise.resolve(undefined);
+      });
+
+      const result = await resolveCredentialStrategy(
+        projectName,
+        'Agent3',
+        'Gemini',
+        'secondary-key',
+        configBaseDir,
+        existingCredentials
+      );
+
+      expect(result).toEqual({
+        reuse: true,
+        credentialName: 'MyProjectAgent2Gemini',
+        envVarName: 'AGENTCORE_CREDENTIAL_MYPROJECTAGENT2GEMINI',
+        isAgentScoped: true,
+      });
+    });
+
+    it('agent3 reuses project-scoped credential when using main key', async () => {
+      const existingCredentials: Credential[] = [
+        { name: 'MyProjectGemini', type: 'ApiKeyCredentialProvider' },
+        { name: 'MyProjectAgent2Gemini', type: 'ApiKeyCredentialProvider' },
+      ];
+
+      mockGetEnvVar.mockImplementation((envVar: string) => {
+        if (envVar === 'AGENTCORE_CREDENTIAL_MYPROJECTGEMINI') return Promise.resolve('main-key');
+        if (envVar === 'AGENTCORE_CREDENTIAL_MYPROJECTAGENT2GEMINI') return Promise.resolve('secondary-key');
+        return Promise.resolve(undefined);
+      });
+
+      const result = await resolveCredentialStrategy(
+        projectName,
+        'Agent3',
+        'Gemini',
+        'main-key',
+        configBaseDir,
+        existingCredentials
+      );
+
+      expect(result).toEqual({
+        reuse: true,
         credentialName: 'MyProjectGemini',
         envVarName: 'AGENTCORE_CREDENTIAL_MYPROJECTGEMINI',
         isAgentScoped: false,
+      });
+    });
+
+    it('creates new agent-scoped credential when key matches no existing credential', async () => {
+      const existingCredentials: Credential[] = [
+        { name: 'MyProjectGemini', type: 'ApiKeyCredentialProvider' },
+        { name: 'MyProjectAgent2Gemini', type: 'ApiKeyCredentialProvider' },
+      ];
+
+      mockGetEnvVar.mockImplementation((envVar: string) => {
+        if (envVar === 'AGENTCORE_CREDENTIAL_MYPROJECTGEMINI') return Promise.resolve('main-key');
+        if (envVar === 'AGENTCORE_CREDENTIAL_MYPROJECTAGENT2GEMINI') return Promise.resolve('secondary-key');
+        return Promise.resolve(undefined);
+      });
+
+      const result = await resolveCredentialStrategy(
+        projectName,
+        'Agent3',
+        'Gemini',
+        'third-key',
+        configBaseDir,
+        existingCredentials
+      );
+
+      expect(result).toEqual({
+        reuse: false,
+        credentialName: 'MyProjectAgent3Gemini',
+        envVarName: 'AGENTCORE_CREDENTIAL_MYPROJECTAGENT3GEMINI',
+        isAgentScoped: true,
       });
     });
   });

--- a/src/cli/operations/identity/api-key-credential-provider.ts
+++ b/src/cli/operations/identity/api-key-credential-provider.ts
@@ -11,6 +11,7 @@ import {
   GetApiKeyCredentialProviderCommand,
   ResourceNotFoundException,
   SetTokenVaultCMKCommand,
+  UpdateApiKeyCredentialProviderCommand,
 } from '@aws-sdk/client-bedrock-agentcore-control';
 
 /**
@@ -53,6 +54,30 @@ export async function createApiKeyProvider(
     if (errorName === 'ConflictException' || errorName === 'ResourceAlreadyExistsException') {
       return { success: true };
     }
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/**
+ * Update an existing API key credential provider with a new API key.
+ */
+export async function updateApiKeyProvider(
+  client: BedrockAgentCoreControlClient,
+  providerName: string,
+  apiKey: string
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    await client.send(
+      new UpdateApiKeyCredentialProviderCommand({
+        name: providerName,
+        apiKey: apiKey,
+      })
+    );
+    return { success: true };
+  } catch (error) {
     return {
       success: false,
       error: error instanceof Error ? error.message : String(error),

--- a/src/cli/operations/identity/create-identity.ts
+++ b/src/cli/operations/identity/create-identity.ts
@@ -38,9 +38,8 @@ export function computeDefaultCredentialEnvVarName(credentialName: string): stri
  * - Bedrock uses IAM, no credential needed
  * - No API key provided, no credential needed
  * - No existing credential for provider → create project-scoped
- * - Existing credential but can't read key → create project-scoped (treat as fresh)
- * - Existing credential with matching key → reuse
- * - Existing credential with different key → create agent-scoped
+ * - Any existing credential with matching key → reuse it
+ * - No matching key → create agent-scoped (or project-scoped if first)
  */
 export async function resolveCredentialStrategy(
   projectName: string,
@@ -60,31 +59,27 @@ export async function resolveCredentialStrategy(
     return { reuse: true, credentialName: '', envVarName: '', isAgentScoped: false };
   }
 
-  // Check for existing project-scoped credential
-  const projectScopedName = `${projectName}${modelProvider}`;
-  const existingCredential = existingCredentials.find(c => c.name === projectScopedName);
+  // Check ALL existing credentials for a matching API key
+  for (const cred of existingCredentials) {
+    const envVarName = computeDefaultCredentialEnvVarName(cred.name);
+    const existingApiKey = await getEnvVar(envVarName, configBaseDir);
+    if (existingApiKey === newApiKey) {
+      const isAgentScoped = cred.name !== `${projectName}${modelProvider}`;
+      return { reuse: true, credentialName: cred.name, envVarName, isAgentScoped };
+    }
+  }
 
-  if (!existingCredential) {
-    // First agent with this provider - create project-scoped credential
+  // No matching key found - create new credential
+  const projectScopedName = `${projectName}${modelProvider}`;
+  const hasProjectScoped = existingCredentials.some(c => c.name === projectScopedName);
+
+  if (!hasProjectScoped) {
+    // First agent with this provider - create project-scoped
     const envVarName = computeDefaultCredentialEnvVarName(projectScopedName);
     return { reuse: false, credentialName: projectScopedName, envVarName, isAgentScoped: false };
   }
 
-  // Credential exists - compare API keys
-  const existingEnvVarName = computeDefaultCredentialEnvVarName(projectScopedName);
-  const existingApiKey = await getEnvVar(existingEnvVarName, configBaseDir);
-
-  if (existingApiKey === undefined) {
-    // Can't read existing key - treat as no existing credential
-    return { reuse: false, credentialName: projectScopedName, envVarName: existingEnvVarName, isAgentScoped: false };
-  }
-
-  if (existingApiKey === newApiKey) {
-    // Same key - reuse existing credential
-    return { reuse: true, credentialName: projectScopedName, envVarName: existingEnvVarName, isAgentScoped: false };
-  }
-
-  // Different key - create agent-scoped credential
+  // Project-scoped exists with different key - create agent-scoped
   const agentScopedName = `${projectName}${agentName}${modelProvider}`;
   const agentScopedEnvVarName = computeDefaultCredentialEnvVarName(agentScopedName);
   return { reuse: false, credentialName: agentScopedName, envVarName: agentScopedEnvVarName, isAgentScoped: true };

--- a/src/cli/operations/identity/create-identity.ts
+++ b/src/cli/operations/identity/create-identity.ts
@@ -1,5 +1,5 @@
-import { ConfigIO, setEnvVar } from '../../../lib';
-import type { Credential } from '../../../schema';
+import { ConfigIO, getEnvVar, setEnvVar } from '../../../lib';
+import type { Credential, ModelProvider } from '../../../schema';
 
 /**
  * Config for creating a credential resource.
@@ -10,10 +10,84 @@ export interface CreateCredentialConfig {
 }
 
 /**
+ * Result of resolving credential strategy for an agent.
+ */
+export interface CredentialStrategy {
+  /** True if reusing existing credential, false if creating new */
+  reuse: boolean;
+  /** Credential name to use (empty string if no credential needed) */
+  credentialName: string;
+  /** Environment variable name for the API key */
+  envVarName: string;
+  /** True if this is an agent-scoped credential */
+  isAgentScoped: boolean;
+}
+
+/**
  * Compute the default env var name for a credential.
  */
 export function computeDefaultCredentialEnvVarName(credentialName: string): string {
   return `AGENTCORE_CREDENTIAL_${credentialName.toUpperCase()}`;
+}
+
+/**
+ * Resolve credential strategy for adding an agent.
+ * Determines whether to reuse existing credential or create new one.
+ *
+ * Logic:
+ * - Bedrock uses IAM, no credential needed
+ * - No API key provided, no credential needed
+ * - No existing credential for provider → create project-scoped
+ * - Existing credential but can't read key → create project-scoped (treat as fresh)
+ * - Existing credential with matching key → reuse
+ * - Existing credential with different key → create agent-scoped
+ */
+export async function resolveCredentialStrategy(
+  projectName: string,
+  agentName: string,
+  modelProvider: ModelProvider,
+  newApiKey: string | undefined,
+  configBaseDir: string,
+  existingCredentials: Credential[]
+): Promise<CredentialStrategy> {
+  // Bedrock uses IAM, no credential needed
+  if (modelProvider === 'Bedrock') {
+    return { reuse: true, credentialName: '', envVarName: '', isAgentScoped: false };
+  }
+
+  // No API key provided, no credential needed
+  if (!newApiKey) {
+    return { reuse: true, credentialName: '', envVarName: '', isAgentScoped: false };
+  }
+
+  // Check for existing project-scoped credential
+  const projectScopedName = `${projectName}${modelProvider}`;
+  const existingCredential = existingCredentials.find(c => c.name === projectScopedName);
+
+  if (!existingCredential) {
+    // First agent with this provider - create project-scoped credential
+    const envVarName = computeDefaultCredentialEnvVarName(projectScopedName);
+    return { reuse: false, credentialName: projectScopedName, envVarName, isAgentScoped: false };
+  }
+
+  // Credential exists - compare API keys
+  const existingEnvVarName = computeDefaultCredentialEnvVarName(projectScopedName);
+  const existingApiKey = await getEnvVar(existingEnvVarName, configBaseDir);
+
+  if (existingApiKey === undefined) {
+    // Can't read existing key - treat as no existing credential
+    return { reuse: false, credentialName: projectScopedName, envVarName: existingEnvVarName, isAgentScoped: false };
+  }
+
+  if (existingApiKey === newApiKey) {
+    // Same key - reuse existing credential
+    return { reuse: true, credentialName: projectScopedName, envVarName: existingEnvVarName, isAgentScoped: false };
+  }
+
+  // Different key - create agent-scoped credential
+  const agentScopedName = `${projectName}${agentName}${modelProvider}`;
+  const agentScopedEnvVarName = computeDefaultCredentialEnvVarName(agentScopedName);
+  return { reuse: false, credentialName: agentScopedName, envVarName: agentScopedEnvVarName, isAgentScoped: true };
 }
 
 // Alias for old name

--- a/src/cli/operations/identity/index.ts
+++ b/src/cli/operations/identity/index.ts
@@ -1,1 +1,11 @@
-export { apiKeyProviderExists, createApiKeyProvider, setTokenVaultKmsKey } from './api-key-credential-provider';
+export {
+  apiKeyProviderExists,
+  createApiKeyProvider,
+  setTokenVaultKmsKey,
+  updateApiKeyProvider,
+} from './api-key-credential-provider';
+export {
+  computeDefaultCredentialEnvVarName,
+  resolveCredentialStrategy,
+  type CredentialStrategy,
+} from './create-identity';

--- a/src/cli/operations/remove/__tests__/get-agent-scoped-credentials.test.ts
+++ b/src/cli/operations/remove/__tests__/get-agent-scoped-credentials.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest';
 describe('getAgentScopedCredentials', () => {
   const projectName = 'MyProject';
 
-  const makeCredential = (name: string): Credential => ({ name, type: 'ApiKey' });
+  const makeCredential = (name: string): Credential => ({ name, type: 'ApiKeyCredentialProvider' });
 
   describe('matches agent-scoped credentials', () => {
     it('matches credential for the specified agent', () => {
@@ -14,7 +14,7 @@ describe('getAgentScopedCredentials', () => {
       const result = getAgentScopedCredentials(projectName, 'Agent2', credentials);
 
       expect(result).toHaveLength(1);
-      expect(result[0].name).toBe('MyProjectAgent2Gemini');
+      expect(result[0]!.name).toBe('MyProjectAgent2Gemini');
     });
 
     it('matches multiple providers for same agent', () => {
@@ -76,7 +76,7 @@ describe('getAgentScopedCredentials', () => {
       const result = getAgentScopedCredentials(projectName, 'TestA', credentials);
 
       expect(result).toHaveLength(1);
-      expect(result[0].name).toBe('MyProjectTestAGemini');
+      expect(result[0]!.name).toBe('MyProjectTestAGemini');
     });
 
     it('TestAB does NOT match TestA credentials', () => {
@@ -85,7 +85,7 @@ describe('getAgentScopedCredentials', () => {
       const result = getAgentScopedCredentials(projectName, 'TestAB', credentials);
 
       expect(result).toHaveLength(1);
-      expect(result[0].name).toBe('MyProjectTestABGemini');
+      expect(result[0]!.name).toBe('MyProjectTestABGemini');
     });
 
     it('handles agent names with numbers', () => {

--- a/src/cli/operations/remove/__tests__/get-agent-scoped-credentials.test.ts
+++ b/src/cli/operations/remove/__tests__/get-agent-scoped-credentials.test.ts
@@ -1,0 +1,112 @@
+import type { Credential } from '../../../../schema/index.js';
+import { getAgentScopedCredentials } from '../remove-agent.js';
+import { describe, expect, it } from 'vitest';
+
+describe('getAgentScopedCredentials', () => {
+  const projectName = 'MyProject';
+
+  const makeCredential = (name: string): Credential => ({ name, type: 'ApiKey' });
+
+  describe('matches agent-scoped credentials', () => {
+    it('matches credential for the specified agent', () => {
+      const credentials = [makeCredential('MyProjectAgent2Gemini'), makeCredential('MyProjectGemini')];
+
+      const result = getAgentScopedCredentials(projectName, 'Agent2', credentials);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('MyProjectAgent2Gemini');
+    });
+
+    it('matches multiple providers for same agent', () => {
+      const credentials = [
+        makeCredential('MyProjectAgent2Gemini'),
+        makeCredential('MyProjectAgent2OpenAI'),
+        makeCredential('MyProjectAgent2Anthropic'),
+      ];
+
+      const result = getAgentScopedCredentials(projectName, 'Agent2', credentials);
+
+      expect(result).toHaveLength(3);
+    });
+
+    it('matches OpenAI provider', () => {
+      const credentials = [makeCredential('MyProjectAgent1OpenAI')];
+      const result = getAgentScopedCredentials(projectName, 'Agent1', credentials);
+      expect(result).toHaveLength(1);
+    });
+
+    it('matches Anthropic provider', () => {
+      const credentials = [makeCredential('MyProjectAgent1Anthropic')];
+      const result = getAgentScopedCredentials(projectName, 'Agent1', credentials);
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe('does NOT match', () => {
+    it('does not match project-scoped credentials', () => {
+      const credentials = [makeCredential('MyProjectGemini')];
+
+      const result = getAgentScopedCredentials(projectName, 'Agent1', credentials);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('does not match credentials for different agent', () => {
+      const credentials = [makeCredential('MyProjectAgent1Gemini')];
+
+      const result = getAgentScopedCredentials(projectName, 'Agent2', credentials);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('does not match Bedrock (no credentials)', () => {
+      const credentials = [makeCredential('MyProjectAgent1Bedrock')];
+
+      const result = getAgentScopedCredentials(projectName, 'Agent1', credentials);
+
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('pattern edge cases', () => {
+    it('TestA does NOT match TestAB credentials', () => {
+      // Critical edge case: Agent "TestA" should not match "TestAB"'s credentials
+      const credentials = [makeCredential('MyProjectTestAGemini'), makeCredential('MyProjectTestABGemini')];
+
+      const result = getAgentScopedCredentials(projectName, 'TestA', credentials);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('MyProjectTestAGemini');
+    });
+
+    it('TestAB does NOT match TestA credentials', () => {
+      const credentials = [makeCredential('MyProjectTestAGemini'), makeCredential('MyProjectTestABGemini')];
+
+      const result = getAgentScopedCredentials(projectName, 'TestAB', credentials);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe('MyProjectTestABGemini');
+    });
+
+    it('handles agent names with numbers', () => {
+      const credentials = [makeCredential('MyProjectAgent123Gemini')];
+
+      const result = getAgentScopedCredentials(projectName, 'Agent123', credentials);
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('returns empty array for empty credentials', () => {
+      const result = getAgentScopedCredentials(projectName, 'Agent1', []);
+      expect(result).toHaveLength(0);
+    });
+
+    it('handles project names with numbers', () => {
+      const credentials = [makeCredential('Project123Agent1Gemini')];
+
+      const result = getAgentScopedCredentials('Project123', 'Agent1', credentials);
+
+      expect(result).toHaveLength(1);
+    });
+  });
+});

--- a/src/cli/operations/remove/remove-agent.ts
+++ b/src/cli/operations/remove/remove-agent.ts
@@ -37,6 +37,7 @@ export async function getRemovableAgents(): Promise<string[]> {
 
 /**
  * Preview what will be removed when removing an agent.
+ * Note: Credentials are preserved to allow reuse if agent is re-added.
  */
 export async function previewRemoveAgent(agentName: string): Promise<RemovalPreview> {
   const configIO = new ConfigIO();
@@ -50,17 +51,9 @@ export async function previewRemoveAgent(agentName: string): Promise<RemovalPrev
   const summary: string[] = [`Removing agent: ${agentName}`];
   const schemaChanges: SchemaChange[] = [];
 
-  // Identify agent-scoped credentials
-  const agentCredentials = getAgentScopedCredentials(project.name, agentName, project.credentials);
-  if (agentCredentials.length > 0) {
-    summary.push(`Will remove ${agentCredentials.length} agent-scoped credential(s):`);
-    agentCredentials.forEach(c => summary.push(`  - ${c.name}`));
-  }
-
   const afterSpec = {
     ...project,
     agents: project.agents.filter(a => a.name !== agentName),
-    credentials: project.credentials.filter(c => !agentCredentials.some(ac => ac.name === c.name)),
   };
 
   schemaChanges.push({
@@ -74,6 +67,7 @@ export async function previewRemoveAgent(agentName: string): Promise<RemovalPrev
 
 /**
  * Remove an agent from the project.
+ * Note: Credentials are preserved to allow reuse if agent is re-added.
  */
 export async function removeAgent(agentName: string): Promise<RemovalResult> {
   try {
@@ -85,12 +79,8 @@ export async function removeAgent(agentName: string): Promise<RemovalResult> {
       return { ok: false, error: `Agent "${agentName}" not found.` };
     }
 
-    // Remove agent
+    // Remove agent (credentials preserved for potential reuse)
     project.agents.splice(agentIndex, 1);
-
-    // Remove agent-scoped credentials
-    const agentCredentials = getAgentScopedCredentials(project.name, agentName, project.credentials);
-    project.credentials = project.credentials.filter(c => !agentCredentials.some(ac => ac.name === c.name));
 
     await configIO.writeProjectSpec(project);
 

--- a/src/cli/operations/remove/remove-agent.ts
+++ b/src/cli/operations/remove/remove-agent.ts
@@ -1,5 +1,26 @@
 import { ConfigIO } from '../../../lib';
+import type { Credential } from '../../../schema';
 import type { RemovalPreview, RemovalResult, SchemaChange } from './types';
+
+// Providers that use credentials (Bedrock uses IAM, no credential)
+export const CREDENTIAL_PROVIDERS = ['Gemini', 'OpenAI', 'Anthropic'] as const;
+
+/**
+ * Find agent-scoped credentials for a given agent.
+ * Pattern: {projectName}{agentName}{provider}
+ */
+export function getAgentScopedCredentials(
+  projectName: string,
+  agentName: string,
+  credentials: Credential[]
+): Credential[] {
+  const prefix = `${projectName}${agentName}`;
+  return credentials.filter(c => {
+    if (!c.name.startsWith(prefix)) return false;
+    const suffix = c.name.slice(prefix.length);
+    return CREDENTIAL_PROVIDERS.includes(suffix as (typeof CREDENTIAL_PROVIDERS)[number]);
+  });
+}
 
 /**
  * Get list of agents available for removal.
@@ -29,9 +50,17 @@ export async function previewRemoveAgent(agentName: string): Promise<RemovalPrev
   const summary: string[] = [`Removing agent: ${agentName}`];
   const schemaChanges: SchemaChange[] = [];
 
+  // Identify agent-scoped credentials
+  const agentCredentials = getAgentScopedCredentials(project.name, agentName, project.credentials);
+  if (agentCredentials.length > 0) {
+    summary.push(`Will remove ${agentCredentials.length} agent-scoped credential(s):`);
+    agentCredentials.forEach(c => summary.push(`  - ${c.name}`));
+  }
+
   const afterSpec = {
     ...project,
     agents: project.agents.filter(a => a.name !== agentName),
+    credentials: project.credentials.filter(c => !agentCredentials.some(ac => ac.name === c.name)),
   };
 
   schemaChanges.push({
@@ -56,7 +85,13 @@ export async function removeAgent(agentName: string): Promise<RemovalResult> {
       return { ok: false, error: `Agent "${agentName}" not found.` };
     }
 
+    // Remove agent
     project.agents.splice(agentIndex, 1);
+
+    // Remove agent-scoped credentials
+    const agentCredentials = getAgentScopedCredentials(project.name, agentName, project.credentials);
+    project.credentials = project.credentials.filter(c => !agentCredentials.some(ac => ac.name === c.name));
+
     await configIO.writeProjectSpec(project);
 
     return { ok: true };

--- a/src/cli/tui/screens/agent/useAddAgent.ts
+++ b/src/cli/tui/screens/agent/useAddAgent.ts
@@ -5,9 +5,10 @@ import { type PythonSetupResult, setupPythonProject } from '../../../operations'
 import {
   mapGenerateConfigToRenderConfig,
   mapModelProviderToCredentials,
+  mapModelProviderToIdentityProviders,
   writeAgentToProject,
 } from '../../../operations/agent/generate';
-import { computeDefaultCredentialEnvVarName } from '../../../operations/identity/create-identity';
+import { resolveCredentialStrategy } from '../../../operations/identity/create-identity';
 import { createRenderer } from '../../../templates';
 import type { GenerateConfig } from '../generate/types';
 import type { AddAgentConfig } from './types';
@@ -138,26 +139,50 @@ async function handleCreatePath(
   const generateConfig = mapAddAgentConfigToGenerateConfig(config);
   const agentPath = join(projectRoot, config.name);
 
-  // Generate agent files - pass actual project name for credential naming
-  const renderConfig = mapGenerateConfigToRenderConfig(generateConfig, project.name);
+  // Resolve credential strategy FIRST to determine correct credential name
+  let identityProviders: ReturnType<typeof mapModelProviderToIdentityProviders> = [];
+  let strategy: Awaited<ReturnType<typeof resolveCredentialStrategy>> | undefined;
+
+  if (config.modelProvider !== 'Bedrock') {
+    strategy = await resolveCredentialStrategy(
+      project.name,
+      config.name,
+      config.modelProvider,
+      config.apiKey,
+      configBaseDir,
+      project.credentials
+    );
+
+    // Build identity providers with the correct credential name from strategy
+    identityProviders = [
+      {
+        name: strategy.credentialName,
+        envVarName: strategy.envVarName,
+      },
+    ];
+  }
+
+  // Generate agent files with correct identity provider
+  const renderConfig = mapGenerateConfigToRenderConfig(generateConfig, identityProviders);
   const renderer = createRenderer(renderConfig);
   await renderer.render({ outputDir: projectRoot });
 
   // Write agent to project config
-  await writeAgentToProject(generateConfig, { configBaseDir });
+  if (strategy) {
+    await writeAgentToProject(generateConfig, { configBaseDir, credentialStrategy: strategy });
+
+    if (config.apiKey) {
+      await setEnvVar(strategy.envVarName, config.apiKey, configBaseDir);
+    }
+  } else {
+    // Bedrock: no credentials needed
+    await writeAgentToProject(generateConfig, { configBaseDir });
+  }
 
   // Set up Python environment if applicable
   let pythonSetupResult: PythonSetupResult | undefined;
   if (config.language === 'Python') {
     pythonSetupResult = await setupPythonProject({ projectDir: agentPath });
-  }
-
-  // Write API key to agentcore/.env for non-Bedrock providers
-  if (config.apiKey && config.modelProvider !== 'Bedrock') {
-    // Use project-scoped credential name: {projectName}{modelProvider}
-    const credentialName = `${project.name}${config.modelProvider}`;
-    const envVarName = computeDefaultCredentialEnvVarName(credentialName);
-    await setEnvVar(envVarName, config.apiKey, configBaseDir);
   }
 
   return {
@@ -183,19 +208,34 @@ async function handleByoPath(
   // Append new agent
   project.agents.push(agent);
 
-  // Add credentials for non-Bedrock providers
-  const credentials = mapModelProviderToCredentials(config.modelProvider, project.name);
-  project.credentials.push(...credentials);
+  // Handle credential creation with smart reuse detection
+  if (config.modelProvider !== 'Bedrock') {
+    const strategy = await resolveCredentialStrategy(
+      project.name,
+      config.name,
+      config.modelProvider,
+      config.apiKey,
+      configBaseDir,
+      project.credentials
+    );
 
-  // Write updated project
-  await configIO.writeProjectSpec(project);
+    if (!strategy.reuse) {
+      const credentials = mapModelProviderToCredentials(config.modelProvider, project.name);
+      if (credentials.length > 0) {
+        credentials[0].name = strategy.credentialName;
+        project.credentials.push(...credentials);
+      }
+    }
 
-  // Write API key to agentcore/.env for non-Bedrock providers
-  if (config.apiKey && config.modelProvider !== 'Bedrock') {
-    // Use project-scoped credential name: {projectName}{modelProvider}
-    const credentialName = `${project.name}${config.modelProvider}`;
-    const envVarName = computeDefaultCredentialEnvVarName(credentialName);
-    await setEnvVar(envVarName, config.apiKey, configBaseDir);
+    // Write updated project
+    await configIO.writeProjectSpec(project);
+
+    if (config.apiKey) {
+      await setEnvVar(strategy.envVarName, config.apiKey, configBaseDir);
+    }
+  } else {
+    // Bedrock: no credentials needed
+    await configIO.writeProjectSpec(project);
   }
 
   return { ok: true, type: 'byo', agentName: config.name };

--- a/src/cli/tui/screens/agent/useAddAgent.ts
+++ b/src/cli/tui/screens/agent/useAddAgent.ts
@@ -222,7 +222,7 @@ async function handleByoPath(
     if (!strategy.reuse) {
       const credentials = mapModelProviderToCredentials(config.modelProvider, project.name);
       if (credentials.length > 0) {
-        credentials[0].name = strategy.credentialName;
+        credentials[0]!.name = strategy.credentialName;
         project.credentials.push(...credentials);
       }
     }

--- a/src/cli/tui/screens/create/useCreateFlow.ts
+++ b/src/cli/tui/screens/create/useCreateFlow.ts
@@ -358,7 +358,7 @@ export function useCreateFlow(cwd: string): CreateFlowState {
                   if (!strategy.reuse) {
                     const credentials = mapModelProviderToCredentials(addAgentConfig.modelProvider, project.name);
                     if (credentials.length > 0) {
-                      credentials[0].name = strategy.credentialName;
+                      credentials[0]!.name = strategy.credentialName;
                       project.credentials.push(...credentials);
                     }
                   }

--- a/src/cli/tui/screens/create/useCreateFlow.ts
+++ b/src/cli/tui/screens/create/useCreateFlow.ts
@@ -6,9 +6,10 @@ import { initGitRepo, setupPythonProject, writeEnvFile, writeGitignore } from '.
 import {
   mapGenerateConfigToRenderConfig,
   mapModelProviderToCredentials,
+  mapModelProviderToIdentityProviders,
   writeAgentToProject,
 } from '../../../operations/agent/generate';
-import { computeDefaultCredentialEnvVarName } from '../../../operations/identity/create-identity';
+import { resolveCredentialStrategy } from '../../../operations/identity/create-identity';
 import { CDKRenderer, createRenderer } from '../../../templates';
 import { type Step, areStepsComplete, hasStepError } from '../../components';
 import { withMinDuration } from '../../utils';
@@ -295,13 +296,46 @@ export function useCreateFlow(cwd: string): CreateFlowState {
                 };
 
                 logger.logSubStep(`Framework: ${generateConfig.sdk}`);
-                // Pass actual project name for credential naming in templates
-                const renderConfig = mapGenerateConfigToRenderConfig(generateConfig, projectName);
+
+                // Resolve credential strategy FIRST (new project has no existing credentials)
+                let identityProviders: ReturnType<typeof mapModelProviderToIdentityProviders> = [];
+                let strategy: Awaited<ReturnType<typeof resolveCredentialStrategy>> | undefined;
+
+                if (addAgentConfig.modelProvider !== 'Bedrock') {
+                  strategy = await resolveCredentialStrategy(
+                    projectName,
+                    addAgentConfig.name,
+                    addAgentConfig.modelProvider,
+                    addAgentConfig.apiKey,
+                    configBaseDir,
+                    [] // New project has no existing credentials
+                  );
+
+                  identityProviders = [
+                    {
+                      name: strategy.credentialName,
+                      envVarName: strategy.envVarName,
+                    },
+                  ];
+                }
+
+                // Render with correct identity provider
+                const renderConfig = mapGenerateConfigToRenderConfig(generateConfig, identityProviders);
                 const renderer = createRenderer(renderConfig);
                 logger.logSubStep('Rendering agent template...');
                 await renderer.render({ outputDir: projectRoot });
                 logger.logSubStep('Writing agent to project...');
-                await writeAgentToProject(generateConfig, { configBaseDir });
+
+                if (strategy) {
+                  await writeAgentToProject(generateConfig, { configBaseDir, credentialStrategy: strategy });
+
+                  if (addAgentConfig.apiKey) {
+                    logger.logSubStep('Writing API key to .env...');
+                    await setEnvVar(strategy.envVarName, addAgentConfig.apiKey, configBaseDir);
+                  }
+                } else {
+                  await writeAgentToProject(generateConfig, { configBaseDir });
+                }
               } else {
                 // BYO path: just write config to project (no file generation)
                 logger.logSubStep('Writing BYO agent config to project...');
@@ -309,19 +343,33 @@ export function useCreateFlow(cwd: string): CreateFlowState {
                 const project = await configIO.readProjectSpec();
                 const agent = mapByoConfigToAgent(addAgentConfig);
                 project.agents.push(agent);
-                // Add credentials for non-Bedrock providers
-                const credentials = mapModelProviderToCredentials(addAgentConfig.modelProvider, project.name);
-                project.credentials.push(...credentials);
-                await configIO.writeProjectSpec(project);
-              }
 
-              // Write API key to agentcore/.env for non-Bedrock providers
-              if (addAgentConfig.apiKey && addAgentConfig.modelProvider !== 'Bedrock') {
-                logger.logSubStep('Writing API key to .env...');
-                // Use project-scoped credential name: {projectName}{modelProvider}
-                const credentialName = `${projectName}${addAgentConfig.modelProvider}`;
-                const envVarName = computeDefaultCredentialEnvVarName(credentialName);
-                await setEnvVar(envVarName, addAgentConfig.apiKey, configBaseDir);
+                // Handle credentials for BYO (new project, so always project-scoped)
+                if (addAgentConfig.modelProvider !== 'Bedrock') {
+                  const strategy = await resolveCredentialStrategy(
+                    projectName,
+                    addAgentConfig.name,
+                    addAgentConfig.modelProvider,
+                    addAgentConfig.apiKey,
+                    configBaseDir,
+                    [] // New project has no existing credentials
+                  );
+
+                  if (!strategy.reuse) {
+                    const credentials = mapModelProviderToCredentials(addAgentConfig.modelProvider, project.name);
+                    if (credentials.length > 0) {
+                      credentials[0].name = strategy.credentialName;
+                      project.credentials.push(...credentials);
+                    }
+                  }
+
+                  if (addAgentConfig.apiKey) {
+                    logger.logSubStep('Writing API key to .env...');
+                    await setEnvVar(strategy.envVarName, addAgentConfig.apiKey, configBaseDir);
+                  }
+                }
+
+                await configIO.writeProjectSpec(project);
               }
             });
             logger.endStep('success');

--- a/src/cli/tui/screens/generate/useGenerateFlow.ts
+++ b/src/cli/tui/screens/generate/useGenerateFlow.ts
@@ -1,7 +1,11 @@
 import { APP_DIR, ConfigIO } from '../../../../lib';
 import { getErrorMessage } from '../../../errors';
 import { type PythonSetupResult, setupPythonProject } from '../../../operations';
-import { mapGenerateConfigToRenderConfig, writeAgentToProject } from '../../../operations/agent/generate';
+import {
+  mapGenerateConfigToRenderConfig,
+  mapModelProviderToIdentityProviders,
+  writeAgentToProject,
+} from '../../../operations/agent/generate';
 import { createRenderer } from '../../../templates';
 import type { Step } from '../../components';
 import { useProject } from '../../hooks';
@@ -68,8 +72,9 @@ export function useGenerateFlow(): GenerateFlowState {
         const configIO = new ConfigIO({ baseDir: project.configRoot });
         const projectSpec = await configIO.readProjectSpec();
 
-        // Pass actual project name for credential naming in templates
-        const renderConfig = mapGenerateConfigToRenderConfig(config, projectSpec.name);
+        // Build identity providers for template rendering
+        const identityProviders = mapModelProviderToIdentityProviders(config.modelProvider, projectSpec.name);
+        const renderConfig = mapGenerateConfigToRenderConfig(config, identityProviders);
         const renderer = createRenderer(renderConfig);
         await renderer.render({ outputDir: project.projectRoot });
         await writeAgentToProject(config);


### PR DESCRIPTION
## Description

Implements smart credential detection for multi-agent projects. When adding a new agent with a non-Bedrock model provider:

- **Same API key as existing agent** → Reuses the project-scoped credential ({projectName}{provider})
- **Different API key** → Creates an agent-scoped credential ({projectName}{agentName}{provider})

Fixes Issue #148, #162, and #169

### Deploy Flow Fixes:

Problem: After destroy and redeploy, credentials weren't being recreated because:
1. Mainline only showed missing credentials in the prompt - if .env.local had the key, it was skipped
2. If provider already existed, mainline returned 'exists' without updating - stale credentials persisted

Solution:
- getAllCredentials() - Shows ALL credentials in prompt, not just missing ones
- Always update provider on deploy - ensures credentials stay in sync with .env.local
- Added updateApiKeyProvider() to update existing providers

### Other Fixes:
- getAgentScopedCredentials() - Cleans up agent-scoped credentials on agent removal
- Fixed double-execution bugs in useCdkPreflight and CredentialSourcePrompt


## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran npm run test:all
- [ ] I ran npm run typecheck
- [ ] I ran npm run lint
- [x] If I modified src/assets/, I ran npm run test:update-snapshots and committed the updated snapshots

Note: typecheck and lint have pre-existing failures in mainline unrelated to this PR.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.