### PR TITLE
fix: prevent spurious agent startup in dev mode and remove tiktoken

### DIFF
--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -2095,7 +2095,6 @@ dependencies = [
     "mcp >= 1.19.0",
     "langchain-mcp-adapters >= 0.1.11",
     "langchain >= 1.0.3",
-    "tiktoken == 0.11.0",
     "bedrock-agentcore >= 1.0.3",
     "botocore[crt] >= 1.35.0",
 {{#if (eq modelProvider "Bedrock")}}

--- a/src/assets/python/langchain_langgraph/base/pyproject.toml
+++ b/src/assets/python/langchain_langgraph/base/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
     "mcp >= 1.19.0",
     "langchain-mcp-adapters >= 0.1.11",
     "langchain >= 1.0.3",
-    "tiktoken == 0.11.0",
     "bedrock-agentcore >= 1.0.3",
     "botocore[crt] >= 1.35.0",
 {{#if (eq modelProvider "Bedrock")}}

--- a/src/cli/tui/hooks/useDevServer.ts
+++ b/src/cli/tui/hooks/useDevServer.ts
@@ -87,7 +87,7 @@ export function useDevServer(options: { workingDir: string; port: number; agentN
   }, [options.workingDir]);
 
   const config: DevConfig | null = useMemo(() => {
-    if (!project) {
+    if (!project || !options.agentName) {
       return null;
     }
     return getDevConfig(options.workingDir, project, configRoot, options.agentName);

--- a/src/schema/constants.ts
+++ b/src/schema/constants.ts
@@ -95,7 +95,6 @@ export const RESERVED_PROJECT_NAMES: readonly string[] = [
   'pytest',
   'pytestasyncio',
   'pythondotenv',
-  'tiktoken',
   // Build tools
   'hatchling',
   'setuptools',


### PR DESCRIPTION
## Summary
- **Dev mode bug**: When running `agentcore dev` with multiple agents, the first agent's server would briefly start before the user selected one. This happened because `useDevServer` called `getDevConfig` with `agentName: undefined`, which defaults to `agents[0]`. Added a guard so the server only starts after an agent is explicitly selected.
- **Remove tiktoken**: Removed `tiktoken == 0.11.0` from the LangChain/LangGraph template dependencies as the package no longer resolves correctly. Also removed it from the reserved project names list.

## Test plan
- [ ] Run `agentcore dev` in a project with 2+ agents — verify only the selected agent's server starts (no brief startup of the first agent)
- [ ] Run `agentcore dev --agent <name>` — verify single-agent and `--agent` flag flows still work
- [ ] Create a new LangChain project — verify `pyproject.toml` no longer includes tiktoken
- [ ] `npm test` passes (149 test files, 1 snapshot updated)