### PR TITLE
feat: add conversation history to invoke TUI

### DIFF
--- a/src/cli/tui/screens/invoke/InvokeScreen.tsx
+++ b/src/cli/tui/screens/invoke/InvokeScreen.tsx
@@ -1,7 +1,7 @@
-import { GradientText, LogLink, Panel, Screen, ScrollableText, SelectList, TextInput } from '../../components';
+import { GradientText, LogLink, Panel, Screen, SelectList, TextInput } from '../../components';
 import { useInvokeFlow } from './useInvokeFlow';
-import { Box, Text, useInput } from 'ink';
-import React, { useEffect, useState } from 'react';
+import { Box, Text, useInput, useStdout } from 'ink';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 interface InvokeScreenProps {
   /** Whether running in interactive TUI mode (from App.tsx) vs CLI mode */
@@ -13,6 +13,81 @@ interface InvokeScreenProps {
 
 type Mode = 'select-agent' | 'chat' | 'input';
 
+/**
+ * Render conversation messages as a single string for scrolling.
+ */
+function formatConversation(messages: { role: 'user' | 'assistant'; content: string }[]): string {
+  const lines: string[] = [];
+
+  for (const msg of messages) {
+    // Skip empty assistant messages (placeholder before streaming starts)
+    if (msg.role === 'assistant' && !msg.content) continue;
+
+    if (msg.role === 'user') {
+      lines.push(`> ${msg.content}`);
+    } else {
+      lines.push(msg.content);
+    }
+    lines.push(''); // blank line between messages
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Word-wrap a single line to fit within maxWidth.
+ */
+function wrapLine(line: string, maxWidth: number): string[] {
+  if (!line) return [''];
+  if (line.length <= maxWidth) return [line];
+
+  const wrapped: string[] = [];
+  const words = line.split(' ');
+  let currentLine = '';
+
+  for (const word of words) {
+    if (word.length > maxWidth) {
+      if (currentLine) {
+        wrapped.push(currentLine);
+        currentLine = '';
+      }
+      for (let i = 0; i < word.length; i += maxWidth) {
+        wrapped.push(word.slice(i, i + maxWidth));
+      }
+      continue;
+    }
+
+    const testLine = currentLine ? `${currentLine} ${word}` : word;
+    if (testLine.length <= maxWidth) {
+      currentLine = testLine;
+    } else {
+      if (currentLine) {
+        wrapped.push(currentLine);
+      }
+      currentLine = word;
+    }
+  }
+
+  if (currentLine) {
+    wrapped.push(currentLine);
+  }
+
+  return wrapped.length > 0 ? wrapped : [''];
+}
+
+/**
+ * Wrap multi-line text to fit within maxWidth.
+ */
+function wrapText(text: string, maxWidth: number): string[] {
+  if (!text) return [];
+  const lines = text.split('\n');
+  const wrapped: string[] = [];
+  for (const line of lines) {
+    wrapped.push(...wrapLine(line, maxWidth));
+  }
+  return wrapped;
+}
+
 export function InvokeScreen({
   isInteractive: _isInteractive,
   onExit,
@@ -22,6 +97,10 @@ export function InvokeScreen({
   const { phase, config, selectedAgent, messages, error, logFilePath, sessionId, selectAgent, invoke, newSession } =
     useInvokeFlow({ initialSessionId });
   const [mode, setMode] = useState<Mode>('select-agent');
+  const [scrollOffset, setScrollOffset] = useState(0);
+  const [userScrolled, setUserScrolled] = useState(false);
+  const { stdout } = useStdout();
+  const justCancelledRef = useRef(false);
 
   // Handle initial prompt - skip agent selection if only one agent
   useEffect(() => {
@@ -46,7 +125,7 @@ export function InvokeScreen({
   }, [initialPrompt, phase, messages.length, onExit]);
 
   // Return to input mode after invoke completes
-  const prevPhaseRef = React.useRef(phase);
+  const prevPhaseRef = useRef(phase);
   useEffect(() => {
     if (prevPhaseRef.current === 'invoking' && phase === 'ready' && !initialPrompt) {
       queueMicrotask(() => setMode('input'));
@@ -54,34 +133,112 @@ export function InvokeScreen({
     prevPhaseRef.current = phase;
   }, [phase, initialPrompt]);
 
-  useInput((input, key) => {
-    if (phase === 'loading' || phase === 'error' || !config) return;
+  // Calculate available height for conversation display
+  const terminalHeight = stdout?.rows ?? 24;
+  const terminalWidth = stdout?.columns ?? 80;
+  const baseHeight = Math.max(5, terminalHeight - 12);
+  const displayHeight = mode === 'input' ? Math.max(3, baseHeight - 2) : baseHeight;
+  const contentWidth = Math.max(40, terminalWidth - 4);
 
-    if (key.escape || (key.ctrl && input === 'q')) {
-      if (mode === 'input') {
-        setMode('chat');
-      } else if (mode === 'chat' && config.agents.length > 1) {
-        setMode('select-agent');
-      } else {
-        onExit();
+  // Format conversation content
+  const conversationText = useMemo(() => formatConversation(messages), [messages]);
+
+  // Wrap text for display
+  const lines = useMemo(() => wrapText(conversationText, contentWidth), [conversationText, contentWidth]);
+
+  const totalLines = lines.length;
+  const maxScroll = Math.max(0, totalLines - displayHeight);
+  const needsScroll = totalLines > displayHeight;
+
+  // Auto-scroll to bottom when user hasn't manually scrolled up
+  const effectiveOffset = useMemo(() => {
+    if (totalLines === 0) return 0;
+    if (!userScrolled && totalLines > displayHeight) return maxScroll;
+    return Math.min(scrollOffset, maxScroll);
+  }, [totalLines, userScrolled, scrollOffset, maxScroll, displayHeight]);
+
+  const scrollUp = useCallback(
+    (amount = 1) => {
+      if (!needsScroll) return;
+      setUserScrolled(true);
+      setScrollOffset(prev => {
+        const current = userScrolled ? prev : maxScroll;
+        return Math.max(0, current - amount);
+      });
+    },
+    [needsScroll, userScrolled, maxScroll]
+  );
+
+  const scrollDown = useCallback(
+    (amount = 1) => {
+      if (!needsScroll) return;
+      setScrollOffset(prev => {
+        const next = Math.min(maxScroll, prev + amount);
+        if (next >= maxScroll) {
+          setUserScrolled(false);
+        }
+        return next;
+      });
+    },
+    [needsScroll, maxScroll]
+  );
+
+  useInput(
+    (input, key) => {
+      if (phase === 'loading' || phase === 'error' || !config) return;
+
+      // Agent selection mode
+      if (mode === 'select-agent') {
+        if (key.escape || (key.ctrl && input === 'q')) {
+          onExit();
+          return;
+        }
+        if (key.upArrow) selectAgent((selectedAgent - 1 + config.agents.length) % config.agents.length);
+        if (key.downArrow) selectAgent((selectedAgent + 1) % config.agents.length);
+        if (key.return) setMode('input');
+        return;
       }
-      return;
-    }
 
-    if (mode === 'select-agent') {
-      if (key.upArrow) selectAgent((selectedAgent - 1 + config.agents.length) % config.agents.length);
-      if (key.downArrow) selectAgent((selectedAgent + 1) % config.agents.length);
-      if (key.return) setMode('input');
-    }
+      // Chat mode
+      if (mode === 'chat') {
+        if (key.escape || (key.ctrl && input === 'q') || (key.ctrl && input === 'c')) {
+          if (justCancelledRef.current) {
+            justCancelledRef.current = false;
+            return;
+          }
+          if (config.agents.length > 1) {
+            setMode('select-agent');
+            return;
+          }
+          onExit();
+          return;
+        }
 
-    if (mode === 'chat' && input === 'i' && phase === 'ready') {
-      setMode('input');
-    }
+        justCancelledRef.current = false;
 
-    if (mode === 'chat' && input === 'n' && phase === 'ready') {
-      newSession();
-    }
-  });
+        // Enter or 'i' to start typing (only when not invoking)
+        if ((key.return || input === 'i') && phase === 'ready') {
+          setMode('input');
+          return;
+        }
+
+        // New session
+        if (input === 'n' && phase === 'ready') {
+          newSession();
+          setScrollOffset(0);
+          setUserScrolled(false);
+          return;
+        }
+
+        // Scroll controls
+        if (key.upArrow) scrollUp(1);
+        else if (key.downArrow) scrollDown(1);
+        else if (key.pageUp) scrollUp(displayHeight);
+        else if (key.pageDown) scrollDown(displayHeight);
+      }
+    },
+    { isActive: mode === 'chat' || mode === 'select-agent' }
+  );
 
   // Error state - show error in main screen
   if (phase === 'error') {
@@ -105,11 +262,16 @@ export function InvokeScreen({
   }));
 
   // Dynamic help text
-  const helpText = {
-    'select-agent': '↑↓ select · Enter confirm · Esc quit',
-    chat: '↑↓ scroll · Esc back',
-    input: 'Enter send · Esc cancel',
-  }[mode];
+  const helpText =
+    mode === 'select-agent'
+      ? '↑↓ select · Enter confirm · Esc quit'
+      : mode === 'input'
+        ? 'Enter send · Esc cancel'
+        : phase === 'invoking'
+          ? '↑↓ scroll'
+          : messages.length > 0
+            ? `↑↓ scroll · Enter invoke · N new session · ${config.agents.length > 1 ? 'Esc back' : 'Esc quit'}`
+            : `Enter to send a message · ${config.agents.length > 1 ? 'Esc back' : 'Esc quit'}`;
 
   const headerContent = (
     <Box flexDirection="column">
@@ -133,6 +295,7 @@ export function InvokeScreen({
           <Text color="magenta">{sessionId?.slice(0, 8) ?? 'none'}</Text>
         </Box>
       )}
+      {logFilePath && <LogLink filePath={logFilePath} />}
     </Box>
   );
 
@@ -147,57 +310,72 @@ export function InvokeScreen({
     );
   }
 
-  // Get the current message pair (user prompt and assistant response)
-  const userMessage = messages.find(m => m.role === 'user');
-  const assistantMessage = messages.find(m => m.role === 'assistant');
+  // Visible lines for display
+  const visibleLines = lines.slice(effectiveOffset, effectiveOffset + displayHeight);
 
-  // Show messages in both chat and input modes so user can see conversation while typing
-  const showMessages = mode === 'chat' || mode === 'input';
+  // Check if the last assistant message is empty (streaming hasn't started yet)
+  const lastMessage = messages[messages.length - 1];
+  const showThinking = phase === 'invoking' && lastMessage?.role === 'assistant' && !lastMessage.content;
 
   return (
     <Screen title="AgentCore Invoke" onExit={onExit} helpText={helpText} headerContent={headerContent}>
       <Box flexDirection="column" flexGrow={1}>
-        {messages.length === 0 && mode === 'chat' && <Text dimColor>Press &apos;i&apos; to send a message</Text>}
-
-        {/* User prompt */}
-        {showMessages && userMessage && (
-          <Box marginBottom={1}>
-            <Text color="blue">&gt; {userMessage.content}</Text>
+        {/* Conversation display - always visible when there's content */}
+        {messages.length > 0 && (
+          <Box flexDirection="column" height={needsScroll ? displayHeight : undefined}>
+            {visibleLines.map((line, idx) => {
+              // Detect user messages (start with "> ")
+              const isUserMessage = line.startsWith('> ');
+              return (
+                <Text key={effectiveOffset + idx} color={isUserMessage ? 'blue' : 'green'} wrap="truncate">
+                  {line || ' '}
+                </Text>
+              );
+            })}
+            {/* Thinking indicator - shows while waiting for response to start */}
+            {showThinking && <GradientText text="Thinking..." />}
           </Box>
         )}
 
-        {/* Assistant response with scrolling */}
-        {showMessages && assistantMessage?.content && (
-          <Box marginBottom={1} flexDirection="column">
-            <ScrollableText
-              content={assistantMessage.content}
-              color="green"
-              isStreaming={phase === 'invoking'}
-              isActive={mode === 'chat' || mode === 'input'}
+        {/* Scroll indicator */}
+        {needsScroll && (
+          <Text dimColor>
+            [{effectiveOffset + 1}-{Math.min(effectiveOffset + displayHeight, totalLines)} of {totalLines}]
+          </Text>
+        )}
+
+        {/* Input area */}
+        {mode === 'chat' && phase === 'ready' && messages.length > 0 && (
+          <Box>
+            <Text dimColor>&gt; </Text>
+          </Box>
+        )}
+        {mode === 'chat' && phase === 'ready' && messages.length === 0 && (
+          <Text dimColor>Press Enter to send a message</Text>
+        )}
+        {mode === 'input' && phase === 'ready' && (
+          <Box>
+            <Text color="blue">&gt; </Text>
+            <TextInput
+              prompt=""
+              hideArrow
+              onSubmit={text => {
+                if (text.trim()) {
+                  setMode('chat');
+                  setUserScrolled(false);
+                  void invoke(text);
+                } else {
+                  setMode('chat');
+                }
+              }}
+              onCancel={() => {
+                justCancelledRef.current = true;
+                setMode('chat');
+              }}
+              onUpArrow={() => scrollUp(1)}
+              onDownArrow={() => scrollDown(1)}
             />
           </Box>
-        )}
-
-        {/* Invoking indicator */}
-        {phase === 'invoking' && <GradientText text="Invoking..." />}
-
-        {/* Log file link after response */}
-        {logFilePath && messages.length > 0 && phase === 'ready' && (
-          <Box marginTop={1}>
-            <LogLink filePath={logFilePath} />
-          </Box>
-        )}
-
-        {/* Input prompt */}
-        {mode === 'input' && phase === 'ready' && (
-          <TextInput
-            prompt=""
-            onSubmit={text => {
-              setMode('chat');
-              void invoke(text);
-            }}
-            onCancel={() => setMode('chat')}
-          />
         )}
       </Box>
     </Screen>

--- a/src/cli/tui/screens/invoke/useInvokeFlow.ts
+++ b/src/cli/tui/screens/invoke/useInvokeFlow.ts
@@ -132,11 +132,8 @@ export function useInvokeFlow(options: InvokeFlowOptions = {}): InvokeFlowState 
 
       const logger = loggerRef.current;
 
-      // Clear previous messages and start fresh with new user message and empty assistant message
-      setMessages([
-        { role: 'user', content: prompt },
-        { role: 'assistant', content: '' },
-      ]);
+      // Append new user message and empty assistant message (conversation history is preserved)
+      setMessages(prev => [...prev, { role: 'user', content: prompt }, { role: 'assistant', content: '' }]);
       setPhase('invoking');
       streamingContentRef.current = '';
 


### PR DESCRIPTION

## Description

Invoke now preserves and displays full conversation history like the dev screen, instead of showing only the latest message pair. Also pins the log file link in the header.

Now consistent with `dev` invoke experience in the TUI

## Related Issues

## Documentation PR


## Type of Change

<!-- Check all that apply -->

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

Manually tested CLI invoke flow post running build

- [X] I ran `npm run test:all`
- [X] I ran `npm run typecheck`
- [X] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
