### PR TITLE
fix: hide help command from TUI command list

### DIFF
--- a/src/cli/tui/utils/commands.ts
+++ b/src/cli/tui/utils/commands.ts
@@ -11,7 +11,7 @@ export interface CommandMeta {
 /**
  * Commands hidden from TUI help but still available via CLI.
  */
-const HIDDEN_FROM_TUI = ['update', 'package'] as const;
+const HIDDEN_FROM_TUI = ['help', 'update', 'package'] as const;
 
 /**
  * Commands hidden from TUI when inside an existing project.


### PR DESCRIPTION
## Description

Hide the help command from the TUI command list. The help command is CLI-only (agentcore help modes) and doesn't make sense in the TUI since the TUI itself serves as the interactive help interface. Previously, selecting "help" from the command list would show a "TODO: implement help" placeholder message to users.

## Related Issues

Closes #236

## Documentation PR

N/A - no documentation changes needed

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran npm run test:all
- [x] I ran npm run typecheck
- [x] I ran npm run lint
- [ ] If I modified src/assets/, I ran npm run test:update-snapshots and committed the updated snapshots

Manual testing: Built and installed the CLI globally (npm run build && npm pack && npm install -g *.tgz), verified the help command no longer appears in the TUI command list.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.