### PR TITLE
Make Strands template Agent sessionful

### DIFF
--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -2391,27 +2391,47 @@ def add_numbers(a: int, b: int) -> int:
     return a+b
 tools.append(add_numbers)
 
-{{#if hasMemory}}
-session_manager = get_memory_session_manager('default-memory-session', 'default-memory-user')
-{{/if}}
 
+{{#if hasMemory}}
+def agent_factory():
+    cache = {}
+    def get_or_create_agent(session_id, user_id):
+        key = f"{session_id}/{user_id}"
+        if key not in cache:
+            # Create an agent for the given session_id and user_id
+            cache[key] = Agent(
+                model=load_model(),
+                session_manager=get_memory_session_manager(session_id, user_id),
+                system_prompt="""
+                    You are a helpful assistant. Use tools when appropriate.
+                """,
+                tools=tools+[mcp_client]
+            )
+        return cache[key]
+    return get_or_create_agent
+get_or_create_agent = agent_factory()
+{{else}}
 # Create agent
 agent = Agent(
     model=load_model(),
-{{#if hasMemory}}
-    session_manager=session_manager,
-{{/if}}
     system_prompt="""
         You are a helpful assistant. Use tools when appropriate.
     """,
     tools=tools+[mcp_client]
 )
+{{/if}}
 
 
 @app.entrypoint
 async def invoke(payload, context):
     log.info("Invoking Agent.....")
 
+{{#if hasMemory}}
+    session_id = getattr(context, 'session_id', 'default-session')
+    user_id = getattr(context, 'user_id', 'default-user')
+    agent = get_or_create_agent(session_id, user_id)
+
+{{/if}}
     # Execute and format response
     stream = agent.stream_async(payload.get("prompt"))
 

--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -2367,8 +2367,7 @@ Thumbs.db"
 `;
 
 exports[`Assets Directory Snapshots > Python framework assets > python/python/strands/base/main.py should match snapshot 1`] = `
-"import os
-from strands import Agent, tool
+"from strands import Agent, tool
 from bedrock_agentcore.runtime import BedrockAgentCoreApp
 from model.load import load_model
 from mcp_client.client import get_streamable_http_mcp_client
@@ -2378,8 +2377,6 @@ from memory.session import get_memory_session_manager
 
 app = BedrockAgentCoreApp()
 log = app.logger
-
-REGION = os.getenv("AWS_REGION")
 
 # Define a Streamable HTTP MCP Client
 mcp_client = get_streamable_http_mcp_client()
@@ -2394,42 +2391,39 @@ def add_numbers(a: int, b: int) -> int:
     return a+b
 tools.append(add_numbers)
 
+{{#if hasMemory}}
+session_manager = get_memory_session_manager('default-memory-session', 'default-memory-user')
+{{/if}}
+
+# Create agent
+agent = Agent(
+    model=load_model(),
+{{#if hasMemory}}
+    session_manager=session_manager,
+{{/if}}
+    system_prompt="""
+        You are a helpful assistant. Use tools when appropriate.
+    """,
+    tools=tools+[mcp_client]
+)
+
+
 @app.entrypoint
 async def invoke(payload, context):
     log.info("Invoking Agent.....")
-{{#if hasMemory}}
-    session_id = getattr(context, 'session_id', 'default-session')
-    user_id = getattr(context, 'user_id', 'default-user')
-    session_manager = get_memory_session_manager(session_id, user_id)
-{{/if}}
 
-    with mcp_client as client:
-        # Get MCP Tools
-        mcp_tools = client.list_tools_sync()
+    # Execute and format response
+    stream = agent.stream_async(payload.get("prompt"))
 
-        # Create agent
-        agent = Agent(
-            model=load_model(),
-{{#if hasMemory}}
-            session_manager=session_manager,
-{{/if}}
-            system_prompt="""
-                You are a helpful assistant. Use tools when appropriate.
-            """,
-            tools=tools+mcp_tools
-        )
-
-        # Execute and format response
-        stream = agent.stream_async(payload.get("prompt"))
-
-        async for event in stream:
-            # Handle Text parts of the response
-            if "data" in event and isinstance(event["data"], str):
-                yield event["data"]
+    async for event in stream:
+        # Handle Text parts of the response
+        if "data" in event and isinstance(event["data"], str):
+            yield event["data"]
 
 
 if __name__ == "__main__":
-    app.run()"
+    app.run()
+"
 `;
 
 exports[`Assets Directory Snapshots > Python framework assets > python/python/strands/base/mcp_client/client.py should match snapshot 1`] = `

--- a/src/assets/python/strands/base/main.py
+++ b/src/assets/python/strands/base/main.py
@@ -1,4 +1,3 @@
-import os
 from strands import Agent, tool
 from bedrock_agentcore.runtime import BedrockAgentCoreApp
 from model.load import load_model
@@ -9,8 +8,6 @@ from memory.session import get_memory_session_manager
 
 app = BedrockAgentCoreApp()
 log = app.logger
-
-REGION = os.getenv("AWS_REGION")
 
 # Define a Streamable HTTP MCP Client
 mcp_client = get_streamable_http_mcp_client()
@@ -25,38 +22,34 @@ def add_numbers(a: int, b: int) -> int:
     return a+b
 tools.append(add_numbers)
 
+{{#if hasMemory}}
+session_manager = get_memory_session_manager('default-memory-session', 'default-memory-user')
+{{/if}}
+
+# Create agent
+agent = Agent(
+    model=load_model(),
+{{#if hasMemory}}
+    session_manager=session_manager,
+{{/if}}
+    system_prompt="""
+        You are a helpful assistant. Use tools when appropriate.
+    """,
+    tools=tools+[mcp_client]
+)
+
+
 @app.entrypoint
 async def invoke(payload, context):
     log.info("Invoking Agent.....")
-{{#if hasMemory}}
-    session_id = getattr(context, 'session_id', 'default-session')
-    user_id = getattr(context, 'user_id', 'default-user')
-    session_manager = get_memory_session_manager(session_id, user_id)
-{{/if}}
 
-    with mcp_client as client:
-        # Get MCP Tools
-        mcp_tools = client.list_tools_sync()
+    # Execute and format response
+    stream = agent.stream_async(payload.get("prompt"))
 
-        # Create agent
-        agent = Agent(
-            model=load_model(),
-{{#if hasMemory}}
-            session_manager=session_manager,
-{{/if}}
-            system_prompt="""
-                You are a helpful assistant. Use tools when appropriate.
-            """,
-            tools=tools+mcp_tools
-        )
-
-        # Execute and format response
-        stream = agent.stream_async(payload.get("prompt"))
-
-        async for event in stream:
-            # Handle Text parts of the response
-            if "data" in event and isinstance(event["data"], str):
-                yield event["data"]
+    async for event in stream:
+        # Handle Text parts of the response
+        if "data" in event and isinstance(event["data"], str):
+            yield event["data"]
 
 
 if __name__ == "__main__":

--- a/src/assets/python/strands/base/main.py
+++ b/src/assets/python/strands/base/main.py
@@ -22,27 +22,47 @@ def add_numbers(a: int, b: int) -> int:
     return a+b
 tools.append(add_numbers)
 
-{{#if hasMemory}}
-session_manager = get_memory_session_manager('default-memory-session', 'default-memory-user')
-{{/if}}
 
+{{#if hasMemory}}
+def agent_factory():
+    cache = {}
+    def get_or_create_agent(session_id, user_id):
+        key = f"{session_id}/{user_id}"
+        if key not in cache:
+            # Create an agent for the given session_id and user_id
+            cache[key] = Agent(
+                model=load_model(),
+                session_manager=get_memory_session_manager(session_id, user_id),
+                system_prompt="""
+                    You are a helpful assistant. Use tools when appropriate.
+                """,
+                tools=tools+[mcp_client]
+            )
+        return cache[key]
+    return get_or_create_agent
+get_or_create_agent = agent_factory()
+{{else}}
 # Create agent
 agent = Agent(
     model=load_model(),
-{{#if hasMemory}}
-    session_manager=session_manager,
-{{/if}}
     system_prompt="""
         You are a helpful assistant. Use tools when appropriate.
     """,
     tools=tools+[mcp_client]
 )
+{{/if}}
 
 
 @app.entrypoint
 async def invoke(payload, context):
     log.info("Invoking Agent.....")
 
+{{#if hasMemory}}
+    session_id = getattr(context, 'session_id', 'default-session')
+    user_id = getattr(context, 'user_id', 'default-user')
+    agent = get_or_create_agent(session_id, user_id)
+
+{{/if}}
     # Execute and format response
     stream = agent.stream_async(payload.get("prompt"))
 


### PR DESCRIPTION
## Description

In the Strands template, create the `Agent` outside of the request handler, enabling the agent to be "sessionful," that is, keep its state in between calls to the same session.

## Related Issues

Closes #134 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [X] Other (please describe): Improvement

## Testing

How have you tested the change?

- [X] I ran `npm run test:all`
- [X] I ran `npm run typecheck`
- [X] I ran `npm run lint`
- [X] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots
- [X] **Tested end to end**

## Checklist

- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
