### PR TITLE
fix: align command descriptions in TUI help screen

### DIFF
--- a/src/cli/tui/screens/home/HelpScreen.tsx
+++ b/src/cli/tui/screens/home/HelpScreen.tsx
@@ -30,6 +30,18 @@ function HelpDisplay({ items, query, cursor, clampedIndex, notice }: HelpDisplay
   const { contentWidth } = useLayout();
   const divider = '─'.repeat(contentWidth);
 
+  // Calculate max label length for description alignment
+  const maxLabelLen = useMemo(() => {
+    if (items.length === 0) return 0;
+    return Math.max(
+      ...items.map(item =>
+        item.matchedSubcommand
+          ? item.command.title.length + 3 + item.matchedSubcommand.length
+          : item.command.title.length
+      )
+    );
+  }, [items]);
+
   return (
     <Box flexDirection="column">
       {/* Header */}
@@ -57,6 +69,10 @@ function HelpDisplay({ items, query, cursor, clampedIndex, notice }: HelpDisplay
             const selected = idx === clampedIndex;
             const itemKey = item.matchedSubcommand ? `${item.command.id}-${item.matchedSubcommand}` : item.command.id;
             const desc = truncateDescription(item.command.description, MAX_DESC_WIDTH);
+            const labelLen = item.matchedSubcommand
+              ? item.command.title.length + 3 + item.matchedSubcommand.length
+              : item.command.title.length;
+            const padding = ' '.repeat(Math.max(1, maxLabelLen - labelLen + 2));
             return (
               <Box key={itemKey}>
                 <Text color={selected ? 'cyan' : 'white'}>{selected ? '❯' : ' '} </Text>
@@ -71,7 +87,8 @@ function HelpDisplay({ items, query, cursor, clampedIndex, notice }: HelpDisplay
                     </Text>
                   </>
                 )}
-                <Text dimColor> {desc}</Text>
+                <Text>{padding}</Text>
+                <Text dimColor>{desc}</Text>
               </Box>
             );
           })


### PR DESCRIPTION
## Description

align help screen text + description

## Related Issues

<!-- Link to related issues using #issue-number format -->

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Check all that apply -->

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:all`
- [ ] I ran `npm run typecheck`
- [ ] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
