### PR TITLE
fix: correct gateway success message to reference gateway-target command

### DIFF
--- a/src/cli/tui/screens/mcp/AddGatewayFlow.tsx
+++ b/src/cli/tui/screens/mcp/AddGatewayFlow.tsx
@@ -73,7 +73,7 @@ export function AddGatewayFlow({ isInteractive = true, onExit, onBack, onDev, on
       <AddSuccessScreen
         isInteractive={isInteractive}
         message={`Added gateway: ${flow.gatewayName}`}
-        detail="Gateway defined in `agentcore/mcp.json`. Next: Use 'add tool' to route tools through this gateway."
+        detail="Gateway defined in `agentcore/mcp.json`. Next: Use 'add gateway-target' to route targets through this gateway."
         loading={flow.loading}
         loadingMessage={flow.loadingMessage}
         showDevOption={true}


### PR DESCRIPTION
## Description

Fix the success message shown after creating a gateway. It previously said "Use 'add tool' to route tools through this gateway" which references the old command name. Updated to say "Use '
add gateway-target' to route targets through this gateway" to match the actual CLI command.

## Related Issue

N/A

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

- [x] I ran npm run test:unit and npm run test:integ
- [x] I ran npm run typecheck
- [x] I ran npm run lint
- [ ] If I modified src/assets/, I ran npm run test:update-snapshots and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.