### PR TITLE
Add GitHub issue templates and require issues for PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,73 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: ['bug']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please fill out the sections below so we can reproduce and fix the issue.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug.
+      placeholder: Describe what happened...
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Run `agentcore ...`
+        2. Select ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened.
+    validations:
+      required: true
+
+  - type: input
+    id: cli-version
+    attributes:
+      label: CLI Version
+      description: Output of `agentcore --version`
+      placeholder: '1.0.0'
+    validations:
+      required: false
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      options:
+        - macOS
+        - Windows
+        - Linux
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other context, screenshots, or logs that might help.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security Vulnerability
+    url: https://aws.amazon.com/security/vulnerability-reporting/
+    about: Please report security vulnerabilities through AWS Security, not GitHub issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+labels: ['enhancement']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature. Please describe what you'd like and why it would be useful.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of the feature or enhancement you'd like.
+      placeholder: Describe the feature...
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: What does "done" look like? List concrete, testable criteria.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other context, screenshots, mockups, or examples.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,9 +2,11 @@
 
 <!-- Provide a detailed description of the changes in this PR -->
 
-## Related Issues
+## Related Issue
 
-<!-- Link to related issues using #issue-number format -->
+<!-- Every PR must be associated with an issue. Link it below using #issue-number format. -->
+
+Closes #
 
 ## Documentation PR
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,10 +22,12 @@ reported the issue. Please try to include as much information as you can. Detail
 
 Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
 
-1. You are working against the latest source on the _main_ branch.
-2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem
+1. **Every PR must be linked to an issue.** Open an issue first (or find an existing one) and reference it in your PR
+   using `Closes #issue-number`. PRs without an associated issue will not be reviewed.
+2. You are working against the latest source on the _main_ branch.
+3. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem
    already.
-3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
+4. You open an issue to discuss any significant work - we would hate for your time to be wasted.
 
 To send us a pull request, please:
 


### PR DESCRIPTION
## Description

- Add structured GitHub issue templates (bug report + feature request) so all new issues follow a consistent format with required fields
- Disable blank issues to enforce template usage
- Update PR template to require every PR to reference an associated issue (`Closes #`)
- Update CONTRIBUTING.md to document that PRs without a linked issue will not be reviewed

## Related Issue

Closes #86

## Type of Change

- [x] Documentation update

## Testing

Once merged to `main`, verify at https://github.com/aws/agentcore-cli/issues/new/choose — you should see "Bug Report" and "Feature Request" as the only options (no blank issue).

## Files Changed

- `.github/ISSUE_TEMPLATE/bug_report.yml` — structured bug report form
- `.github/ISSUE_TEMPLATE/feature_request.yml` — structured feature request form
- `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues, links security reporting
- `.github/pull_request_template.md` — requires issue linkage
- `CONTRIBUTING.md` — documents PR-to-issue requirement