### PR TITLE
fix: ensure agentcore create exits after completion in non-interactiv…

### DIFF
--- a/src/cli/commands/create/command.tsx
+++ b/src/cli/commands/create/command.tsx
@@ -12,7 +12,16 @@ import { Text, render } from 'ink';
 /** Render CreateScreen for interactive TUI mode */
 function handleCreateTUI(): void {
   const cwd = getWorkingDirectory();
-  const { unmount } = render(<CreateScreen cwd={cwd} isInteractive={false} onExit={() => unmount()} />);
+  const { unmount } = render(
+    <CreateScreen
+      cwd={cwd}
+      isInteractive={false}
+      onExit={() => {
+        unmount();
+        process.exit(0);
+      }}
+    />
+  );
 }
 
 /** Print completion summary after successful create */
@@ -156,7 +165,8 @@ export const registerCreate = (program: Command) => {
           options.memory = options.memory ?? 'none';
         }
 
-        if (options.name) {
+        if (options.name || options.json || options.dryRun) {
+          // CLI mode - any non-interactive flag triggers CLI mode
           await handleCreateCLI(options as CreateOptions);
         } else {
           handleCreateTUI();

--- a/src/cli/tui/screens/create/CreateScreen.tsx
+++ b/src/cli/tui/screens/create/CreateScreen.tsx
@@ -171,10 +171,10 @@ export function CreateScreen({ cwd, isInteractive, onExit, onNavigate }: CreateS
 
   // Auto-exit when project creation completes successfully
   useEffect(() => {
-    if (allSuccess && isInteractive) {
+    if (allSuccess) {
       handleExit();
     }
-  }, [allSuccess, isInteractive, handleExit]);
+  }, [allSuccess, handleExit]);
 
   // Create prompt navigation
   const { selectedIndex: createPromptIndex } = useListNavigation({


### PR DESCRIPTION
…e mode (#199)

Closes https://github.com/aws/agentcore-cli/issues/199

## Description

When running agentcore create with --json flag, the process hangs instead of exiting after completion. Three issues were fixed:

  1. --json and --dry-run flags now route to CLI mode (matching the deploy command pattern) instead of falling through to TUI mode
  2. The standalone TUI auto-exits after successful project creation — the isInteractive guard on the auto-exit useEffect was preventing this
  3. handleCreateTUI's onExit callback now calls process.exit(0) after unmounting (matching the deploy command pattern)

## Related Issues

https://github.com/aws/agentcore-cli/issues/199

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Check all that apply -->

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [X] I ran `npm run test:all`
- [X] I ran `npm run typecheck`
- [X] I ran `npm run lint`
- [X] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
