### PR TITLE
fix: add .venv/bin to PATH in container Dockerfile

### DIFF
--- a/src/assets/container/python/Dockerfile
+++ b/src/assets/container/python/Dockerfile
@@ -11,7 +11,8 @@ ENV UV_SYSTEM_PYTHON=1 \
     PYTHONUNBUFFERED=1 \
     DOCKER_CONTAINER=1 \
     UV_DEFAULT_INDEX=${UV_DEFAULT_INDEX} \
-    UV_INDEX=${UV_INDEX}
+    UV_INDEX=${UV_INDEX} \
+    PATH="/app/.venv/bin:$PATH"
 
 RUN useradd -m -u 1000 bedrock_agentcore
 


### PR DESCRIPTION
## Description

Container builds using `uv sync` fail at runtime with `exec: "opentelemetry-instrument": executable file not found in $PATH`. This happens because `uv sync` ignores `UV_SYSTEM_PYTHON=1` and always creates a `.venv` directory, installing console scripts to `/app/.venv/bin/` which is not on `$PATH`. This adds `/app/.venv/bin` to PATH in the container Dockerfile template.

The other alternative solution is to switch from `uv sync` to `uv pip install --system .` which would actually install to system Python and put scripts in `/usr/local/bin`. This would also make `UV_SYSTEM_PYTHON=1` meaningful.

## Related Issue

Closes #

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [x] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
