### PR TITLE
ci: add Slack notification for new issues

### DIFF
--- a/.github/workflows/slack-issue-notification.yml
+++ b/.github/workflows/slack-issue-notification.yml
@@ -1,0 +1,23 @@
+name: Slack Issue Notification
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  notify-slack:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send issue details to Slack
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+            issue_title: "${{ github.event.issue.title }}"
+            issue_number: "${{ github.event.issue.number }}"
+            issue_url: "${{ github.event.issue.html_url }}"
+            issue_author: "${{ github.event.issue.user.login }}"
+            issue_body: ${{ toJSON(github.event.issue.body) }}
+            repository: "${{ github.repository }}"
+            created_at: "${{ github.event.issue.created_at }}"


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that sends Slack notifications when new issues are opened
- Uses `slackapi/slack-github-action@v2.0.0` with a webhook trigger
- Sends issue title, number, URL, author, body, repository name, and creation timestamp

## Test plan
- [x] Workflow file is valid YAML (verified locally)
- [x] `SLACK_WEBHOOK_URL` repository secret has been set
- [ ] Open a test issue on the repo and verify the Slack notification arrives