### PR TITLE
fix: show friendly error when commands run from wrong directory (#206)

### DIFF
--- a/src/cli/commands/dev/command.tsx
+++ b/src/cli/commands/dev/command.tsx
@@ -1,10 +1,12 @@
 import { getWorkingDirectory } from '../../../lib';
+import { getErrorMessage } from '../../errors';
 import { getDevSupportedAgents, invokeAgent, invokeAgentStreaming, loadProjectConfig } from '../../operations/dev';
 import { FatalError } from '../../tui/components';
 import { LayoutProvider } from '../../tui/context';
 import { COMMAND_DESCRIPTIONS } from '../../tui/copy';
+import { requireProject } from '../../tui/guards';
 import type { Command } from '@commander-js/extra-typings';
-import { render } from 'ink';
+import { Text, render } from 'ink';
 import React from 'react';
 
 // Alternate screen buffer - same as main TUI
@@ -46,140 +48,148 @@ export const registerDev = (program: Command) => {
     .option('-s, --stream', 'Stream response when using --invoke')
     .option('-l, --logs', 'Run dev server with logs to stdout (non-interactive)')
     .action(async opts => {
-      const port = parseInt(opts.port, 10);
+      try {
+        const port = parseInt(opts.port, 10);
 
-      // If --invoke provided, call the dev server and exit
-      if (opts.invoke) {
-        const { getAgentPort } = await import('../../operations/dev');
-        const invokeProject = await loadProjectConfig(getWorkingDirectory());
+        // If --invoke provided, call the dev server and exit
+        if (opts.invoke) {
+          const { getAgentPort } = await import('../../operations/dev');
+          const invokeProject = await loadProjectConfig(getWorkingDirectory());
 
-        // Determine which agent/port to invoke
-        let invokePort = port;
-        if (opts.agent && invokeProject) {
-          invokePort = getAgentPort(invokeProject, opts.agent, port);
-        } else if (invokeProject && invokeProject.agents.length > 1 && !opts.agent) {
-          const names = invokeProject.agents.map(a => a.name).join(', ');
-          console.error(`Error: Multiple agents found. Use --agent to specify which one.`);
-          console.error(`Available: ${names}`);
+          // Determine which agent/port to invoke
+          let invokePort = port;
+          if (opts.agent && invokeProject) {
+            invokePort = getAgentPort(invokeProject, opts.agent, port);
+          } else if (invokeProject && invokeProject.agents.length > 1 && !opts.agent) {
+            const names = invokeProject.agents.map(a => a.name).join(', ');
+            console.error(`Error: Multiple agents found. Use --agent to specify which one.`);
+            console.error(`Available: ${names}`);
+            process.exit(1);
+          }
+
+          await invokeDevServer(invokePort, opts.invoke, opts.stream ?? false);
+          return;
+        }
+
+        requireProject();
+
+        const workingDir = getWorkingDirectory();
+        const project = await loadProjectConfig(workingDir);
+
+        if (!project) {
+          render(<FatalError message="No agentcore project found." suggestedCommand="agentcore create" />);
           process.exit(1);
         }
 
-        await invokeDevServer(invokePort, opts.invoke, opts.stream ?? false);
-        return;
-      }
+        if (!project.agents || project.agents.length === 0) {
+          render(<FatalError message="No agents defined in project." suggestedCommand="agentcore add agent" />);
+          process.exit(1);
+        }
 
-      const workingDir = getWorkingDirectory();
-      const project = await loadProjectConfig(workingDir);
+        const supportedAgents = getDevSupportedAgents(project);
+        if (supportedAgents.length === 0) {
+          render(
+            <FatalError message="No agents support dev mode. Dev mode requires Python agents with an entrypoint." />
+          );
+          process.exit(1);
+        }
 
-      if (!project) {
-        render(<FatalError message="No agentcore project found." suggestedCommand="agentcore create" />);
-        process.exit(1);
-      }
+        // If --logs provided, run non-interactive mode
+        if (opts.logs) {
+          const { findAvailablePort, getDevConfig, getAgentPort, spawnDevServer } =
+            await import('../../operations/dev');
+          const { findConfigRoot, readEnvFile } = await import('../../../lib');
+          const { ExecLogger } = await import('../../logging');
 
-      if (!project.agents || project.agents.length === 0) {
-        render(<FatalError message="No agents defined in project." suggestedCommand="agentcore add agent" />);
-        process.exit(1);
-      }
+          // Require --agent if multiple agents
+          if (project.agents.length > 1 && !opts.agent) {
+            const names = project.agents.map(a => a.name).join(', ');
+            console.error(`Error: Multiple agents found. Use --agent to specify which one.`);
+            console.error(`Available: ${names}`);
+            process.exit(1);
+          }
 
-      const supportedAgents = getDevSupportedAgents(project);
-      if (supportedAgents.length === 0) {
-        render(
-          <FatalError message="No agents support dev mode. Dev mode requires Python agents with an entrypoint." />
+          const agentName = opts.agent ?? project.agents[0]?.name;
+          const configRoot = findConfigRoot(workingDir);
+          const envVars = configRoot ? await readEnvFile(configRoot) : {};
+          const config = getDevConfig(workingDir, project, configRoot ?? undefined, agentName);
+
+          // Create logger for log file path
+          const logger = new ExecLogger({ command: 'dev' });
+
+          // Calculate port based on agent index
+          const basePort = getAgentPort(project, config.agentName, port);
+          const actualPort = await findAvailablePort(basePort);
+          if (actualPort !== basePort) {
+            console.log(`Port ${basePort} in use, using ${actualPort}`);
+          }
+
+          console.log(`Starting dev server...`);
+          console.log(`Agent: ${config.agentName}`);
+          console.log(`Server: http://localhost:${actualPort}/invocations`);
+          console.log(`Log: ${logger.getRelativeLogPath()}`);
+          console.log(`Press Ctrl+C to stop\n`);
+
+          const child = spawnDevServer({
+            module: config.module,
+            cwd: config.directory,
+            port: actualPort,
+            isPython: config.isPython,
+            envVars,
+            callbacks: {
+              onLog: (level, msg) => {
+                const prefix = level === 'error' ? '❌' : level === 'warn' ? '⚠️' : '→';
+                console.log(`${prefix} ${msg}`);
+                logger.log(msg, level === 'error' ? 'error' : 'info');
+              },
+              onExit: code => {
+                console.log(`\nServer exited with code ${code ?? 0}`);
+                logger.finalize(code === 0);
+                process.exit(code ?? 0);
+              },
+            },
+          });
+
+          // Handle Ctrl+C
+          process.on('SIGINT', () => {
+            console.log('\nStopping server...');
+            child?.kill('SIGTERM');
+          });
+
+          // Keep process alive
+          // eslint-disable-next-line @typescript-eslint/no-empty-function
+          await new Promise(() => {});
+        }
+
+        // Enter alternate screen buffer for fullscreen mode
+        process.stdout.write(ENTER_ALT_SCREEN);
+
+        const exitAltScreen = () => {
+          process.stdout.write(EXIT_ALT_SCREEN);
+          process.stdout.write(SHOW_CURSOR);
+        };
+
+        const { DevScreen } = await import('../../tui/screens/dev/DevScreen');
+        const { unmount, waitUntilExit } = render(
+          <LayoutProvider>
+            <DevScreen
+              onBack={() => {
+                exitAltScreen();
+                unmount();
+                process.exit(0);
+              }}
+              workingDir={workingDir}
+              port={port}
+              agentName={opts.agent}
+            />
+          </LayoutProvider>
         );
+
+        await waitUntilExit();
+        exitAltScreen();
+      } catch (error) {
+        render(<Text color="red">Error: {getErrorMessage(error)}</Text>);
         process.exit(1);
       }
-
-      // If --logs provided, run non-interactive mode
-      if (opts.logs) {
-        const { findAvailablePort, getDevConfig, getAgentPort, spawnDevServer } = await import('../../operations/dev');
-        const { findConfigRoot, readEnvFile } = await import('../../../lib');
-        const { ExecLogger } = await import('../../logging');
-
-        // Require --agent if multiple agents
-        if (project.agents.length > 1 && !opts.agent) {
-          const names = project.agents.map(a => a.name).join(', ');
-          console.error(`Error: Multiple agents found. Use --agent to specify which one.`);
-          console.error(`Available: ${names}`);
-          process.exit(1);
-        }
-
-        const agentName = opts.agent ?? project.agents[0]?.name;
-        const configRoot = findConfigRoot(workingDir);
-        const envVars = configRoot ? await readEnvFile(configRoot) : {};
-        const config = getDevConfig(workingDir, project, configRoot ?? undefined, agentName);
-
-        // Create logger for log file path
-        const logger = new ExecLogger({ command: 'dev' });
-
-        // Calculate port based on agent index
-        const basePort = getAgentPort(project, config.agentName, port);
-        const actualPort = await findAvailablePort(basePort);
-        if (actualPort !== basePort) {
-          console.log(`Port ${basePort} in use, using ${actualPort}`);
-        }
-
-        console.log(`Starting dev server...`);
-        console.log(`Agent: ${config.agentName}`);
-        console.log(`Server: http://localhost:${actualPort}/invocations`);
-        console.log(`Log: ${logger.getRelativeLogPath()}`);
-        console.log(`Press Ctrl+C to stop\n`);
-
-        const child = spawnDevServer({
-          module: config.module,
-          cwd: config.directory,
-          port: actualPort,
-          isPython: config.isPython,
-          envVars,
-          callbacks: {
-            onLog: (level, msg) => {
-              const prefix = level === 'error' ? '❌' : level === 'warn' ? '⚠️' : '→';
-              console.log(`${prefix} ${msg}`);
-              logger.log(msg, level === 'error' ? 'error' : 'info');
-            },
-            onExit: code => {
-              console.log(`\nServer exited with code ${code ?? 0}`);
-              logger.finalize(code === 0);
-              process.exit(code ?? 0);
-            },
-          },
-        });
-
-        // Handle Ctrl+C
-        process.on('SIGINT', () => {
-          console.log('\nStopping server...');
-          child?.kill('SIGTERM');
-        });
-
-        // Keep process alive
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        await new Promise(() => {});
-      }
-
-      // Enter alternate screen buffer for fullscreen mode
-      process.stdout.write(ENTER_ALT_SCREEN);
-
-      const exitAltScreen = () => {
-        process.stdout.write(EXIT_ALT_SCREEN);
-        process.stdout.write(SHOW_CURSOR);
-      };
-
-      const { DevScreen } = await import('../../tui/screens/dev/DevScreen');
-      const { unmount, waitUntilExit } = render(
-        <LayoutProvider>
-          <DevScreen
-            onBack={() => {
-              exitAltScreen();
-              unmount();
-              process.exit(0);
-            }}
-            workingDir={workingDir}
-            port={port}
-            agentName={opts.agent}
-          />
-        </LayoutProvider>
-      );
-
-      await waitUntilExit();
-      exitAltScreen();
     });
 };

--- a/src/cli/tui/guards/index.ts
+++ b/src/cli/tui/guards/index.ts
@@ -1,1 +1,7 @@
-export { projectExists, requireProject, MissingProjectMessage } from './project';
+export {
+  projectExists,
+  getProjectRootMismatch,
+  requireProject,
+  MissingProjectMessage,
+  WrongDirectoryMessage,
+} from './project';

--- a/src/cli/tui/guards/project.tsx
+++ b/src/cli/tui/guards/project.tsx
@@ -1,6 +1,7 @@
 import { findConfigRoot, getWorkingDirectory } from '../../../lib';
 import { FatalError } from '../components';
 import { Box, Text, render } from 'ink';
+import { dirname, resolve } from 'path';
 import React from 'react';
 
 /**
@@ -9,6 +10,24 @@ import React from 'react';
  */
 export function projectExists(baseDir: string = getWorkingDirectory()): boolean {
   return findConfigRoot(baseDir) !== null;
+}
+
+/**
+ * Check if the current working directory is the project root.
+ * Returns the project root path if cwd is a subdirectory, or null if at the root.
+ * Returns null if no project is found at all (use projectExists for that check).
+ */
+export function getProjectRootMismatch(baseDir: string = getWorkingDirectory()): string | null {
+  const configRoot = findConfigRoot(baseDir);
+  if (!configRoot) {
+    return null;
+  }
+  const projectRoot = resolve(dirname(configRoot));
+  const resolvedCwd = resolve(baseDir);
+  if (resolvedCwd !== projectRoot) {
+    return projectRoot;
+  }
+  return null;
 }
 
 interface MissingProjectMessageProps {
@@ -33,17 +52,53 @@ export function MissingProjectMessage({ inTui }: MissingProjectMessageProps) {
 }
 
 /**
+ * Inline message component for wrong directory.
+ * Used within TUI screens to show a notice when the user is in a subdirectory.
+ */
+export function WrongDirectoryMessage({ projectRoot }: { projectRoot: string }) {
+  return (
+    <Box flexDirection="column">
+      <Text color="red">Please run this command from your project root directory.</Text>
+      <Text>
+        Project root: <Text color="blue">{projectRoot}</Text>
+      </Text>
+      <Text>
+        Run <Text color="blue">cd {projectRoot}</Text> and try again.
+      </Text>
+    </Box>
+  );
+}
+
+/**
  * Guard that checks for project and exits with error message if not found.
+ * Also checks that the user is running from the project root directory,
+ * not from a subdirectory like app/ or agentcore/.
+ *
  * Call this early in command handlers before rendering screens.
  *
  * @param inTui - If true, shows "create" instead of "agentcore create"
  */
 export function requireProject(inTui = false): void {
-  if (projectExists()) {
-    return;
+  const cwd = getWorkingDirectory();
+  const configRoot = findConfigRoot(cwd);
+
+  if (!configRoot) {
+    const suggestedCommand = inTui ? 'create' : 'agentcore create';
+    render(<FatalError message="No agentcore project found." suggestedCommand={suggestedCommand} />);
+    process.exit(1);
   }
 
-  const suggestedCommand = inTui ? 'create' : 'agentcore create';
-  render(<FatalError message="No agentcore project found." suggestedCommand={suggestedCommand} />);
-  process.exit(1);
+  const projectRoot = resolve(dirname(configRoot));
+  const resolvedCwd = resolve(cwd);
+
+  if (resolvedCwd !== projectRoot) {
+    render(
+      <FatalError
+        message="Please run this command from your project root directory."
+        detail={`You are in: ${resolvedCwd}\nProject root: ${projectRoot}`}
+        suggestedCommand={`cd ${projectRoot}`}
+      />
+    );
+    process.exit(1);
+  }
 }


### PR DESCRIPTION
## Description

 Commands fail with the full JS stack trace when run from a subdirectory of the project (e.g., app/ or agentcore/) instead of the project root. This happens because findConfigRoot() walks up and finds the project, but downstream code (CDK toolkit, path resolution, etc.) assumes process.cwd() is the project root.                                                                                                                                            

This fix adds early detection of the cwd vs project root mismatch and shows a friendly error message instead of a stack trace:

  - CLI commands (agentcore dev, agentcore deploy, etc.): requireProject() now checks that cwd matches the project root and exits with a clear messageshowing the current directory, the project root, and a cd suggestion.
  - Interactive TUI: When selecting a command from the menu while in a subdirectory, a notice is shown instead of navigating to a screen that would crash.
  - dev command: Added requireProject() guard (was the only command missing it) and wrapped the action in a try/catch safety net.


## Related Issues

Closes https://github.com/aws/agentcore-cli/issues/206

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Check all that apply -->

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [X] I ran `npm run test:all`
- [X] I ran `npm run typecheck`
- [X] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
