### PR TITLE
fix: remove AutoGen from add/create flows

### DIFF
--- a/src/cli/commands/add/command.tsx
+++ b/src/cli/commands/add/command.tsx
@@ -260,7 +260,7 @@ export function registerAdd(program: Command) {
     .option('--name <name>', 'Agent name (start with letter, alphanumeric only, max 64 chars)')
     .option('--type <type>', 'Agent type: create or byo', 'create')
     .option('--language <lang>', 'Language: Python (create), or Python/TypeScript/Other (BYO)')
-    .option('--framework <fw>', 'Framework: Strands, LangChain_LangGraph, AutoGen, CrewAI, GoogleADK, OpenAIAgents')
+    .option('--framework <fw>', 'Framework: Strands, LangChain_LangGraph, CrewAI, GoogleADK, OpenAIAgents')
     .option('--model-provider <provider>', 'Model provider: Bedrock, Anthropic, OpenAI, Gemini')
     .option('--api-key <key>', 'API key for non-Bedrock providers')
     .option('--memory <mem>', 'Memory: none, shortTerm, longAndShortTerm (create path only)')

--- a/src/cli/commands/create/command.tsx
+++ b/src/cli/commands/create/command.tsx
@@ -136,7 +136,7 @@ export const registerCreate = (program: Command) => {
     .option('--language <language>', 'Target language (Python, TypeScript)')
     .option(
       '--framework <framework>',
-      'Agent framework (Strands, LangChain_LangGraph, AutoGen, CrewAI, GoogleADK, OpenAIAgents)'
+      'Agent framework (Strands, LangChain_LangGraph, CrewAI, GoogleADK, OpenAIAgents)'
     )
     .option('--model-provider <provider>', 'Model provider (Bedrock, Anthropic, OpenAI, Gemini)')
     .option('--api-key <key>', 'API key for non-Bedrock providers')

--- a/src/cli/templates/index.ts
+++ b/src/cli/templates/index.ts
@@ -1,4 +1,3 @@
-import { AutoGenRenderer } from './AutoGenRenderer';
 import type { BaseRenderer } from './BaseRenderer';
 import { CrewAIRenderer } from './CrewAIRenderer';
 import { GoogleADKRenderer } from './GoogleADKRenderer';
@@ -10,7 +9,6 @@ import type { AgentRenderConfig } from './types';
 export { BaseRenderer, type RendererContext } from './BaseRenderer';
 export { CDKRenderer, type CDKRendererContext } from './CDKRenderer';
 export { renderMcpToolTemplate } from './McpToolRenderer';
-export { AutoGenRenderer } from './AutoGenRenderer';
 export { CrewAIRenderer } from './CrewAIRenderer';
 export { GoogleADKRenderer } from './GoogleADKRenderer';
 export { LangGraphRenderer } from './LangGraphRenderer';
@@ -25,8 +23,6 @@ export function createRenderer(config: AgentRenderConfig): BaseRenderer {
   switch (config.sdkFramework) {
     case 'Strands':
       return new StrandsRenderer(config);
-    case 'AutoGen':
-      return new AutoGenRenderer(config);
     case 'CrewAI':
       return new CrewAIRenderer(config);
     case 'GoogleADK':

--- a/src/cli/tui/screens/agent/types.ts
+++ b/src/cli/tui/screens/agent/types.ts
@@ -84,7 +84,6 @@ export const LANGUAGE_OPTIONS = [
 export const FRAMEWORK_OPTIONS = [
   { id: 'Strands', title: 'Strands Agents SDK', description: 'AWS native agent framework' },
   { id: 'LangChain_LangGraph', title: 'LangChain + LangGraph', description: 'Popular open-source frameworks' },
-  { id: 'AutoGen', title: 'AutoGen', description: 'Microsoft multi-agent framework' },
   { id: 'GoogleADK', title: 'Google ADK', description: 'Google Agent Development Kit' },
   { id: 'OpenAIAgents', title: 'OpenAI Agents', description: 'OpenAI native agent SDK' },
 ] as const;

--- a/src/cli/tui/screens/generate/types.ts
+++ b/src/cli/tui/screens/generate/types.ts
@@ -46,7 +46,6 @@ export const LANGUAGE_OPTIONS = [
 export const SDK_OPTIONS = [
   { id: 'Strands', title: 'Strands Agents SDK', description: 'AWS native agent framework' },
   { id: 'LangChain_LangGraph', title: 'LangChain + LangGraph', description: 'Popular open-source frameworks' },
-  { id: 'AutoGen', title: 'AutoGen', description: 'Microsoft multi-agent framework' },
   { id: 'GoogleADK', title: 'Google ADK', description: 'Google Agent Development Kit' },
   { id: 'OpenAIAgents', title: 'OpenAI Agents', description: 'OpenAI native agent SDK' },
 ] as const;

--- a/src/schema/constants.ts
+++ b/src/schema/constants.ts
@@ -4,14 +4,7 @@ import { z } from 'zod';
 // Feature Constants (shared across all schemas)
 // ============================================================================
 
-export const SDKFrameworkSchema = z.enum([
-  'Strands',
-  'LangChain_LangGraph',
-  'AutoGen',
-  'CrewAI',
-  'GoogleADK',
-  'OpenAIAgents',
-]);
+export const SDKFrameworkSchema = z.enum(['Strands', 'LangChain_LangGraph', 'CrewAI', 'GoogleADK', 'OpenAIAgents']);
 export type SDKFramework = z.infer<typeof SDKFrameworkSchema>;
 
 export const TargetLanguageSchema = z.enum(['Python', 'TypeScript', 'Other']);
@@ -29,7 +22,6 @@ export type ModelProvider = z.infer<typeof ModelProviderSchema>;
 export const SDK_MODEL_PROVIDER_MATRIX: Record<SDKFramework, readonly ModelProvider[]> = {
   Strands: ['Bedrock', 'Anthropic', 'OpenAI', 'Gemini'] as const,
   LangChain_LangGraph: ['Bedrock', 'Anthropic', 'OpenAI', 'Gemini'] as const,
-  AutoGen: ['Bedrock', 'Anthropic', 'OpenAI', 'Gemini'] as const,
   CrewAI: ['Bedrock', 'Anthropic', 'OpenAI', 'Gemini'] as const,
   GoogleADK: ['Gemini'] as const,
   OpenAIAgents: ['OpenAI'] as const,


### PR DESCRIPTION
## Summary
- Temporarily removes AutoGen as a selectable framework option from the CLI (fixes #211)
- Preserves `AutoGenRenderer.ts` and template assets (`src/assets/python/autogen/`) for future re-enablement
- AutoGen-related names remain reserved in `RESERVED_PROJECT_NAMES`

## Changes
- Remove `AutoGen` from `SDKFrameworkSchema` enum and `SDK_MODEL_PROVIDER_MATRIX`
- Remove `AutoGen` from `--framework` CLI help text in add/create commands  
- Remove `AutoGen` from TUI `SDK_OPTIONS` and `FRAMEWORK_OPTIONS` arrays
- Remove `AutoGen` import/export and case from `createRenderer` factory

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (0 errors)
- [x] `npm run test:unit` passes (262 tests)
- [ ] Verify `agentcore create --help` does not list AutoGen
- [ ] Verify `agentcore add agent --help` does not list AutoGen
- [ ] Verify TUI framework selection does not show AutoGen