### PR TITLE
fix: hide gateway and mcp-tool subcommands from TUI suggestions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/agentcore-cli",
-  "version": "0.1.8",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/agentcore-cli",
-      "version": "0.1.8",
+      "version": "0.1.1",
       "hasInstallScript": true,
       "dependencies": {
         "@aws-cdk/toolkit-lib": "^1.13.0",

--- a/src/cli/tui/utils/commands.ts
+++ b/src/cli/tui/utils/commands.ts
@@ -19,6 +19,13 @@ const HIDDEN_FROM_TUI = ['update', 'package'] as const;
  */
 const HIDDEN_WHEN_IN_PROJECT = ['create'] as const;
 
+/**
+ * Subcommands hidden from TUI suggestions.
+ * These are registered with { hidden: true } in commander but we track them
+ * here since commander doesn't expose a public API to check hidden status.
+ */
+const HIDDEN_SUBCOMMANDS = ['gateway', 'mcp-tool'] as const;
+
 interface GetCommandsOptions {
   /** Whether user is currently inside an AgentCore project */
   inProject?: boolean;
@@ -36,7 +43,9 @@ export function getCommandsForUI(program: Command, options: GetCommandsOptions =
       id: cmd.name(),
       title: cmd.name(),
       description: cmd.description(),
-      subcommands: cmd.commands.map(sub => sub.name()),
+      subcommands: cmd.commands
+        .filter(sub => !HIDDEN_SUBCOMMANDS.includes(sub.name() as (typeof HIDDEN_SUBCOMMANDS)[number]))
+        .map(sub => sub.name()),
       disabled: false,
     }));
 }


### PR DESCRIPTION
## Description

Fixes #157

Hidden subcommands (gateway, mcp-tool) were appearing in TUI help screen suggestions when users typed matching text. These commands are registered with { hidden: true } in commander to hide them from CLI help, but the TUI's getCommandsForUI() was exposing all subcommands regardless of hidden status.

Added HIDDEN_SUBCOMMANDS list to filter these out from TUI suggestions, matching the existing pattern used for HIDDEN_FROM_TUI.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran npm run test:all
- [x] I ran npm run typecheck
- [x] I ran npm run lint
- [ ] If I modified src/assets/, I ran npm run test:update-snapshots and committed the updated snapshots

Manual testing: Built and installed CLI globally, verified "gateway" and "mcp-tool" no longer appear in TUI suggestions.

## Checklist

- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.