### PR TITLE
fix: `agentcore create` launching CLI instead of TUI

### DIFF
--- a/src/cli/commands/create/__tests__/create.test.ts
+++ b/src/cli/commands/create/__tests__/create.test.ts
@@ -206,4 +206,13 @@ describe('create command', () => {
       expect(json.error).toContain('already exists');
     });
   });
+
+  describe('no flags', () => {
+    it('launches TUI when no flags provided', async () => {
+      const result = await runCLI(['create'], testDir);
+
+      // TUI outputs "AgentCore Create" header
+      expect(result.stdout).toContain('AgentCore Create');
+    });
+  });
 });

--- a/src/cli/commands/create/command.tsx
+++ b/src/cli/commands/create/command.tsx
@@ -165,9 +165,6 @@ export const registerCreate = (program: Command) => {
           options.memory = options.memory ?? 'none';
         }
 
-        // Always default language to Python (only supported option)
-        options.language = options.language ?? 'Python';
-
         // Any flag triggers non-interactive CLI mode
         const hasAnyFlag = Boolean(
           options.name ??
@@ -186,6 +183,8 @@ export const registerCreate = (program: Command) => {
         );
 
         if (hasAnyFlag) {
+          // Default language to Python (only supported option) for CLI mode
+          options.language = options.language ?? 'Python';
           await handleCreateCLI(options as CreateOptions);
         } else {
           handleCreateTUI();


### PR DESCRIPTION
## Description

Running agentcore create without any flags was incorrectly showing --name is required error instead of launching the interactive TUI.

The issue was that options.language was being defaulted to 'Python' before the hasAnyFlag check. Since hasAnyFlag includes options.language in its boolean check, it always
evaluated to true, causing CLI mode to run instead of TUI mode.

Fix moves the language default assignment inside the if (hasAnyFlag) block so it only applies when CLI mode is already determined.

## Related Issues

None

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran npm run test:all
- [x] I ran npm run typecheck
- [x] I ran npm run lint
- [ ] If I modified src/assets/, I ran npm run test:update-snapshots and committed the updated snapshots

Added regression test that verifies agentcore create without flags launches TUI (checks for "AgentCore Create" header in output).

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published