### PR TITLE
fix invoke session id threading

### DIFF
--- a/src/cli/commands/invoke/action.ts
+++ b/src/cli/commands/invoke/action.ts
@@ -95,6 +95,7 @@ export async function handleInvoke(context: InvokeContext, options: InvokeOption
         region: targetConfig.region,
         runtimeArn: agentState.runtimeArn,
         payload: options.prompt,
+        sessionId: options.sessionId,
         logger, // Pass logger for SSE event debugging
       });
 
@@ -124,6 +125,7 @@ export async function handleInvoke(context: InvokeContext, options: InvokeOption
     region: targetConfig.region,
     runtimeArn: agentState.runtimeArn,
     payload: options.prompt,
+    sessionId: options.sessionId,
   });
 
   logger.logResponse(response.content);

--- a/src/cli/commands/invoke/command.tsx
+++ b/src/cli/commands/invoke/command.tsx
@@ -120,6 +120,7 @@ export const registerInvoke = (program: Command) => {
               prompt,
               agentName: cliOptions.agent,
               targetName: cliOptions.target ?? 'default',
+              sessionId: cliOptions.sessionId,
               json: cliOptions.json,
               stream: cliOptions.stream,
             });

--- a/src/cli/commands/invoke/types.ts
+++ b/src/cli/commands/invoke/types.ts
@@ -2,6 +2,7 @@ export interface InvokeOptions {
   agentName?: string;
   targetName?: string;
   prompt?: string;
+  sessionId?: string;
   json?: boolean;
   stream?: boolean;
 }

--- a/src/cli/tui/screens/invoke/useInvokeFlow.ts
+++ b/src/cli/tui/screens/invoke/useInvokeFlow.ts
@@ -4,7 +4,7 @@ import type {
   AwsDeploymentTarget,
   AgentCoreProjectSpec as _AgentCoreProjectSpec,
 } from '../../../../schema';
-import { invokeAgentRuntimeStreaming, stopRuntimeSession } from '../../../aws';
+import { invokeAgentRuntimeStreaming } from '../../../aws';
 import { getErrorMessage } from '../../../errors';
 import { InvokeLogger } from '../../../logging';
 import { generateSessionId } from '../../../operations/session';
@@ -172,18 +172,6 @@ export function useInvokeFlow(options: InvokeFlowOptions = {}): InvokeFlowState 
         }
 
         logger.logResponse(streamingContentRef.current);
-
-        // Stop the session after invoke completes (cleanup)
-        const finalSessionId = result.sessionId ?? sessionId;
-        if (finalSessionId) {
-          void stopRuntimeSession({
-            region: config.target.region,
-            runtimeArn: agent.state.runtimeArn,
-            sessionId: finalSessionId,
-          }).catch(() => {
-            // Silently ignore stop errors - session will expire anyway
-          });
-        }
 
         setPhase('ready');
       } catch (err) {


### PR DESCRIPTION
The PR does two things:

1. It fixes a bug where, when specifying the session ID when calling `invoke` manually, the session ID was not threaded through to the actual API call, causing new sessions to be created on every call.
2. It removes a call to `stopRuntimeSession` in the TUI layer had occurred after every successful invoke, which caused multi-turn and other "sessionful" features to look like they were failing. We don't have to worry about not stopping these sessions—they'll timeout and stop on their own.