### PR TITLE
fix: add fallback URL for docs/memory.md link in unsupported terminals 

### DIFF
--- a/src/cli/tui/screens/add/AddFlow.tsx
+++ b/src/cli/tui/screens/add/AddFlow.tsx
@@ -247,13 +247,14 @@ export function AddFlow(props: AddFlowProps) {
           !flow.loading && (
             <Box flexDirection="column">
               <AgentAddedSummary config={flow.config} projectName={flow.projectName} projectPath={flow.projectPath} />
-              <Box marginTop={1}>
+              <Box marginTop={1} flexDirection="column">
                 <Text color="yellow">
                   Note: {memoryNotePrefix}
                   <Link url={`https://github.com/aws/agentcore-cli/blob/main/docs/memory.md${memoryDocAnchor}`}>
                     <Text color="cyan">docs/memory.md</Text>
                   </Link>
                 </Text>
+                <Text dimColor>https://github.com/aws/agentcore-cli/blob/main/docs/memory.md</Text>
               </Box>
             </Box>
           )
@@ -287,13 +288,14 @@ export function AddFlow(props: AddFlowProps) {
           !flow.loading && (
             <Box flexDirection="column">
               <AgentAddedSummary config={flow.config} projectName={flow.projectName} />
-              <Box marginTop={1}>
+              <Box marginTop={1} flexDirection="column">
                 <Text color="yellow">
                   Note: {memoryNotePrefix}
                   <Link url={`https://github.com/aws/agentcore-cli/blob/main/docs/memory.md${memoryDocAnchor}`}>
                     <Text color="cyan">docs/memory.md</Text>
                   </Link>
                 </Text>
+                <Text dimColor>https://github.com/aws/agentcore-cli/blob/main/docs/memory.md</Text>
               </Box>
             </Box>
           )

--- a/src/cli/tui/screens/memory/AddMemoryFlow.tsx
+++ b/src/cli/tui/screens/memory/AddMemoryFlow.tsx
@@ -69,6 +69,7 @@ export function AddMemoryFlow({ isInteractive = true, onExit, onBack, onDev, onD
               </Link>{' '}
               to learn how to connect memory to your agent.
             </Text>
+            <Text dimColor>https://github.com/aws/agentcore-cli/blob/main/docs/memory.md</Text>
             <Text color="yellow">
               Once you deploy, the memory resource will be created in your account, but it is not automatically
               connected to your agent. You must configure your agent code to use this memory.


### PR DESCRIPTION
## Description

Some terminals (e.g., VSCode's integrated terminal) don't properly support OSC 8 terminal hyperlinks used by ink-link. When the docs/memory.md link is displayed after agent creation, VSCode interprets the display text as a local file path and opens it in the editor instead of navigating to the GitHub URL.

This adds a visible fallback URL (dimmed) below the docs/memory.md hyperlink so users can always access the documentation regardless of terminal support. The hidden hyperlink still points to the full URL with the anchor fragment.

## Related Issue

Closes #307

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran npm run test:all
- [x] I ran npm run typecheck
- [x] I ran npm run lint
- [ ] If I modified src/assets/, I ran npm run test:update-snapshots and committed the updated snapshots

Manual testing: ran agentcore create inside an existing project, confirmed the fallback URL renders on its own line below the hyperlink text.

## Checklist

- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.