### PR TITLE
chore: add memory documentation hints to CLI output

### DIFF
--- a/src/cli/tui/screens/add/AddFlow.tsx
+++ b/src/cli/tui/screens/add/AddFlow.tsx
@@ -15,6 +15,7 @@ import { AddSuccessScreen } from './AddSuccessScreen';
 import { AddTargetScreen } from './AddTargetScreen';
 import { useAddTarget, useExistingTargets } from './useAddTarget';
 import { Box, Text } from 'ink';
+import Link from 'ink-link';
 import React, { useCallback, useEffect, useState } from 'react';
 
 type FlowState =
@@ -254,13 +255,29 @@ export function AddFlow(props: AddFlowProps) {
   }
 
   if (flow.name === 'agent-create-success') {
+    const memoryDocAnchor =
+      flow.config.memory !== 'none'
+        ? '#swapping-or-changing-memory-strands'
+        : '#adding-memory-to-an-agent-without-memory-strands';
+    const memoryNotePrefix =
+      flow.config.memory !== 'none' ? 'To swap or change memory later, see ' : 'To add memory later, see ';
     return (
       <AddSuccessScreen
         isInteractive={props.isInteractive}
         message={`Created agent: ${flow.agentName}`}
         summary={
           !flow.loading && (
-            <AgentAddedSummary config={flow.config} projectName={flow.projectName} projectPath={flow.projectPath} />
+            <Box flexDirection="column">
+              <AgentAddedSummary config={flow.config} projectName={flow.projectName} projectPath={flow.projectPath} />
+              <Box marginTop={1}>
+                <Text color="yellow">
+                  Note: {memoryNotePrefix}
+                  <Link url={`https://github.com/aws/agentcore-cli/blob/main/docs/memory.md${memoryDocAnchor}`}>
+                    <Text color="cyan">docs/memory.md</Text>
+                  </Link>
+                </Text>
+              </Box>
+            </Box>
           )
         }
         detail="Deploy with `agentcore deploy`."
@@ -278,11 +295,31 @@ export function AddFlow(props: AddFlowProps) {
   }
 
   if (flow.name === 'agent-byo-success') {
+    const memoryDocAnchor =
+      flow.config.memory !== 'none'
+        ? '#swapping-or-changing-memory-strands'
+        : '#adding-memory-to-an-agent-without-memory-strands';
+    const memoryNotePrefix =
+      flow.config.memory !== 'none' ? 'To swap or change memory later, see ' : 'To add memory later, see ';
     return (
       <AddSuccessScreen
         isInteractive={props.isInteractive}
         message={`Added agent: ${flow.agentName}`}
-        summary={!flow.loading && <AgentAddedSummary config={flow.config} projectName={flow.projectName} />}
+        summary={
+          !flow.loading && (
+            <Box flexDirection="column">
+              <AgentAddedSummary config={flow.config} projectName={flow.projectName} />
+              <Box marginTop={1}>
+                <Text color="yellow">
+                  Note: {memoryNotePrefix}
+                  <Link url={`https://github.com/aws/agentcore-cli/blob/main/docs/memory.md${memoryDocAnchor}`}>
+                    <Text color="cyan">docs/memory.md</Text>
+                  </Link>
+                </Text>
+              </Box>
+            </Box>
+          )
+        }
         detail="Deploy with `agentcore deploy`."
         loading={flow.loading}
         loadingMessage={flow.loadingMessage}

--- a/src/cli/tui/screens/memory/AddMemoryFlow.tsx
+++ b/src/cli/tui/screens/memory/AddMemoryFlow.tsx
@@ -3,7 +3,8 @@ import { useCreateMemory, useExistingMemoryNames } from '../../hooks/useCreateMe
 import { AddSuccessScreen } from '../add/AddSuccessScreen';
 import { AddMemoryScreen } from './AddMemoryScreen';
 import type { AddMemoryConfig } from './types';
-import { Text } from 'ink';
+import { Box, Text } from 'ink';
+import Link from 'ink-link';
 import React, { useCallback, useEffect, useState } from 'react';
 
 type FlowState =
@@ -60,10 +61,19 @@ export function AddMemoryFlow({ isInteractive = true, onExit, onBack, onDev, onD
         message={`Added memory: ${flow.memoryName}`}
         detail="Memory added to project in `agentcore/agentcore.json`."
         summary={
-          <Text color="yellow">
-            Note: Once you deploy, the memory resource will be created in your account, but it is not automatically
-            connected to your agent. You must configure your agent code to use this memory.
-          </Text>
+          <Box flexDirection="column">
+            <Text color="yellow">
+              Note: See{' '}
+              <Link url="https://github.com/aws/agentcore-cli/blob/main/docs/memory.md#swapping-or-changing-memory-strands">
+                <Text color="cyan">docs/memory.md</Text>
+              </Link>{' '}
+              to learn how to connect memory to your agent.
+            </Text>
+            <Text color="yellow">
+              Once you deploy, the memory resource will be created in your account, but it is not automatically
+              connected to your agent. You must configure your agent code to use this memory.
+            </Text>
+          </Box>
         }
         onAddAnother={onBack}
         onDev={onDev}


### PR DESCRIPTION
## Description

Improves discoverability of memory configuration documentation by adding contextual hints in CLI output.

Changes:
- Added "Swapping or Changing Memory (Strands)" section to docs/memory.md explaining how to change which memory an agent uses
- Added "Adding Memory to an Agent Without Memory (Strands)" section with step-by-step instructions
- After agentcore add agent: Shows a note with clickable link to relevant docs section based on whether memory was selected
- After agentcore add memory: Shows a note explaining memory isn't auto-connected, with link to docs

Links use ink-link (existing pattern from LogLink.tsx) for clickable hyperlinks in supported terminals, with anchor fragments to navigate directly to the relevant section.

## Related Issues

N/A

## Documentation PR

Documentation is included in this PR (docs/memory.md)

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran npm run test:all
- [x] I ran npm run typecheck
- [x] I ran npm run lint
- [ ] If I modified src/assets/, I ran npm run test:update-snapshots and committed the updated snapshots

Manually tested by running npm pack && npm install -g and verifying the notes appear after agentcore add agent and agentcore add memory.

## Checklist

- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.