### PR TITLE
fix: add retry logic for CDK changeset conflicts and improve deploy loggin

### DIFF
--- a/src/cli/__tests__/errors.test.ts
+++ b/src/cli/__tests__/errors.test.ts
@@ -161,9 +161,9 @@ describe('errors', () => {
 
     it('returns true for changeset in progress message patterns', () => {
       expect(isChangesetInProgressError(new Error('ChangeSet is currently in progress'))).toBe(true);
-      expect(
-        isChangesetInProgressError(new Error('An operation on this changeset is currently in progress'))
-      ).toBe(true);
+      expect(isChangesetInProgressError(new Error('An operation on this changeset is currently in progress'))).toBe(
+        true
+      );
     });
 
     it('returns false for other errors', () => {

--- a/src/cli/__tests__/errors.test.ts
+++ b/src/cli/__tests__/errors.test.ts
@@ -1,4 +1,10 @@
-import { getErrorMessage, isExpiredTokenError, isNoCredentialsError, isStackInProgressError } from '../errors.js';
+import {
+  getErrorMessage,
+  isChangesetInProgressError,
+  isExpiredTokenError,
+  isNoCredentialsError,
+  isStackInProgressError,
+} from '../errors.js';
 import { describe, expect, it } from 'vitest';
 
 describe('errors', () => {
@@ -141,6 +147,35 @@ describe('errors', () => {
       expect(isStackInProgressError(null)).toBe(false);
       expect(isStackInProgressError(undefined)).toBe(false);
       expect(isStackInProgressError({})).toBe(false);
+    });
+  });
+
+  describe('isChangesetInProgressError', () => {
+    it('returns true for InvalidChangeSetStatus errors', () => {
+      expect(
+        isChangesetInProgressError(
+          new Error('InvalidChangeSetStatusException: An operation on this ChangeSet is currently in progress.')
+        )
+      ).toBe(true);
+    });
+
+    it('returns true for changeset in progress message patterns', () => {
+      expect(isChangesetInProgressError(new Error('ChangeSet is currently in progress'))).toBe(true);
+      expect(
+        isChangesetInProgressError(new Error('An operation on this changeset is currently in progress'))
+      ).toBe(true);
+    });
+
+    it('returns false for other errors', () => {
+      expect(isChangesetInProgressError(new Error('Stack not found'))).toBe(false);
+      expect(isChangesetInProgressError(new Error('some other error'))).toBe(false);
+      expect(isChangesetInProgressError(new Error('UPDATE_IN_PROGRESS'))).toBe(false);
+    });
+
+    it('returns false for edge cases', () => {
+      expect(isChangesetInProgressError(null)).toBe(false);
+      expect(isChangesetInProgressError(undefined)).toBe(false);
+      expect(isChangesetInProgressError({})).toBe(false);
     });
   });
 });

--- a/src/cli/errors.ts
+++ b/src/cli/errors.ts
@@ -125,3 +125,23 @@ export function isStackInProgressError(err: unknown): boolean {
 
   return false;
 }
+
+/**
+ * Checks if an error indicates a CloudFormation changeset operation is in progress.
+ * This typically occurs when multiple deploys race and one tries to create/delete
+ * a changeset while another operation is already using it.
+ */
+export function isChangesetInProgressError(err: unknown): boolean {
+  const message = getErrorMessage(err).toLowerCase();
+
+  // CloudFormation changeset conflict patterns
+  if (
+    message.includes('invalidchangesetstatus') ||
+    message.includes('changeset is currently in progress') ||
+    message.includes('an operation on this changeset is currently in progress')
+  ) {
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION

Closes issue #165

## Description

- Adds retry logic with exponential backoff for CDK changeset race conditions during deploy                                                                                                                                                       - When parallel asset publishing causes InvalidChangeSetStatusException, the deploy now retries up to 3 times (5s, 10s, 20s delays) instead of failing
- Improves deploy logging to show stack output polling progress when stream outputs aren't available 


 Problem
                                                                                                                                                                                                                                                   
  During agentcore deploy, parallel CDK operations can cause a race condition where one process tries to delete a changeset that's already in progress. This results in:
  InvalidChangeSetStatusException: ChangeSet is currently in the CREATE_IN_PROGRESS state and cannot be deleted.

  The deploy would show FAILED but then succeed ~30 seconds later, confusing users.

  Solution

  1. Added isChangesetInProgressError() to detect changeset race conditions
  2. Added retry logic in CdkToolkitWrapper.deploy() with exponential backoff
  3. Enhanced logging in useDeployFlow.ts to show polling attempts when retrieving stack outputs

  Test plan

  - Unit tests added for isChangesetInProgressError()
  - I personally couldn't recreate this flow 

## Related Issues

https://github.com/aws/agentcore-cli/issues/165

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Check all that apply -->

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:all`
- [ ] I ran `npm run typecheck`
- [ ] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
