### PR TITLE
fix: use npm Trusted Publishing (OIDC) in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,6 +285,7 @@ jobs:
       url: https://www.npmjs.com/package/@aws/agentcore
     permissions:
       contents: write
+      id-token: write
 
     steps:
       - name: Checkout latest main (AFTER PR merge)
@@ -350,9 +351,7 @@ jobs:
         run: npm run build
 
       - name: Publish to npm
-        run: npm publish --access=public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_SECRET }}
+        run: npm publish --access=public --provenance
 
       - name: Create and push tag
         env:


### PR DESCRIPTION
## Summary
- Add `id-token: write` permission for OIDC token exchange
- Add `--provenance` flag to `npm publish` for provenance attestation
- Remove `NPM_SECRET` token — authentication now handled via OIDC

## Test plan
- [ ] Trigger a release workflow run and verify the publish step authenticates via OIDC
- [ ] Confirm the published package shows provenance attestation on npmjs.com