### PR TITLE
fix: override fast-xml-parser to 5.3.6 for CVE-2026-26278

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8817,9 +8817,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.4.tgz",
-      "integrity": "sha512-EFd6afGmXlCx8H8WTZHhAoDaWaGyuIBoZJ2mknrNxug+aZKjkp0a0dlars9Izl+jF+7Gu1/5f/2h68cQpe0IiA==",
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.6.tgz",
+      "integrity": "sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==",
       "funding": [
         {
           "type": "github",
@@ -8828,7 +8828,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^2.1.0"
+        "strnum": "^2.1.2"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -13594,8 +13594,10 @@
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "extraneous": true,
+      "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -120,6 +120,12 @@
     "typescript-eslint": "^8.50.1",
     "vitest": "^4.0.18"
   },
+  "overridesComments": {
+    "fast-xml-parser": "CVE-2026-26278: @aws-sdk/xml-builder pins fast-xml-parser@5.3.4 which is vulnerable to DoS via entity expansion. Remove this override once @aws-sdk/xml-builder updates its pin to >=5.3.6."
+  },
+  "overrides": {
+    "fast-xml-parser": "5.3.6"
+  },
   "engines": {
     "node": ">=20"
   },


### PR DESCRIPTION
## Description

 Add npm override to force `fast-xml-parser@5.3.6`, resolving CVE-2026-26278 (DoS via XML entity expansion). `@aws-sdk/xml-builder` pins the vulnerable `5.3.4` — override should be removed once AWS updates their pin.

## Related Issue

<!-- Every PR must be associated with an issue. Link it below using #issue-number format. -->

Closes https://github.com/aws/agentcore-cli/issues/329

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Check all that apply -->

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe): chore override

## Testing

How have you tested the change?

- [X] I ran `npm run test:unit` and `npm run test:integ`
- [X] I ran `npm run typecheck`
- [X] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
