### PR TITLE
feat(deploy): make any flag trigger non-interactive CLI mode

### DIFF
--- a/src/cli/commands/deploy/__tests__/deploy.test.ts
+++ b/src/cli/commands/deploy/__tests__/deploy.test.ts
@@ -17,8 +17,9 @@ describe('deploy --help', () => {
     const result = await runCLI(['deploy', '--help'], process.cwd());
     expect(result.stdout.includes('--target')).toBeTruthy();
     expect(result.stdout.includes('--yes')).toBeTruthy();
-    expect(result.stdout.includes('--progress')).toBeTruthy();
+    expect(result.stdout.includes('--verbose')).toBeTruthy();
     expect(result.stdout.includes('--json')).toBeTruthy();
+    expect(result.stdout.includes('--plan')).toBeTruthy();
   });
 });
 

--- a/src/cli/commands/deploy/command.tsx
+++ b/src/cli/commands/deploy/command.tsx
@@ -122,22 +122,25 @@ export const registerDeploy = (program: Command) => {
     .command('deploy')
     .alias('p')
     .description(COMMAND_DESCRIPTIONS.deploy)
-    .option('--target <target>', 'Deployment target name')
-    .option('-y, --yes', 'Auto-confirm prompts (e.g., bootstrap)')
-    .option('--progress', 'Show deployment progress in real-time')
-    .option('-v, --verbose', 'Show resource-level deployment events')
-    .option('--json', 'Output as JSON')
-    .option('--plan', 'Preview deployment without deploying (dry-run)')
+    .option('--target <target>', 'Deployment target name (default: "default") [non-interactive]')
+    .option('-y, --yes', 'Auto-confirm prompts, read credentials from env [non-interactive]')
+    .option('-v, --verbose', 'Show resource-level deployment events [non-interactive]')
+    .option('--json', 'Output as JSON [non-interactive]')
+    .option('--plan', 'Preview deployment without deploying (dry-run) [non-interactive]')
     .action(
-      async (cliOptions: { target?: string; yes?: boolean; progress?: boolean; json?: boolean; plan?: boolean }) => {
+      async (cliOptions: { target?: string; yes?: boolean; verbose?: boolean; json?: boolean; plan?: boolean }) => {
         try {
           requireProject();
-          if (cliOptions.json || cliOptions.target || cliOptions.progress || cliOptions.plan) {
-            // Default to "default" target in CLI mode
-            const options = { ...cliOptions, target: cliOptions.target ?? 'default' };
+          if (cliOptions.json || cliOptions.target || cliOptions.plan || cliOptions.yes || cliOptions.verbose) {
+            // CLI mode - any flag triggers non-interactive mode
+            const options = {
+              ...cliOptions,
+              target: cliOptions.target ?? 'default',
+              progress: !cliOptions.json,
+            };
             await handleDeployCLI(options as DeployOptions);
           } else {
-            handleDeployTUI({ autoConfirm: cliOptions.yes });
+            handleDeployTUI();
           }
         } catch (error) {
           if (cliOptions.json) {


### PR DESCRIPTION
## Description

Fixes #164 

Makes agentcore deploy fully non-interactive when any CLI flag is passed. Key changes:

- Any flag (--target, -y, --verbose, --json, --plan) triggers CLI mode instead of TUI
- Removed --progress flag - progress spinners now always shown in CLI mode (unless --json)
- CLI mode reads credentials from process.env (e.g., AGENTCORE_CREDENTIAL_OPENAI_API_KEY) enabling fully automated deploys
- Updated help text with [non-interactive] tags to clarify behavior

This enables CI/CD pipelines and scripts to run agentcore deploy -y with credentials set via environment variables, without any interactive prompts.

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran npm run test:all
- [x] I ran npm run typecheck
- [x] I ran npm run lint
- [ ] If I modified src/assets/, I ran npm run test:update-snapshots and committed the updated snapshots

Manual testing:
- agentcore deploy → TUI launches
- agentcore deploy -y → CLI mode with progress spinners
- agentcore deploy --plan → CLI mode, stops before deploy
- agentcore deploy --json → JSON output, no spinners
- agentcore deploy --help → Shows [non-interactive] tags

## Checklist

- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.