### PR TITLE
fix: validate agents exist before dev/deploy commands

### DIFF
--- a/src/cli/commands/dev/command.tsx
+++ b/src/cli/commands/dev/command.tsx
@@ -114,6 +114,11 @@ export const registerDev = (program: Command) => {
           const envVars = configRoot ? await readEnvFile(configRoot) : {};
           const config = getDevConfig(workingDir, project, configRoot ?? undefined, agentName);
 
+          if (!config) {
+            console.error('Error: No dev-supported agents found.');
+            process.exit(1);
+          }
+
           // Create logger for log file path
           const logger = new ExecLogger({ command: 'dev' });
 

--- a/src/cli/operations/deploy/preflight.ts
+++ b/src/cli/operations/deploy/preflight.ts
@@ -70,6 +70,13 @@ export async function validateProject(): Promise<PreflightContext> {
   const projectSpec = await configIO.readProjectSpec();
   const awsTargets = await configIO.readAWSDeploymentTargets();
 
+  // Validate that at least one agent is defined
+  if (!projectSpec.agents || projectSpec.agents.length === 0) {
+    throw new Error(
+      'No agents defined in project. Add at least one agent with "agentcore add agent" before deploying.'
+    );
+  }
+
   // Validate runtime names don't exceed AWS limits
   validateRuntimeNames(projectSpec);
 

--- a/src/cli/operations/dev/__tests__/config.test.ts
+++ b/src/cli/operations/dev/__tests__/config.test.ts
@@ -1,0 +1,167 @@
+import type { AgentCoreProjectSpec, DirectoryPath, FilePath } from '../../../../schema';
+import { getDevConfig, getDevSupportedAgents } from '../config';
+import { describe, expect, it } from 'vitest';
+
+// Helper to cast strings to branded path types for testing
+const filePath = (s: string) => s as FilePath;
+const dirPath = (s: string) => s as DirectoryPath;
+
+describe('getDevConfig', () => {
+  const workingDir = '/test/project';
+
+  it('returns null when project has no agents', () => {
+    const project: AgentCoreProjectSpec = {
+      name: 'TestProject',
+      version: 1,
+      agents: [],
+      memories: [],
+      credentials: [],
+    };
+
+    const config = getDevConfig(workingDir, project);
+    expect(config).toBeNull();
+  });
+
+  it('returns null when project has no dev-supported agents', () => {
+    const project: AgentCoreProjectSpec = {
+      name: 'TestProject',
+      version: 1,
+      agents: [
+        {
+          type: 'AgentCoreRuntime',
+          name: 'NodeAgent',
+          build: 'CodeZip',
+          runtimeVersion: 'NODE_20',
+          entrypoint: filePath('index.js'), // Not a Python agent
+          codeLocation: dirPath('./agents/node'),
+        },
+      ],
+      memories: [],
+      credentials: [],
+    };
+
+    const config = getDevConfig(workingDir, project);
+    expect(config).toBeNull();
+  });
+
+  it('returns config when project has a Python agent', () => {
+    const project: AgentCoreProjectSpec = {
+      name: 'TestProject',
+      version: 1,
+      agents: [
+        {
+          type: 'AgentCoreRuntime',
+          name: 'PythonAgent',
+          build: 'CodeZip',
+          runtimeVersion: 'PYTHON_3_12',
+          entrypoint: filePath('main.py'),
+          codeLocation: dirPath('./agents/python'),
+        },
+      ],
+      memories: [],
+      credentials: [],
+    };
+
+    const config = getDevConfig(workingDir, project, '/test/project/agentcore');
+    expect(config).not.toBeNull();
+    expect(config?.agentName).toBe('PythonAgent');
+    expect(config?.module).toBe('main.py');
+  });
+
+  it('throws when project is null', () => {
+    expect(() => getDevConfig(workingDir, null)).toThrow('No project configuration found');
+  });
+
+  it('throws when specified agent not found', () => {
+    const project: AgentCoreProjectSpec = {
+      name: 'TestProject',
+      version: 1,
+      agents: [
+        {
+          type: 'AgentCoreRuntime',
+          name: 'PythonAgent',
+          build: 'CodeZip',
+          runtimeVersion: 'PYTHON_3_12',
+          entrypoint: filePath('main.py'),
+          codeLocation: dirPath('./agents/python'),
+        },
+      ],
+      memories: [],
+      credentials: [],
+    };
+
+    expect(() => getDevConfig(workingDir, project, undefined, 'NonExistentAgent')).toThrow(
+      'Agent "NonExistentAgent" not found'
+    );
+  });
+});
+
+describe('getDevSupportedAgents', () => {
+  it('returns empty array when project is null', () => {
+    expect(getDevSupportedAgents(null)).toEqual([]);
+  });
+
+  it('returns empty array when project has no agents', () => {
+    const project: AgentCoreProjectSpec = {
+      name: 'TestProject',
+      version: 1,
+      agents: [],
+      memories: [],
+      credentials: [],
+    };
+
+    expect(getDevSupportedAgents(project)).toEqual([]);
+  });
+
+  it('returns empty array when no agents are Python', () => {
+    const project: AgentCoreProjectSpec = {
+      name: 'TestProject',
+      version: 1,
+      agents: [
+        {
+          type: 'AgentCoreRuntime',
+          name: 'NodeAgent',
+          build: 'CodeZip',
+          runtimeVersion: 'NODE_20',
+          entrypoint: filePath('index.js'),
+          codeLocation: dirPath('./agents/node'),
+        },
+      ],
+      memories: [],
+      credentials: [],
+    };
+
+    expect(getDevSupportedAgents(project)).toEqual([]);
+  });
+
+  it('returns only Python agents with entrypoints', () => {
+    const project: AgentCoreProjectSpec = {
+      name: 'TestProject',
+      version: 1,
+      agents: [
+        {
+          type: 'AgentCoreRuntime',
+          name: 'PythonAgent',
+          build: 'CodeZip',
+          runtimeVersion: 'PYTHON_3_12',
+          entrypoint: filePath('main.py'),
+          codeLocation: dirPath('./agents/python'),
+        },
+        {
+          type: 'AgentCoreRuntime',
+          name: 'NodeAgent',
+          build: 'CodeZip',
+          runtimeVersion: 'NODE_20',
+          entrypoint: filePath('index.js'),
+          codeLocation: dirPath('./agents/node'),
+        },
+      ],
+      memories: [],
+      credentials: [],
+    };
+
+    const supported = getDevSupportedAgents(project);
+    expect(supported).toHaveLength(1);
+    expect(supported[0]?.name).toBe('PythonAgent');
+  });
+});

--- a/src/cli/operations/dev/config.ts
+++ b/src/cli/operations/dev/config.ts
@@ -91,7 +91,7 @@ export function getDevConfig(
   project: AgentCoreProjectSpec | null,
   configRoot?: string,
   agentName?: string
-): DevConfig {
+): DevConfig | null {
   if (!project) {
     throw new Error('No project configuration found');
   }
@@ -110,7 +110,8 @@ export function getDevConfig(
   }
 
   if (!targetAgent) {
-    throw new Error('No dev-supported agents found. Dev mode requires Python agents.');
+    // Return null instead of throwing - let caller handle the UI for no agents
+    return null;
   }
 
   const supportResult = isDevSupported(targetAgent);

--- a/src/cli/tui/screens/dev/DevScreen.tsx
+++ b/src/cli/tui/screens/dev/DevScreen.tsx
@@ -111,6 +111,7 @@ export function DevScreen(props: DevScreenProps) {
   const [selectedAgentIndex, setSelectedAgentIndex] = useState(0);
   const [selectedAgentName, setSelectedAgentName] = useState<string | undefined>(props.agentName);
   const [agentsLoaded, setAgentsLoaded] = useState(false);
+  const [noAgentsError, setNoAgentsError] = useState(false);
 
   const workingDir = props.workingDir ?? process.cwd();
 
@@ -136,8 +137,8 @@ export function DevScreen(props: DevScreenProps) {
         setSelectedAgentName(agents[0].name);
         setMode('input');
       } else if (agents.length === 0) {
-        // No supported agents, will show error via useDevServer
-        setMode('input');
+        // No supported agents, show error screen
+        setNoAgentsError(true);
       }
 
       setAgentsLoaded(true);
@@ -323,8 +324,23 @@ export function DevScreen(props: DevScreenProps) {
   );
 
   // Return null while loading
-  if (!agentsLoaded || (mode !== 'select-agent' && (!configLoaded || !config))) {
+  if (!agentsLoaded || (mode !== 'select-agent' && !noAgentsError && (!configLoaded || !config))) {
     return null;
+  }
+
+  // Show error screen if no agents are defined
+  if (noAgentsError) {
+    return (
+      <Screen title="Dev Server" onExit={props.onBack} helpText="Esc quit">
+        <Box flexDirection="column">
+          <Text color="red">No agents defined in project.</Text>
+          <Text>Dev mode requires at least one Python agent with an entrypoint.</Text>
+          <Text>
+            Run <Text color="blue">agentcore add agent</Text> to create one.
+          </Text>
+        </Box>
+      </Screen>
+    );
   }
 
   const statusColor = { starting: 'yellow', running: 'green', error: 'red', stopped: 'gray' }[status];


### PR DESCRIPTION
## Summary
- **Issue #150**: Running `dev` without agents crashes the CLI. Now shows error screen with guidance.
- **Issue #151**: Running `deploy` without agents fails late. Now validates in preflight and shows clear error.

## Changes
- `DevScreen.tsx`: Added `noAgentsError` state; renders helpful error screen when no agents found
- `preflight.ts`: Added validation in `validateProject()` to check agents array before proceeding

## Test plan
- [x] Build passes (`npm run build`)
- [x] All unit tests pass (`npm test`)
- [ ] Manual test: Create project without agents, run `agentcore dev` → shows error screen
- [ ] Manual test: Create project without agents, run `agentcore deploy` → shows preflight error

Closes #150 
Closes #151 