### PR TITLE
refactor: remove gateway bind flow from add gateway TUI

### DIFF
--- a/src/cli/tui/screens/mcp/AddGatewayFlow.tsx
+++ b/src/cli/tui/screens/mcp/AddGatewayFlow.tsx
@@ -1,30 +1,13 @@
-import { ErrorPrompt, Panel, Screen, TextInput, WizardSelect } from '../../components';
-import type { SelectableItem } from '../../components';
-import { HELP_TEXT } from '../../constants';
-import { useListNavigation } from '../../hooks';
-import { useAgents, useAttachGateway, useGateways } from '../../hooks/useAttach';
+import { ErrorPrompt } from '../../components';
 import { useCreateGateway, useExistingGateways, useUnassignedTargets } from '../../hooks/useCreateMcp';
 import { AddSuccessScreen } from '../add/AddSuccessScreen';
 import { AddGatewayScreen } from './AddGatewayScreen';
 import type { AddGatewayConfig } from './types';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 type FlowState =
-  | { name: 'mode-select' }
   | { name: 'create-wizard' }
-  | { name: 'bind-select-agent' }
-  | { name: 'bind-select-gateway'; targetAgent: string }
-  | { name: 'bind-enter-name'; targetAgent: string; gatewayName: string }
-  | { name: 'bind-enter-description'; targetAgent: string; gatewayName: string; mcpProviderName: string }
-  | {
-      name: 'bind-enter-envvar';
-      targetAgent: string;
-      gatewayName: string;
-      mcpProviderName: string;
-      description: string;
-    }
   | { name: 'create-success'; gatewayName: string; loading?: boolean; loadingMessage?: string }
-  | { name: 'bind-success'; gatewayName: string; targetAgent: string }
   | { name: 'error'; message: string };
 
 interface AddGatewayFlowProps {
@@ -40,11 +23,6 @@ interface AddGatewayFlowProps {
   onDeploy?: () => void;
 }
 
-const MODE_OPTIONS: SelectableItem[] = [
-  { id: 'create', title: 'Create new gateway', description: 'Define a new gateway for your project' },
-  { id: 'bind', title: 'Bind existing gateway', description: 'Attach an existing gateway to an agent' },
-];
-
 export function AddGatewayFlow({
   isInteractive = true,
   availableAgents,
@@ -56,62 +34,16 @@ export function AddGatewayFlow({
   const { createGateway, reset: resetCreate } = useCreateGateway();
   const { gateways: existingGateways, refresh: refreshGateways } = useExistingGateways();
   const { targets: unassignedTargets } = useUnassignedTargets();
-  const [flow, setFlow] = useState<FlowState>({ name: 'mode-select' });
-
-  // Bind flow hooks
-  const { agents: allAgents, isLoading: isLoadingAgents } = useAgents();
-  const { gateways: bindableGateways } = useGateways();
-  const { attach: attachGateway } = useAttachGateway();
+  const [flow, setFlow] = useState<FlowState>({ name: 'create-wizard' });
 
   // In non-interactive mode, exit after success (but not while loading)
   useEffect(() => {
     if (!isInteractive) {
-      if ((flow.name === 'create-success' && !flow.loading) || flow.name === 'bind-success') {
+      if (flow.name === 'create-success' && !flow.loading) {
         onExit();
       }
     }
   }, [isInteractive, flow, onExit]);
-
-  // Mode selection navigation
-  const modeNav = useListNavigation({
-    items: MODE_OPTIONS,
-    onSelect: item => {
-      if (item.id === 'create') {
-        setFlow({ name: 'create-wizard' });
-      } else {
-        setFlow({ name: 'bind-select-agent' });
-      }
-    },
-    onExit: onBack,
-    isActive: flow.name === 'mode-select',
-  });
-
-  // Agent selection for bind flow
-  const agentItems: SelectableItem[] = useMemo(() => allAgents.map(name => ({ id: name, title: name })), [allAgents]);
-
-  const agentNav = useListNavigation({
-    items: agentItems,
-    onSelect: item => setFlow({ name: 'bind-select-gateway', targetAgent: item.id }),
-    onExit: () => setFlow({ name: 'mode-select' }),
-    isActive: flow.name === 'bind-select-agent',
-  });
-
-  // Gateway selection for bind flow
-  const gatewayItems: SelectableItem[] = useMemo(
-    () => bindableGateways.map(name => ({ id: name, title: name })),
-    [bindableGateways]
-  );
-
-  const gatewayNav = useListNavigation({
-    items: gatewayItems,
-    onSelect: item => {
-      if (flow.name === 'bind-select-gateway') {
-        setFlow({ name: 'bind-enter-name', targetAgent: flow.targetAgent, gatewayName: item.id });
-      }
-    },
-    onExit: () => setFlow({ name: 'bind-select-agent' }),
-    isActive: flow.name === 'bind-select-gateway',
-  });
 
   const handleCreateComplete = useCallback(
     (config: AddGatewayConfig) => {
@@ -132,53 +64,6 @@ export function AddGatewayFlow({
     [createGateway]
   );
 
-  const handleBindComplete = useCallback(
-    async (_envVarName: string) => {
-      if (flow.name !== 'bind-enter-envvar') return;
-
-      const result = await attachGateway();
-
-      if (result.ok) {
-        setFlow({ name: 'bind-success', gatewayName: flow.gatewayName, targetAgent: flow.targetAgent });
-      } else {
-        setFlow({ name: 'error', message: 'Failed to bind gateway' });
-      }
-    },
-    [flow, attachGateway]
-  );
-
-  // Mode selection screen
-  if (flow.name === 'mode-select') {
-    // Check if there are gateways to bind
-    const hasGatewaysToBind = bindableGateways.length > 0;
-
-    // If no gateways exist to bind, skip to create
-    if (!hasGatewaysToBind) {
-      return (
-        <AddGatewayScreen
-          existingGateways={existingGateways}
-          availableAgents={availableAgents}
-          unassignedTargets={unassignedTargets}
-          onComplete={handleCreateComplete}
-          onExit={onBack}
-        />
-      );
-    }
-
-    return (
-      <Screen title="Add Gateway" onExit={onBack} helpText={HELP_TEXT.NAVIGATE_SELECT}>
-        <Panel>
-          <WizardSelect
-            title="What would you like to do?"
-            description="Create a new gateway or bind an existing one to an agent"
-            items={MODE_OPTIONS}
-            selectedIndex={modeNav.selectedIndex}
-          />
-        </Panel>
-      </Screen>
-    );
-  }
-
   // Create wizard
   if (flow.name === 'create-wizard') {
     return (
@@ -187,145 +72,8 @@ export function AddGatewayFlow({
         availableAgents={availableAgents}
         unassignedTargets={unassignedTargets}
         onComplete={handleCreateComplete}
-        onExit={() => setFlow({ name: 'mode-select' })}
+        onExit={onBack}
       />
-    );
-  }
-
-  // Bind flow - select agent
-  if (flow.name === 'bind-select-agent') {
-    if (isLoadingAgents) {
-      return null;
-    }
-    return (
-      <Screen title="Bind Gateway" onExit={() => setFlow({ name: 'mode-select' })} helpText={HELP_TEXT.NAVIGATE_SELECT}>
-        <Panel>
-          <WizardSelect
-            title="Select target agent"
-            description="Which agent should use the gateway?"
-            items={agentItems}
-            selectedIndex={agentNav.selectedIndex}
-            emptyMessage="No agents defined. Add an agent first."
-          />
-        </Panel>
-      </Screen>
-    );
-  }
-
-  // Bind flow - select gateway
-  if (flow.name === 'bind-select-gateway') {
-    return (
-      <Screen
-        title="Bind Gateway"
-        onExit={() => setFlow({ name: 'bind-select-agent' })}
-        helpText={HELP_TEXT.NAVIGATE_SELECT}
-      >
-        <Panel>
-          <WizardSelect
-            title="Select gateway to bind"
-            description={`Which gateway should ${flow.targetAgent} use?`}
-            items={gatewayItems}
-            selectedIndex={gatewayNav.selectedIndex}
-            emptyMessage="No gateways available. Create a gateway first."
-          />
-        </Panel>
-      </Screen>
-    );
-  }
-
-  // Bind flow - enter MCP provider name
-  if (flow.name === 'bind-enter-name') {
-    const defaultName = `${flow.gatewayName}-provider`;
-    return (
-      <Screen
-        title="Bind Gateway"
-        onExit={() => setFlow({ name: 'bind-select-gateway', targetAgent: flow.targetAgent })}
-        helpText={HELP_TEXT.TEXT_INPUT}
-      >
-        <Panel>
-          <TextInput
-            prompt="MCP provider name (how this gateway appears to the agent)"
-            initialValue={defaultName}
-            onSubmit={value =>
-              setFlow({
-                name: 'bind-enter-description',
-                targetAgent: flow.targetAgent,
-                gatewayName: flow.gatewayName,
-                mcpProviderName: value,
-              })
-            }
-            onCancel={() => setFlow({ name: 'bind-select-gateway', targetAgent: flow.targetAgent })}
-          />
-        </Panel>
-      </Screen>
-    );
-  }
-
-  // Bind flow - enter description
-  if (flow.name === 'bind-enter-description') {
-    const defaultDescription = `Tools provided by ${flow.gatewayName} gateway`;
-    return (
-      <Screen
-        title="Bind Gateway"
-        onExit={() =>
-          setFlow({ name: 'bind-enter-name', targetAgent: flow.targetAgent, gatewayName: flow.gatewayName })
-        }
-        helpText={HELP_TEXT.TEXT_INPUT}
-      >
-        <Panel>
-          <TextInput
-            prompt="Description"
-            initialValue={defaultDescription}
-            onSubmit={value =>
-              setFlow({
-                name: 'bind-enter-envvar',
-                targetAgent: flow.targetAgent,
-                gatewayName: flow.gatewayName,
-                mcpProviderName: flow.mcpProviderName,
-                description: value,
-              })
-            }
-            onCancel={() =>
-              setFlow({ name: 'bind-enter-name', targetAgent: flow.targetAgent, gatewayName: flow.gatewayName })
-            }
-          />
-        </Panel>
-      </Screen>
-    );
-  }
-
-  // Bind flow - enter env var name
-  if (flow.name === 'bind-enter-envvar') {
-    const defaultEnvVar = `${flow.mcpProviderName.toUpperCase().replace(/[^A-Z0-9]/g, '_')}_URL`;
-    return (
-      <Screen
-        title="Bind Gateway"
-        onExit={() =>
-          setFlow({
-            name: 'bind-enter-description',
-            targetAgent: flow.targetAgent,
-            gatewayName: flow.gatewayName,
-            mcpProviderName: flow.mcpProviderName,
-          })
-        }
-        helpText={HELP_TEXT.TEXT_INPUT}
-      >
-        <Panel>
-          <TextInput
-            prompt="Environment variable name for gateway URL"
-            initialValue={defaultEnvVar}
-            onSubmit={value => void handleBindComplete(value)}
-            onCancel={() =>
-              setFlow({
-                name: 'bind-enter-description',
-                targetAgent: flow.targetAgent,
-                gatewayName: flow.gatewayName,
-                mcpProviderName: flow.mcpProviderName,
-              })
-            }
-          />
-        </Panel>
-      </Screen>
     );
   }
 
@@ -349,22 +97,6 @@ export function AddGatewayFlow({
     );
   }
 
-  // Bind success
-  if (flow.name === 'bind-success') {
-    return (
-      <AddSuccessScreen
-        isInteractive={isInteractive}
-        message={`Bound gateway: ${flow.gatewayName}`}
-        detail={`Agent "${flow.targetAgent}" now uses gateway "${flow.gatewayName}".`}
-        showDevOption={true}
-        onAddAnother={onBack}
-        onDev={onDev}
-        onDeploy={onDeploy}
-        onExit={onExit}
-      />
-    );
-  }
-
   // Error
   return (
     <ErrorPrompt
@@ -372,7 +104,7 @@ export function AddGatewayFlow({
       detail={flow.message}
       onBack={() => {
         resetCreate();
-        setFlow({ name: 'mode-select' });
+        setFlow({ name: 'create-wizard' });
       }}
       onExit={onExit}
     />


### PR DESCRIPTION
## Description

Remove the "bind existing gateway to agent" flow from the `agentcore add gateway` TUI.

In Phase 1, gateways are project-level resources — all agents automatically get access to all gateways via CDK environment variables. The bind flow (select agent → select gateway → enter provider name → enter description → enter env var) was pre-Phase 1 code for manually attaching gateways to specific agents, which is no longer how gateways work.

`agentcore add gateway` now goes straight to the create gateway wizard. The mode selection screen ("Create new gateway" vs "Bind existing gateway") is removed.

-274 lines removed, flow simplified from 8 states to 3.

## Related Issue

Part of the MCP Gateway Phase 1 integration (gateway-integration branch).

## Type of Change

- [x] Other (please describe): Cleanup of pre-Phase 1 code

## Testing

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
