### PR TITLE
fix: remove mcp.ts from generated .llm-context folder

### DIFF
--- a/src/cli/templates/schema-assets.ts
+++ b/src/cli/templates/schema-assets.ts
@@ -12,8 +12,6 @@ import llmContextReadmeSrc from '../../schema/llm-compacted/README.md';
 import agentcoreSchemaSrc from '../../schema/llm-compacted/agentcore.ts';
 // @ts-expect-error - text import handled by build plugin
 import awsTargetsSchemaSrc from '../../schema/llm-compacted/aws-targets.ts';
-// @ts-expect-error - text import handled by build plugin
-import mcpSchemaSrc from '../../schema/llm-compacted/mcp.ts';
 import { readFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
@@ -38,6 +36,5 @@ function getContent(imported: unknown, filename: string): string {
 export const LLM_CONTEXT_FILES: Record<string, string> = {
   'README.md': getContent(llmContextReadmeSrc, 'README.md'),
   'agentcore.ts': getContent(agentcoreSchemaSrc, 'agentcore.ts'),
-  'mcp.ts': getContent(mcpSchemaSrc, 'mcp.ts'),
   'aws-targets.ts': getContent(awsTargetsSchemaSrc, 'aws-targets.ts'),
 };

--- a/src/schema/llm-compacted/README.md
+++ b/src/schema/llm-compacted/README.md
@@ -7,7 +7,6 @@
 | File             | JSON Config        | Purpose                              |
 | ---------------- | ------------------ | ------------------------------------ |
 | `agentcore.ts`   | `agentcore.json`   | Project and agent environment config |
-| `mcp.ts`         | `mcp.json`         | MCP gateways and tools               |
 | `aws-targets.ts` | `aws-targets.json` | Deployment targets                   |
 
 ## Usage

--- a/web-harness/schema-assets-mock.ts
+++ b/web-harness/schema-assets-mock.ts
@@ -8,6 +8,5 @@
 export const LLM_CONTEXT_FILES: Record<string, string> = {
   'README.md': '# LLM Context Files\n\nMock content for browser testing.',
   'agentcore.ts': 'export const AgentCoreSchema = {};',
-  'mcp.ts': 'export const McpSchema = {};',
   'aws-targets.ts': 'export const AwsTargetsSchema = {};',
 };


### PR DESCRIPTION
MCP support is not yet public-facing; stop vending mcp.ts schema to the .llm-context directory created by `agentcore create`.

## Description

<!-- Provide a detailed description of the changes in this PR -->

## Related Issue

<!-- Every PR must be associated with an issue. Link it below using #issue-number format. -->

Closes #

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Check all that apply -->

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [X] I ran `npm run test:all`
- [X] I ran `npm run typecheck`
- [X] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
