### PR TITLE
fix: add package marker comment to __init__.py template files

### DIFF
--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -934,7 +934,7 @@ if __name__ == "__main__":
 `;
 
 exports[`Assets Directory Snapshots > Python framework assets > python/python/autogen/base/mcp_client/__init__.py should match snapshot 1`] = `
-"
+"# Package marker
 "
 `;
 
@@ -961,7 +961,7 @@ async def get_streamable_http_mcp_tools() -> List[StreamableHttpMcpToolAdapter]:
 `;
 
 exports[`Assets Directory Snapshots > Python framework assets > python/python/autogen/base/model/__init__.py should match snapshot 1`] = `
-"
+"# Package marker
 "
 `;
 
@@ -1293,7 +1293,7 @@ if __name__ == "__main__":
 `;
 
 exports[`Assets Directory Snapshots > Python framework assets > python/python/crewai/base/model/__init__.py should match snapshot 1`] = `
-"
+"# Package marker
 "
 `;
 
@@ -1653,7 +1653,7 @@ if __name__ == "__main__":
 `;
 
 exports[`Assets Directory Snapshots > Python framework assets > python/python/googleadk/base/mcp_client/__init__.py should match snapshot 1`] = `
-"
+"# Package marker
 "
 `;
 
@@ -1677,7 +1677,7 @@ def get_streamable_http_mcp_client() -> MCPToolset:
 `;
 
 exports[`Assets Directory Snapshots > Python framework assets > python/python/googleadk/base/model/__init__.py should match snapshot 1`] = `
-"
+"# Package marker
 "
 `;
 
@@ -1901,7 +1901,7 @@ if __name__ == "__main__":
 `;
 
 exports[`Assets Directory Snapshots > Python framework assets > python/python/langchain_langgraph/base/mcp_client/__init__.py should match snapshot 1`] = `
-"
+"# Package marker
 "
 `;
 
@@ -1929,7 +1929,7 @@ def get_streamable_http_mcp_client() -> MultiServerMCPClient:
 `;
 
 exports[`Assets Directory Snapshots > Python framework assets > python/python/langchain_langgraph/base/model/__init__.py should match snapshot 1`] = `
-"
+"# Package marker
 "
 `;
 
@@ -2256,7 +2256,7 @@ if __name__ == "__main__":
 `;
 
 exports[`Assets Directory Snapshots > Python framework assets > python/python/openaiagents/base/mcp_client/__init__.py should match snapshot 1`] = `
-"
+"# Package marker
 "
 `;
 
@@ -2279,7 +2279,7 @@ def get_streamable_http_mcp_client() -> MCPServerStreamableHttp:
 `;
 
 exports[`Assets Directory Snapshots > Python framework assets > python/python/openaiagents/base/model/__init__.py should match snapshot 1`] = `
-"
+"# Package marker
 "
 `;
 
@@ -2524,7 +2524,7 @@ if __name__ == "__main__":
 `;
 
 exports[`Assets Directory Snapshots > Python framework assets > python/python/strands/base/mcp_client/__init__.py should match snapshot 1`] = `
-"
+"# Package marker
 "
 `;
 
@@ -2544,7 +2544,7 @@ def get_streamable_http_mcp_client() -> MCPClient:
 `;
 
 exports[`Assets Directory Snapshots > Python framework assets > python/python/strands/base/model/__init__.py should match snapshot 1`] = `
-"
+"# Package marker
 "
 `;
 
@@ -2701,7 +2701,10 @@ packages = ["."]
 "
 `;
 
-exports[`Assets Directory Snapshots > Python framework assets > python/python/strands/capabilities/memory/__init__.py should match snapshot 1`] = `""`;
+exports[`Assets Directory Snapshots > Python framework assets > python/python/strands/capabilities/memory/__init__.py should match snapshot 1`] = `
+"# Package marker
+"
+`;
 
 exports[`Assets Directory Snapshots > Python framework assets > python/python/strands/capabilities/memory/session.py should match snapshot 1`] = `
 "import os

--- a/src/assets/python/autogen/base/mcp_client/__init__.py
+++ b/src/assets/python/autogen/base/mcp_client/__init__.py
@@ -1,1 +1,1 @@
-
+# Package marker

--- a/src/assets/python/autogen/base/model/__init__.py
+++ b/src/assets/python/autogen/base/model/__init__.py
@@ -1,1 +1,1 @@
-
+# Package marker

--- a/src/assets/python/crewai/base/model/__init__.py
+++ b/src/assets/python/crewai/base/model/__init__.py
@@ -1,1 +1,1 @@
-
+# Package marker

--- a/src/assets/python/googleadk/base/mcp_client/__init__.py
+++ b/src/assets/python/googleadk/base/mcp_client/__init__.py
@@ -1,1 +1,1 @@
-
+# Package marker

--- a/src/assets/python/googleadk/base/model/__init__.py
+++ b/src/assets/python/googleadk/base/model/__init__.py
@@ -1,1 +1,1 @@
-
+# Package marker

--- a/src/assets/python/langchain_langgraph/base/mcp_client/__init__.py
+++ b/src/assets/python/langchain_langgraph/base/mcp_client/__init__.py
@@ -1,1 +1,1 @@
-
+# Package marker

--- a/src/assets/python/langchain_langgraph/base/model/__init__.py
+++ b/src/assets/python/langchain_langgraph/base/model/__init__.py
@@ -1,1 +1,1 @@
-
+# Package marker

--- a/src/assets/python/openaiagents/base/mcp_client/__init__.py
+++ b/src/assets/python/openaiagents/base/mcp_client/__init__.py
@@ -1,1 +1,1 @@
-
+# Package marker

--- a/src/assets/python/openaiagents/base/model/__init__.py
+++ b/src/assets/python/openaiagents/base/model/__init__.py
@@ -1,1 +1,1 @@
-
+# Package marker

--- a/src/assets/python/strands/base/mcp_client/__init__.py
+++ b/src/assets/python/strands/base/mcp_client/__init__.py
@@ -1,1 +1,1 @@
-
+# Package marker

--- a/src/assets/python/strands/base/model/__init__.py
+++ b/src/assets/python/strands/base/model/__init__.py
@@ -1,1 +1,1 @@
-
+# Package marker

--- a/src/assets/python/strands/capabilities/memory/__init__.py
+++ b/src/assets/python/strands/capabilities/memory/__init__.py
@@ -1,0 +1,1 @@
+# Package marker


### PR DESCRIPTION
## Summary

- Replaced empty/near-empty (0–1 byte) content in all 12 `__init__.py` template files with `# Package marker` comment
- These files were fragile through the Handlebars rendering pipeline and npm tarball distribution, causing missing `__init__.py` in generated projects ("works in Docker, breaks locally" for editable installs, pytest, mypy)
- Updated corresponding snapshot tests

## Files changed

12 `__init__.py` files across all framework templates (`autogen`, `crewai`, `googleadk`, `langchain_langgraph`, `openaiagents`, `strands`) in `model/` and `mcp_client/` directories, plus `strands/capabilities/memory/__init__.py`.

## Test plan

- [x] `npm run build` succeeds
- [x] `npm test` passes (14 pre-existing failures unrelated to this change)
- [x] `npm pack --dry-run | grep __init__` shows all 12 files at 17B
- [x] End-to-end: generated project contains `model/__init__.py` and `mcp_client/__init__.py` with `# Package marker` content