### PR TITLE
feat: add preview-major bump type

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
         type: choice
         options:
           - preview
+          - preview-major
           - patch
           - minor
           - major


### PR DESCRIPTION
## Summary
- Adds `preview-major` bump type that increments the major preview number and resets minor to 0
  - `0.3.0-preview.1.0` → `0.3.0-preview.2.0`
- Existing `preview` continues to bump minor: `0.3.0-preview.1.0` → `0.3.0-preview.1.1`
- Added to workflow dispatch options, CLI validation, and help text

## Test plan
- [ ] Merge, then run the release workflow with `preview-major` to publish `0.3.0-preview.2.0`