### PR TITLE
fix: add default namespaces to memory strategies

### DIFF
--- a/src/cli/operations/agent/generate/schema-mapper.ts
+++ b/src/cli/operations/agent/generate/schema-mapper.ts
@@ -6,8 +6,10 @@ import type {
   FilePath,
   Memory,
   MemoryStrategy,
+  MemoryStrategyType,
   ModelProvider,
 } from '../../../../schema';
+import { DEFAULT_STRATEGY_NAMESPACES } from '../../../../schema';
 import type {
   AgentRenderConfig,
   IdentityProviderRenderConfig,
@@ -59,9 +61,14 @@ export function mapGenerateInputToMemories(memory: MemoryOption, projectName: st
   // Short term memory has no strategies - just base memory with expiration time
   // Long term memory includes strategies for semantic search, summarization, and user preferences
   if (memory === 'longAndShortTerm') {
-    strategies.push({ type: 'SEMANTIC' });
-    strategies.push({ type: 'USER_PREFERENCE' });
-    strategies.push({ type: 'SUMMARIZATION' });
+    const strategyTypes: MemoryStrategyType[] = ['SEMANTIC', 'USER_PREFERENCE', 'SUMMARIZATION'];
+    for (const type of strategyTypes) {
+      const defaultNamespaces = DEFAULT_STRATEGY_NAMESPACES[type];
+      strategies.push({
+        type,
+        ...(defaultNamespaces && { namespaces: defaultNamespaces }),
+      });
+    }
   }
 
   return [

--- a/src/cli/operations/memory/create-memory.ts
+++ b/src/cli/operations/memory/create-memory.ts
@@ -1,5 +1,6 @@
 import { ConfigIO } from '../../../lib';
-import type { Memory, MemoryStrategy } from '../../../schema';
+import type { Memory, MemoryStrategy, MemoryStrategyType } from '../../../schema';
+import { DEFAULT_STRATEGY_NAMESPACES } from '../../../schema';
 
 /**
  * Config for creating a memory resource.
@@ -35,11 +36,21 @@ export async function createMemory(config: CreateMemoryConfig): Promise<Memory> 
     throw new Error(`Memory "${config.name}" already exists.`);
   }
 
+  // Map strategies with their default namespaces
+  const strategies: MemoryStrategy[] = config.strategies.map(s => {
+    const strategyType = s.type as MemoryStrategyType;
+    const defaultNamespaces = DEFAULT_STRATEGY_NAMESPACES[strategyType];
+    return {
+      type: strategyType,
+      ...(defaultNamespaces && { namespaces: defaultNamespaces }),
+    };
+  });
+
   const memory: Memory = {
     type: 'AgentCoreMemory',
     name: config.name,
     eventExpiryDuration: config.eventExpiryDuration,
-    strategies: config.strategies as MemoryStrategy[],
+    strategies,
   };
 
   project.memories.push(memory);

--- a/src/schema/schemas/agentcore-project.ts
+++ b/src/schema/schemas/agentcore-project.ts
@@ -8,12 +8,12 @@
  */
 import { isReservedProjectName } from '../constants';
 import { AgentEnvSpecSchema } from './agent-env';
-import { MemoryStrategySchema, MemoryStrategyTypeSchema } from './primitives/memory';
+import { DEFAULT_STRATEGY_NAMESPACES, MemoryStrategySchema, MemoryStrategyTypeSchema } from './primitives/memory';
 import { uniqueBy } from './zod-util';
 import { z } from 'zod';
 
 // Re-export for convenience
-export { MemoryStrategySchema, MemoryStrategyTypeSchema };
+export { DEFAULT_STRATEGY_NAMESPACES, MemoryStrategySchema, MemoryStrategyTypeSchema };
 export type { MemoryStrategy, MemoryStrategyType } from './primitives/memory';
 
 // ============================================================================

--- a/src/schema/schemas/primitives/index.ts
+++ b/src/schema/schemas/primitives/index.ts
@@ -1,2 +1,7 @@
 export type { MemoryStrategy, MemoryStrategyType } from './memory';
-export { MemoryStrategySchema, MemoryStrategyNameSchema, MemoryStrategyTypeSchema } from './memory';
+export {
+  DEFAULT_STRATEGY_NAMESPACES,
+  MemoryStrategyNameSchema,
+  MemoryStrategySchema,
+  MemoryStrategyTypeSchema,
+} from './memory';

--- a/src/schema/schemas/primitives/memory.ts
+++ b/src/schema/schemas/primitives/memory.ts
@@ -17,6 +17,17 @@ export const MemoryStrategyTypeSchema = z.enum(['SEMANTIC', 'SUMMARIZATION', 'US
 export type MemoryStrategyType = z.infer<typeof MemoryStrategyTypeSchema>;
 
 /**
+ * Default namespaces for each memory strategy type.
+ * These match the patterns generated in CLI session.py templates.
+ * CUSTOM strategy intentionally has no default namespace.
+ */
+export const DEFAULT_STRATEGY_NAMESPACES: Partial<Record<MemoryStrategyType, string[]>> = {
+  SEMANTIC: ['/users/{actorId}/facts'],
+  USER_PREFERENCE: ['/users/{actorId}/preferences'],
+  SUMMARIZATION: ['/summaries/{actorId}/{sessionId}'],
+};
+
+/**
  * Memory strategy name validation.
  * Pattern: ^[a-zA-Z][a-zA-Z0-9_]{0,47}$
  * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-bedrockagentcore-memory.html#cfn-bedrockagentcore-memory-name


### PR DESCRIPTION
## Summary

- Add default namespaces to memory strategies when creating memory via CLI
- Ensures deployed namespaces match the patterns in session.py templates
- Fixes namespace mismatch between CLI-generated templates and service defaults

**Default namespaces by strategy type:**
| Strategy | Namespace |
|----------|-----------|
| SEMANTIC | `/users/{actorId}/facts` |
| USER_PREFERENCE | `/users/{actorId}/preferences` |
| SUMMARIZATION | `/summaries/{actorId}/{sessionId}` |

**Behavior:**
- `agentcore create` with `longAndShortTerm` memory: all 3 strategies get default namespaces
- `agentcore add memory --strategies X,Y`: only selected strategies get their default namespaces

- Closes #237 
## Test plan

- [x] Added unit test for `add memory` flow verifying namespaces are set
- [x] Added unit test for `create` flow with `longAndShortTerm` memory
- [x] All existing tests pass