### PR TITLE
chore: disable npm caching in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 20.x
-          cache: 'npm'
 
       - name: Configure git
         run: |
@@ -218,7 +217,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 20.x
-          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
@@ -307,7 +305,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22.x
-          cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Ensure npm 11.5.1+ for trusted publishing


### PR DESCRIPTION
## Summary
- Removes `cache: 'npm'` from all three jobs in the release workflow (`prepare-release`, `test-and-build`, `publish-npm`)
- Ensures fresh `npm ci` installs during releases with no cached dependencies
- Addresses security review feedback to eliminate cached artifact reuse in the release pipeline

## Test plan
- [x] Trigger a dry-run of the release workflow and verify all three jobs install dependencies fresh
- [x] Confirm other workflows (lint, build-and-test, e2e) still use caching as before