### PR TITLE
fix: improve CLI help consistency and interactive/non-interactive mode behavior

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -3,6 +3,7 @@ import { registerCreate } from './commands/create';
 import { registerDeploy } from './commands/deploy';
 import { registerDestroy } from './commands/destroy';
 import { registerDev } from './commands/dev';
+import { registerHelp } from './commands/help';
 import { registerInvoke } from './commands/invoke';
 import { registerPackage } from './commands/package';
 import { registerRemove } from './commands/remove';
@@ -101,6 +102,17 @@ export function createProgram(): Command {
 
   registerCommands(program);
 
+  // Add help footer to all subcommands explaining interactive vs non-interactive
+  const helpFooter =
+    '\nRun without flags for interactive mode. Flags marked [non-interactive] trigger CLI mode.\nRun `agentcore help modes` for details.';
+  program.commands.forEach(cmd => {
+    cmd.addHelpText('after', helpFooter);
+    // Also add to nested subcommands (e.g., add agent, remove agent)
+    cmd.commands.forEach(subcmd => {
+      subcmd.addHelpText('after', helpFooter);
+    });
+  });
+
   return program;
 }
 
@@ -110,6 +122,7 @@ export function registerCommands(program: Command) {
   registerDeploy(program);
   registerDestroy(program);
   registerCreate(program);
+  registerHelp(program);
   registerInvoke(program);
   registerPackage(program);
   registerRemove(program);

--- a/src/cli/commands/add/command.tsx
+++ b/src/cli/commands/add/command.tsx
@@ -243,11 +243,11 @@ export function registerAdd(program: Command) {
   addCmd
     .command('target')
     .description('Add a deployment target')
-    .option('--name <name>', 'Target name')
-    .option('--account <id>', 'AWS account ID')
-    .option('--region <region>', 'AWS region')
-    .option('--description <desc>', 'Optional description')
-    .option('--json', 'Output as JSON')
+    .option('--name <name>', 'Target name [non-interactive]')
+    .option('--account <id>', 'AWS account ID [non-interactive]')
+    .option('--region <region>', 'AWS region [non-interactive]')
+    .option('--description <desc>', 'Optional description [non-interactive]')
+    .option('--json', 'Output as JSON [non-interactive]')
     .action(async options => {
       requireProject();
       await handleAddTargetCLI(options);
@@ -257,16 +257,19 @@ export function registerAdd(program: Command) {
   addCmd
     .command('agent')
     .description('Add an agent to the project')
-    .option('--name <name>', 'Agent name (start with letter, alphanumeric only, max 64 chars)')
-    .option('--type <type>', 'Agent type: create or byo', 'create')
-    .option('--language <lang>', 'Language: Python (create), or Python/TypeScript/Other (BYO)')
-    .option('--framework <fw>', 'Framework: Strands, LangChain_LangGraph, CrewAI, GoogleADK, OpenAIAgents')
-    .option('--model-provider <provider>', 'Model provider: Bedrock, Anthropic, OpenAI, Gemini')
-    .option('--api-key <key>', 'API key for non-Bedrock providers')
-    .option('--memory <mem>', 'Memory: none, shortTerm, longAndShortTerm (create path only)')
-    .option('--code-location <path>', 'Path to existing code (BYO path only)')
-    .option('--entrypoint <file>', 'Entry file relative to code-location (BYO, default: main.py)')
-    .option('--json', 'Output as JSON')
+    .option('--name <name>', 'Agent name (start with letter, alphanumeric only, max 64 chars) [non-interactive]')
+    .option('--type <type>', 'Agent type: create or byo [non-interactive]', 'create')
+    .option('--language <lang>', 'Language: Python (create), or Python/TypeScript/Other (BYO) [non-interactive]')
+    .option(
+      '--framework <fw>',
+      'Framework: Strands, LangChain_LangGraph, CrewAI, GoogleADK, OpenAIAgents [non-interactive]'
+    )
+    .option('--model-provider <provider>', 'Model provider: Bedrock, Anthropic, OpenAI, Gemini [non-interactive]')
+    .option('--api-key <key>', 'API key for non-Bedrock providers [non-interactive]')
+    .option('--memory <mem>', 'Memory: none, shortTerm, longAndShortTerm (create path only) [non-interactive]')
+    .option('--code-location <path>', 'Path to existing code (BYO path only) [non-interactive]')
+    .option('--entrypoint <file>', 'Entry file relative to code-location (BYO, default: main.py) [non-interactive]')
+    .option('--json', 'Output as JSON [non-interactive]')
     .action(async options => {
       requireProject();
       await handleAddAgentCLI(options as AddAgentOptions);
@@ -310,10 +313,13 @@ export function registerAdd(program: Command) {
   addCmd
     .command('memory')
     .description('Add a memory resource to the project')
-    .option('--name <name>', 'Memory name')
-    .option('--strategies <types>', 'Comma-separated strategies: SEMANTIC, SUMMARIZATION, USER_PREFERENCE, CUSTOM')
-    .option('--expiry <days>', 'Event expiry duration in days (default: 30)', parseInt)
-    .option('--json', 'Output as JSON')
+    .option('--name <name>', 'Memory name [non-interactive]')
+    .option(
+      '--strategies <types>',
+      'Comma-separated strategies: SEMANTIC, SUMMARIZATION, USER_PREFERENCE, CUSTOM [non-interactive]'
+    )
+    .option('--expiry <days>', 'Event expiry duration in days (default: 30) [non-interactive]', parseInt)
+    .option('--json', 'Output as JSON [non-interactive]')
     .action(async options => {
       requireProject();
       await handleAddMemoryCLI(options as AddMemoryOptions);
@@ -323,9 +329,9 @@ export function registerAdd(program: Command) {
   addCmd
     .command('identity')
     .description('Add a credential to the project')
-    .option('--name <name>', 'Credential name')
-    .option('--api-key <key>', 'The API key value')
-    .option('--json', 'Output as JSON')
+    .option('--name <name>', 'Credential name [non-interactive]')
+    .option('--api-key <key>', 'The API key value [non-interactive]')
+    .option('--json', 'Output as JSON [non-interactive]')
     .action(async options => {
       requireProject();
       await handleAddIdentityCLI(options as AddIdentityOptions);

--- a/src/cli/commands/create/command.tsx
+++ b/src/cli/commands/create/command.tsx
@@ -139,22 +139,22 @@ export const registerCreate = (program: Command) => {
   program
     .command('create')
     .description(COMMAND_DESCRIPTIONS.create)
-    .option('--name <name>', 'Project name (start with letter, alphanumeric only, max 36 chars)')
-    .option('--no-agent', 'Skip agent creation')
-    .option('--defaults', 'Use defaults (Python, Strands, Bedrock, no memory)')
-    .option('--language <language>', 'Target language (Python, TypeScript)')
+    .option('--name <name>', 'Project name (start with letter, alphanumeric only, max 36 chars) [non-interactive]')
+    .option('--no-agent', 'Skip agent creation [non-interactive]')
+    .option('--defaults', 'Use defaults (Python, Strands, Bedrock, no memory) [non-interactive]')
+    .option('--language <language>', 'Target language (Python, TypeScript) [non-interactive]')
     .option(
       '--framework <framework>',
-      'Agent framework (Strands, LangChain_LangGraph, CrewAI, GoogleADK, OpenAIAgents)'
+      'Agent framework (Strands, LangChain_LangGraph, CrewAI, GoogleADK, OpenAIAgents) [non-interactive]'
     )
-    .option('--model-provider <provider>', 'Model provider (Bedrock, Anthropic, OpenAI, Gemini)')
-    .option('--api-key <key>', 'API key for non-Bedrock providers')
-    .option('--memory <option>', 'Memory option (none, shortTerm, longAndShortTerm)')
-    .option('--output-dir <dir>', 'Output directory (default: current directory)')
-    .option('--skip-git', 'Skip git repository initialization')
-    .option('--skip-python-setup', 'Skip Python virtual environment setup')
-    .option('--dry-run', 'Preview what would be created without making changes')
-    .option('--json', 'Output as JSON')
+    .option('--model-provider <provider>', 'Model provider (Bedrock, Anthropic, OpenAI, Gemini) [non-interactive]')
+    .option('--api-key <key>', 'API key for non-Bedrock providers [non-interactive]')
+    .option('--memory <option>', 'Memory option (none, shortTerm, longAndShortTerm) [non-interactive]')
+    .option('--output-dir <dir>', 'Output directory (default: current directory) [non-interactive]')
+    .option('--skip-git', 'Skip git repository initialization [non-interactive]')
+    .option('--skip-python-setup', 'Skip Python virtual environment setup [non-interactive]')
+    .option('--dry-run', 'Preview what would be created without making changes [non-interactive]')
+    .option('--json', 'Output as JSON [non-interactive]')
     .action(async options => {
       try {
         // Apply defaults if --defaults flag is set
@@ -165,8 +165,24 @@ export const registerCreate = (program: Command) => {
           options.memory = options.memory ?? 'none';
         }
 
-        if (options.name || options.json || options.dryRun) {
-          // CLI mode - any non-interactive flag triggers CLI mode
+        // Any flag triggers non-interactive CLI mode
+        const hasAnyFlag = Boolean(
+          options.name ??
+          (options.agent === false ? true : null) ??
+          options.defaults ??
+          options.language ??
+          options.framework ??
+          options.modelProvider ??
+          options.apiKey ??
+          options.memory ??
+          options.outputDir ??
+          options.skipGit ??
+          options.skipPythonSetup ??
+          options.dryRun ??
+          options.json
+        );
+
+        if (hasAnyFlag) {
           await handleCreateCLI(options as CreateOptions);
         } else {
           handleCreateTUI();

--- a/src/cli/commands/destroy/command.tsx
+++ b/src/cli/commands/destroy/command.tsx
@@ -55,14 +55,19 @@ export const registerDestroy = (program: Command) => {
     .command('destroy')
     .alias('x')
     .description(COMMAND_DESCRIPTIONS.destroy)
-    .option('--target <target>', 'Deployment target name to destroy')
-    .option('-y, --yes', 'Skip confirmation prompt')
-    .option('--json', 'Output as JSON')
+    .option('--target <target>', 'Deployment target name to destroy [non-interactive]')
+    .option('-y, --yes', 'Skip confirmation prompt [non-interactive]')
+    .option('--json', 'Output as JSON [non-interactive]')
     .action(async (cliOptions: { target?: string; yes?: boolean; json?: boolean }) => {
       try {
         requireProject();
-        if (cliOptions.target) {
-          await handleDestroyCLI(cliOptions as DestroyOptions);
+        // Any flag triggers non-interactive CLI mode
+        if (cliOptions.target || cliOptions.yes || cliOptions.json) {
+          const options = {
+            ...cliOptions,
+            target: cliOptions.target ?? 'default',
+          };
+          await handleDestroyCLI(options as DestroyOptions);
         } else {
           handleDestroyTUI();
         }

--- a/src/cli/commands/dev/command.tsx
+++ b/src/cli/commands/dev/command.tsx
@@ -44,9 +44,9 @@ export const registerDev = (program: Command) => {
     .description(COMMAND_DESCRIPTIONS.dev)
     .option('-p, --port <port>', 'Port for development server', '8080')
     .option('-a, --agent <name>', 'Agent to run or invoke (required if multiple agents)')
-    .option('-i, --invoke <prompt>', 'Invoke the running dev server with a prompt')
-    .option('-s, --stream', 'Stream response when using --invoke')
-    .option('-l, --logs', 'Run dev server with logs to stdout (non-interactive)')
+    .option('-i, --invoke <prompt>', 'Invoke running dev server (use --agent if multiple) [non-interactive]')
+    .option('-s, --stream', 'Stream response when using --invoke [non-interactive]')
+    .option('-l, --logs', 'Run dev server with logs to stdout [non-interactive]')
     .action(async opts => {
       try {
         const port = parseInt(opts.port, 10);

--- a/src/cli/commands/help/command.tsx
+++ b/src/cli/commands/help/command.tsx
@@ -1,0 +1,55 @@
+import type { Command } from '@commander-js/extra-typings';
+
+const MODES_HELP = `
+INTERACTIVE MODE (TUI)
+  Run any command without flags to launch the interactive terminal UI.
+  
+  Features:
+    • Guided prompts walk you through options
+    • Real-time streaming for invoke and dev
+    • Visual feedback and progress indicators
+  
+  Examples:
+    agentcore                    # Launch main menu
+    agentcore create             # Guided project creation
+    agentcore add                # Add resources interactively
+    agentcore invoke             # Chat with deployed agent
+
+NON-INTERACTIVE MODE (CLI)
+  Pass any flag marked [non-interactive] to run in CLI mode.
+  
+  Features:
+    • Scriptable for CI/CD pipelines
+    • JSON output with --json flag
+    • No prompts - fails fast on missing required options
+  
+  Examples:
+    agentcore create --name MyProject --defaults --json
+    agentcore deploy --target prod --yes
+    agentcore invoke "Hello" --stream
+    agentcore remove agent --name OldAgent --force
+
+FLAGS THAT TRIGGER CLI MODE
+  Most flags trigger non-interactive mode, including:
+    --name, --json, --yes, --force, --target, --stream, etc.
+  
+  Some flags work in both modes:
+    --session-id (invoke), --port (dev), --agent (dev)
+`;
+
+export const registerHelp = (program: Command) => {
+  const helpCmd = program
+    .command('help')
+    .description('Display help topics')
+    .action(() => {
+      console.log('Available help topics: modes');
+      console.log('Run `agentcore help <topic>` for details.');
+    });
+
+  helpCmd
+    .command('modes')
+    .description('Explain interactive vs non-interactive modes')
+    .action(() => {
+      console.log(MODES_HELP);
+    });
+};

--- a/src/cli/commands/help/index.ts
+++ b/src/cli/commands/help/index.ts
@@ -1,0 +1,1 @@
+export { registerHelp } from './command';

--- a/src/cli/commands/invoke/command.tsx
+++ b/src/cli/commands/invoke/command.tsx
@@ -90,13 +90,13 @@ export const registerInvoke = (program: Command) => {
     .command('invoke')
     .alias('i')
     .description(COMMAND_DESCRIPTIONS.invoke)
-    .argument('[prompt]', 'Prompt to send to the agent')
-    .option('--prompt <text>', 'Prompt to send to the agent')
-    .option('--agent <name>', 'Select specific agent')
-    .option('--target <name>', 'Select deployment target')
+    .argument('[prompt]', 'Prompt to send to the agent [non-interactive]')
+    .option('--prompt <text>', 'Prompt to send to the agent [non-interactive]')
+    .option('--agent <name>', 'Select specific agent [non-interactive]')
+    .option('--target <name>', 'Select deployment target [non-interactive]')
     .option('--session-id <id>', 'Use specific session ID for conversation continuity')
-    .option('--json', 'Output as JSON')
-    .option('--stream', 'Stream response in real-time')
+    .option('--json', 'Output as JSON [non-interactive]')
+    .option('--stream', 'Stream response in real-time (TUI streams by default) [non-interactive]')
     .action(
       async (
         positionalPrompt: string | undefined,
@@ -115,7 +115,7 @@ export const registerInvoke = (program: Command) => {
           const prompt = cliOptions.prompt ?? positionalPrompt;
 
           // CLI mode if any CLI-specific options provided (follows deploy command pattern)
-          if (prompt || cliOptions.json || cliOptions.target || cliOptions.stream) {
+          if (prompt || cliOptions.json || cliOptions.target || cliOptions.stream || cliOptions.agent) {
             await handleInvokeCLI({
               prompt,
               agentName: cliOptions.agent,

--- a/src/cli/commands/remove/__tests__/remove.test.ts
+++ b/src/cli/commands/remove/__tests__/remove.test.ts
@@ -96,7 +96,7 @@ describe('remove command', () => {
       expect(json.success).toBe(false);
     });
 
-    it('removes existing agent with --name and --force (TUI mode)', async () => {
+    it('removes existing agent with --name and --force (non-interactive)', async () => {
       // Add another agent for this test
       const addResult = await runCLI(
         [
@@ -118,7 +118,7 @@ describe('remove command', () => {
       );
       expect(addResult.exitCode).toBe(0);
 
-      // Remove agent using TUI mode with --name and --force (no --json)
+      // Remove agent using non-interactive mode with --name and --force (no --json)
       const result = await runCLI(['remove', 'agent', '--name', 'TUITestAgent', '--force'], projectDir);
       expect(result.exitCode).toBe(0);
 

--- a/src/cli/commands/remove/command.tsx
+++ b/src/cli/commands/remove/command.tsx
@@ -78,21 +78,22 @@ function registerResourceRemove(
   removeCommand
     .command(subcommand)
     .description(description)
-    .option('--name <name>', 'Name of resource to remove')
-    .option('--force', 'Skip confirmation prompt')
-    .option('--json', 'Output as JSON')
+    .option('--name <name>', 'Name of resource to remove [non-interactive]')
+    .option('--force', 'Skip confirmation prompt [non-interactive]')
+    .option('--json', 'Output as JSON [non-interactive]')
     .action(async (cliOptions: { name?: string; force?: boolean; json?: boolean }) => {
       try {
         requireProject();
-        if (cliOptions.json) {
+        // Any flag triggers non-interactive CLI mode
+        if (cliOptions.name || cliOptions.force || cliOptions.json) {
           await handleRemoveCLI({
             resourceType,
             name: cliOptions.name,
             force: cliOptions.force,
-            json: true,
+            json: cliOptions.json,
           });
         } else {
-          handleRemoveResourceTUI(resourceType, { force: cliOptions.force, name: cliOptions.name });
+          handleRemoveResourceTUI(resourceType, {});
         }
       } catch (error) {
         if (cliOptions.json) {
@@ -116,22 +117,20 @@ export const registerRemove = (program: Command) => {
   removeCommand
     .command('all')
     .description('Reset all agentcore schemas to empty state')
-    .option('--force', 'Skip confirmation prompts')
-    .option('--dry-run', 'Show what would be reset without actually resetting')
-    .option('--json', 'Output as JSON')
+    .option('--force', 'Skip confirmation prompts [non-interactive]')
+    .option('--dry-run', 'Show what would be reset without actually resetting [non-interactive]')
+    .option('--json', 'Output as JSON [non-interactive]')
     .action(async (cliOptions: { force?: boolean; dryRun?: boolean; json?: boolean }) => {
       try {
-        if (cliOptions.json) {
+        // Any flag triggers non-interactive CLI mode
+        if (cliOptions.force || cliOptions.dryRun || cliOptions.json) {
           await handleRemoveAllCLI({
             force: cliOptions.force,
             dryRun: cliOptions.dryRun,
-            json: true,
+            json: cliOptions.json,
           });
         } else {
-          handleRemoveAllTUI({
-            force: cliOptions.force,
-            dryRun: cliOptions.dryRun,
-          });
+          handleRemoveAllTUI({});
         }
       } catch (error) {
         if (cliOptions.json) {


### PR DESCRIPTION
## Description

Behavior fixes:
- destroy: --yes or --json alone now triggers CLI mode (was only --target)
- remove: --name or --force alone now triggers CLI mode (was only --json)
- create: any flag now triggers CLI mode (was only --name)
- invoke: --agent now triggers CLI mode

Help improvements:
- Add [non-interactive] annotations to all flags that trigger CLI mode
- Add footer to all subcommand help explaining modes
- Add 'agentcore help modes' command with detailed explanation
- Clarify --stream on invoke: 'TUI streams by default'
- Clarify --invoke on dev: 'use --agent if multiple'
- Remove [non-interactive] from --session-id (works in both modes)

Test updates:
- Rename test from 'TUI mode' to 'non-interactive' to match new behavior

## Related Issues

Closes #226 

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Check all that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:all`
- [ ] I ran `npm run typecheck`
- [ ] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
