### PR TITLE
fix: hide CrewAI from framework options due to artifact size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ agentcore invoke --stream
 | Strands             | AWS-native, streaming support |
 | LangChain/LangGraph | Graph-based workflows         |
 | AutoGen             | Multi-agent conversations     |
-| CrewAI              | Role-based agent teams        |
 | Google ADK          | Gemini models only            |
 | OpenAI Agents       | OpenAI models only            |
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -30,21 +30,21 @@ agentcore create --name MyProject --no-agent
 agentcore create --name MyProject --defaults --dry-run
 ```
 
-| Flag                   | Description                                                                        |
-| ---------------------- | ---------------------------------------------------------------------------------- |
-| `--name <name>`        | Project name (alphanumeric, max 23 chars)                                          |
-| `--defaults`           | Use defaults (Python, Strands, Bedrock, no memory)                                 |
-| `--no-agent`           | Skip agent creation                                                                |
-| `--language <lang>`    | `Python` or `TypeScript`                                                           |
-| `--framework <fw>`     | `Strands`, `LangChain_LangGraph`, `AutoGen`, `CrewAI`, `GoogleADK`, `OpenAIAgents` |
-| `--model-provider <p>` | `Bedrock`, `Anthropic`, `OpenAI`, `Gemini`                                         |
-| `--api-key <key>`      | API key for non-Bedrock providers                                                  |
-| `--memory <opt>`       | `none`, `shortTerm`, `longAndShortTerm`                                            |
-| `--output-dir <dir>`   | Output directory                                                                   |
-| `--skip-git`           | Skip git initialization                                                            |
-| `--skip-python-setup`  | Skip venv setup                                                                    |
-| `--dry-run`            | Preview without creating                                                           |
-| `--json`               | JSON output                                                                        |
+| Flag                   | Description                                                              |
+| ---------------------- | ------------------------------------------------------------------------ |
+| `--name <name>`        | Project name (alphanumeric, max 23 chars)                                |
+| `--defaults`           | Use defaults (Python, Strands, Bedrock, no memory)                       |
+| `--no-agent`           | Skip agent creation                                                      |
+| `--language <lang>`    | `Python` or `TypeScript`                                                 |
+| `--framework <fw>`     | `Strands`, `LangChain_LangGraph`, `AutoGen`, `GoogleADK`, `OpenAIAgents` |
+| `--model-provider <p>` | `Bedrock`, `Anthropic`, `OpenAI`, `Gemini`                               |
+| `--api-key <key>`      | API key for non-Bedrock providers                                        |
+| `--memory <opt>`       | `none`, `shortTerm`, `longAndShortTerm`                                  |
+| `--output-dir <dir>`   | Output directory                                                         |
+| `--skip-git`           | Skip git initialization                                                  |
+| `--skip-python-setup`  | Skip venv setup                                                          |
+| `--dry-run`            | Preview without creating                                                 |
+| `--json`               | JSON output                                                              |
 
 ### deploy
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -54,17 +54,17 @@ Main project configuration containing agents and their capabilities.
 }
 ```
 
-| Field               | Required | Description                                                                        |
-| ------------------- | -------- | ---------------------------------------------------------------------------------- |
-| `name`              | Yes      | Agent name (1-64 chars, alphanumeric)                                              |
-| `id`                | Yes      | Unique identifier                                                                  |
-| `sdkFramework`      | Yes      | `Strands`, `LangChain_LangGraph`, `AutoGen`, `CrewAI`, `GoogleADK`, `OpenAIAgents` |
-| `targetLanguage`    | Yes      | `Python` or `TypeScript`                                                           |
-| `modelProvider`     | Yes      | `Bedrock`, `Anthropic`, `OpenAI`, `Gemini`                                         |
-| `runtime`           | Yes      | Runtime configuration                                                              |
-| `memoryProviders`   | Yes      | Memory configurations                                                              |
-| `identityProviders` | Yes      | Identity/API key configurations                                                    |
-| `remoteTools`       | Yes      | Agent-to-agent references                                                          |
+| Field               | Required | Description                                                              |
+| ------------------- | -------- | ------------------------------------------------------------------------ |
+| `name`              | Yes      | Agent name (1-64 chars, alphanumeric)                                    |
+| `id`                | Yes      | Unique identifier                                                        |
+| `sdkFramework`      | Yes      | `Strands`, `LangChain_LangGraph`, `AutoGen`, `GoogleADK`, `OpenAIAgents` |
+| `targetLanguage`    | Yes      | `Python` or `TypeScript`                                                 |
+| `modelProvider`     | Yes      | `Bedrock`, `Anthropic`, `OpenAI`, `Gemini`                               |
+| `runtime`           | Yes      | Runtime configuration                                                    |
+| `memoryProviders`   | Yes      | Memory configurations                                                    |
+| `identityProviders` | Yes      | Identity/API key configurations                                          |
+| `remoteTools`       | Yes      | Agent-to-agent references                                                |
 
 ### Runtime Configuration
 

--- a/src/cli/tui/screens/agent/types.ts
+++ b/src/cli/tui/screens/agent/types.ts
@@ -85,7 +85,6 @@ export const FRAMEWORK_OPTIONS = [
   { id: 'Strands', title: 'Strands Agents SDK', description: 'AWS native agent framework' },
   { id: 'LangChain_LangGraph', title: 'LangChain + LangGraph', description: 'Popular open-source frameworks' },
   { id: 'AutoGen', title: 'AutoGen', description: 'Microsoft multi-agent framework' },
-  { id: 'CrewAI', title: 'CrewAI', description: 'Role-based agent orchestration' },
   { id: 'GoogleADK', title: 'Google ADK', description: 'Google Agent Development Kit' },
   { id: 'OpenAIAgents', title: 'OpenAI Agents', description: 'OpenAI native agent SDK' },
 ] as const;

--- a/src/cli/tui/screens/generate/types.ts
+++ b/src/cli/tui/screens/generate/types.ts
@@ -47,7 +47,6 @@ export const SDK_OPTIONS = [
   { id: 'Strands', title: 'Strands Agents SDK', description: 'AWS native agent framework' },
   { id: 'LangChain_LangGraph', title: 'LangChain + LangGraph', description: 'Popular open-source frameworks' },
   { id: 'AutoGen', title: 'AutoGen', description: 'Microsoft multi-agent framework' },
-  { id: 'CrewAI', title: 'CrewAI', description: 'Role-based agent orchestration' },
   { id: 'GoogleADK', title: 'Google ADK', description: 'Google Agent Development Kit' },
   { id: 'OpenAIAgents', title: 'OpenAI Agents', description: 'OpenAI native agent SDK' },
 ] as const;


### PR DESCRIPTION
## Summary

- Remove CrewAI from TUI framework selection options (both `create` and `add agent` flows)
- Remove CrewAI from documentation (README, commands.md, configuration.md)
- Keep all backend code intact (schema, renderer, templates) for easy re-enablement

## Background

CrewAI deployment fails with `ArtifactSizeError` because packaged artifacts exceed the 262MB Lambda limit (actual: 277MB). This fix hides CrewAI from user selection until the artifact size issue is resolved.

## Test plan

- [x] TypeScript check passes: `npm run typecheck`
- [x] Linting passes: `npm run lint`
- [ ] Run `agentcore create` and verify CrewAI does not appear in framework options
- [ ] Run `agentcore add agent` with type "create" and verify CrewAI does not appear

Closes #156