### PR TITLE
fix(tui): show env var name when skipping API key entry

### DIFF
--- a/src/cli/commands/add/__tests__/add-agent.test.ts
+++ b/src/cli/commands/add/__tests__/add-agent.test.ts
@@ -201,6 +201,36 @@ describe('add agent command', () => {
     });
   });
 
+  describe('API key handling', () => {
+    it('writes env var to .env.local for non-Bedrock provider without API key', async () => {
+      const agentName = `OpenAIAgent${Date.now()}`;
+      const result = await runCLI(
+        [
+          'add',
+          'agent',
+          '--name',
+          agentName,
+          '--language',
+          'Python',
+          '--framework',
+          'OpenAIAgents',
+          '--model-provider',
+          'OpenAI',
+          '--memory',
+          'none',
+          '--json',
+        ],
+        projectDir
+      );
+
+      expect(result.exitCode, `stdout: ${result.stdout}, stderr: ${result.stderr}`).toBe(0);
+
+      // Verify env var is written to .env.local (even without API key)
+      const envContent = await readFile(join(projectDir, 'agentcore/.env.local'), 'utf-8');
+      expect(envContent.includes('AGENTCORE_CREDENTIAL_TESTPROJOPENAI=')).toBeTruthy();
+    });
+  });
+
   describe('BYO path', () => {
     it('registers BYO agent', async () => {
       const agentName = `ByoAgent${Date.now()}`;

--- a/src/cli/operations/identity/__tests__/create-identity.test.ts
+++ b/src/cli/operations/identity/__tests__/create-identity.test.ts
@@ -1,0 +1,19 @@
+import { computeDefaultCredentialEnvVarName } from '../create-identity';
+import { describe, expect, it } from 'vitest';
+
+describe('computeDefaultCredentialEnvVarName', () => {
+  it('generates correct env var name for project and provider', () => {
+    expect(computeDefaultCredentialEnvVarName('MyProjectOpenAI')).toBe('AGENTCORE_CREDENTIAL_MYPROJECTOPENAI');
+    expect(computeDefaultCredentialEnvVarName('TestAppAnthropic')).toBe('AGENTCORE_CREDENTIAL_TESTAPPANTHROPIC');
+    expect(computeDefaultCredentialEnvVarName('ChatBotGemini')).toBe('AGENTCORE_CREDENTIAL_CHATBOTGEMINI');
+  });
+
+  it('converts to uppercase', () => {
+    expect(computeDefaultCredentialEnvVarName('lowercase')).toBe('AGENTCORE_CREDENTIAL_LOWERCASE');
+    expect(computeDefaultCredentialEnvVarName('MixedCase')).toBe('AGENTCORE_CREDENTIAL_MIXEDCASE');
+  });
+
+  it('handles empty string', () => {
+    expect(computeDefaultCredentialEnvVarName('')).toBe('AGENTCORE_CREDENTIAL_');
+  });
+});

--- a/src/cli/tui/screens/create/CreateScreen.tsx
+++ b/src/cli/tui/screens/create/CreateScreen.tsx
@@ -1,4 +1,5 @@
 import { ProjectNameSchema } from '../../../../schema';
+import { computeDefaultCredentialEnvVarName } from '../../../operations/identity/create-identity';
 import {
   LogLink,
   type NextStep,
@@ -55,6 +56,15 @@ function buildExitMessage(projectName: string, steps: Step[], agentConfig: AddAg
     lines.push(`    agentcore/  \x1b[2mConfig and CDK project\x1b[0m`);
   }
   lines.push('');
+
+  // API key reminder if skipped
+  if (agentConfig && agentConfig.modelProvider !== 'Bedrock' && !agentConfig.apiKey) {
+    const credentialName = `${projectName}${agentConfig.modelProvider}`;
+    const envVarName = computeDefaultCredentialEnvVarName(credentialName);
+    lines.push('\x1b[33mNote:\x1b[0m API key not configured.');
+    lines.push(`Fill in \x1b[36m${envVarName}\x1b[0m in agentcore/.env.local before running.`);
+    lines.push('');
+  }
 
   // Success message
   lines.push('\x1b[32mProject created successfully!\x1b[0m');


### PR DESCRIPTION
## Summary

- When users skip entering an API key during create/add agent flows, the confirmation screen now shows the specific environment variable name they need to set later
- For example: `Not set - add AGENTCORE_CREDENTIAL_MYPROJECTOPENAI to .env later` instead of just `Not set (add to .env later)`
- This helps users know exactly which env var to configure in their `.env` file

## Changes

- Add `credentialProjectName` prop to `GenerateWizardUI` for add agent flow
- Update `ConfirmView` to compute and display the env var name using `computeDefaultCredentialEnvVarName`
- Update `AddAgentScreen` BYO confirm view with env var name
- Fetch project name from project spec for credential naming in add agent flows

## Test plan
<img width="799" height="612" alt="Screenshot 2026-02-09 at 2 30 23 PM" src="https://github.com/user-attachments/assets/09db5960-c6ac-4a19-9967-38a4d3001faf" />


- [x] **Standalone create flow**: Run `agentcore create`, select non-Bedrock provider, skip API key - verify env var name is shown
- [x] **Add agent - Create path**: In existing project, run `agentcore add agent`, select "Create new agent", skip API key - verify env var uses project name (not agent name)
- [x] **Add agent - BYO path**: Select "Bring my own code", skip API key - verify env var uses project name
- [x] **Bedrock provider**: Verify no API key message is shown (already handled)
- [x] **API key provided**: Verify "Configured" still shows correctly when API key is entered

Closes #191