### PR TITLE
feat: add VPC network mode to schema [1/3]

### DIFF
--- a/src/schema/__tests__/constants.test.ts
+++ b/src/schema/__tests__/constants.test.ts
@@ -74,12 +74,12 @@ describe('NetworkModeSchema', () => {
     expect(NetworkModeSchema.safeParse('PUBLIC').success).toBe(true);
   });
 
-  it('accepts PRIVATE', () => {
-    expect(NetworkModeSchema.safeParse('PRIVATE').success).toBe(true);
+  it('accepts VPC', () => {
+    expect(NetworkModeSchema.safeParse('VPC').success).toBe(true);
   });
 
   it('rejects other modes', () => {
-    expect(NetworkModeSchema.safeParse('VPC').success).toBe(false);
+    expect(NetworkModeSchema.safeParse('PRIVATE').success).toBe(false);
   });
 });
 

--- a/src/schema/constants.ts
+++ b/src/schema/constants.ts
@@ -139,5 +139,5 @@ export type NodeRuntime = z.infer<typeof NodeRuntimeSchema>;
 export const RuntimeVersionSchema = z.union([PythonRuntimeSchema, NodeRuntimeSchema]);
 export type RuntimeVersion = z.infer<typeof RuntimeVersionSchema>;
 
-export const NetworkModeSchema = z.enum(['PUBLIC', 'PRIVATE']);
+export const NetworkModeSchema = z.enum(['PUBLIC', 'VPC']);
 export type NetworkMode = z.infer<typeof NetworkModeSchema>;

--- a/src/schema/llm-compacted/agentcore.ts
+++ b/src/schema/llm-compacted/agentcore.ts
@@ -26,9 +26,18 @@ type BuildType = 'CodeZip' | 'Container';
 type PythonRuntime = 'PYTHON_3_10' | 'PYTHON_3_11' | 'PYTHON_3_12' | 'PYTHON_3_13';
 type NodeRuntime = 'NODE_18' | 'NODE_20' | 'NODE_22';
 type RuntimeVersion = PythonRuntime | NodeRuntime;
-type NetworkMode = 'PUBLIC' | 'PRIVATE';
+type NetworkMode = 'PUBLIC' | 'VPC';
 type MemoryStrategyType = 'SEMANTIC' | 'SUMMARIZATION' | 'USER_PREFERENCE';
 type ModelProvider = 'Bedrock' | 'Gemini' | 'OpenAI' | 'Anthropic';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// NETWORK CONFIG
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface NetworkConfig {
+  subnets: string[]; // @regex ^subnet-[0-9a-zA-Z]{8,17}$ @min 1 @max 16
+  securityGroups: string[]; // @regex ^sg-[0-9a-zA-Z]{8,17}$ @min 1 @max 16
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // AGENT
@@ -43,6 +52,7 @@ interface AgentEnvSpec {
   runtimeVersion: RuntimeVersion;
   envVars?: EnvVar[];
   networkMode?: NetworkMode; // default 'PUBLIC'
+  networkConfig?: NetworkConfig; // Required when networkMode is 'VPC'
   instrumentation?: Instrumentation; // OTel settings
   modelProvider?: ModelProvider; // Model provider used by this agent
 }

--- a/src/schema/llm-compacted/mcp.ts
+++ b/src/schema/llm-compacted/mcp.ts
@@ -145,4 +145,4 @@ interface IamPolicyDocument {
 type GatewayTargetType = 'lambda' | 'mcpServer' | 'openApiSchema' | 'smithyModel';
 type PythonRuntime = 'PYTHON_3_10' | 'PYTHON_3_11' | 'PYTHON_3_12' | 'PYTHON_3_13';
 type NodeRuntime = 'NODE_18' | 'NODE_20' | 'NODE_22';
-type NetworkMode = 'PUBLIC' | 'PRIVATE';
+type NetworkMode = 'PUBLIC' | 'VPC';

--- a/src/schema/schemas/__tests__/agent-env.test.ts
+++ b/src/schema/schemas/__tests__/agent-env.test.ts
@@ -7,6 +7,7 @@ import {
   EnvVarSchema,
   GatewayNameSchema,
   InstrumentationSchema,
+  NetworkConfigSchema,
 } from '../agent-env.js';
 import { describe, expect, it } from 'vitest';
 
@@ -235,11 +236,49 @@ describe('AgentEnvSpecSchema', () => {
 
   it('accepts agent with network mode', () => {
     expect(AgentEnvSpecSchema.safeParse({ ...validPythonAgent, networkMode: 'PUBLIC' }).success).toBe(true);
-    expect(AgentEnvSpecSchema.safeParse({ ...validPythonAgent, networkMode: 'PRIVATE' }).success).toBe(true);
+    expect(
+      AgentEnvSpecSchema.safeParse({
+        ...validPythonAgent,
+        networkMode: 'VPC',
+        networkConfig: {
+          subnets: ['subnet-12345678'],
+          securityGroups: ['sg-12345678'],
+        },
+      }).success
+    ).toBe(true);
   });
 
   it('rejects invalid network mode', () => {
+    expect(AgentEnvSpecSchema.safeParse({ ...validPythonAgent, networkMode: 'PRIVATE' }).success).toBe(false);
+  });
+
+  it('rejects VPC mode without networkConfig', () => {
     expect(AgentEnvSpecSchema.safeParse({ ...validPythonAgent, networkMode: 'VPC' }).success).toBe(false);
+  });
+
+  it('rejects networkConfig without VPC mode', () => {
+    expect(
+      AgentEnvSpecSchema.safeParse({
+        ...validPythonAgent,
+        networkMode: 'PUBLIC',
+        networkConfig: {
+          subnets: ['subnet-12345678'],
+          securityGroups: ['sg-12345678'],
+        },
+      }).success
+    ).toBe(false);
+  });
+
+  it('rejects networkConfig with missing networkMode', () => {
+    expect(
+      AgentEnvSpecSchema.safeParse({
+        ...validPythonAgent,
+        networkConfig: {
+          subnets: ['subnet-12345678'],
+          securityGroups: ['sg-12345678'],
+        },
+      }).success
+    ).toBe(false);
   });
 
   it('accepts agent with instrumentation config', () => {
@@ -257,5 +296,55 @@ describe('AgentEnvSpecSchema', () => {
   it('rejects missing required fields', () => {
     expect(AgentEnvSpecSchema.safeParse({ type: 'AgentCoreRuntime' }).success).toBe(false);
     expect(AgentEnvSpecSchema.safeParse({ ...validPythonAgent, name: undefined }).success).toBe(false);
+  });
+});
+
+describe('NetworkConfigSchema', () => {
+  it('accepts valid network config', () => {
+    const result = NetworkConfigSchema.safeParse({
+      subnets: ['subnet-12345678'],
+      securityGroups: ['sg-12345678'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts multiple subnets and security groups', () => {
+    const result = NetworkConfigSchema.safeParse({
+      subnets: ['subnet-12345678', 'subnet-abcdef12'],
+      securityGroups: ['sg-12345678', 'sg-abcdef12'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects empty subnets array', () => {
+    const result = NetworkConfigSchema.safeParse({
+      subnets: [],
+      securityGroups: ['sg-12345678'],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty security groups array', () => {
+    const result = NetworkConfigSchema.safeParse({
+      subnets: ['subnet-12345678'],
+      securityGroups: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid subnet format', () => {
+    const result = NetworkConfigSchema.safeParse({
+      subnets: ['invalid-subnet'],
+      securityGroups: ['sg-12345678'],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid security group format', () => {
+    const result = NetworkConfigSchema.safeParse({
+      subnets: ['subnet-12345678'],
+      securityGroups: ['invalid-sg'],
+    });
+    expect(result.success).toBe(false);
   });
 });

--- a/src/schema/schemas/__tests__/mcp.test.ts
+++ b/src/schema/schemas/__tests__/mcp.test.ts
@@ -238,8 +238,8 @@ describe('RuntimeConfigSchema', () => {
     }
   });
 
-  it('accepts explicit PRIVATE networkMode', () => {
-    const result = RuntimeConfigSchema.safeParse({ ...validRuntime, networkMode: 'PRIVATE' });
+  it('accepts explicit VPC networkMode', () => {
+    const result = RuntimeConfigSchema.safeParse({ ...validRuntime, networkMode: 'VPC' });
     expect(result.success).toBe(true);
   });
 

--- a/src/schema/schemas/agent-env.ts
+++ b/src/schema/schemas/agent-env.ts
@@ -104,24 +104,59 @@ export const InstrumentationSchema = z.object({
 export type Instrumentation = z.infer<typeof InstrumentationSchema>;
 
 /**
+ * VPC network configuration for agents running in VPC mode.
+ * Requires at least one subnet and one security group.
+ */
+export const NetworkConfigSchema = z.object({
+  subnets: z
+    .array(z.string().regex(/^subnet-[0-9a-zA-Z]{8,17}$/))
+    .min(1)
+    .max(16),
+  securityGroups: z
+    .array(z.string().regex(/^sg-[0-9a-zA-Z]{8,17}$/))
+    .min(1)
+    .max(16),
+});
+export type NetworkConfig = z.infer<typeof NetworkConfigSchema>;
+
+/**
  * AgentEnvSpec - represents an AgentCore Runtime.
  * This is a top-level resource in the schema.
  */
-export const AgentEnvSpecSchema = z.object({
-  type: AgentTypeSchema,
-  name: AgentNameSchema,
-  build: BuildTypeSchema,
-  entrypoint: EntrypointSchema,
-  codeLocation: DirectoryPathSchema,
-  runtimeVersion: RuntimeVersionSchemaFromConstants,
-  /** Environment variables to set on the runtime */
-  envVars: z.array(EnvVarSchema).optional(),
-  /** Network mode for the runtime. Defaults to PUBLIC. */
-  networkMode: NetworkModeSchema.optional(),
-  /** Instrumentation settings for observability. Defaults to OTel enabled. */
-  instrumentation: InstrumentationSchema.optional(),
-  /** Model provider used by this agent. Optional for backwards compatibility. */
-  modelProvider: ModelProviderSchema.optional(),
-});
+export const AgentEnvSpecSchema = z
+  .object({
+    type: AgentTypeSchema,
+    name: AgentNameSchema,
+    build: BuildTypeSchema,
+    entrypoint: EntrypointSchema,
+    codeLocation: DirectoryPathSchema,
+    runtimeVersion: RuntimeVersionSchemaFromConstants,
+    /** Environment variables to set on the runtime */
+    envVars: z.array(EnvVarSchema).optional(),
+    /** Network mode for the runtime. Defaults to PUBLIC. */
+    networkMode: NetworkModeSchema.optional(),
+    /** VPC network configuration. Required when networkMode is VPC. */
+    networkConfig: NetworkConfigSchema.optional(),
+    /** Instrumentation settings for observability. Defaults to OTel enabled. */
+    instrumentation: InstrumentationSchema.optional(),
+    /** Model provider used by this agent. Optional for backwards compatibility. */
+    modelProvider: ModelProviderSchema.optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.networkMode === 'VPC' && !data.networkConfig) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['networkConfig'],
+        message: 'networkConfig is required when networkMode is VPC',
+      });
+    }
+    if (data.networkMode !== 'VPC' && data.networkConfig) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['networkConfig'],
+        message: 'networkConfig is only allowed when networkMode is VPC',
+      });
+    }
+  });
 
 export type AgentEnvSpec = z.infer<typeof AgentEnvSpecSchema>;


### PR DESCRIPTION
## Summary

Fix `NetworkModeSchema` enum and add VPC configuration schema support. This is the foundation PR that PR #2 and #3 build on.

- Fix `NetworkModeSchema` enum from `PUBLIC | PRIVATE` to `PUBLIC | VPC` to match the [AWS API](https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_NetworkConfiguration.html)
- Add `NetworkConfigSchema` with subnet ID (`subnet-*`) and security group ID (`sg-*`) regex validation, array bounds (1-16)
- Add `networkConfig` optional field to `AgentEnvSpec`
- Add `.superRefine()` cross-field validation: VPC mode requires `networkConfig`, PUBLIC mode rejects it
- Update LLM-compacted schema documentation

### Files changed (7)

| File | Change |
|------|--------|
| `src/schema/constants.ts` | Fix enum: `PRIVATE` → `VPC` |
| `src/schema/schemas/agent-env.ts` | Add `NetworkConfigSchema`, `networkConfig` field, `.superRefine()` |
| `src/schema/llm-compacted/agentcore.ts` | Add `NetworkConfig` type, update `NetworkMode` |
| `src/schema/llm-compacted/mcp.ts` | Update `NetworkMode` type |
| `src/schema/__tests__/constants.test.ts` | VPC enum tests |
| `src/schema/schemas/__tests__/agent-env.test.ts` | 10 new VPC cross-field validation tests |
| `src/schema/schemas/__tests__/mcp.test.ts` | Update PRIVATE → VPC in existing test |

### Stack

- **PR 1/3 (this)**: Schema foundation → `main`
- **PR 2/3**: CLI commands (create, add) → `main` (includes this PR's commits)
- **PR 3/3**: Dev/invoke UX messages → `main` (includes this PR's commits)
- **CDK companion**: https://github.com/aws/agentcore-l3-cdk-constructs/pull/54

PRs 2 and 3 can be reviewed in parallel. Merge this first, then 2 and 3 in any order.

## Test plan

- [x] All unit tests pass (`npm test`)
- [x] TypeScript compiles clean
- [x] Lint and prettier pass