### PR TITLE
fix: disallow underscores in deployment target names and sanitize stack names

### DIFF
--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -44,8 +44,12 @@ function toEnvironment(target: AwsDeploymentTarget): Environment {
   };
 }
 
+function sanitize(name: string): string {
+  return name.replace(/_/g, '-');
+}
+
 function toStackName(projectName: string, targetName: string): string {
-  return \`AgentCore-\${projectName}-\${targetName}\`;
+  return \`AgentCore-\${sanitize(projectName)}-\${sanitize(targetName)}\`;
 }
 
 async function main() {

--- a/src/assets/cdk/bin/cdk.ts
+++ b/src/assets/cdk/bin/cdk.ts
@@ -11,8 +11,12 @@ function toEnvironment(target: AwsDeploymentTarget): Environment {
   };
 }
 
+function sanitize(name: string): string {
+  return name.replace(/_/g, '-');
+}
+
 function toStackName(projectName: string, targetName: string): string {
-  return `AgentCore-${projectName}-${targetName}`;
+  return `AgentCore-${sanitize(projectName)}-${sanitize(targetName)}`;
 }
 
 async function main() {

--- a/src/schema/schemas/__tests__/aws-targets.test.ts
+++ b/src/schema/schemas/__tests__/aws-targets.test.ts
@@ -73,7 +73,10 @@ describe('DeploymentTargetNameSchema', () => {
     expect(DeploymentTargetNameSchema.safeParse('default').success).toBe(true);
     expect(DeploymentTargetNameSchema.safeParse('prod').success).toBe(true);
     expect(DeploymentTargetNameSchema.safeParse('dev-us-east').success).toBe(true);
-    expect(DeploymentTargetNameSchema.safeParse('staging_env').success).toBe(true);
+  });
+
+  it('rejects name with underscores', () => {
+    expect(DeploymentTargetNameSchema.safeParse('staging_env').success).toBe(false);
   });
 
   it('rejects name starting with digit', () => {

--- a/src/schema/schemas/aws-targets.ts
+++ b/src/schema/schemas/aws-targets.ts
@@ -27,8 +27,8 @@ export const DeploymentTargetNameSchema = z
   .min(1)
   .max(64)
   .regex(
-    /^[a-zA-Z][a-zA-Z0-9_-]*$/,
-    'Name must start with a letter and contain only alphanumeric characters, hyphens, and underscores'
+    /^[a-zA-Z][a-zA-Z0-9-]*$/,
+    'Name must start with a letter and contain only alphanumeric characters and hyphens'
   )
   .describe('Unique identifier for the deployment target');
 


### PR DESCRIPTION
## Description

CloudFormation stack names must match `[a-zA-Z][-a-zA-Z0-9]*` — underscores are not allowed. The `DeploymentTargetNameSchema` regex permitted underscores, causing CDK synth to succeed but deploy to fail with a confusing CloudFormation error.

This PR:
1. Tightens the schema regex from `/^[a-zA-Z][a-zA-Z0-9_-]*$/` to `/^[a-zA-Z][a-zA-Z0-9-]*$/` to reject underscores at validation time
2. Adds a `sanitize()` helper in `toStackName()` that replaces `_` with `-` as defense-in-depth

## Related Issue

Closes #TMPL-05

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [x] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.