### PR TITLE
fix: exclude CHANGELOG.md from prettier checks

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+CHANGELOG.md


### PR DESCRIPTION
## Summary

Fixes the release workflow failing due to prettier checking the generated CHANGELOG.md file.

### Changes
- Add `.prettierignore` to exclude `CHANGELOG.md` from prettier checks
- Improve changelog entry insertion logic for cleaner output structure

### Why
The auto-generated changelog doesn't match prettier's markdown style (blank lines after headers, etc.). Rather than fight prettier's formatting, we exclude the file since changelogs are auto-generated anyway.