### PR TITLE
chore: add npm package metadata for search discoverability

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,31 @@
   "name": "@aws/agentcore",
   "version": "0.3.0-preview.1.0",
   "description": "CLI for Amazon Bedrock AgentCore",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aws/agentcore-cli.git"
+  },
+  "homepage": "https://github.com/aws/agentcore-cli",
+  "bugs": {
+    "url": "https://github.com/aws/agentcore-cli/issues"
+  },
+  "keywords": [
+    "aws",
+    "amazon",
+    "bedrock",
+    "agentcore",
+    "cli",
+    "agents",
+    "ai",
+    "cdk",
+    "langchain",
+    "langgraph",
+    "openai",
+    "anthropic",
+    "google-adk",
+    "strands"
+  ],
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {


### PR DESCRIPTION
## Summary
- Add `license`, `repository`, `homepage`, `bugs`, and `keywords` fields to `package.json`
- Package is currently not discoverable via npm search due to missing metadata
- Keywords include supported agent frameworks: Strands, LangChain, LangGraph, OpenAI, Anthropic, Google ADK

## Test plan
- [x] Verify `package.json` is valid JSON
- [x] Verify `npm pack --dry-run` still works correctly
- [x] After publish, confirm package appears in npm search results