### PR TITLE
fix: handle unhandled promise rejection in vended CDK main()

### DIFF
--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -80,7 +80,10 @@ async function main() {
   app.synth();
 }
 
-main();
+main().catch((error: unknown) => {
+  console.error('AgentCore CDK synthesis failed:', error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});
 "
 `;
 

--- a/src/assets/cdk/bin/cdk.ts
+++ b/src/assets/cdk/bin/cdk.ts
@@ -47,4 +47,7 @@ async function main() {
   app.synth();
 }
 
-main();
+main().catch((error: unknown) => {
+  console.error('AgentCore CDK synthesis failed:', error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Description

Adds a `.catch()` handler to the bare `main()` call in the vended `cdk/bin/cdk.ts`. Without this, any error during config reading or stack construction produces an opaque `UnhandledPromiseRejection` instead of a clear message.

Closes #408

## Type of Change

- [x] Bug fix

## Testing

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [x] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots