### PR TITLE
fix: run build before tests in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,11 +229,11 @@ jobs:
       - name: Run type check
         run: npm run typecheck
 
-      - name: Run tests
-        run: npm run test:unit
-
       - name: Build package
         run: npm run build
+
+      - name: Run tests
+        run: npm run test:unit
 
       - name: Pack for verification
         run: npm pack


### PR DESCRIPTION
## Summary

Fixes test failures in the release workflow by running `npm run build` before `npm run test:unit`.

### Problem
The unit tests use `runCLI` which spawns the built CLI binary at `dist/cli/index.mjs`. The workflow was running tests before the build step, causing "MODULE_NOT_FOUND" errors.

### Fix
Reorder steps: build → tests (instead of tests → build)