### PR TITLE
fix: resolve ESLint errors across codebase

### DIFF
--- a/src/cli/commands/package/action.ts
+++ b/src/cli/commands/package/action.ts
@@ -40,7 +40,7 @@ export interface PackageResult {
   error?: string;
 }
 
-export async function handlePackage(context: PackageContext): Promise<PackageResult> {
+export function handlePackage(context: PackageContext): PackageResult {
   const { project, configBaseDir, targetAgent } = context;
   const results: PackageAgentResult[] = [];
   const skipped: string[] = [];

--- a/src/cli/commands/package/command.tsx
+++ b/src/cli/commands/package/command.tsx
@@ -14,7 +14,7 @@ export const registerPackage = (program: Command) => {
     .action(async options => {
       try {
         const context = await loadPackageConfig(options);
-        const result = await handlePackage(context);
+        const result = handlePackage(context);
 
         // Report skipped agents
         for (const name of result.skipped) {

--- a/src/cli/tui/components/ResourceGraph.tsx
+++ b/src/cli/tui/components/ResourceGraph.tsx
@@ -1,6 +1,5 @@
 import type {
   AgentCoreDeployedState,
-  AgentCoreGateway,
   AgentCoreMcpRuntimeTool,
   AgentCoreMcpSpec,
   AgentCoreProjectSpec,
@@ -80,7 +79,13 @@ function ResourceRow({
   );
 }
 
-export function ResourceGraph({ project, mcp, agentName, agentStatuses, deployedAgents }: ResourceGraphProps) {
+export function ResourceGraph({
+  project,
+  mcp,
+  agentName,
+  agentStatuses,
+  deployedAgents: _deployedAgents,
+}: ResourceGraphProps) {
   const allAgents = project.agents ?? [];
   const agents = agentName ? allAgents.filter(a => a.name === agentName) : allAgents;
   const memories = project.memories ?? [];

--- a/src/cli/tui/hooks/useAttach.ts
+++ b/src/cli/tui/hooks/useAttach.ts
@@ -97,35 +97,39 @@ export const useOwnedMemories = useMemories;
 export const useOwnedIdentities = useCredentials;
 
 // Stub attach hooks (no-op in v2, resources have implicit access)
+const noop = () => {
+  /* no-op */
+};
+
 export function useAttachAgent() {
   return {
-    attach: async () => ({ ok: true as const }),
+    attach: () => Promise.resolve({ ok: true as const }),
     isLoading: false,
-    reset: () => {},
+    reset: noop,
   };
 }
 
 export function useAttachMemory() {
   return {
-    attach: async () => ({ ok: true as const }),
+    attach: () => Promise.resolve({ ok: true as const }),
     isLoading: false,
-    reset: () => {},
+    reset: noop,
   };
 }
 
 export function useAttachIdentity() {
   return {
-    attach: async () => ({ ok: true as const }),
+    attach: () => Promise.resolve({ ok: true as const }),
     isLoading: false,
-    reset: () => {},
+    reset: noop,
   };
 }
 
 export function useAttachGateway() {
   return {
-    attach: async () => ({ ok: true as const }),
+    attach: () => Promise.resolve({ ok: true as const }),
     isLoading: false,
-    reset: () => {},
+    reset: noop,
   };
 }
 

--- a/src/cli/tui/hooks/useListNavigation.ts
+++ b/src/cli/tui/hooks/useListNavigation.ts
@@ -1,5 +1,5 @@
 import { useInput } from 'ink';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 interface UseListNavigationOptions<T> {
   /** The list of items to navigate */
@@ -69,13 +69,13 @@ export function useListNavigation<T>({
     return idx >= 0 ? idx : 0;
   });
 
-  // Reset selection when resetKey changes
-  useEffect(() => {
-    if (resetKey !== undefined) {
-      const idx = isDisabled ? items.findIndex(item => !isDisabled(item)) : 0;
-      setSelectedIndex(idx >= 0 ? idx : 0);
-    }
-  }, [resetKey]);
+  // Reset selection when resetKey changes (using state sync pattern to avoid setState in effect)
+  const [prevResetKey, setPrevResetKey] = useState(resetKey);
+  if (resetKey !== undefined && resetKey !== prevResetKey) {
+    setPrevResetKey(resetKey);
+    const idx = isDisabled ? items.findIndex(item => !isDisabled(item)) : 0;
+    setSelectedIndex(idx >= 0 ? idx : 0);
+  }
 
   // Find next non-disabled index in given direction
   const findNextIndex = (current: number, direction: 1 | -1): number => {

--- a/src/cli/tui/screens/agent/AddAgentFlow.tsx
+++ b/src/cli/tui/screens/agent/AddAgentFlow.tsx
@@ -14,6 +14,6 @@ interface AddAgentFlowProps {
   onDeploy?: () => void;
 }
 
-export function AddAgentFlow({ existingAgentNames, onComplete, onBack, onDeploy }: AddAgentFlowProps) {
+export function AddAgentFlow({ existingAgentNames, onComplete, onBack, onDeploy: _onDeploy }: AddAgentFlowProps) {
   return <AddAgentScreen existingAgentNames={existingAgentNames} onComplete={onComplete} onExit={onBack} />;
 }

--- a/src/cli/tui/screens/package/PackageScreen.tsx
+++ b/src/cli/tui/screens/package/PackageScreen.tsx
@@ -114,7 +114,7 @@ export function PackageScreen({ isInteractive: _isInteractive, onExit }: Package
           try {
             // Package this specific agent
             const singleAgentContext = { ...context, targetAgent: agent.name };
-            const result = await handlePackage(singleAgentContext);
+            const result = handlePackage(singleAgentContext);
 
             const agentResult = result.results[0];
             if (agentResult) {

--- a/src/lib/packaging/node.ts
+++ b/src/lib/packaging/node.ts
@@ -33,7 +33,7 @@ function isNodeRuntimeVersion(version: RuntimeVersion): version is NodeRuntime {
  * Extracts Node version from runtime constant.
  * Example: NODE_20 -> "20" (for use with node version checks)
  */
-function extractNodeVersion(runtime: NodeRuntime): string {
+function _extractNodeVersion(runtime: NodeRuntime): string {
   const match = NODE_RUNTIME_REGEX.exec(runtime);
   if (!match) {
     throw new PackagingError(`Unsupported Node runtime value: ${runtime}`);


### PR DESCRIPTION
## Summary
- Remove unused imports and prefix unused parameters with underscore
- Convert async functions without await to sync where appropriate  
- Replace setState in useEffect with state sync pattern to avoid cascading renders
- Use shared noop function for empty stub methods

## Test plan
- [x] `npm run lint` passes with 0 errors
- [x] Pre-commit hooks pass (eslint, prettier, secretlint, typecheck)