### PR TITLE
refactor: remove dead agent binding step from add gateway wizard

### DIFF
--- a/src/cli/commands/add/actions.ts
+++ b/src/cli/commands/add/actions.ts
@@ -243,17 +243,9 @@ async function handleByoPath(
 
 // Gateway handler
 function buildGatewayConfig(options: ValidatedAddGatewayOptions): AddGatewayConfig {
-  const agents = options.agents
-    ? options.agents
-        .split(',')
-        .map(s => s.trim())
-        .filter(Boolean)
-    : [];
-
   const config: AddGatewayConfig = {
     name: options.name,
     description: options.description ?? `Gateway for ${options.name}`,
-    agents,
     authorizerType: options.authorizerType,
     jwtConfig: undefined,
   };

--- a/src/cli/commands/add/command.tsx
+++ b/src/cli/commands/add/command.tsx
@@ -272,7 +272,6 @@ export function registerAdd(program: Command) {
     .option('--discovery-url <url>', 'OIDC discovery URL (required for CUSTOM_JWT)')
     .option('--allowed-audience <values>', 'Comma-separated allowed audience values (required for CUSTOM_JWT)')
     .option('--allowed-clients <values>', 'Comma-separated allowed client IDs (required for CUSTOM_JWT)')
-    .option('--agents <names>', 'Comma-separated agent names to attach gateway to')
     .option('--json', 'Output as JSON')
     .action(async options => {
       requireProject();

--- a/src/cli/tui/screens/add/AddFlow.tsx
+++ b/src/cli/tui/screens/add/AddFlow.tsx
@@ -325,7 +325,6 @@ export function AddFlow(props: AddFlowProps) {
     return (
       <AddGatewayFlow
         isInteractive={props.isInteractive}
-        availableAgents={agents}
         onExit={props.onExit}
         onBack={() => setFlow({ name: 'select' })}
         onDev={props.onDev}

--- a/src/cli/tui/screens/mcp/AddGatewayFlow.tsx
+++ b/src/cli/tui/screens/mcp/AddGatewayFlow.tsx
@@ -13,8 +13,6 @@ type FlowState =
 interface AddGatewayFlowProps {
   /** Whether running in interactive TUI mode */
   isInteractive?: boolean;
-  /** Available agents for the create wizard */
-  availableAgents: string[];
   onExit: () => void;
   onBack: () => void;
   /** Called when user selects dev from success screen to run agent locally */
@@ -25,7 +23,6 @@ interface AddGatewayFlowProps {
 
 export function AddGatewayFlow({
   isInteractive = true,
-  availableAgents,
   onExit,
   onBack,
   onDev,
@@ -69,7 +66,6 @@ export function AddGatewayFlow({
     return (
       <AddGatewayScreen
         existingGateways={existingGateways}
-        availableAgents={availableAgents}
         unassignedTargets={unassignedTargets}
         onComplete={handleCreateComplete}
         onExit={onBack}

--- a/src/cli/tui/screens/mcp/AddGatewayScreen.tsx
+++ b/src/cli/tui/screens/mcp/AddGatewayScreen.tsx
@@ -23,7 +23,6 @@ interface AddGatewayScreenProps {
   onComplete: (config: AddGatewayConfig) => void;
   onExit: () => void;
   existingGateways: string[];
-  availableAgents: string[];
   unassignedTargets: string[];
 }
 
@@ -31,7 +30,6 @@ export function AddGatewayScreen({
   onComplete,
   onExit,
   existingGateways,
-  availableAgents,
   unassignedTargets,
 }: AddGatewayScreenProps) {
   const wizard = useAddGatewayWizard(unassignedTargets.length);
@@ -40,11 +38,6 @@ export function AddGatewayScreen({
   const [jwtSubStep, setJwtSubStep] = useState(0);
   const [jwtDiscoveryUrl, setJwtDiscoveryUrl] = useState('');
   const [jwtAudience, setJwtAudience] = useState('');
-
-  const agentItems: SelectableItem[] = useMemo(
-    () => availableAgents.map(name => ({ id: name, title: name })),
-    [availableAgents]
-  );
 
   const unassignedTargetItems: SelectableItem[] = useMemo(
     () => unassignedTargets.map(name => ({ id: name, title: name })),
@@ -59,7 +52,6 @@ export function AddGatewayScreen({
   const isNameStep = wizard.step === 'name';
   const isAuthorizerStep = wizard.step === 'authorizer';
   const isJwtConfigStep = wizard.step === 'jwt-config';
-  const isAgentsStep = wizard.step === 'agents';
   const isIncludeTargetsStep = wizard.step === 'include-targets';
   const isConfirmStep = wizard.step === 'confirm';
 
@@ -68,15 +60,6 @@ export function AddGatewayScreen({
     onSelect: item => wizard.setAuthorizerType(item.id as GatewayAuthorizerType),
     onExit: () => wizard.goBack(),
     isActive: isAuthorizerStep,
-  });
-
-  const agentsNav = useMultiSelectNavigation({
-    items: agentItems,
-    getId: item => item.id,
-    onConfirm: ids => wizard.setAgents(ids),
-    onExit: () => wizard.goBack(),
-    isActive: isAgentsStep,
-    requireSelection: false,
   });
 
   const targetsNav = useMultiSelectNavigation({
@@ -135,14 +118,13 @@ export function AddGatewayScreen({
     }
   };
 
-  const helpText =
-    isAgentsStep || isIncludeTargetsStep
-      ? 'Space toggle · Enter confirm · Esc back'
-      : isConfirmStep
-        ? HELP_TEXT.CONFIRM_CANCEL
-        : isAuthorizerStep
-          ? HELP_TEXT.NAVIGATE_SELECT
-          : HELP_TEXT.TEXT_INPUT;
+  const helpText = isIncludeTargetsStep
+    ? 'Space toggle · Enter confirm · Esc back'
+    : isConfirmStep
+      ? HELP_TEXT.CONFIRM_CANCEL
+      : isAuthorizerStep
+        ? HELP_TEXT.NAVIGATE_SELECT
+        : HELP_TEXT.TEXT_INPUT;
 
   const headerContent = <StepIndicator steps={wizard.steps} currentStep={wizard.step} labels={GATEWAY_STEP_LABELS} />;
 
@@ -187,20 +169,6 @@ export function AddGatewayScreen({
           />
         )}
 
-        {isAgentsStep &&
-          (agentItems.length > 0 ? (
-            <WizardMultiSelect
-              title="Select agents to use this gateway"
-              items={agentItems}
-              cursorIndex={agentsNav.cursorIndex}
-              selectedIds={agentsNav.selectedIds}
-            />
-          ) : (
-            <Text dimColor>
-              No agents defined. Add agents first via `agentcore add agent`. Press Enter to continue.
-            </Text>
-          ))}
-
         {isIncludeTargetsStep &&
           (unassignedTargetItems.length > 0 ? (
             <WizardMultiSelect
@@ -226,7 +194,6 @@ export function AddGatewayScreen({
                     { label: 'Allowed Clients', value: wizard.config.jwtConfig.allowedClients.join(', ') },
                   ]
                 : []),
-              { label: 'Agents', value: wizard.config.agents.length > 0 ? wizard.config.agents.join(', ') : '(none)' },
               {
                 label: 'Targets',
                 value:

--- a/src/cli/tui/screens/mcp/types.ts
+++ b/src/cli/tui/screens/mcp/types.ts
@@ -4,13 +4,11 @@ import type { GatewayAuthorizerType, NodeRuntime, PythonRuntime, ToolDefinition 
 // Gateway Flow Types
 // ─────────────────────────────────────────────────────────────────────────────
 
-export type AddGatewayStep = 'name' | 'authorizer' | 'jwt-config' | 'agents' | 'include-targets' | 'confirm';
+export type AddGatewayStep = 'name' | 'authorizer' | 'jwt-config' | 'include-targets' | 'confirm';
 
 export interface AddGatewayConfig {
   name: string;
   description: string;
-  /** Agent names that will use this gateway */
-  agents: string[];
   /** Authorization type for the gateway */
   authorizerType: GatewayAuthorizerType;
   /** JWT authorizer configuration (when authorizerType is 'CUSTOM_JWT') */
@@ -27,7 +25,6 @@ export const GATEWAY_STEP_LABELS: Record<AddGatewayStep, string> = {
   name: 'Name',
   authorizer: 'Authorizer',
   'jwt-config': 'JWT Config',
-  agents: 'Agents',
   'include-targets': 'Include Targets',
   confirm: 'Confirm',
 };

--- a/src/cli/tui/screens/mcp/useAddGatewayWizard.ts
+++ b/src/cli/tui/screens/mcp/useAddGatewayWizard.ts
@@ -4,8 +4,8 @@ import { useCallback, useMemo, useState } from 'react';
 
 /** Maps authorizer type to the next step after authorizer selection */
 const AUTHORIZER_NEXT_STEP: Record<GatewayAuthorizerType, AddGatewayStep> = {
-  NONE: 'agents',
-  AWS_IAM: 'agents',
+  NONE: 'confirm',
+  AWS_IAM: 'confirm',
   CUSTOM_JWT: 'jwt-config',
 };
 
@@ -13,7 +13,6 @@ function getDefaultConfig(): AddGatewayConfig {
   return {
     name: '',
     description: '',
-    agents: [],
     authorizerType: 'NONE',
     jwtConfig: undefined,
     selectedTargets: [],
@@ -31,8 +30,6 @@ export function useAddGatewayWizard(unassignedTargetsCount = 0) {
     if (config.authorizerType === 'CUSTOM_JWT') {
       baseSteps.push('jwt-config');
     }
-
-    baseSteps.push('agents');
 
     if (unassignedTargetsCount > 0) {
       baseSteps.push('include-targets');
@@ -76,17 +73,6 @@ export function useAddGatewayWizard(unassignedTargetsCount = 0) {
         ...c,
         jwtConfig,
       }));
-      setStep('agents');
-    },
-    []
-  );
-
-  const setAgents = useCallback(
-    (agents: string[]) => {
-      setConfig(c => ({
-        ...c,
-        agents,
-      }));
       setStep(unassignedTargetsCount > 0 ? 'include-targets' : 'confirm');
     },
     [unassignedTargetsCount]
@@ -114,7 +100,6 @@ export function useAddGatewayWizard(unassignedTargetsCount = 0) {
     setName,
     setAuthorizerType,
     setJwtConfig,
-    setAgents,
     setSelectedTargets,
     reset,
   };


### PR DESCRIPTION
## Description

Remove the dead "Agents" binding step from the add gateway wizard. The step allowed selecting agents to attach to a gateway, but the selection was never used — `config.agents` was collected in the UI but never read by `createGatewayFromWizard` or any downstream code. Also removes the `--agents` CLI flag which was equally a no-op.

Changes:
- Remove `agents` step from gateway wizard flow (Name → Authorizer → Confirm)
- Remove `agents` from `AddGatewayConfig` type and default config
- Remove `setAgents` callback and agent multi-select navigation
- Remove `availableAgents` prop from `AddGatewayScreen` and `AddGatewayFlow`
- Remove `--agents` CLI flag from `add gateway` command
- Clean up step labels and help text

## Related Issue

Closes #

## Documentation PR

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe): Dead code removal

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.