### PR TITLE
feat: add docker container deployment e2e test for Strands/Bedrock

### DIFF
--- a/e2e-tests/container-strands-bedrock.test.ts
+++ b/e2e-tests/container-strands-bedrock.test.ts
@@ -1,0 +1,3 @@
+import { createE2ESuite } from './e2e-helper.js';
+
+createE2ESuite({ framework: 'Strands', modelProvider: 'Bedrock', build: 'Container' });

--- a/e2e-tests/e2e-helper.ts
+++ b/e2e-tests/e2e-helper.ts
@@ -13,6 +13,7 @@ interface E2EConfig {
   framework: string;
   modelProvider: string;
   requiredEnvVar?: string;
+  build?: string;
 }
 
 /**
@@ -63,6 +64,10 @@ export function createE2ESuite(cfg: E2EConfig) {
         'none',
         '--json',
       ];
+
+      if (cfg.build) {
+        createArgs.push('--build', cfg.build);
+      }
 
       // Pass API key so the credential is registered in the project and .env.local
       const apiKey = cfg.requiredEnvVar ? process.env[cfg.requiredEnvVar] : undefined;


### PR DESCRIPTION
## Summary
- Add e2e test coverage for the `--build Container` deployment path (CodeBuild + ECR + container runtime)
- Extend `E2EConfig` in `e2e-helper.ts` with an optional `build` field, backward-compatible with existing tests
- Add `container-strands-bedrock.test.ts` that runs the full create → deploy → invoke lifecycle using Container build

## Test plan
- [x] Unit tests pass
- [x] Typecheck passes
- [x] Lint passes
- [x] Container e2e test passes against real AWS (deploy ~180s, invoke ~11.5s)
- [x] Existing e2e tests unaffected (no `build` field = default CodeZip behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)