### PR TITLE
feat: add VPC network mode support for agent runtimes

### DIFF
--- a/src/cli/commands/add/__tests__/validate.test.ts
+++ b/src/cli/commands/add/__tests__/validate.test.ts
@@ -162,6 +162,52 @@ describe('validate', () => {
       expect(validateAddAgentOptions(validAgentOptionsByo)).toEqual({ valid: true });
       expect(validateAddAgentOptions(validAgentOptionsCreate)).toEqual({ valid: true });
     });
+
+    // VPC validation tests
+    it('rejects invalid network mode', () => {
+      const result = validateAddAgentOptions({ ...validAgentOptionsCreate, networkMode: 'INVALID' as any });
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('Invalid network mode');
+    });
+
+    it('rejects VPC mode without subnets', () => {
+      const result = validateAddAgentOptions({
+        ...validAgentOptionsCreate,
+        networkMode: 'VPC',
+        securityGroups: 'sg-12345678',
+      });
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('--subnets is required');
+    });
+
+    it('rejects VPC mode without security groups', () => {
+      const result = validateAddAgentOptions({
+        ...validAgentOptionsCreate,
+        networkMode: 'VPC',
+        subnets: 'subnet-12345678',
+      });
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('--security-groups is required');
+    });
+
+    it('rejects subnets without VPC mode', () => {
+      const result = validateAddAgentOptions({
+        ...validAgentOptionsCreate,
+        subnets: 'subnet-12345678',
+      });
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('require --network-mode VPC');
+    });
+
+    it('passes for valid VPC options', () => {
+      const result = validateAddAgentOptions({
+        ...validAgentOptionsCreate,
+        networkMode: 'VPC',
+        subnets: 'subnet-12345678',
+        securityGroups: 'sg-12345678',
+      });
+      expect(result.valid).toBe(true);
+    });
   });
 
   describe('validateAddGatewayOptions', () => {

--- a/src/cli/commands/add/actions.ts
+++ b/src/cli/commands/add/actions.ts
@@ -7,6 +7,7 @@ import type {
   GatewayAuthorizerType,
   MemoryStrategyType,
   ModelProvider,
+  NetworkMode,
   SDKFramework,
   TargetLanguage,
 } from '../../../schema';
@@ -29,6 +30,7 @@ import { createRenderer } from '../../templates';
 import type { MemoryOption } from '../../tui/screens/generate/types';
 import type { AddGatewayConfig, AddMcpToolConfig } from '../../tui/screens/mcp/types';
 import { DEFAULT_EVENT_EXPIRY } from '../../tui/screens/memory/types';
+import { parseCommaSeparatedList } from '../shared/vpc-utils';
 import type { AddAgentResult, AddGatewayResult, AddIdentityResult, AddMcpToolResult, AddMemoryResult } from './types';
 import { mkdirSync } from 'fs';
 import { dirname, join } from 'path';
@@ -43,6 +45,9 @@ export interface ValidatedAddAgentOptions {
   modelProvider: ModelProvider;
   apiKey?: string;
   memory?: MemoryOption;
+  networkMode?: NetworkMode;
+  subnets?: string;
+  securityGroups?: string;
   codeLocation?: string;
   entrypoint?: string;
 }
@@ -120,6 +125,9 @@ async function handleCreatePath(options: ValidatedAddAgentOptions, configBaseDir
     modelProvider: options.modelProvider,
     memory: options.memory!,
     language: options.language,
+    networkMode: options.networkMode,
+    subnets: parseCommaSeparatedList(options.subnets),
+    securityGroups: parseCommaSeparatedList(options.securityGroups),
   };
 
   const agentPath = join(projectRoot, APP_DIR, options.name);
@@ -186,6 +194,7 @@ async function handleByoPath(
 
   const project = await configIO.readProjectSpec();
 
+  const networkMode = options.networkMode ?? 'PUBLIC';
   const agent: AgentEnvSpec = {
     type: 'AgentCoreRuntime',
     name: options.name,
@@ -193,7 +202,15 @@ async function handleByoPath(
     entrypoint: (options.entrypoint ?? 'main.py') as FilePath,
     codeLocation: codeLocation as DirectoryPath,
     runtimeVersion: 'PYTHON_3_12',
-    networkMode: 'PUBLIC',
+    networkMode,
+    ...(networkMode === 'VPC' && options.subnets && options.securityGroups
+      ? {
+          networkConfig: {
+            subnets: parseCommaSeparatedList(options.subnets)!,
+            securityGroups: parseCommaSeparatedList(options.securityGroups)!,
+          },
+        }
+      : {}),
   };
 
   project.agents.push(agent);

--- a/src/cli/commands/add/command.tsx
+++ b/src/cli/commands/add/command.tsx
@@ -40,6 +40,9 @@ async function handleAddAgentCLI(options: AddAgentOptions): Promise<void> {
     modelProvider: options.modelProvider!,
     apiKey: options.apiKey,
     memory: options.memory,
+    networkMode: options.networkMode,
+    subnets: options.subnets,
+    securityGroups: options.securityGroups,
     codeLocation: options.codeLocation,
     entrypoint: options.entrypoint,
   });
@@ -227,6 +230,9 @@ export function registerAdd(program: Command) {
     .option('--model-provider <provider>', 'Model provider: Bedrock, Anthropic, OpenAI, Gemini [non-interactive]')
     .option('--api-key <key>', 'API key for non-Bedrock providers [non-interactive]')
     .option('--memory <mem>', 'Memory: none, shortTerm, longAndShortTerm (create path only) [non-interactive]')
+    .option('--network-mode <mode>', 'Network mode: PUBLIC or VPC (default: PUBLIC) [non-interactive]')
+    .option('--subnets <ids>', 'Comma-separated subnet IDs (required for VPC mode) [non-interactive]')
+    .option('--security-groups <ids>', 'Comma-separated security group IDs (required for VPC mode) [non-interactive]')
     .option('--code-location <path>', 'Path to existing code (BYO path only) [non-interactive]')
     .option('--entrypoint <file>', 'Entry file relative to code-location (BYO, default: main.py) [non-interactive]')
     .option('--json', 'Output as JSON [non-interactive]')

--- a/src/cli/commands/add/types.ts
+++ b/src/cli/commands/add/types.ts
@@ -1,4 +1,4 @@
-import type { GatewayAuthorizerType, ModelProvider, SDKFramework, TargetLanguage } from '../../../schema';
+import type { GatewayAuthorizerType, ModelProvider, NetworkMode, SDKFramework, TargetLanguage } from '../../../schema';
 import type { MemoryOption } from '../../tui/screens/generate/types';
 
 // Agent types
@@ -11,6 +11,9 @@ export interface AddAgentOptions {
   modelProvider?: ModelProvider;
   apiKey?: string;
   memory?: MemoryOption;
+  networkMode?: NetworkMode;
+  subnets?: string;
+  securityGroups?: string;
   codeLocation?: string;
   entrypoint?: string;
   json?: boolean;

--- a/src/cli/commands/add/validate.ts
+++ b/src/cli/commands/add/validate.ts
@@ -7,6 +7,7 @@ import {
   TargetLanguageSchema,
   getSupportedModelProviders,
 } from '../../../schema';
+import { validateVpcOptions } from '../shared/vpc-utils';
 import type {
   AddAgentOptions,
   AddGatewayOptions,
@@ -101,6 +102,9 @@ export function validateAddAgentOptions(options: AddAgentOptions): ValidationRes
       };
     }
   }
+
+  const vpcResult = validateVpcOptions(options);
+  if (!vpcResult.valid) return vpcResult;
 
   return { valid: true };
 }

--- a/src/cli/commands/create/__tests__/validate.test.ts
+++ b/src/cli/commands/create/__tests__/validate.test.ts
@@ -132,6 +132,90 @@ describe('validateCreateOptions', () => {
     expect(result.valid).toBe(true);
   });
 
+  // VPC validation tests
+  it('rejects invalid network mode', () => {
+    const result = validateCreateOptions(
+      {
+        name: 'VpcTest1',
+        language: 'Python',
+        framework: 'Strands',
+        modelProvider: 'Bedrock',
+        memory: 'none',
+        networkMode: 'INVALID',
+      },
+      testDir
+    );
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('Invalid network mode');
+  });
+
+  it('rejects VPC mode without subnets', () => {
+    const result = validateCreateOptions(
+      {
+        name: 'VpcTest2',
+        language: 'Python',
+        framework: 'Strands',
+        modelProvider: 'Bedrock',
+        memory: 'none',
+        networkMode: 'VPC',
+        securityGroups: 'sg-12345678',
+      },
+      testDir
+    );
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('--subnets is required');
+  });
+
+  it('rejects VPC mode without security groups', () => {
+    const result = validateCreateOptions(
+      {
+        name: 'VpcTest3',
+        language: 'Python',
+        framework: 'Strands',
+        modelProvider: 'Bedrock',
+        memory: 'none',
+        networkMode: 'VPC',
+        subnets: 'subnet-12345678',
+      },
+      testDir
+    );
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('--security-groups is required');
+  });
+
+  it('rejects subnets without VPC mode', () => {
+    const result = validateCreateOptions(
+      {
+        name: 'VpcTest4',
+        language: 'Python',
+        framework: 'Strands',
+        modelProvider: 'Bedrock',
+        memory: 'none',
+        subnets: 'subnet-12345678',
+      },
+      testDir
+    );
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('require --network-mode VPC');
+  });
+
+  it('returns valid with VPC mode and required options', () => {
+    const result = validateCreateOptions(
+      {
+        name: 'VpcTest5',
+        language: 'Python',
+        framework: 'Strands',
+        modelProvider: 'Bedrock',
+        memory: 'none',
+        networkMode: 'VPC',
+        subnets: 'subnet-12345678',
+        securityGroups: 'sg-12345678',
+      },
+      testDir
+    );
+    expect(result.valid).toBe(true);
+  });
+
   it('returns invalid for unsupported framework/model combination', () => {
     // GoogleADK only supports certain providers, not all
     const result = validateCreateOptions(

--- a/src/cli/commands/create/action.ts
+++ b/src/cli/commands/create/action.ts
@@ -4,6 +4,7 @@ import type {
   BuildType,
   DeployedState,
   ModelProvider,
+  NetworkMode,
   SDKFramework,
   TargetLanguage,
 } from '../../../schema';
@@ -120,6 +121,9 @@ export interface CreateWithAgentOptions {
   modelProvider: ModelProvider;
   apiKey?: string;
   memory: MemoryOption;
+  networkMode?: NetworkMode;
+  subnets?: string[];
+  securityGroups?: string[];
   skipGit?: boolean;
   skipPythonSetup?: boolean;
   onProgress?: ProgressCallback;
@@ -135,6 +139,9 @@ export async function createProjectWithAgent(options: CreateWithAgentOptions): P
     modelProvider,
     apiKey,
     memory,
+    networkMode,
+    subnets,
+    securityGroups,
     skipGit,
     skipPythonSetup,
     onProgress,
@@ -172,6 +179,9 @@ export async function createProjectWithAgent(options: CreateWithAgentOptions): P
       apiKey,
       memory,
       language,
+      networkMode,
+      subnets,
+      securityGroups,
     };
 
     // Resolve credential strategy FIRST (new project has no existing credentials)

--- a/src/cli/commands/create/command.tsx
+++ b/src/cli/commands/create/command.tsx
@@ -1,8 +1,9 @@
 import { getWorkingDirectory } from '../../../lib';
-import type { BuildType, ModelProvider, SDKFramework, TargetLanguage } from '../../../schema';
+import type { BuildType, ModelProvider, NetworkMode, SDKFramework, TargetLanguage } from '../../../schema';
 import { getErrorMessage } from '../../errors';
 import { COMMAND_DESCRIPTIONS } from '../../tui/copy';
 import { CreateScreen } from '../../tui/screens/create';
+import { parseCommaSeparatedList } from '../shared/vpc-utils';
 import { type ProgressCallback, createProject, createProjectWithAgent, getDryRunInfo } from './action';
 import type { CreateOptions } from './types';
 import { validateCreateOptions } from './validate';
@@ -120,6 +121,9 @@ async function handleCreateCLI(options: CreateOptions): Promise<void> {
         modelProvider: options.modelProvider as ModelProvider,
         apiKey: options.apiKey,
         memory: options.memory as 'none' | 'shortTerm' | 'longAndShortTerm',
+        networkMode: options.networkMode as NetworkMode | undefined,
+        subnets: parseCommaSeparatedList(options.subnets),
+        securityGroups: parseCommaSeparatedList(options.securityGroups),
         skipGit: options.skipGit,
         skipPythonSetup: options.skipPythonSetup,
         onProgress,
@@ -152,6 +156,9 @@ export const registerCreate = (program: Command) => {
     .option('--model-provider <provider>', 'Model provider (Bedrock, Anthropic, OpenAI, Gemini) [non-interactive]')
     .option('--api-key <key>', 'API key for non-Bedrock providers [non-interactive]')
     .option('--memory <option>', 'Memory option (none, shortTerm, longAndShortTerm) [non-interactive]')
+    .option('--network-mode <mode>', 'Network mode: PUBLIC or VPC (default: PUBLIC) [non-interactive]')
+    .option('--subnets <ids>', 'Comma-separated subnet IDs (required for VPC mode) [non-interactive]')
+    .option('--security-groups <ids>', 'Comma-separated security group IDs (required for VPC mode) [non-interactive]')
     .option('--output-dir <dir>', 'Output directory (default: current directory) [non-interactive]')
     .option('--skip-git', 'Skip git repository initialization [non-interactive]')
     .option('--skip-python-setup', 'Skip Python virtual environment setup [non-interactive]')
@@ -179,6 +186,9 @@ export const registerCreate = (program: Command) => {
           options.modelProvider ??
           options.apiKey ??
           options.memory ??
+          options.networkMode ??
+          options.subnets ??
+          options.securityGroups ??
           options.outputDir ??
           options.skipGit ??
           options.skipPythonSetup ??

--- a/src/cli/commands/create/types.ts
+++ b/src/cli/commands/create/types.ts
@@ -8,6 +8,9 @@ export interface CreateOptions {
   modelProvider?: string;
   apiKey?: string;
   memory?: string;
+  networkMode?: string;
+  subnets?: string;
+  securityGroups?: string;
   outputDir?: string;
   skipGit?: boolean;
   skipPythonSetup?: boolean;

--- a/src/cli/commands/create/validate.ts
+++ b/src/cli/commands/create/validate.ts
@@ -6,6 +6,7 @@ import {
   TargetLanguageSchema,
   getSupportedModelProviders,
 } from '../../../schema';
+import { validateVpcOptions } from '../shared/vpc-utils';
 import type { CreateOptions } from './types';
 import { existsSync } from 'fs';
 import { join } from 'path';
@@ -120,6 +121,9 @@ export function validateCreateOptions(options: CreateOptions, cwd?: string): Val
       };
     }
   }
+
+  const vpcResult = validateVpcOptions(options);
+  if (!vpcResult.valid) return vpcResult;
 
   return { valid: true };
 }

--- a/src/cli/commands/dev/command.tsx
+++ b/src/cli/commands/dev/command.tsx
@@ -144,6 +144,12 @@ export const registerDev = (program: Command) => {
           const targetAgent = project.agents.find(a => a.name === config.agentName);
           const providerInfo = targetAgent?.modelProvider ?? '(see agent code)';
 
+          if (targetAgent?.networkMode === 'VPC') {
+            console.warn(
+              'Warning: This agent uses VPC network mode. Local dev server runs outside your VPC. Network behavior may differ from deployed environment.'
+            );
+          }
+
           console.log(`Starting dev server...`);
           console.log(`Agent: ${config.agentName}`);
           console.log(`Provider: ${providerInfo}`);
@@ -176,6 +182,20 @@ export const registerDev = (program: Command) => {
           // Keep process alive
           // eslint-disable-next-line @typescript-eslint/no-empty-function
           await new Promise(() => {});
+        }
+
+        // Warn if the target agent uses VPC mode
+        {
+          const vpcAgent = opts.agent
+            ? project.agents.find(a => a.name === opts.agent)
+            : project.agents.length === 1
+              ? project.agents[0]
+              : undefined;
+          if (vpcAgent?.networkMode === 'VPC') {
+            console.warn(
+              'Warning: This agent uses VPC network mode. Local dev server runs outside your VPC. Network behavior may differ from deployed environment.'
+            );
+          }
         }
 
         // Enter alternate screen buffer for fullscreen mode

--- a/src/cli/commands/invoke/action.ts
+++ b/src/cli/commands/invoke/action.ts
@@ -67,6 +67,12 @@ export async function handleInvoke(context: InvokeContext, options: InvokeOption
     return { success: false, error: 'No agents defined in configuration' };
   }
 
+  if (agentSpec.networkMode === 'VPC') {
+    console.warn(
+      'Warning: This agent uses VPC network mode. Invocation may require setting up VPC Endpoints for S3, ECR, Bedrock. If your agent uses a non-Bedrock model provider, VPC will require public internet access.'
+    );
+  }
+
   // Get the deployed state for this specific agent
   const agentState = targetState?.resources?.agents?.[agentSpec.name];
 

--- a/src/cli/commands/shared/vpc-utils.ts
+++ b/src/cli/commands/shared/vpc-utils.ts
@@ -1,0 +1,54 @@
+import { NetworkModeSchema } from '../../../schema';
+
+export interface VpcOptions {
+  networkMode?: string;
+  subnets?: string;
+  securityGroups?: string;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  error?: string;
+}
+
+/**
+ * Parse a comma-separated string into a trimmed, non-empty array.
+ * Returns undefined if the input is undefined.
+ */
+export function parseCommaSeparatedList(value: string | undefined): string[] | undefined {
+  if (value === undefined) return undefined;
+  const items = value
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean);
+  return items.length > 0 ? items : undefined;
+}
+
+/**
+ * Shared VPC option validation for CLI commands.
+ * Validates network mode enum, requires subnets+security groups for VPC,
+ * and rejects VPC flags without VPC mode.
+ */
+export function validateVpcOptions(options: VpcOptions): ValidationResult {
+  if (options.networkMode) {
+    const nmResult = NetworkModeSchema.safeParse(options.networkMode);
+    if (!nmResult.success) {
+      return { valid: false, error: `Invalid network mode: ${options.networkMode}. Use PUBLIC or VPC` };
+    }
+
+    if (options.networkMode === 'VPC') {
+      if (!options.subnets) {
+        return { valid: false, error: '--subnets is required when --network-mode is VPC' };
+      }
+      if (!options.securityGroups) {
+        return { valid: false, error: '--security-groups is required when --network-mode is VPC' };
+      }
+    }
+  }
+
+  if (options.networkMode !== 'VPC' && (options.subnets || options.securityGroups)) {
+    return { valid: false, error: '--subnets and --security-groups require --network-mode VPC' };
+  }
+
+  return { valid: true };
+}

--- a/src/cli/operations/agent/generate/__tests__/schema-mapper.test.ts
+++ b/src/cli/operations/agent/generate/__tests__/schema-mapper.test.ts
@@ -93,6 +93,34 @@ describe('mapGenerateConfigToAgent', () => {
     const result = mapGenerateConfigToAgent(baseConfig);
     expect(result.codeLocation).toBe('app/TestProject/');
   });
+
+  it('uses config.networkMode when provided', () => {
+    const config: GenerateConfig = {
+      ...baseConfig,
+      networkMode: 'VPC',
+      subnets: ['subnet-12345678'],
+      securityGroups: ['sg-12345678'],
+    };
+    const result = mapGenerateConfigToAgent(config);
+    expect(result.networkMode).toBe('VPC');
+    expect(result.networkConfig).toEqual({
+      subnets: ['subnet-12345678'],
+      securityGroups: ['sg-12345678'],
+    });
+  });
+
+  it('defaults to PUBLIC when networkMode is not provided', () => {
+    const result = mapGenerateConfigToAgent(baseConfig);
+    expect(result.networkMode).toBe('PUBLIC');
+    expect(result.networkConfig).toBeUndefined();
+  });
+
+  it('does not include networkConfig for PUBLIC mode', () => {
+    const config: GenerateConfig = { ...baseConfig, networkMode: 'PUBLIC' };
+    const result = mapGenerateConfigToAgent(config);
+    expect(result.networkMode).toBe('PUBLIC');
+    expect(result.networkConfig).toBeUndefined();
+  });
 });
 
 describe('mapGenerateConfigToResources', () => {

--- a/src/cli/operations/agent/generate/schema-mapper.ts
+++ b/src/cli/operations/agent/generate/schema-mapper.ts
@@ -103,17 +103,27 @@ export function mapModelProviderToCredentials(modelProvider: ModelProvider, proj
  */
 export function mapGenerateConfigToAgent(config: GenerateConfig): AgentEnvSpec {
   const codeLocation = `${APP_DIR}/${config.projectName}/`;
+  const networkMode = config.networkMode ?? DEFAULT_NETWORK_MODE;
 
-  return {
+  const agent: AgentEnvSpec = {
     type: 'AgentCoreRuntime',
     name: config.projectName,
     build: config.buildType ?? 'CodeZip',
     entrypoint: DEFAULT_PYTHON_ENTRYPOINT as FilePath,
     codeLocation: codeLocation as DirectoryPath,
     runtimeVersion: DEFAULT_PYTHON_VERSION,
-    networkMode: DEFAULT_NETWORK_MODE,
+    networkMode,
     modelProvider: config.modelProvider,
   };
+
+  if (networkMode === 'VPC' && config.subnets && config.securityGroups) {
+    agent.networkConfig = {
+      subnets: config.subnets,
+      securityGroups: config.securityGroups,
+    };
+  }
+
+  return agent;
 }
 
 /**

--- a/src/cli/tui/screens/generate/types.ts
+++ b/src/cli/tui/screens/generate/types.ts
@@ -1,4 +1,4 @@
-import type { BuildType, ModelProvider, SDKFramework, TargetLanguage } from '../../../../schema';
+import type { BuildType, ModelProvider, NetworkMode, SDKFramework, TargetLanguage } from '../../../../schema';
 import { DEFAULT_MODEL_IDS, getSupportedModelProviders } from '../../../../schema';
 
 export type GenerateStep =
@@ -25,6 +25,9 @@ export interface GenerateConfig {
   apiKey?: string;
   memory: MemoryOption;
   language: TargetLanguage;
+  networkMode?: NetworkMode;
+  subnets?: string[];
+  securityGroups?: string[];
 }
 
 /** Base steps - apiKey and memory are conditionally added based on selections */

--- a/src/schema/__tests__/constants.test.ts
+++ b/src/schema/__tests__/constants.test.ts
@@ -74,12 +74,12 @@ describe('NetworkModeSchema', () => {
     expect(NetworkModeSchema.safeParse('PUBLIC').success).toBe(true);
   });
 
-  it('accepts PRIVATE', () => {
-    expect(NetworkModeSchema.safeParse('PRIVATE').success).toBe(true);
+  it('accepts VPC', () => {
+    expect(NetworkModeSchema.safeParse('VPC').success).toBe(true);
   });
 
   it('rejects other modes', () => {
-    expect(NetworkModeSchema.safeParse('VPC').success).toBe(false);
+    expect(NetworkModeSchema.safeParse('PRIVATE').success).toBe(false);
   });
 });
 

--- a/src/schema/constants.ts
+++ b/src/schema/constants.ts
@@ -139,5 +139,5 @@ export type NodeRuntime = z.infer<typeof NodeRuntimeSchema>;
 export const RuntimeVersionSchema = z.union([PythonRuntimeSchema, NodeRuntimeSchema]);
 export type RuntimeVersion = z.infer<typeof RuntimeVersionSchema>;
 
-export const NetworkModeSchema = z.enum(['PUBLIC', 'PRIVATE']);
+export const NetworkModeSchema = z.enum(['PUBLIC', 'VPC']);
 export type NetworkMode = z.infer<typeof NetworkModeSchema>;

--- a/src/schema/llm-compacted/agentcore.ts
+++ b/src/schema/llm-compacted/agentcore.ts
@@ -26,9 +26,18 @@ type BuildType = 'CodeZip' | 'Container';
 type PythonRuntime = 'PYTHON_3_10' | 'PYTHON_3_11' | 'PYTHON_3_12' | 'PYTHON_3_13';
 type NodeRuntime = 'NODE_18' | 'NODE_20' | 'NODE_22';
 type RuntimeVersion = PythonRuntime | NodeRuntime;
-type NetworkMode = 'PUBLIC' | 'PRIVATE';
+type NetworkMode = 'PUBLIC' | 'VPC';
 type MemoryStrategyType = 'SEMANTIC' | 'SUMMARIZATION' | 'USER_PREFERENCE';
 type ModelProvider = 'Bedrock' | 'Gemini' | 'OpenAI' | 'Anthropic';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// NETWORK CONFIG
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface NetworkConfig {
+  subnets: string[]; // @regex ^subnet-[0-9a-zA-Z]{8,17}$ @min 1 @max 16
+  securityGroups: string[]; // @regex ^sg-[0-9a-zA-Z]{8,17}$ @min 1 @max 16
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // AGENT
@@ -43,6 +52,7 @@ interface AgentEnvSpec {
   runtimeVersion: RuntimeVersion;
   envVars?: EnvVar[];
   networkMode?: NetworkMode; // default 'PUBLIC'
+  networkConfig?: NetworkConfig; // Required when networkMode is 'VPC'
   instrumentation?: Instrumentation; // OTel settings
   modelProvider?: ModelProvider; // Model provider used by this agent
 }

--- a/src/schema/llm-compacted/mcp.ts
+++ b/src/schema/llm-compacted/mcp.ts
@@ -145,4 +145,4 @@ interface IamPolicyDocument {
 type GatewayTargetType = 'lambda' | 'mcpServer' | 'openApiSchema' | 'smithyModel';
 type PythonRuntime = 'PYTHON_3_10' | 'PYTHON_3_11' | 'PYTHON_3_12' | 'PYTHON_3_13';
 type NodeRuntime = 'NODE_18' | 'NODE_20' | 'NODE_22';
-type NetworkMode = 'PUBLIC' | 'PRIVATE';
+type NetworkMode = 'PUBLIC' | 'VPC';

--- a/src/schema/schemas/__tests__/agent-env.test.ts
+++ b/src/schema/schemas/__tests__/agent-env.test.ts
@@ -7,6 +7,7 @@ import {
   EnvVarSchema,
   GatewayNameSchema,
   InstrumentationSchema,
+  NetworkConfigSchema,
 } from '../agent-env.js';
 import { describe, expect, it } from 'vitest';
 
@@ -235,11 +236,49 @@ describe('AgentEnvSpecSchema', () => {
 
   it('accepts agent with network mode', () => {
     expect(AgentEnvSpecSchema.safeParse({ ...validPythonAgent, networkMode: 'PUBLIC' }).success).toBe(true);
-    expect(AgentEnvSpecSchema.safeParse({ ...validPythonAgent, networkMode: 'PRIVATE' }).success).toBe(true);
+    expect(
+      AgentEnvSpecSchema.safeParse({
+        ...validPythonAgent,
+        networkMode: 'VPC',
+        networkConfig: {
+          subnets: ['subnet-12345678'],
+          securityGroups: ['sg-12345678'],
+        },
+      }).success
+    ).toBe(true);
   });
 
   it('rejects invalid network mode', () => {
+    expect(AgentEnvSpecSchema.safeParse({ ...validPythonAgent, networkMode: 'PRIVATE' }).success).toBe(false);
+  });
+
+  it('rejects VPC mode without networkConfig', () => {
     expect(AgentEnvSpecSchema.safeParse({ ...validPythonAgent, networkMode: 'VPC' }).success).toBe(false);
+  });
+
+  it('rejects networkConfig without VPC mode', () => {
+    expect(
+      AgentEnvSpecSchema.safeParse({
+        ...validPythonAgent,
+        networkMode: 'PUBLIC',
+        networkConfig: {
+          subnets: ['subnet-12345678'],
+          securityGroups: ['sg-12345678'],
+        },
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects networkConfig with missing networkMode', () => {
+    expect(
+      AgentEnvSpecSchema.safeParse({
+        ...validPythonAgent,
+        networkConfig: {
+          subnets: ['subnet-12345678'],
+          securityGroups: ['sg-12345678'],
+        },
+      }).success
+    ).toBe(false);
   });
 
   it('accepts agent with instrumentation config', () => {
@@ -257,5 +296,55 @@ describe('AgentEnvSpecSchema', () => {
   it('rejects missing required fields', () => {
     expect(AgentEnvSpecSchema.safeParse({ type: 'AgentCoreRuntime' }).success).toBe(false);
     expect(AgentEnvSpecSchema.safeParse({ ...validPythonAgent, name: undefined }).success).toBe(false);
+  });
+});
+
+describe('NetworkConfigSchema', () => {
+  it('accepts valid network config', () => {
+    const result = NetworkConfigSchema.safeParse({
+      subnets: ['subnet-12345678'],
+      securityGroups: ['sg-12345678'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts multiple subnets and security groups', () => {
+    const result = NetworkConfigSchema.safeParse({
+      subnets: ['subnet-12345678', 'subnet-abcdef12'],
+      securityGroups: ['sg-12345678', 'sg-abcdef12'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects empty subnets array', () => {
+    const result = NetworkConfigSchema.safeParse({
+      subnets: [],
+      securityGroups: ['sg-12345678'],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty security groups array', () => {
+    const result = NetworkConfigSchema.safeParse({
+      subnets: ['subnet-12345678'],
+      securityGroups: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid subnet format', () => {
+    const result = NetworkConfigSchema.safeParse({
+      subnets: ['invalid-subnet'],
+      securityGroups: ['sg-12345678'],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid security group format', () => {
+    const result = NetworkConfigSchema.safeParse({
+      subnets: ['subnet-12345678'],
+      securityGroups: ['invalid-sg'],
+    });
+    expect(result.success).toBe(false);
   });
 });

--- a/src/schema/schemas/__tests__/mcp.test.ts
+++ b/src/schema/schemas/__tests__/mcp.test.ts
@@ -238,8 +238,8 @@ describe('RuntimeConfigSchema', () => {
     }
   });
 
-  it('accepts explicit PRIVATE networkMode', () => {
-    const result = RuntimeConfigSchema.safeParse({ ...validRuntime, networkMode: 'PRIVATE' });
+  it('accepts explicit VPC networkMode', () => {
+    const result = RuntimeConfigSchema.safeParse({ ...validRuntime, networkMode: 'VPC' });
     expect(result.success).toBe(true);
   });
 

--- a/src/schema/schemas/agent-env.ts
+++ b/src/schema/schemas/agent-env.ts
@@ -104,24 +104,59 @@ export const InstrumentationSchema = z.object({
 export type Instrumentation = z.infer<typeof InstrumentationSchema>;
 
 /**
+ * VPC network configuration for agents running in VPC mode.
+ * Requires at least one subnet and one security group.
+ */
+export const NetworkConfigSchema = z.object({
+  subnets: z
+    .array(z.string().regex(/^subnet-[0-9a-zA-Z]{8,17}$/))
+    .min(1)
+    .max(16),
+  securityGroups: z
+    .array(z.string().regex(/^sg-[0-9a-zA-Z]{8,17}$/))
+    .min(1)
+    .max(16),
+});
+export type NetworkConfig = z.infer<typeof NetworkConfigSchema>;
+
+/**
  * AgentEnvSpec - represents an AgentCore Runtime.
  * This is a top-level resource in the schema.
  */
-export const AgentEnvSpecSchema = z.object({
-  type: AgentTypeSchema,
-  name: AgentNameSchema,
-  build: BuildTypeSchema,
-  entrypoint: EntrypointSchema,
-  codeLocation: DirectoryPathSchema,
-  runtimeVersion: RuntimeVersionSchemaFromConstants,
-  /** Environment variables to set on the runtime */
-  envVars: z.array(EnvVarSchema).optional(),
-  /** Network mode for the runtime. Defaults to PUBLIC. */
-  networkMode: NetworkModeSchema.optional(),
-  /** Instrumentation settings for observability. Defaults to OTel enabled. */
-  instrumentation: InstrumentationSchema.optional(),
-  /** Model provider used by this agent. Optional for backwards compatibility. */
-  modelProvider: ModelProviderSchema.optional(),
-});
+export const AgentEnvSpecSchema = z
+  .object({
+    type: AgentTypeSchema,
+    name: AgentNameSchema,
+    build: BuildTypeSchema,
+    entrypoint: EntrypointSchema,
+    codeLocation: DirectoryPathSchema,
+    runtimeVersion: RuntimeVersionSchemaFromConstants,
+    /** Environment variables to set on the runtime */
+    envVars: z.array(EnvVarSchema).optional(),
+    /** Network mode for the runtime. Defaults to PUBLIC. */
+    networkMode: NetworkModeSchema.optional(),
+    /** VPC network configuration. Required when networkMode is VPC. */
+    networkConfig: NetworkConfigSchema.optional(),
+    /** Instrumentation settings for observability. Defaults to OTel enabled. */
+    instrumentation: InstrumentationSchema.optional(),
+    /** Model provider used by this agent. Optional for backwards compatibility. */
+    modelProvider: ModelProviderSchema.optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.networkMode === 'VPC' && !data.networkConfig) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['networkConfig'],
+        message: 'networkConfig is required when networkMode is VPC',
+      });
+    }
+    if (data.networkMode !== 'VPC' && data.networkConfig) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['networkConfig'],
+        message: 'networkConfig is only allowed when networkMode is VPC',
+      });
+    }
+  });
 
 export type AgentEnvSpec = z.infer<typeof AgentEnvSpecSchema>;


### PR DESCRIPTION
## Summary

- **Fix NetworkModeSchema**: Correct enum values from `PUBLIC | PRIVATE` to `PUBLIC | VPC` to match the [AWS API](https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_NetworkConfiguration.html)
- **Add VPC configuration schema**: New `NetworkConfigSchema` with subnet/security group ID validation, cross-field validation (VPC mode requires networkConfig, PUBLIC mode rejects it)
- **Add CLI flags**: `--network-mode`, `--subnets`, `--security-groups` for both `create` and `add agent` commands with shared validation utilities
- **Propagate VPC config**: Schema mapper, GenerateConfig, and BYO agent path all pass VPC fields through to the AgentEnvSpec
- **Developer experience**: Info messages in `dev` command and VPC Endpoint guidance in `invoke` command when agents use VPC mode
- **Tests**: 23 new unit tests covering schema validation, CLI validation, and schema mapping for VPC configurations

### Files changed (23)

| Area | Files | Change |
|------|-------|--------|
| Schema | `constants.ts`, `agent-env.ts`, `llm-compacted/*.ts` | Fix enum, add NetworkConfig, update docs |
| Create cmd | `command.tsx`, `action.ts`, `validate.ts`, `types.ts` | Add VPC CLI flags and validation |
| Add cmd | `command.tsx`, `actions.ts`, `validate.ts`, `types.ts` | Add VPC CLI flags and validation |
| Dev cmd | `command.tsx` | VPC info message |
| Invoke cmd | `action.ts` | VPC Endpoint guidance warning |
| Shared | `shared/vpc-utils.ts` (new) | Consolidated VPC parsing and validation |
| Operations | `schema-mapper.ts`, `generate/types.ts` | Pass VPC fields through |
| Tests | 6 test files | 23 new VPC-related tests |

### Companion PR

CDK construct changes: https://github.com/aws/agentcore-l3-cdk-constructs/pull/54

## Test plan

- [x] All 1776 unit tests pass (`npm test`)
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] Lint passes with 0 errors
- [x] Prettier formatting verified
- [ ] Manual test: `agentcore create --name test --defaults --network-mode VPC --subnets subnet-xxx --security-groups sg-xxx --dry-run`
- [ ] Manual test: Deploy VPC-mode agent and verify CloudFormation template includes NetworkModeConfig
- [ ] Manual test: Invoke VPC-mode agent from within VPC