### PR TITLE
fix: add .env and .git exclusions to dockerignore template

### DIFF
--- a/src/assets/container/python/dockerignore.template
+++ b/src/assets/container/python/dockerignore.template
@@ -15,6 +15,13 @@ build/
 .coverage
 htmlcov/
 
+# Secrets and environment files
+.env
+.env.*
+
+# Version control
+.git/
+
 # AgentCore build artifacts
 .agentcore/artifacts/
 *.zip


### PR DESCRIPTION
## Summary
- Fixes CONT-04 (P1): The dockerignore template was missing exclusions for sensitive files, creating a security trap for every generated container project.
- Adds `.env` and `.env.*` exclusions to prevent credentials/API keys from being baked into Docker images.
- Adds `.git/` exclusion to prevent git history (which may contain accidentally committed secrets) from being included.
- Only affects newly scaffolded container projects; existing user projects are not impacted.

## Test plan
- [x] Snapshot tests pass (72/72)
- [ ] Scaffold a new container-type agent project and verify the generated `.dockerignore` includes the new exclusions
- [ ] Create a `.env` file in the project, run `docker build`, and confirm it is not present in the image