### PR TITLE
fix: include APP_DIR in agent path for TUI add agent venv setup

### DIFF
--- a/src/cli/tui/screens/agent/useAddAgent.ts
+++ b/src/cli/tui/screens/agent/useAddAgent.ts
@@ -1,4 +1,4 @@
-import { ConfigIO, NoProjectError, findConfigRoot, setEnvVar } from '../../../../lib';
+import { APP_DIR, ConfigIO, NoProjectError, findConfigRoot, setEnvVar } from '../../../../lib';
 import type { AgentEnvSpec, DirectoryPath, FilePath } from '../../../../schema';
 import { getErrorMessage } from '../../../errors';
 import { type PythonSetupResult, setupPythonProject } from '../../../operations';
@@ -143,7 +143,7 @@ async function handleCreatePath(
   const project = await configIO.readProjectSpec();
 
   const generateConfig = mapAddAgentConfigToGenerateConfig(config);
-  const agentPath = join(projectRoot, config.name);
+  const agentPath = join(projectRoot, APP_DIR, config.name);
 
   // Resolve credential strategy FIRST to determine correct credential name
   let identityProviders: ReturnType<typeof mapModelProviderToIdentityProviders> = [];


### PR DESCRIPTION
## Summary
- Fixed missing `APP_DIR` ('app/') in the path calculation for `setupPythonProject` in the TUI add agent flow
- The venv was being created in `projectRoot/<agentName>` instead of `projectRoot/app/<agentName>`

## Root Cause
In `useAddAgent.ts`, the `handleCreatePath` function calculated the agent path as:
```typescript
const agentPath = join(projectRoot, config.name);  // Wrong
```

While the CLI flags path in `actions.ts` correctly used:
```typescript
const agentPath = join(projectRoot, APP_DIR, options.name);  // Correct
```

## Test plan
- [ ] Run `agentcore add agent` via TUI and verify `.venv` is created in `app/<agentName>/`
- [ ] Compare behavior with `agentcore create` which should work correctly