### PR TITLE
fix: add publishConfig for GitHub Packages registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "agentcore",
   "version": "0.3.0-preview.1.2",
   "description": "CLI for Amazon Bedrock AgentCore",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {


### PR DESCRIPTION
## Summary

Fixes npm publish failing with `ENEEDAUTH` error by adding `publishConfig` to specify the GitHub Packages registry.

### Changes
- Added `publishConfig.registry` pointing to `https://npm.pkg.github.com`

### Problem
Without this config, npm defaults to publishing to `npmjs.org` which requires separate authentication.