### PR TITLE
fix(memory): remove unsupported EPISODIC strategy

### DIFF
--- a/src/cli/commands/add/command.tsx
+++ b/src/cli/commands/add/command.tsx
@@ -311,10 +311,7 @@ export function registerAdd(program: Command) {
     .command('memory')
     .description('Add a memory resource to the project')
     .option('--name <name>', 'Memory name')
-    .option(
-      '--strategies <types>',
-      'Comma-separated strategies: SEMANTIC, SUMMARIZATION, USER_PREFERENCE, EPISODIC, CUSTOM'
-    )
+    .option('--strategies <types>', 'Comma-separated strategies: SEMANTIC, SUMMARIZATION, USER_PREFERENCE, CUSTOM')
     .option('--expiry <days>', 'Event expiry duration in days (default: 30)', parseInt)
     .option('--json', 'Output as JSON')
     .action(async options => {

--- a/src/cli/commands/add/validate.ts
+++ b/src/cli/commands/add/validate.ts
@@ -22,7 +22,7 @@ export interface ValidationResult {
 // Constants
 const MEMORY_OPTIONS = ['none', 'shortTerm', 'longAndShortTerm'] as const;
 const OIDC_WELL_KNOWN_SUFFIX = '/.well-known/openid-configuration';
-const VALID_STRATEGIES = ['SEMANTIC', 'SUMMARIZATION', 'USER_PREFERENCE', 'EPISODIC', 'CUSTOM'];
+const VALID_STRATEGIES = ['SEMANTIC', 'SUMMARIZATION', 'USER_PREFERENCE', 'CUSTOM'];
 
 // Agent validation
 export function validateAddAgentOptions(options: AddAgentOptions): ValidationResult {


### PR DESCRIPTION
## Description

Fix #202 

Removes EPISODIC from the list of valid memory strategies. This strategy was listed in the CLI validation and help text but is not actually supported by the schema (MemoryStrategyTypeSchema only includes SEMANTIC, SUMMARIZATION, USER_PREFERENCE, CUSTOM).

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran npm run test:all
- [x] I ran npm run typecheck
- [x] I ran npm run lint
- [ ] If I modified src/assets/, I ran npm run test:update-snapshots and committed the updated snapshots

Manual testing:
- agentcore add memory --help → No longer shows EPISODIC
- agentcore add memory --name Test --strategies EPISODIC → Correctly rejects with "Invalid strategy"

## Checklist

- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.