### PR TITLE
fix: correct action path in agent-restricted workflow

### DIFF
--- a/.github/workflows/agent-restricted.yml
+++ b/.github/workflows/agent-restricted.yml
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Run Strands Agent
-        uses: ./
+        uses: ./.github/actions/strands-action
         with:
           prompt: ${{ inputs.prompt }}
           provider: ${{ inputs.provider }}


### PR DESCRIPTION
## Description

The agent-restricted.yml workflow's "Run Strands Agent" step used uses: ./, which expects an action.yml at the repo root. The action definition actually lives at .github/actions/strands-action/action.yml. Changed the path to uses: ./.github/actions/strands-action to match strands-command.yml, which already references it correctly.

## Related Issue

Closes #

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran npm run test:all
- [x] I ran npm run typecheck
- [x] I ran npm run lint
- [ ] If I modified src/assets/, I ran npm run test:update-snapshots and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.