### PR TITLE
fix: add mcp as explicit dependency in strands template

### DIFF
--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -2692,7 +2692,8 @@ dependencies = [
     "bedrock-agentcore >= 1.0.3",
     "botocore[crt] >= 1.35.0",
     {{#if (eq modelProvider "Gemini")}}"google-genai >= 1.0.0",
-    {{/if}}{{#if (eq modelProvider "OpenAI")}}"openai >= 1.0.0",
+    {{/if}}"mcp >= 1.19.0",
+    {{#if (eq modelProvider "OpenAI")}}"openai >= 1.0.0",
     {{/if}}"strands-agents >= 1.13.0",
 ]
 

--- a/src/assets/python/strands/base/pyproject.toml
+++ b/src/assets/python/strands/base/pyproject.toml
@@ -14,7 +14,8 @@ dependencies = [
     "bedrock-agentcore >= 1.0.3",
     "botocore[crt] >= 1.35.0",
     {{#if (eq modelProvider "Gemini")}}"google-genai >= 1.0.0",
-    {{/if}}{{#if (eq modelProvider "OpenAI")}}"openai >= 1.0.0",
+    {{/if}}"mcp >= 1.19.0",
+    {{#if (eq modelProvider "OpenAI")}}"openai >= 1.0.0",
     {{/if}}"strands-agents >= 1.13.0",
 ]
 


### PR DESCRIPTION
## Summary
- The strands template's `mcp_client/client.py` imports directly from the `mcp` package (`from mcp.client.streamable_http import streamablehttp_client`), but `mcp` was not declared in `pyproject.toml`
- It was only available as a transitive dependency through `strands-agents`, which is fragile coupling that may break on any `strands-agents` update
- Adds `"mcp >= 1.19.0"` as an explicit dependency, matching the version floor used by the `langchain_langgraph` template

## Test plan
- [x] All 148 unit test files pass (1737 tests)
- [x] Snapshot updated and verified
- [x] `pip install --dry-run` confirms no dependency resolution conflicts between `mcp >= 1.19.0` and `strands-agents >= 1.13.0`