### PR TITLE
Remove duplicate security vulnerability link from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,1 @@
 blank_issues_enabled: false
-contact_links:
-  - name: Security Vulnerability
-    url: https://aws.amazon.com/security/vulnerability-reporting/
-    about: Please report security vulnerabilities through AWS Security, not GitHub issues.


### PR DESCRIPTION
## Description
- Remove the `contact_links` security vulnerability entry from `.github/ISSUE_TEMPLATE/config.yml`
- `SECURITY.md` at the repo root already causes GitHub to surface a security link on the issue chooser page, so the config entry was creating a duplicate

## Related Issue

Closes #86

## Type of Change

- [x] Documentation update