### PR TITLE
fix: drop wip and statuses write from PR title workflow

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -9,7 +9,6 @@ jobs:
   validate-pr-title:
     runs-on: ubuntu-latest
     permissions:
-      statuses: write
       pull-requests: read
     steps:
       - uses: amannn/action-semantic-pull-request@v6.1.1
@@ -36,8 +35,6 @@ jobs:
             The subject "{subject}" found in the pull request title "{title}"
             must start with a lowercase letter.
             Example: "feat: add deploy command"
-          # Allow [WIP] prefix to skip validation on in-progress PRs
-          wip: true
           # Validate the commit message when a PR has a single commit, since
           # GitHub suggests using it as the merge commit message on squash-merge
           validateSingleCommit: true


### PR DESCRIPTION
## Description

Removes `wip: true` and `statuses: write` permission from the PR title validation workflow. The `wip` option requires `statuses: write` to set commit statuses, which fails when the repo default workflow permissions are read-only. Since we don't use `[WIP]` prefixed PR titles, removing it lets the workflow run with read-only permissions.

## Related Issue

N/A

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.