### PR TITLE
fix: allow creating memory with zero strategies (#210)

### DIFF
--- a/src/cli/commands/add/__tests__/add-memory.test.ts
+++ b/src/cli/commands/add/__tests__/add-memory.test.ts
@@ -35,12 +35,12 @@ describe('add memory command', () => {
       expect(json.error.includes('--name'), `Error: ${json.error}`).toBeTruthy();
     });
 
-    it('requires strategies flag', async () => {
-      const result = await runCLI(['add', 'memory', '--name', 'test', '--json'], projectDir);
-      expect(result.exitCode).toBe(1);
+    it('allows omitting strategies flag', async () => {
+      const memoryName = `noStrat${Date.now()}`;
+      const result = await runCLI(['add', 'memory', '--name', memoryName, '--json'], projectDir);
+      expect(result.exitCode, `stdout: ${result.stdout}, stderr: ${result.stderr}`).toBe(0);
       const json = JSON.parse(result.stdout);
-      expect(json.success).toBe(false);
-      expect(json.error.includes('--strategies'), `Error: ${json.error}`).toBeTruthy();
+      expect(json.success).toBe(true);
     });
 
     it('validates strategy types', async () => {

--- a/src/cli/commands/add/__tests__/validate.test.ts
+++ b/src/cli/commands/add/__tests__/validate.test.ts
@@ -289,30 +289,23 @@ describe('validate', () => {
 
   describe('validateAddMemoryOptions', () => {
     // AC20: Required fields validated
-    it('returns error for missing required fields', () => {
-      const requiredFields: { field: keyof AddMemoryOptions; error: string }[] = [
-        { field: 'name', error: '--name is required' },
-        { field: 'strategies', error: '--strategies is required' },
-      ];
-
-      for (const { field, error } of requiredFields) {
-        const opts = { ...validMemoryOptions, [field]: undefined };
-        const result = validateAddMemoryOptions(opts);
-        expect(result.valid, `Should fail for missing ${String(field)}`).toBe(false);
-        expect(result.error).toBe(error);
-      }
+    it('returns error for missing name', () => {
+      const result = validateAddMemoryOptions({ ...validMemoryOptions, name: undefined });
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('--name is required');
     });
 
-    // AC21: Invalid/empty strategies rejected
-    it('returns error for invalid or empty strategies', () => {
-      let result = validateAddMemoryOptions({ ...validMemoryOptions, strategies: 'INVALID' });
+    // AC21: Invalid strategies rejected, empty strategies allowed
+    it('returns error for invalid strategies', () => {
+      const result = validateAddMemoryOptions({ ...validMemoryOptions, strategies: 'INVALID' });
       expect(result.valid).toBe(false);
       expect(result.error?.includes('Invalid strategy')).toBeTruthy();
       expect(result.error?.includes('SEMANTIC')).toBeTruthy();
+    });
 
-      result = validateAddMemoryOptions({ ...validMemoryOptions, strategies: ',,,' });
-      expect(result.valid).toBe(false);
-      expect(result.error).toBe('At least one strategy is required');
+    it('allows empty strategies', () => {
+      expect(validateAddMemoryOptions({ ...validMemoryOptions, strategies: ',,,' })).toEqual({ valid: true });
+      expect(validateAddMemoryOptions({ ...validMemoryOptions, strategies: undefined })).toEqual({ valid: true });
     });
 
     // AC22: Valid options pass

--- a/src/cli/commands/add/actions.ts
+++ b/src/cli/commands/add/actions.ts
@@ -66,7 +66,7 @@ export interface ValidatedAddMcpToolOptions {
 
 export interface ValidatedAddMemoryOptions {
   name: string;
-  strategies: string;
+  strategies?: string;
   expiry?: number;
 }
 
@@ -308,10 +308,12 @@ export async function handleAddMcpTool(options: ValidatedAddMcpToolOptions): Pro
 export async function handleAddMemory(options: ValidatedAddMemoryOptions): Promise<AddMemoryResult> {
   try {
     const strategies = options.strategies
-      .split(',')
-      .map(s => s.trim())
-      .filter(Boolean)
-      .map(type => ({ type: type as MemoryStrategyType }));
+      ? options.strategies
+          .split(',')
+          .map(s => s.trim())
+          .filter(Boolean)
+          .map(type => ({ type: type as MemoryStrategyType }))
+      : [];
 
     const result = await createMemory({
       name: options.name,

--- a/src/cli/commands/add/command.tsx
+++ b/src/cli/commands/add/command.tsx
@@ -178,7 +178,7 @@ async function handleAddMemoryCLI(options: AddMemoryOptions): Promise<void> {
 
   const result = await handleAddMemory({
     name: options.name!,
-    strategies: options.strategies!,
+    strategies: options.strategies,
     expiry: options.expiry,
   });
 

--- a/src/cli/commands/add/validate.ts
+++ b/src/cli/commands/add/validate.ts
@@ -196,21 +196,16 @@ export function validateAddMemoryOptions(options: AddMemoryOptions): ValidationR
     return { valid: false, error: '--name is required' };
   }
 
-  if (!options.strategies) {
-    return { valid: false, error: '--strategies is required' };
-  }
+  if (options.strategies) {
+    const strategies = options.strategies
+      .split(',')
+      .map(s => s.trim())
+      .filter(Boolean);
 
-  const strategies = options.strategies
-    .split(',')
-    .map(s => s.trim())
-    .filter(Boolean);
-  if (strategies.length === 0) {
-    return { valid: false, error: 'At least one strategy is required' };
-  }
-
-  for (const strategy of strategies) {
-    if (!VALID_STRATEGIES.includes(strategy)) {
-      return { valid: false, error: `Invalid strategy: ${strategy}. Must be one of: ${VALID_STRATEGIES.join(', ')}` };
+    for (const strategy of strategies) {
+      if (!VALID_STRATEGIES.includes(strategy)) {
+        return { valid: false, error: `Invalid strategy: ${strategy}. Must be one of: ${VALID_STRATEGIES.join(', ')}` };
+      }
     }
   }
 

--- a/src/cli/tui/screens/memory/AddMemoryScreen.tsx
+++ b/src/cli/tui/screens/memory/AddMemoryScreen.tsx
@@ -55,7 +55,7 @@ export function AddMemoryScreen({ onComplete, onExit, existingMemoryNames }: Add
     onConfirm: ids => wizard.setStrategyTypes(ids as MemoryStrategyType[]),
     onExit: () => wizard.goBack(),
     isActive: isStrategiesStep,
-    requireSelection: true,
+    requireSelection: false,
   });
 
   useListNavigation({
@@ -102,7 +102,7 @@ export function AddMemoryScreen({ onComplete, onExit, existingMemoryNames }: Add
         {isStrategiesStep && (
           <WizardMultiSelect
             title="Select memory strategies"
-            description="Choose one or more strategies for this memory"
+            description="Choose strategies for this memory (optional)"
             items={strategyItems}
             cursorIndex={strategiesNav.cursorIndex}
             selectedIds={strategiesNav.selectedIds}
@@ -114,7 +114,7 @@ export function AddMemoryScreen({ onComplete, onExit, existingMemoryNames }: Add
             fields={[
               { label: 'Name', value: wizard.config.name },
               { label: 'Event Expiry', value: `${wizard.config.eventExpiryDuration} days` },
-              { label: 'Strategies', value: wizard.config.strategies.map(s => s.type).join(', ') },
+              { label: 'Strategies', value: wizard.config.strategies.map(s => s.type).join(', ') || 'None' },
             ]}
           />
         )}


### PR DESCRIPTION
## Description

Remove the minimum 1 strategy requirement when adding memory, allowing users to create a memory with an empty strategies array. The Zod schema already supported this via `.default([])`, but the TUI and CLI validation layers blocked it.

## Related Issues

Fixes #210 

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Check all that apply -->

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [X] I ran `npm run test:all`
- [X] I ran `npm run typecheck`
- [X] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
