### PR TITLE
fix: correct API key file path in credential success message

### DIFF
--- a/src/cli/tui/screens/identity/AddIdentityFlow.tsx
+++ b/src/cli/tui/screens/identity/AddIdentityFlow.tsx
@@ -59,7 +59,7 @@ export function AddIdentityFlow({ isInteractive = true, onExit, onBack, onDev, o
       <AddSuccessScreen
         isInteractive={isInteractive}
         message={`Added credential: ${flow.identityName}`}
-        detail="Credential added to project in `agentcore/agentcore.json`. API key stored in `agentcore/.env`."
+        detail="Credential added to project in `agentcore/agentcore.json`. API key stored in `agentcore/.env.local`."
         showDevOption={true}
         onAddAnother={onBack}
         onDev={onDev}


### PR DESCRIPTION
## Summary
- Fixed the credential success message to show the correct file path `.env.local` instead of `.env`
- The message was inconsistent with the actual `ENV_FILE` constant defined in `src/lib/constants.ts`

## Test plan
- [x] Run `agentcore add credential` and verify the success message shows `agentcore/.env.local`

Closes #144