### PR TITLE
fix: prettier formatting for gateway-status.ts

### DIFF
--- a/src/cli/operations/deploy/gateway-status.ts
+++ b/src/cli/operations/deploy/gateway-status.ts
@@ -30,7 +30,9 @@ export function formatTargetStatus(status: string): string {
 export async function getGatewayTargetStatuses(gatewayId: string, region: string): Promise<TargetSyncStatus[]> {
   try {
     const client = new BedrockAgentCoreControlClient({ region });
-    const response = await client.send(new ListGatewayTargetsCommand({ gatewayIdentifier: gatewayId, maxResults: 100 }));
+    const response = await client.send(
+      new ListGatewayTargetsCommand({ gatewayIdentifier: gatewayId, maxResults: 100 })
+    );
 
     return (response.items ?? []).map(target => ({
       name: target.name ?? 'unknown',


### PR DESCRIPTION
One-line prettier fix. `gateway-status.ts` had a formatting issue that was causing CI format checks to fail on all PRs branching from `feat/gateway-integration`.