### PR TITLE
chore: bump bedrock-agentcore minimum to >= 1.3.0

### DIFF
--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -1096,7 +1096,7 @@ dependencies = [
     "autogen-ext[mcp] >= 0.7.5",
     "opentelemetry-distro",
     "opentelemetry-exporter-otlp",
-    "bedrock-agentcore >= 1.0.3",
+    "bedrock-agentcore >= 1.3.0",
     "botocore[crt] >= 1.35.0",
     "python-dotenv >= 1.0.1",
     "tiktoken",
@@ -1418,7 +1418,7 @@ requires-python = ">=3.11"
 dependencies = [
     "opentelemetry-distro",
     "opentelemetry-exporter-otlp",
-    "bedrock-agentcore >= 1.0.3",
+    "bedrock-agentcore >= 1.3.0",
     "botocore[crt] >= 1.35.0",
     "python-dotenv >= 1.0.1",
 {{#if (eq modelProvider "Bedrock")}}
@@ -1694,7 +1694,7 @@ dependencies = [
     "opentelemetry-distro",
     "opentelemetry-exporter-otlp",
     "google-adk >= 1.17.0",
-    "bedrock-agentcore >= 1.0.3",
+    "bedrock-agentcore >= 1.3.0",
     "botocore[crt] >= 1.35.0",
     "python-dotenv >= 1.0.1",
 ]
@@ -2017,7 +2017,7 @@ dependencies = [
     "langchain-mcp-adapters >= 0.1.11",
     "langchain >= 1.0.3",
     "tiktoken == 0.11.0",
-    "bedrock-agentcore >= 1.0.3",
+    "bedrock-agentcore >= 1.3.0",
     "botocore[crt] >= 1.35.0",
     "python-dotenv >= 1.0.1",
 {{#if (eq modelProvider "Bedrock")}}
@@ -2259,7 +2259,7 @@ requires-python = ">=3.10"
 dependencies = [
     "aws-opentelemetry-distro",
     "openai-agents >= 0.4.2",
-    "bedrock-agentcore >= 1.0.3",
+    "bedrock-agentcore >= 1.3.0",
     "botocore[crt] >= 1.35.0",
     "python-dotenv >= 1.0.1",
 ]
@@ -2594,7 +2594,7 @@ requires-python = ">=3.10"
 dependencies = [
     "anthropic >= 0.30.0",
     "aws-opentelemetry-distro",
-    "bedrock-agentcore >= 1.0.3",
+    "bedrock-agentcore >= 1.3.0",
     "botocore[crt] >= 1.35.0",
     "google-genai >= 1.0.0",
     "openai >= 1.0.0",

--- a/src/assets/python/autogen/base/pyproject.toml
+++ b/src/assets/python/autogen/base/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "autogen-ext[mcp] >= 0.7.5",
     "opentelemetry-distro",
     "opentelemetry-exporter-otlp",
-    "bedrock-agentcore >= 1.0.3",
+    "bedrock-agentcore >= 1.3.0",
     "botocore[crt] >= 1.35.0",
     "python-dotenv >= 1.0.1",
     "tiktoken",

--- a/src/assets/python/crewai/base/pyproject.toml
+++ b/src/assets/python/crewai/base/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.11"
 dependencies = [
     "opentelemetry-distro",
     "opentelemetry-exporter-otlp",
-    "bedrock-agentcore >= 1.0.3",
+    "bedrock-agentcore >= 1.3.0",
     "botocore[crt] >= 1.35.0",
     "python-dotenv >= 1.0.1",
 {{#if (eq modelProvider "Bedrock")}}

--- a/src/assets/python/googleadk/base/pyproject.toml
+++ b/src/assets/python/googleadk/base/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "opentelemetry-distro",
     "opentelemetry-exporter-otlp",
     "google-adk >= 1.17.0",
-    "bedrock-agentcore >= 1.0.3",
+    "bedrock-agentcore >= 1.3.0",
     "botocore[crt] >= 1.35.0",
     "python-dotenv >= 1.0.1",
 ]

--- a/src/assets/python/langchain_langgraph/base/pyproject.toml
+++ b/src/assets/python/langchain_langgraph/base/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "langchain-mcp-adapters >= 0.1.11",
     "langchain >= 1.0.3",
     "tiktoken == 0.11.0",
-    "bedrock-agentcore >= 1.0.3",
+    "bedrock-agentcore >= 1.3.0",
     "botocore[crt] >= 1.35.0",
     "python-dotenv >= 1.0.1",
 {{#if (eq modelProvider "Bedrock")}}

--- a/src/assets/python/openaiagents/base/pyproject.toml
+++ b/src/assets/python/openaiagents/base/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 dependencies = [
     "aws-opentelemetry-distro",
     "openai-agents >= 0.4.2",
-    "bedrock-agentcore >= 1.0.3",
+    "bedrock-agentcore >= 1.3.0",
     "botocore[crt] >= 1.35.0",
     "python-dotenv >= 1.0.1",
 ]

--- a/src/assets/python/strands/base/pyproject.toml
+++ b/src/assets/python/strands/base/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 dependencies = [
     "anthropic >= 0.30.0",
     "aws-opentelemetry-distro",
-    "bedrock-agentcore >= 1.0.3",
+    "bedrock-agentcore >= 1.3.0",
     "botocore[crt] >= 1.35.0",
     "google-genai >= 1.0.0",
     "openai >= 1.0.0",


### PR DESCRIPTION
## Summary
- Bumps `bedrock-agentcore` floor pin from `>= 1.0.3` to `>= 1.3.0` across all 6 Python framework templates
- Updates snapshot tests to match

## Why
v1.3.0 includes important changes since 1.0.3:
- **Removed deprecated APIs**: `save_turn()` and `process_turn()` methods were removed (verified no template code uses these)
- **Bug fixes**: `download_file`/`download_files` binary content crash, workload identity endpoint URLs, bytes serialization, empty text messages breaking Converse API
- **Features**: Bidirectional streaming, episodic memory strategies, memory metadata support, WebSocket session_id support, code interpreter convenience methods

Bumping the floor pin ensures new projects start with a consistent, stable baseline.

## Test plan
- [x] Verified no template code uses removed `save_turn()`/`process_turn()` APIs
- [x] Unit tests pass (292/292)
- [x] Snapshot tests updated and passing (6 snapshots updated)