### PR TITLE
feat: use aws-opentelemetry-distro in Strands and OpenAIAgents templates

### DIFF
--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -2264,8 +2264,7 @@ description = "AgentCore Runtime Application using OpenAI Agents SDK"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "opentelemetry-distro",
-    "opentelemetry-exporter-otlp",
+    "aws-opentelemetry-distro",
     "openai-agents >= 0.4.2",
     "bedrock-agentcore >= 1.0.3",
     "botocore[crt] >= 1.35.0",
@@ -2601,8 +2600,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "anthropic >= 0.30.0",
-    "opentelemetry-distro",
-    "opentelemetry-exporter-otlp",
+    "aws-opentelemetry-distro",
     "bedrock-agentcore >= 1.0.3",
     "botocore[crt] >= 1.35.0",
     "google-genai >= 1.0.0",

--- a/src/assets/python/openaiagents/base/pyproject.toml
+++ b/src/assets/python/openaiagents/base/pyproject.toml
@@ -9,8 +9,7 @@ description = "AgentCore Runtime Application using OpenAI Agents SDK"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "opentelemetry-distro",
-    "opentelemetry-exporter-otlp",
+    "aws-opentelemetry-distro",
     "openai-agents >= 0.4.2",
     "bedrock-agentcore >= 1.0.3",
     "botocore[crt] >= 1.35.0",

--- a/src/assets/python/strands/base/pyproject.toml
+++ b/src/assets/python/strands/base/pyproject.toml
@@ -10,8 +10,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "anthropic >= 0.30.0",
-    "opentelemetry-distro",
-    "opentelemetry-exporter-otlp",
+    "aws-opentelemetry-distro",
     "bedrock-agentcore >= 1.0.3",
     "botocore[crt] >= 1.35.0",
     "google-genai >= 1.0.0",


### PR DESCRIPTION
## Summary

- Replace generic `opentelemetry-distro` and `opentelemetry-exporter-otlp` with `aws-opentelemetry-distro` in Strands and OpenAIAgents templates
- Provides better AWS integration out of the box including X-Ray trace propagation and AWS resource detection

## Test plan

- [x] Verified `aws-opentelemetry-distro` resolves correctly with Strands dependencies
- [x] Verified `aws-opentelemetry-distro` resolves correctly with OpenAI Agents dependencies
- [x] Verified imports work: `from amazon.opentelemetry.distro import aws_opentelemetry_distro`
- [x] Updated snapshot tests