### PR TITLE
fix(remove): pass --name flag to TUI flow for direct resource removal

### DIFF
--- a/src/cli/commands/remove/__tests__/remove.test.ts
+++ b/src/cli/commands/remove/__tests__/remove.test.ts
@@ -96,6 +96,38 @@ describe('remove command', () => {
       expect(json.success).toBe(false);
     });
 
+    it('removes existing agent with --name and --force (TUI mode)', async () => {
+      // Add another agent for this test
+      const addResult = await runCLI(
+        [
+          'add',
+          'agent',
+          '--name',
+          'TUITestAgent',
+          '--language',
+          'Python',
+          '--framework',
+          'Strands',
+          '--model-provider',
+          'Bedrock',
+          '--memory',
+          'none',
+          '--json',
+        ],
+        projectDir
+      );
+      expect(addResult.exitCode).toBe(0);
+
+      // Remove agent using TUI mode with --name and --force (no --json)
+      const result = await runCLI(['remove', 'agent', '--name', 'TUITestAgent', '--force'], projectDir);
+      expect(result.exitCode).toBe(0);
+
+      // Verify agent is removed from schema
+      const schema = JSON.parse(await readFile(join(projectDir, 'agentcore', 'agentcore.json'), 'utf-8'));
+      const agent = schema.agents.find((a: { name: string }) => a.name === 'TUITestAgent');
+      expect(agent, 'TUITestAgent should be removed from schema').toBeUndefined();
+    });
+
     it('removes existing agent', async () => {
       const result = await runCLI(['remove', 'agent', '--name', 'TestAgent', '--json'], projectDir);
       expect(result.exitCode).toBe(0);

--- a/src/cli/commands/remove/command.tsx
+++ b/src/cli/commands/remove/command.tsx
@@ -12,6 +12,7 @@ import React from 'react';
 interface TUIRemoveOptions {
   force?: boolean;
   dryRun?: boolean;
+  name?: string;
 }
 
 function handleRemoveAllTUI(options: TUIRemoveOptions = {}): void {
@@ -28,12 +29,13 @@ function handleRemoveAllTUI(options: TUIRemoveOptions = {}): void {
   );
 }
 
-function handleRemoveResourceTUI(resourceType: ResourceType, options: { force?: boolean }): void {
+function handleRemoveResourceTUI(resourceType: ResourceType, options: { force?: boolean; name?: string }): void {
   const { clear, unmount } = render(
     <RemoveFlow
       isInteractive={false}
       force={options.force}
       initialResourceType={resourceType}
+      initialResourceName={options.name}
       onExit={() => {
         clear();
         unmount();
@@ -90,7 +92,7 @@ function registerResourceRemove(
             json: true,
           });
         } else {
-          handleRemoveResourceTUI(resourceType, { force: cliOptions.force });
+          handleRemoveResourceTUI(resourceType, { force: cliOptions.force, name: cliOptions.name });
         }
       } catch (error) {
         if (cliOptions.json) {


### PR DESCRIPTION
## Summary

- Fixes the `--name` flag being ignored when running `agentcore remove agent --name MyAgent` without `--json`
- Previously, the TUI would show the agent selection screen instead of directly removing the named agent

## Changes

- Add `name` parameter to `TUIRemoveOptions` interface and pass it to `RemoveFlow` component
- Add `initialResourceName` prop to `RemoveFlow` that triggers auto-selection via `useEffect`
- Prevent selection screens from rendering while waiting for auto-selection to complete
- Add test case for TUI mode removal with `--name` and `--force` flags

## Test plan

- [x] Unit tests pass: `npm test -- src/cli/commands/remove/__tests__/remove.test.ts`
- [x] Manual test: `agentcore remove agent --name TestAgent --force` removes agent directly without showing selection screen

Closes #171