### PR TITLE
fix: improve container dev startup UX and surface runtime errors

### DIFF
--- a/src/cli/tui/hooks/useDevServer.ts
+++ b/src/cli/tui/hooks/useDevServer.ts
@@ -28,7 +28,7 @@ export interface ConversationMessage {
 
 const MAX_LOG_ENTRIES = 50;
 
-export function useDevServer(options: { workingDir: string; port: number; agentName?: string }) {
+export function useDevServer(options: { workingDir: string; port: number; agentName?: string; onReady?: () => void }) {
   const [logs, setLogs] = useState<LogEntry[]>([]);
   const [status, setStatus] = useState<ServerStatus>('starting');
   const [isStreaming, setIsStreaming] = useState(false);
@@ -45,6 +45,8 @@ export function useDevServer(options: { workingDir: string; port: number; agentN
 
   const serverRef = useRef<DevServer | null>(null);
   const loggerRef = useRef<DevLogger | null>(null);
+  const onReadyRef = useRef(options.onReady);
+  onReadyRef.current = options.onReady;
   // Track instance ID to ignore callbacks from stale server instances
   const instanceIdRef = useRef(0);
   // Track if we're intentionally restarting to ignore exit callbacks
@@ -127,6 +129,7 @@ export function useDevServer(options: { workingDir: string; port: number; agentN
           ) {
             serverReady = true;
             setStatus('running');
+            onReadyRef.current?.();
             addLog('system', `Server ready at http://localhost:${port}/invocations`);
           } else {
             addLog(level, message);


### PR DESCRIPTION
## Description

Fixes the agentcore dev UX for container agents. Previously, when starting a container dev server, the TUI immediately showed a "running" input box while the container image was still building, causing the CLI to appear frozen and unresponsive. Additionally, when the container
runtime failed to start (e.g., Finch VM not running), the error was only visible in log files — the TUI showed a generic "error" status with no explanation.

This PR:
- Shows Status: Starting container... during container build/startup instead of hiding the status line
- Hides the input box until the server is actually ready (status === 'running')
- Defers mode transition to 'input' until the server reports readiness via an onReady callback from useDevServer
- Blocks Enter key during startup to prevent a soft-lock where useInput deactivates but no input box renders
- Blocks Ctrl+R during startup to prevent queuing a double container start
- Updates help text during startup to only show quit option
- Surfaces container runtime errors (e.g., "Found finch but not ready") directly in the TUI header

Changes are in DevScreen.tsx and useDevServer.ts (added onReady callback). No new files, types, or dependencies.

## Related Issue

Closes #

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran npm run test:unit and npm run test:integ
- [x] I ran npm run typecheck
- [x] I ran npm run lint
- [ ] If I modified src/assets/, I ran npm run test:update-snapshots and committed the updated snapshots

Manual testing:
- Ran agentcore dev with a container agent — confirmed "Starting container..." status displays during build, input box appears only after server is ready
- Verified Esc to quit works during startup (after build completes, before uvicorn ready)
- Verified Enter is blocked during startup
- Verified CodeZip agents show "Starting..." briefly and transition normally
- Verified container runtime errors (Finch VM not started) display directly in the TUI instead of only in log files

## Checklist

- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.