### PR TITLE
fix: add --chown to Dockerfile COPY so app files are owned by bedrock_agentcore

### DIFF
--- a/src/assets/container/python/Dockerfile
+++ b/src/assets/container/python/Dockerfile
@@ -14,7 +14,7 @@ RUN uv pip install -r pyproject.toml
 RUN useradd -m -u 1000 bedrock_agentcore
 USER bedrock_agentcore
 
-COPY . .
+COPY --chown=bedrock_agentcore:bedrock_agentcore . .
 
 # 8080: AgentCore runtime endpoint
 # 8000: Local dev server (uvicorn)


### PR DESCRIPTION
## Summary
- Fixes CONT-03 (P1): Application files in the container template were owned by `root:root` despite the process running as `bedrock_agentcore`, because Docker's `COPY` defaults to root ownership regardless of the `USER` directive.
- Adds `--chown=bedrock_agentcore:bedrock_agentcore` to the `COPY . .` instruction in `src/assets/container/python/Dockerfile` so files are owned by the correct user.
- Only affects newly scaffolded container projects; existing user projects are not impacted.

## Test plan
- [x] Snapshot tests pass (72/72)
- [x] Scaffold a new container-type agent project and verify the generated Dockerfile includes `--chown`
- [x] Build the container image and verify file ownership: `docker run --rm <image> ls -la /app`
- [x] Deploy a container agent and confirm it responds to an invoke