### PR TITLE
fix: use google-genai instead of google-generativeai for strands template

### DIFF
--- a/src/assets/python/strands/base/pyproject.toml
+++ b/src/assets/python/strands/base/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "opentelemetry-exporter-otlp",
     "bedrock-agentcore >= 1.0.3",
     "botocore[crt] >= 1.35.0",
-    "google-generativeai >= 0.5.0",
+    "google-genai >= 1.0.0",
     "openai >= 1.0.0",
     "python-dotenv >= 1.0.1",
     "strands-agents >= 1.13.0",


### PR DESCRIPTION
 ## Description

Fixes ImportError: cannot import name 'genai' from 'google' when running strands agents with Gemini model provider.

The strands SDK's strands.models.gemini module uses from google import genai, which requires the google-genai package. The template was incorrectly specifying google-generativeai (the older SDK with a different
import path).

### Change
- src/assets/python/strands/base/pyproject.toml: google-generativeai >= 0.5.0 → google-genai >= 1.0.0
