### PR TITLE
prevent repeat project name in same dir

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -32,6 +32,8 @@ jobs:
         run: |
           git config --global user.email "bedrock-agentcore-npm+ci@amazon.com"
           git config --global user.name "CI"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
       - run: npm ci
       - run: npm run build --if-present
       - run: npm run test:unit

--- a/package-lock.json
+++ b/package-lock.json
@@ -600,9 +600,9 @@
       }
     },
     "node_modules/@aws-sdk/client-appsync": {
-      "version": "3.985.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-appsync/-/client-appsync-3.985.0.tgz",
-      "integrity": "sha512-BitG0pksu3kUFNcrWVDLrINT919GmiY6U5/x4cWOrRpntxBfgE/iqGaG4NnPqFkdmUeOtDQ9dinRvw/noIODDA==",
+      "version": "3.986.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-appsync/-/client-appsync-3.986.0.tgz",
+      "integrity": "sha512-OAgSV9pgBaBTsVpvoWPkr9Mi5pJXXCUUGc+ESO4Q972DxUrZupNfHqc9Euec3bLDOLj/vA2GIZBJCdRMTzDklQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -615,7 +615,7 @@
         "@aws-sdk/middleware-user-agent": "^3.972.7",
         "@aws-sdk/region-config-resolver": "^3.972.3",
         "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.985.0",
+        "@aws-sdk/util-endpoints": "3.986.0",
         "@aws-sdk/util-user-agent-browser": "^3.972.3",
         "@aws-sdk/util-user-agent-node": "^3.972.5",
         "@smithy/config-resolver": "^4.4.6",
@@ -651,9 +651,9 @@
       }
     },
     "node_modules/@aws-sdk/client-bedrock-agentcore": {
-      "version": "3.985.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-agentcore/-/client-bedrock-agentcore-3.985.0.tgz",
-      "integrity": "sha512-y7LZVewrWriYuCdUe0fHMLv8EWxblJGW/ojt9Y95klCcbRRmQUP1ckWM8WnQ8QQKdCV0bTPA/UzJ0xp7ZWT51w==",
+      "version": "3.986.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-agentcore/-/client-bedrock-agentcore-3.986.0.tgz",
+      "integrity": "sha512-FPXkV54piBPirvGKs5c2U//1sfewUSieK05ZyRdLw3wy/66uCQ6uL6dD7czXizOCr8+WuTyVj1k+lpwkawA6Cg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -666,7 +666,7 @@
         "@aws-sdk/middleware-user-agent": "^3.972.7",
         "@aws-sdk/region-config-resolver": "^3.972.3",
         "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.985.0",
+        "@aws-sdk/util-endpoints": "3.986.0",
         "@aws-sdk/util-user-agent-browser": "^3.972.3",
         "@aws-sdk/util-user-agent-node": "^3.972.5",
         "@smithy/config-resolver": "^4.4.6",
@@ -705,9 +705,9 @@
       }
     },
     "node_modules/@aws-sdk/client-bedrock-agentcore-control": {
-      "version": "3.985.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-agentcore-control/-/client-bedrock-agentcore-control-3.985.0.tgz",
-      "integrity": "sha512-Bidi1qy5/OpX2jAjHBXxl4dU0mqaVzg/8IcL6DCLY1+uXnnNQgWUXP6Ja/2Jp8+U9IW+bUJsUwRBT+1BW555Kg==",
+      "version": "3.986.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-agentcore-control/-/client-bedrock-agentcore-control-3.986.0.tgz",
+      "integrity": "sha512-RwMWr4W9jXryBPgxN/g4caYvttYDeYQXp4GkRWRqO9VHPVLirzAj6hUyCZr4WLKz5yd7CqHjS3qNqhUej7y6ag==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -720,7 +720,7 @@
         "@aws-sdk/middleware-user-agent": "^3.972.7",
         "@aws-sdk/region-config-resolver": "^3.972.3",
         "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.985.0",
+        "@aws-sdk/util-endpoints": "3.986.0",
         "@aws-sdk/util-user-agent-browser": "^3.972.3",
         "@aws-sdk/util-user-agent-node": "^3.972.5",
         "@smithy/config-resolver": "^4.4.6",
@@ -756,9 +756,9 @@
       }
     },
     "node_modules/@aws-sdk/client-bedrock-runtime": {
-      "version": "3.985.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.985.0.tgz",
-      "integrity": "sha512-jkQ+G+b/6Z6gUsn8jNSjJsFVgxnA4HtyOjrpHfmp8nHWLRFTOIw3HfY2vAlDgg/uUJ7cezVG0/tmbwujFqX25A==",
+      "version": "3.986.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.986.0.tgz",
+      "integrity": "sha512-QFWFS8dCydWP1fsinjDo1QNKI9/aYYiD1KqVaWw7J3aYtdtcdyXD/ghnUms6P/IJycea2k+1xvVpvuejRG3SNw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -771,11 +771,11 @@
         "@aws-sdk/middleware-logger": "^3.972.3",
         "@aws-sdk/middleware-recursion-detection": "^3.972.3",
         "@aws-sdk/middleware-user-agent": "^3.972.7",
-        "@aws-sdk/middleware-websocket": "^3.972.5",
+        "@aws-sdk/middleware-websocket": "^3.972.6",
         "@aws-sdk/region-config-resolver": "^3.972.3",
-        "@aws-sdk/token-providers": "3.985.0",
+        "@aws-sdk/token-providers": "3.986.0",
         "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.985.0",
+        "@aws-sdk/util-endpoints": "3.986.0",
         "@aws-sdk/util-user-agent-browser": "^3.972.3",
         "@aws-sdk/util-user-agent-node": "^3.972.5",
         "@smithy/config-resolver": "^4.4.6",
@@ -814,9 +814,9 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudcontrol": {
-      "version": "3.985.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudcontrol/-/client-cloudcontrol-3.985.0.tgz",
-      "integrity": "sha512-j9jz3Kf2ChfOAHyjdwmodvV6gXKI7TZFxDeqRYYjKJu815UpdNmCQ0t70txyDE6C6zCPJAzt9ZG0lacg/7tp0A==",
+      "version": "3.986.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudcontrol/-/client-cloudcontrol-3.986.0.tgz",
+      "integrity": "sha512-oSYOl2Hz/EnX1Ic4i+UA8468dN7CvRWXJi7469UvW+csS4iWgtBHDGXmr8u9SzenFOyBAA7rhamKyLslzC6Byw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -829,7 +829,7 @@
         "@aws-sdk/middleware-user-agent": "^3.972.7",
         "@aws-sdk/region-config-resolver": "^3.972.3",
         "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.985.0",
+        "@aws-sdk/util-endpoints": "3.986.0",
         "@aws-sdk/util-user-agent-browser": "^3.972.3",
         "@aws-sdk/util-user-agent-node": "^3.972.5",
         "@smithy/config-resolver": "^4.4.6",
@@ -865,9 +865,9 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudformation": {
-      "version": "3.985.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.985.0.tgz",
-      "integrity": "sha512-TN99DU4QOn5ERv1+uKF15L0D2h38GtON2g+oVo2/ICPYr9q6AiQu55TVOL7TJDGv9+0w/HOsCYu/MVpRYyL/bQ==",
+      "version": "3.986.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.986.0.tgz",
+      "integrity": "sha512-JXiixJ7JcIhXwFqKurgkvlY6YNKnup0Mfzj9t59GVfmpKZveqCqqHafBN7z3YIwtioy7NyH4LFbKVDQKAyjdtg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -880,7 +880,7 @@
         "@aws-sdk/middleware-user-agent": "^3.972.7",
         "@aws-sdk/region-config-resolver": "^3.972.3",
         "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.985.0",
+        "@aws-sdk/util-endpoints": "3.986.0",
         "@aws-sdk/util-user-agent-browser": "^3.972.3",
         "@aws-sdk/util-user-agent-node": "^3.972.5",
         "@smithy/config-resolver": "^4.4.6",
@@ -916,9 +916,9 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudwatch-logs": {
-      "version": "3.985.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch-logs/-/client-cloudwatch-logs-3.985.0.tgz",
-      "integrity": "sha512-Spj9DvfbM3nUmBxpyuPhRww9TkJLM0mhNO0p53XAEaUcTZ3zUknhmDJ3rPZIZVEeQcLg4hFT6h7/46OiacJ17A==",
+      "version": "3.986.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch-logs/-/client-cloudwatch-logs-3.986.0.tgz",
+      "integrity": "sha512-i1rpVE4gn7t1lakamh2EfePKJrG2sJM8y3o9xsEzm33oDpWWERUWO/ojB4gBAF1oCguMDqkL2l3cFJKtz0PivQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -931,7 +931,7 @@
         "@aws-sdk/middleware-user-agent": "^3.972.7",
         "@aws-sdk/region-config-resolver": "^3.972.3",
         "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.985.0",
+        "@aws-sdk/util-endpoints": "3.986.0",
         "@aws-sdk/util-user-agent-browser": "^3.972.3",
         "@aws-sdk/util-user-agent-node": "^3.972.5",
         "@smithy/config-resolver": "^4.4.6",
@@ -969,9 +969,9 @@
       }
     },
     "node_modules/@aws-sdk/client-codebuild": {
-      "version": "3.985.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-codebuild/-/client-codebuild-3.985.0.tgz",
-      "integrity": "sha512-/zf/FWaHxuJ6FkygSsL7PG/I+FifV58yEJHpglLYB7T55rvPS1FrBle1WBTo62rrmZJI9yByJu4NQIU6LiOlYg==",
+      "version": "3.986.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-codebuild/-/client-codebuild-3.986.0.tgz",
+      "integrity": "sha512-xAfBZCFJGnDCHCVQfaObPo51CK0Gun9/G4wjgd9AwB5JyNNWC8qaJu67iuqkiXMkvA7Gc1LJu6v//w1aOhG5Pw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -984,7 +984,7 @@
         "@aws-sdk/middleware-user-agent": "^3.972.7",
         "@aws-sdk/region-config-resolver": "^3.972.3",
         "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.985.0",
+        "@aws-sdk/util-endpoints": "3.986.0",
         "@aws-sdk/util-user-agent-browser": "^3.972.3",
         "@aws-sdk/util-user-agent-node": "^3.972.5",
         "@smithy/config-resolver": "^4.4.6",
@@ -1019,9 +1019,9 @@
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity": {
-      "version": "3.985.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.985.0.tgz",
-      "integrity": "sha512-PpHgiNGLsnQ2QHh0wx/uhGV3kxlASp2LOl5Z+LQCnu59i8rjAH1decT03QNWcho3Jz4zg9Kcto6VoAxu6OFb2A==",
+      "version": "3.986.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.986.0.tgz",
+      "integrity": "sha512-nLWdXVyMzXxFOcLHx5GsxYhRlu6UlqBqsSgNktQgg+GksPwyTO6KXuJICFYjQgcUFtXwkABiCuJ+a/NU/yH4NA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -1034,7 +1034,7 @@
         "@aws-sdk/middleware-user-agent": "^3.972.7",
         "@aws-sdk/region-config-resolver": "^3.972.3",
         "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.985.0",
+        "@aws-sdk/util-endpoints": "3.986.0",
         "@aws-sdk/util-user-agent-browser": "^3.972.3",
         "@aws-sdk/util-user-agent-node": "^3.972.5",
         "@smithy/config-resolver": "^4.4.6",
@@ -1069,9 +1069,9 @@
       }
     },
     "node_modules/@aws-sdk/client-ec2": {
-      "version": "3.985.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.985.0.tgz",
-      "integrity": "sha512-x+vBq5HrmDLEmKTXSdN9urExDfj0J+DWkOiYmrN0mN5+4Ufgmc55n84X3XTG3RWGncN2+/s0fDY+H4n/obLc8g==",
+      "version": "3.986.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.986.0.tgz",
+      "integrity": "sha512-C/no36Htt+vtIgnhgeUELcWRM+KldepIR/Iry9c7DMt6aIIlp4G9jS4VBTd5u8ZiDtwHA8ogWNgrzIJSvugAqA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -1085,7 +1085,7 @@
         "@aws-sdk/middleware-user-agent": "^3.972.7",
         "@aws-sdk/region-config-resolver": "^3.972.3",
         "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.985.0",
+        "@aws-sdk/util-endpoints": "3.986.0",
         "@aws-sdk/util-user-agent-browser": "^3.972.3",
         "@aws-sdk/util-user-agent-node": "^3.972.5",
         "@smithy/config-resolver": "^4.4.6",
@@ -1121,9 +1121,9 @@
       }
     },
     "node_modules/@aws-sdk/client-ecr": {
-      "version": "3.985.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecr/-/client-ecr-3.985.0.tgz",
-      "integrity": "sha512-lC0YsfvPErWbWmrVtxXmJfNpCAZD2EZ2jILzpnt0NrFFThKNbuLeOjpLCpS9uOG6/ZC6RxrW88SqL9qxnjoE3g==",
+      "version": "3.986.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecr/-/client-ecr-3.986.0.tgz",
+      "integrity": "sha512-aAb9n01DhqmxbjYAHOad0tCCu8OU+4DKrC18EzrqJx6ITIDWIQ1rG2R81eHdRrtSjkcd4B5dj7OIBVPTmikouQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -1136,7 +1136,7 @@
         "@aws-sdk/middleware-user-agent": "^3.972.7",
         "@aws-sdk/region-config-resolver": "^3.972.3",
         "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.985.0",
+        "@aws-sdk/util-endpoints": "3.986.0",
         "@aws-sdk/util-user-agent-browser": "^3.972.3",
         "@aws-sdk/util-user-agent-node": "^3.972.5",
         "@smithy/config-resolver": "^4.4.6",
@@ -1172,9 +1172,9 @@
       }
     },
     "node_modules/@aws-sdk/client-ecs": {
-      "version": "3.985.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecs/-/client-ecs-3.985.0.tgz",
-      "integrity": "sha512-tPJiEDIn5CkfmUiFUIgkGYPRHAGXd/miOrvwIKx5u9hF+aX4tlT2MXzUPI/xw02x211oldcSQLGn1zvQzj1nSA==",
+      "version": "3.986.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ecs/-/client-ecs-3.986.0.tgz",
+      "integrity": "sha512-3xXucblnIVwO9OUiJ3X1teQR8Rd9ZabjDS/P/iLURd1WTXXW36WIndPV9TrKHcrYEgbMYIf00yQOr+x7J7yrcw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -1187,7 +1187,7 @@
         "@aws-sdk/middleware-user-agent": "^3.972.7",
         "@aws-sdk/region-config-resolver": "^3.972.3",
         "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.985.0",
+        "@aws-sdk/util-endpoints": "3.986.0",
         "@aws-sdk/util-user-agent-browser": "^3.972.3",
         "@aws-sdk/util-user-agent-node": "^3.972.5",
         "@smithy/config-resolver": "^4.4.6",
@@ -1223,9 +1223,9 @@
       }
     },
     "node_modules/@aws-sdk/client-elastic-load-balancing-v2": {
-      "version": "3.985.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-elastic-load-balancing-v2/-/client-elastic-load-balancing-v2-3.985.0.tgz",
-      "integrity": "sha512-zyQyxS5VMJtLse8pwHlaTfaPgJskytj+Y9bGhnlpcgm/SDy/BqAW8JIl0Mh0A9oy/eZnyBQ0EBHjSFV5zT9HBQ==",
+      "version": "3.986.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-elastic-load-balancing-v2/-/client-elastic-load-balancing-v2-3.986.0.tgz",
+      "integrity": "sha512-VjcCNf6dUZjdq0guetFakb//uqOd4UmCM6KvegSF+fjWbNce3lIN8bTKWtB/MKFv9M7xxOpkfC60G4geI3oMuQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -1238,7 +1238,7 @@
         "@aws-sdk/middleware-user-agent": "^3.972.7",
         "@aws-sdk/region-config-resolver": "^3.972.3",
         "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.985.0",
+        "@aws-sdk/util-endpoints": "3.986.0",
         "@aws-sdk/util-user-agent-browser": "^3.972.3",
         "@aws-sdk/util-user-agent-node": "^3.972.5",
         "@smithy/config-resolver": "^4.4.6",
@@ -1274,9 +1274,9 @@
       }
     },
     "node_modules/@aws-sdk/client-iam": {
-      "version": "3.985.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-iam/-/client-iam-3.985.0.tgz",
-      "integrity": "sha512-J7ZHwV8OfVlN9WBIUuLQAjSLIKADMvzchqP9JOgAYfn8ygdBzYRIcL55fXym4nwj7xQoao1wMXEXBH51M0I/Pg==",
+      "version": "3.986.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-iam/-/client-iam-3.986.0.tgz",
+      "integrity": "sha512-Xww27O4Zb+KSoBqCu7703o1IelX/oUEiIk40LS2l84RT8/YdYrfwlO9Q6U3qevcRTDPv05IEUU3tVj3WwgcaVg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -1289,7 +1289,7 @@
         "@aws-sdk/middleware-user-agent": "^3.972.7",
         "@aws-sdk/region-config-resolver": "^3.972.3",
         "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.985.0",
+        "@aws-sdk/util-endpoints": "3.986.0",
         "@aws-sdk/util-user-agent-browser": "^3.972.3",
         "@aws-sdk/util-user-agent-node": "^3.972.5",
         "@smithy/config-resolver": "^4.4.6",
@@ -1325,9 +1325,9 @@
       }
     },
     "node_modules/@aws-sdk/client-kms": {
-      "version": "3.985.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.985.0.tgz",
-      "integrity": "sha512-DachgzIvkZDwknlFdicLpfCnzYBdQtGOox5zYLq953/ZlnlB7YnW74Hh8Ql+IEq/gsup8s2ahzkFvb72SMRHMg==",
+      "version": "3.986.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.986.0.tgz",
+      "integrity": "sha512-tmxFgGPqbeQluof7/VPB1eyUcusj7ZamiIUQNnYxPHwKrsTa+JptFQ864j9mFxdu9x+210YVL55EHrjU0FxKjQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -1340,7 +1340,7 @@
         "@aws-sdk/middleware-user-agent": "^3.972.7",
         "@aws-sdk/region-config-resolver": "^3.972.3",
         "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.985.0",
+        "@aws-sdk/util-endpoints": "3.986.0",
         "@aws-sdk/util-user-agent-browser": "^3.972.3",
         "@aws-sdk/util-user-agent-node": "^3.972.5",
         "@smithy/config-resolver": "^4.4.6",
@@ -1375,9 +1375,9 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda": {
-      "version": "3.985.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.985.0.tgz",
-      "integrity": "sha512-RFQVkOn9wn4LAYBDpOXyN+qY/akpGN1zJrEHkWbE+cXx/ypKo7nRt/r5jSTW2k0MttuI9ViVFemtGn69z22uBA==",
+      "version": "3.986.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.986.0.tgz",
+      "integrity": "sha512-R0VrqSH622b0MmIULLCNbupyU9qqEn+vofIeKng+ALPJY6U7pq7MG0p+bbxLCGztLl0u2vmO237SPZYcFm3hCQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -1390,7 +1390,7 @@
         "@aws-sdk/middleware-user-agent": "^3.972.7",
         "@aws-sdk/region-config-resolver": "^3.972.3",
         "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.985.0",
+        "@aws-sdk/util-endpoints": "3.986.0",
         "@aws-sdk/util-user-agent-browser": "^3.972.3",
         "@aws-sdk/util-user-agent-node": "^3.972.5",
         "@smithy/config-resolver": "^4.4.6",
@@ -1430,9 +1430,9 @@
       }
     },
     "node_modules/@aws-sdk/client-resource-groups-tagging-api": {
-      "version": "3.985.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-resource-groups-tagging-api/-/client-resource-groups-tagging-api-3.985.0.tgz",
-      "integrity": "sha512-XQN8GTB7Hp1ucnRjNfzSJ20gCaMrx3Kfl0Nzxz+AqAf3faaVqiIGrKLIPq4cMPyEJVnWSMjwAJ7c1aPphIPm/Q==",
+      "version": "3.986.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-resource-groups-tagging-api/-/client-resource-groups-tagging-api-3.986.0.tgz",
+      "integrity": "sha512-u88sXS4BLuQ9TlrB8/k8NDt5XSKFKRrMlx0iBQ+Zniqj4d2ACX2iPrpqZTKz9s89olPK0Ru9YKAxxk+TJ8wjJQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -1445,7 +1445,7 @@
         "@aws-sdk/middleware-user-agent": "^3.972.7",
         "@aws-sdk/region-config-resolver": "^3.972.3",
         "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.985.0",
+        "@aws-sdk/util-endpoints": "3.986.0",
         "@aws-sdk/util-user-agent-browser": "^3.972.3",
         "@aws-sdk/util-user-agent-node": "^3.972.5",
         "@smithy/config-resolver": "^4.4.6",
@@ -1480,9 +1480,9 @@
       }
     },
     "node_modules/@aws-sdk/client-route-53": {
-      "version": "3.985.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-route-53/-/client-route-53-3.985.0.tgz",
-      "integrity": "sha512-AccSmXAKOyL3vwwGr9w7zkKyjpD4po+ND1hyOTRFj8p6O4p1NsZYlF74ZxYBIgv7IkWSiEoiziqrPBVf+sZC0Q==",
+      "version": "3.986.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-route-53/-/client-route-53-3.986.0.tgz",
+      "integrity": "sha512-2RtSLZz836Pr/sFRie3hhEaWdfqihcgvUC0zqPu+JTNfsc0Ow1lmFYtoKkypk5yNDjYk8sWxFDa5Pf7cbu7ZwQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -1496,7 +1496,7 @@
         "@aws-sdk/middleware-user-agent": "^3.972.7",
         "@aws-sdk/region-config-resolver": "^3.972.3",
         "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.985.0",
+        "@aws-sdk/util-endpoints": "3.986.0",
         "@aws-sdk/util-user-agent-browser": "^3.972.3",
         "@aws-sdk/util-user-agent-node": "^3.972.5",
         "@smithy/config-resolver": "^4.4.6",
@@ -1532,9 +1532,9 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.985.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.985.0.tgz",
-      "integrity": "sha512-S9TqjzzZEEIKBnC7yFpvqM7CG9ALpY5qhQ5BnDBJtdG20NoGpjKLGUUfD2wmZItuhbrcM4Z8c6m6Fg0XYIOVvw==",
+      "version": "3.986.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.986.0.tgz",
+      "integrity": "sha512-IcDJ8shVVvbxgMe8+dLWcv6uhSwmX65PHTVGX81BhWAElPnp3CL8w/5uzOPRo4n4/bqIk9eskGVEIicw2o+SrA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
@@ -1553,9 +1553,9 @@
         "@aws-sdk/middleware-ssec": "^3.972.3",
         "@aws-sdk/middleware-user-agent": "^3.972.7",
         "@aws-sdk/region-config-resolver": "^3.972.3",
-        "@aws-sdk/signature-v4-multi-region": "3.985.0",
+        "@aws-sdk/signature-v4-multi-region": "3.986.0",
         "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.985.0",
+        "@aws-sdk/util-endpoints": "3.986.0",
         "@aws-sdk/util-user-agent-browser": "^3.972.3",
         "@aws-sdk/util-user-agent-node": "^3.972.5",
         "@smithy/config-resolver": "^4.4.6",
@@ -1598,9 +1598,9 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.985.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.985.0.tgz",
-      "integrity": "sha512-lssQ48JBYTjbpCc2oyev83fvnSnRAbTVzp5GLMuGCxlk9mdME80ArUJL14ZQrzay+7p3m6RdoBmPaa7RWlVTZA==",
+      "version": "3.986.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.986.0.tgz",
+      "integrity": "sha512-SCTzrxzVRX/LqOJbxHXrXI0jhSb9vrdBJIQqD+pocPbPHTyjEbtq3ZWsPWurze3gnTL1XDmpIs0xQ75iy6WnWQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -1613,7 +1613,7 @@
         "@aws-sdk/middleware-user-agent": "^3.972.7",
         "@aws-sdk/region-config-resolver": "^3.972.3",
         "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.985.0",
+        "@aws-sdk/util-endpoints": "3.986.0",
         "@aws-sdk/util-user-agent-browser": "^3.972.3",
         "@aws-sdk/util-user-agent-node": "^3.972.5",
         "@smithy/config-resolver": "^4.4.6",
@@ -1648,9 +1648,9 @@
       }
     },
     "node_modules/@aws-sdk/client-sfn": {
-      "version": "3.985.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sfn/-/client-sfn-3.985.0.tgz",
-      "integrity": "sha512-LRPu0TyZeDL9Hj+hvm/aF36pnUYWbCeqBWyh6Kf93wWh9Jfolaa3DKQipALFZ7LKujvWtXbj5z54BzYMrqn/kw==",
+      "version": "3.986.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sfn/-/client-sfn-3.986.0.tgz",
+      "integrity": "sha512-V9r564wlYD0X+msZLsHmz+Gqw8MdGFpG1e4UEU5SLbvGriuvVttoh5uWaic4sa+zMq7xiuj6mM+GWqsWv6qhtQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -1663,7 +1663,7 @@
         "@aws-sdk/middleware-user-agent": "^3.972.7",
         "@aws-sdk/region-config-resolver": "^3.972.3",
         "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.985.0",
+        "@aws-sdk/util-endpoints": "3.986.0",
         "@aws-sdk/util-user-agent-browser": "^3.972.3",
         "@aws-sdk/util-user-agent-node": "^3.972.5",
         "@smithy/config-resolver": "^4.4.6",
@@ -1698,9 +1698,9 @@
       }
     },
     "node_modules/@aws-sdk/client-ssm": {
-      "version": "3.985.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.985.0.tgz",
-      "integrity": "sha512-7x0TBtdO20yoWHYhWywBUDRrNR1qz6yzizaXbXcPI2gh3kxM4Bl781URGPAaBiGz699eqcZ0pK+TQ9HjyOLpqw==",
+      "version": "3.986.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.986.0.tgz",
+      "integrity": "sha512-90ZSt9LVAOhWntrdTH05STAQmSUnqkODdGcD7uS1kqoch3RxqaCXyi2CRI3OQnxlck82pJTGnCTuBRiIiUSTnw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -1713,7 +1713,7 @@
         "@aws-sdk/middleware-user-agent": "^3.972.7",
         "@aws-sdk/region-config-resolver": "^3.972.3",
         "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.985.0",
+        "@aws-sdk/util-endpoints": "3.986.0",
         "@aws-sdk/util-user-agent-browser": "^3.972.3",
         "@aws-sdk/util-user-agent-node": "^3.972.5",
         "@smithy/config-resolver": "^4.4.6",
@@ -1797,10 +1797,26 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-sts": {
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-endpoints": {
       "version": "3.985.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.985.0.tgz",
-      "integrity": "sha512-YKj2f0FZAXQ/s1460PoVJOGijDwMycknSbDO7EZQnR0TZh5I12AUZzAiNEOXltKJ0TSHex2YDuNwGmlzvXoeuw==",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.985.0.tgz",
+      "integrity": "sha512-vth7UfGSUR3ljvaq8V4Rc62FsM7GUTH/myxPWkaEgOrprz1/Pc72EgTXxj+cPPPDAfHFIpjhkB7T7Td0RJx+BA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-endpoints": "^3.2.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.986.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.986.0.tgz",
+      "integrity": "sha512-MKL3OSaUXJ4Xftl+sm7n7o8pJmX5FQgIFc/suWPoNvKEdMJOC+/+2DYjjpASw5X89LL4+9xL2BHhz0y32m5FYw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -1813,7 +1829,7 @@
         "@aws-sdk/middleware-user-agent": "^3.972.7",
         "@aws-sdk/region-config-resolver": "^3.972.3",
         "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.985.0",
+        "@aws-sdk/util-endpoints": "3.986.0",
         "@aws-sdk/util-user-agent-browser": "^3.972.3",
         "@aws-sdk/util-user-agent-node": "^3.972.5",
         "@smithy/config-resolver": "^4.4.6",
@@ -2106,6 +2122,24 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.985.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.985.0.tgz",
+      "integrity": "sha512-+hwpHZyEq8k+9JL2PkE60V93v2kNhUIv7STFt+EAez1UJsJOQDhc5LpzEX66pNjclI5OTwBROs/DhJjC/BtMjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.7",
+        "@aws-sdk/nested-clients": "3.985.0",
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/shared-ini-file-loader": "^4.4.3",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
       "version": "3.972.5",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.5.tgz",
@@ -2125,12 +2159,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-providers": {
-      "version": "3.985.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.985.0.tgz",
-      "integrity": "sha512-mYjWyt0HiU3dYZif7yAJ+DYerSD/0bh7Umw9tUTFhhXrPePGTbJPyJx+vLmEh2dG2hCr7Qpn6DZdY8sB5yOxhQ==",
+      "version": "3.986.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.986.0.tgz",
+      "integrity": "sha512-3v4xBiZNTanMuYK9t6AP7rtue9zYkO60wXw2DqbksDc+ibyZicq8t8MgN6x796QCTXXowbOrM1U3F0jMkkP/ww==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.985.0",
+        "@aws-sdk/client-cognito-identity": "3.986.0",
         "@aws-sdk/core": "^3.973.7",
         "@aws-sdk/credential-provider-cognito-identity": "^3.972.3",
         "@aws-sdk/credential-provider-env": "^3.972.5",
@@ -2141,7 +2175,7 @@
         "@aws-sdk/credential-provider-process": "^3.972.5",
         "@aws-sdk/credential-provider-sso": "^3.972.5",
         "@aws-sdk/credential-provider-web-identity": "^3.972.5",
-        "@aws-sdk/nested-clients": "3.985.0",
+        "@aws-sdk/nested-clients": "3.986.0",
         "@aws-sdk/types": "^3.973.1",
         "@smithy/config-resolver": "^4.4.6",
         "@smithy/core": "^3.22.1",
@@ -2155,10 +2189,59 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.986.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.986.0.tgz",
+      "integrity": "sha512-/yq4hr3KUBIIX/bcccscXOzFoe6NSiAUFTsHaM2VZWYpPw7JwlqnPsfFVONAjuuYovjP/O+qYBx1oj85C7Dplw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.7",
+        "@aws-sdk/middleware-host-header": "^3.972.3",
+        "@aws-sdk/middleware-logger": "^3.972.3",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.3",
+        "@aws-sdk/middleware-user-agent": "^3.972.7",
+        "@aws-sdk/region-config-resolver": "^3.972.3",
+        "@aws-sdk/types": "^3.973.1",
+        "@aws-sdk/util-endpoints": "3.986.0",
+        "@aws-sdk/util-user-agent-browser": "^3.972.3",
+        "@aws-sdk/util-user-agent-node": "^3.972.5",
+        "@smithy/config-resolver": "^4.4.6",
+        "@smithy/core": "^3.22.1",
+        "@smithy/fetch-http-handler": "^5.3.9",
+        "@smithy/hash-node": "^4.2.8",
+        "@smithy/invalid-dependency": "^4.2.8",
+        "@smithy/middleware-content-length": "^4.2.8",
+        "@smithy/middleware-endpoint": "^4.4.13",
+        "@smithy/middleware-retry": "^4.4.30",
+        "@smithy/middleware-serde": "^4.2.9",
+        "@smithy/middleware-stack": "^4.2.8",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/node-http-handler": "^4.4.9",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/smithy-client": "^4.11.2",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.29",
+        "@smithy/util-defaults-mode-node": "^4.2.32",
+        "@smithy/util-endpoints": "^3.2.8",
+        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/util-retry": "^4.2.8",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/ec2-metadata-service": {
-      "version": "3.985.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/ec2-metadata-service/-/ec2-metadata-service-3.985.0.tgz",
-      "integrity": "sha512-oHwfreqIg54tg55VjOZph6s9BeX7OqncRIHa4yQQ3V7KymZ2pPK4BEC/zo8PFkrBRr3NQrBk52nZI8xF/ojxqg==",
+      "version": "3.986.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/ec2-metadata-service/-/ec2-metadata-service-3.986.0.tgz",
+      "integrity": "sha512-5yQUZgKWX9FNvfVrBaPII1AouskFgCU2MRT1MuPsjqRR5kLgyQdFmkJgPh8GDDfZFqrUdzzK1gb2pzisckA1lg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.1",
@@ -2189,9 +2272,9 @@
       }
     },
     "node_modules/@aws-sdk/lib-storage": {
-      "version": "3.985.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.985.0.tgz",
-      "integrity": "sha512-EnqXf2E+5+7e5zuz8mPl+3Dk/DI0ObSL8s7Tsf6H8FL/p2BJw2LhgtxPnFZUmpanpoMO0hC9/qjXNd+aGPV0/w==",
+      "version": "3.986.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.986.0.tgz",
+      "integrity": "sha512-tcP8NmpBidRHNhGqRQWEHG1vEsMTjOLd28aIS8dfhaFIAxFGMe5CH+fXunYE5ie52NZ5pLUrCvtAnwfBfSBbUw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/abort-controller": "^4.2.8",
@@ -2206,7 +2289,7 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-s3": "^3.985.0"
+        "@aws-sdk/client-s3": "^3.986.0"
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
@@ -2431,10 +2514,26 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.985.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.985.0.tgz",
+      "integrity": "sha512-vth7UfGSUR3ljvaq8V4Rc62FsM7GUTH/myxPWkaEgOrprz1/Pc72EgTXxj+cPPPDAfHFIpjhkB7T7Td0RJx+BA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-endpoints": "^3.2.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/middleware-websocket": {
-      "version": "3.972.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.5.tgz",
-      "integrity": "sha512-BN4A9K71WRIlpQ3+IYGdBC2wVyobZ95g6ZomodmJ8Te772GWo0iDk2Mv6JIHdr842tOTgi1b3npLIFDUS4hl4g==",
+      "version": "3.972.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.6.tgz",
+      "integrity": "sha512-1DedO6N3m8zQ/vG6twNiHtsdwBgk773VdavLEbB3NXeKZDlzSK1BTviqWwvJdKx5UnIy4kGGP6WWpCEFEt/bhQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.1",
@@ -2503,6 +2602,22 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.985.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.985.0.tgz",
+      "integrity": "sha512-vth7UfGSUR3ljvaq8V4Rc62FsM7GUTH/myxPWkaEgOrprz1/Pc72EgTXxj+cPPPDAfHFIpjhkB7T7Td0RJx+BA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-endpoints": "^3.2.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/region-config-resolver": {
       "version": "3.972.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.3.tgz",
@@ -2520,9 +2635,9 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.985.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.985.0.tgz",
-      "integrity": "sha512-W6hTSOPiSbh4IdTYVxN7xHjpCh0qvfQU1GKGBzGQm0ZEIOaMmWqiDEvFfyGYKmfBvumT8vHKxQRTX0av9omtIg==",
+      "version": "3.986.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.986.0.tgz",
+      "integrity": "sha512-Upw+rw7wCH93E6QWxqpAqJLrUmJYVUAWrk4tCOBnkeuwzGERZvJFL5UQ6TAJFj9T18Ih+vNFaACh8J5aP4oTBw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/middleware-sdk-s3": "^3.972.7",
@@ -2537,17 +2652,66 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.985.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.985.0.tgz",
-      "integrity": "sha512-+hwpHZyEq8k+9JL2PkE60V93v2kNhUIv7STFt+EAez1UJsJOQDhc5LpzEX66pNjclI5OTwBROs/DhJjC/BtMjQ==",
+      "version": "3.986.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.986.0.tgz",
+      "integrity": "sha512-1T2/iqONrISWJPUFyznvjVdoZrpFjuhI0FKjTrA2iSmEFpzWu+ctgGHYdxNoBNVzleO8BFD+w8S+rDQAuAre5g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.973.7",
-        "@aws-sdk/nested-clients": "3.985.0",
+        "@aws-sdk/nested-clients": "3.986.0",
         "@aws-sdk/types": "^3.973.1",
         "@smithy/property-provider": "^4.2.8",
         "@smithy/shared-ini-file-loader": "^4.4.3",
         "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.986.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.986.0.tgz",
+      "integrity": "sha512-/yq4hr3KUBIIX/bcccscXOzFoe6NSiAUFTsHaM2VZWYpPw7JwlqnPsfFVONAjuuYovjP/O+qYBx1oj85C7Dplw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.7",
+        "@aws-sdk/middleware-host-header": "^3.972.3",
+        "@aws-sdk/middleware-logger": "^3.972.3",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.3",
+        "@aws-sdk/middleware-user-agent": "^3.972.7",
+        "@aws-sdk/region-config-resolver": "^3.972.3",
+        "@aws-sdk/types": "^3.973.1",
+        "@aws-sdk/util-endpoints": "3.986.0",
+        "@aws-sdk/util-user-agent-browser": "^3.972.3",
+        "@aws-sdk/util-user-agent-node": "^3.972.5",
+        "@smithy/config-resolver": "^4.4.6",
+        "@smithy/core": "^3.22.1",
+        "@smithy/fetch-http-handler": "^5.3.9",
+        "@smithy/hash-node": "^4.2.8",
+        "@smithy/invalid-dependency": "^4.2.8",
+        "@smithy/middleware-content-length": "^4.2.8",
+        "@smithy/middleware-endpoint": "^4.4.13",
+        "@smithy/middleware-retry": "^4.4.30",
+        "@smithy/middleware-serde": "^4.2.9",
+        "@smithy/middleware-stack": "^4.2.8",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/node-http-handler": "^4.4.9",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/smithy-client": "^4.11.2",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.29",
+        "@smithy/util-defaults-mode-node": "^4.2.32",
+        "@smithy/util-endpoints": "^3.2.8",
+        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/util-retry": "^4.2.8",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2580,9 +2744,9 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.985.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.985.0.tgz",
-      "integrity": "sha512-vth7UfGSUR3ljvaq8V4Rc62FsM7GUTH/myxPWkaEgOrprz1/Pc72EgTXxj+cPPPDAfHFIpjhkB7T7Td0RJx+BA==",
+      "version": "3.986.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.986.0.tgz",
+      "integrity": "sha512-Mqi79L38qi1gCG3adlVdbNrSxvcm1IPDLiJPA3OBypY5ewxUyWbaA3DD4goG+EwET6LSFgZJcRSIh6KBNpP5pA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.1",
@@ -9353,13 +9517,13 @@
       "license": "ISC"
     },
     "node_modules/ink": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/ink/-/ink-6.6.0.tgz",
-      "integrity": "sha512-QDt6FgJxgmSxAelcOvOHUvFxbIUjVpCH5bx+Slvc5m7IEcpGt3dYwbz/L+oRnqEGeRvwy1tineKK4ect3nW1vQ==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/ink/-/ink-6.7.0.tgz",
+      "integrity": "sha512-dhB16KfdTO8yYwF2K0E4wPXpL88tdrjjB6w44AZ0ljSktYoUQQcxccq9KL1vpRhk8JIa0A7B7zvjajHqI42teA==",
       "license": "MIT",
       "dependencies": {
-        "@alcalzone/ansi-tokenize": "^0.2.1",
-        "ansi-escapes": "^7.2.0",
+        "@alcalzone/ansi-tokenize": "^0.2.4",
+        "ansi-escapes": "^7.3.0",
         "ansi-styles": "^6.2.1",
         "auto-bind": "^5.0.1",
         "chalk": "^5.6.0",
@@ -9372,12 +9536,14 @@
         "is-in-ci": "^2.0.0",
         "patch-console": "^2.0.0",
         "react-reconciler": "^0.33.0",
+        "scheduler": "^0.27.0",
         "signal-exit": "^3.0.7",
         "slice-ansi": "^7.1.0",
         "stack-utils": "^2.0.6",
-        "string-width": "^8.1.0",
-        "type-fest": "^4.27.0",
-        "widest-line": "^5.0.0",
+        "string-width": "^8.1.1",
+        "terminal-size": "^4.0.1",
+        "type-fest": "^5.4.1",
+        "widest-line": "^6.0.0",
         "wrap-ansi": "^9.0.0",
         "ws": "^8.18.0",
         "yoga-layout": "~3.2.1"
@@ -11074,6 +11240,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse-json/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parse-statements": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/parse-statements/-/parse-statements-1.0.11.tgz",
@@ -11386,6 +11565,19 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -12619,6 +12811,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tar-stream": {
       "version": "3.1.7",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
@@ -12641,6 +12845,18 @@
       },
       "engines": {
         "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/terminal-size": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/terminal-size/-/terminal-size-4.0.1.tgz",
+      "integrity": "sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -12845,12 +13061,15 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.4.4.tgz",
+      "integrity": "sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw==",
       "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
       "engines": {
-        "node": ">=16"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -13501,38 +13720,31 @@
       }
     },
     "node_modules/widest-line": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
-      "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-6.0.0.tgz",
+      "integrity": "sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA==",
       "license": "MIT",
       "dependencies": {
-        "string-width": "^7.0.0"
+        "string-width": "^8.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/widest-line/node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "license": "MIT"
-    },
     "node_modules/widest-line/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.1.tgz",
+      "integrity": "sha512-KpqHIdDL9KwYk22wEOg/VIqYbrnLeSApsKT/bSj6Ez7pn3CftUiLAv2Lccpq1ALcpLV9UX1Ppn92npZWu2w/aw==",
       "license": "MIT",
       "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
+        "get-east-asian-width": "^1.3.0",
         "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/src/cli/commands/create/__tests__/create.test.ts
+++ b/src/cli/commands/create/__tests__/create.test.ts
@@ -152,4 +152,19 @@ describe('create command', () => {
       expect(await exists(join(customDir, name)), 'Should create in custom dir').toBeTruthy();
     });
   });
+
+  describe('existing folder', () => {
+    it('rejects when folder already exists', async () => {
+      const name = `Existing${Date.now()}`;
+      // Create the folder first
+      await mkdir(join(testDir, name), { recursive: true });
+
+      const result = await runCLI(['create', '--name', name, '--no-agent', '--json'], testDir);
+
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.error).toContain('already exists');
+    });
+  });
 });

--- a/src/cli/commands/create/command.tsx
+++ b/src/cli/commands/create/command.tsx
@@ -65,7 +65,9 @@ function printCreateSummary(
 
 /** Handle CLI mode with progress output */
 async function handleCreateCLI(options: CreateOptions): Promise<void> {
-  const validation = validateCreateOptions(options);
+  const cwd = options.outputDir ?? getWorkingDirectory();
+
+  const validation = validateCreateOptions(options, cwd);
   if (!validation.valid) {
     if (options.json) {
       console.log(JSON.stringify({ success: false, error: validation.error }));
@@ -74,8 +76,6 @@ async function handleCreateCLI(options: CreateOptions): Promise<void> {
     }
     process.exit(1);
   }
-
-  const cwd = options.outputDir ?? getWorkingDirectory();
 
   // Handle dry-run mode
   if (options.dryRun) {

--- a/src/cli/tui/screens/create/CreateScreen.tsx
+++ b/src/cli/tui/screens/create/CreateScreen.tsx
@@ -1,4 +1,5 @@
 import { ProjectNameSchema } from '../../../../schema';
+import { validateFolderNotExists } from '../../../commands/create/validate';
 import { computeDefaultCredentialEnvVarName } from '../../../operations/identity/create-identity';
 import {
   LogLink,
@@ -257,6 +258,7 @@ export function CreateScreen({ cwd, isInteractive, onExit, onNavigate }: CreateS
           prompt="Project name"
           initialValue=""
           schema={ProjectNameSchema}
+          customValidation={name => validateFolderNotExists(name, cwd)}
           onSubmit={name => {
             flow.setProjectName(name);
             flow.confirmProjectName();


### PR DESCRIPTION
## Description

Adds a check to prevent overwriting existing project folders when running agentcore create.
Previously, creating a project with the same name as an existing folder would silently
overwrite it.

CLI Mode: Validates folder existence before creation and returns an error with exit code 1.

TUI Mode: Shows real-time validation as the user types the project name - displays a red ✗
mark and error message when the folder already exists, preventing submission until a unique
name is chosen.

Error message: A folder named '<name>' already exists in this directory

## Related Issues

https://github.com/aws/agentcore-cli/issues/203

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Check all that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran npm run test:all
- [x] I ran npm run typecheck
- [x] I ran npm run lint
- [ ] If I modified src/assets/, I ran npm run test:update-snapshots and committed the
updated snapshots

## Checklist

- [ ] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no
new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published
