### PR TITLE
fix: clear mcp.json gateways during remove-all to prevent orphaned AWS resources

### DIFF
--- a/src/cli/commands/remove/__tests__/remove-all.test.ts
+++ b/src/cli/commands/remove/__tests__/remove-all.test.ts
@@ -105,4 +105,31 @@ describe('remove all command', () => {
     expect(json.note).toContain('source code');
     expect(json.note).toContain('agentcore deploy');
   });
+
+  it('clears gateways from mcp.json after remove all', async () => {
+    // Write mcp.json with a gateway and target
+    const mcpPath = join(projectDir, 'agentcore', 'mcp.json');
+    await writeFile(
+      mcpPath,
+      JSON.stringify({
+        agentCoreGateways: [
+          {
+            name: 'TestGateway',
+            authorizerType: 'NONE',
+            targets: [{ name: 'test-target', targetType: 'mcpServer', endpoint: 'https://example.com/mcp' }],
+          },
+        ],
+      })
+    );
+
+    // Run remove all
+    const result = await runCLI(['remove', 'all', '--force', '--json'], projectDir);
+    expect(result.exitCode).toBe(0);
+    const json = JSON.parse(result.stdout);
+    expect(json.success).toBe(true);
+
+    // Verify mcp.json gateways are cleared
+    const mcpAfter = JSON.parse(await readFile(mcpPath, 'utf-8'));
+    expect(mcpAfter.agentCoreGateways.length, 'Gateways should be cleared after remove all').toBe(0);
+  });
 });

--- a/src/cli/commands/remove/actions.ts
+++ b/src/cli/commands/remove/actions.ts
@@ -112,6 +112,11 @@ export async function handleRemoveAll(_options: RemoveAllOptions): Promise<Remov
       credentials: [],
     });
 
+    // Reset mcp.json gateways so a subsequent deploy can tear down gateway resources
+    if (configIO.configExists('mcp')) {
+      await configIO.writeMcpSpec({ agentCoreGateways: [] });
+    }
+
     // Preserve aws-targets.json and deployed-state.json so that
     // a subsequent `agentcore deploy` can tear down existing stacks.
 

--- a/src/cli/tui/screens/remove/useRemoveFlow.ts
+++ b/src/cli/tui/screens/remove/useRemoveFlow.ts
@@ -81,6 +81,26 @@ export function useRemoveFlow({ force, dryRun }: RemoveFlowOptions): RemoveFlowS
         items.push('AgentCore project (corrupted or incomplete)');
       }
 
+      // Check for gateways in mcp.json
+      if (configIO.configExists('mcp')) {
+        try {
+          const mcpSpec = await configIO.readMcpSpec();
+          const gatewayCount = mcpSpec.agentCoreGateways?.length ?? 0;
+          if (gatewayCount > 0) {
+            const targetCount = mcpSpec.agentCoreGateways.reduce(
+              (sum: number, gw: { targets?: unknown[] }) => sum + (gw.targets?.length ?? 0),
+              0
+            );
+            items.push(`${gatewayCount} gateway${gatewayCount > 1 ? 's' : ''}`);
+            if (targetCount > 0) {
+              items.push(`${targetCount} gateway target${targetCount > 1 ? 's' : ''}`);
+            }
+          }
+        } catch {
+          // mcp.json exists but has issues - still allow reset
+        }
+      }
+
       items.push('All schemas will be reset to empty state');
       setItemsToRemove(items);
 
@@ -141,6 +161,11 @@ export function useRemoveFlow({ force, dryRun }: RemoveFlowOptions): RemoveFlowS
             // Reset agentcore.json (keep project name)
             const defaultProjectSpec = createDefaultProjectSpec(projectName || 'Project');
             await configIO.writeProjectSpec(defaultProjectSpec);
+
+            // Reset mcp.json gateways so a subsequent deploy can tear down gateway resources
+            if (configIO.configExists('mcp')) {
+              await configIO.writeMcpSpec({ agentCoreGateways: [] });
+            }
 
             // Preserve aws-targets.json and deployed-state.json so that
             // a subsequent `agentcore deploy` can tear down existing stacks.


### PR DESCRIPTION
## Description
`remove -> All` only reset `agentcore.json`, leaving `mcp.json` untouched. This caused gateway resources (Gateway, Gateway Target, IAM Role) to survive removal — subsequent `agentcore deploy` saw `hasGateways=true`, skipped teardown, and kept gateway resources alive in AWS.

This PR adds `mcp.json` gateway cleanup to both the CLI and TUI remove-all paths:
- `handleRemoveAll()` (CLI): resets `mcp.json` gateways after `writeProjectSpec()`
- `useRemoveFlow()` (TUI): resets `mcp.json` gateways in `runRemoval()` + enumerates gateways/targets in the confirmation list so users see what's being removed

No changes to preflight, teardown, or CDK logic — the existing teardown detection already works correctly once `mcp.json` is cleared.

## Related Issue


## Documentation PR

N/A — no user-facing docs changes needed. The behavior now matches what users already expect.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran npm run test:unit and npm run test:integ
- [x] I ran npm run typecheck
- [x] I ran npm run lint
- [ ] If I modified src/assets/, I ran npm run test:update-snapshots and committed the updated snapshots

Added a new test in remove-all.test.ts that writes mcp.json with a gateway and target, runs `remove all --force --json`, and verifies `agentCoreGateways` is cleared to an empty array. All 1892 unit tests pass with 0 failures.

Also manually tested creating a gateway, gateway target, agent. I deployed these resources, then did remove all, and it worked.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.