### PR TITLE
fix: wire gateway-target CLI flags and default source to existing-endpoint

### DIFF
--- a/src/cli/commands/add/__tests__/validate.test.ts
+++ b/src/cli/commands/add/__tests__/validate.test.ts
@@ -61,9 +61,9 @@ const validGatewayOptionsJwt: AddGatewayOptions = {
 
 const validGatewayTargetOptions: AddGatewayTargetOptions = {
   name: 'test-tool',
-  language: 'Python',
+  source: 'existing-endpoint',
+  endpoint: 'https://example.com/mcp',
   gateway: 'my-gateway',
-  host: 'Lambda',
 };
 
 const validMemoryOptions: AddMemoryOptions = {
@@ -297,14 +297,6 @@ describe('validate', () => {
       expect(result.error).toBe('--name is required');
     });
 
-    it('returns error for missing language (non-existing-endpoint)', async () => {
-      const opts = { ...validGatewayTargetOptions, language: undefined };
-      const result = await validateAddGatewayTargetOptions(opts);
-      expect(result.valid).toBe(false);
-      expect(result.error).toBe('--language is required');
-    });
-
-    // Gateway is required
     it('returns error when --gateway is missing', async () => {
       const opts = { ...validGatewayTargetOptions, gateway: undefined };
       const result = await validateAddGatewayTargetOptions(opts);
@@ -328,22 +320,23 @@ describe('validate', () => {
       expect(result.error).toContain('other-gateway');
     });
 
-    // AC16: Invalid values rejected
-    it('returns error for invalid values', async () => {
-      const result = await validateAddGatewayTargetOptions({
-        ...validGatewayTargetOptions,
-        language: 'Java' as any,
-      });
-      expect(result.valid).toBe(false);
-      expect(result.error?.includes('Invalid language')).toBeTruthy();
-    });
-
     // AC18: Valid options pass
     it('passes for valid gateway target options', async () => {
       const result = await validateAddGatewayTargetOptions({ ...validGatewayTargetOptions });
       expect(result.valid).toBe(true);
     });
     // AC20: existing-endpoint source validation
+    it('rejects create-new source', async () => {
+      const options: AddGatewayTargetOptions = {
+        name: 'test-tool',
+        source: 'create-new' as any,
+        gateway: 'my-gateway',
+      };
+      const result = await validateAddGatewayTargetOptions(options);
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe("Only 'existing-endpoint' source is currently supported");
+    });
+
     it('passes for valid existing-endpoint with https', async () => {
       const options: AddGatewayTargetOptions = {
         name: 'test-tool',
@@ -410,7 +403,7 @@ describe('validate', () => {
 
       const options: AddGatewayTargetOptions = {
         name: 'test-tool',
-        language: 'Python',
+        endpoint: 'https://example.com/mcp',
         gateway: 'my-gateway',
         outboundAuthType: 'API_KEY',
         credentialName: 'missing-cred',
@@ -427,7 +420,7 @@ describe('validate', () => {
 
       const options: AddGatewayTargetOptions = {
         name: 'test-tool',
-        language: 'Python',
+        endpoint: 'https://example.com/mcp',
         gateway: 'my-gateway',
         outboundAuthType: 'API_KEY',
         credentialName: 'any-cred',
@@ -444,7 +437,7 @@ describe('validate', () => {
 
       const options: AddGatewayTargetOptions = {
         name: 'test-tool',
-        language: 'Python',
+        endpoint: 'https://example.com/mcp',
         gateway: 'my-gateway',
         outboundAuthType: 'API_KEY',
         credentialName: 'valid-cred',
@@ -504,6 +497,18 @@ describe('validate', () => {
       });
       expect(result.valid).toBe(false);
       expect(result.error).toContain('--credential-name is required');
+    });
+
+    it('returns error for invalid OAuth discovery URL', async () => {
+      const result = await validateAddGatewayTargetOptions({
+        ...validGatewayTargetOptions,
+        outboundAuthType: 'OAUTH',
+        oauthClientId: 'cid',
+        oauthClientSecret: 'csec',
+        oauthDiscoveryUrl: 'not-a-url',
+      });
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('--oauth-discovery-url must be a valid URL');
     });
 
     it('rejects --host with existing-endpoint', async () => {

--- a/src/cli/commands/add/command.tsx
+++ b/src/cli/commands/add/command.tsx
@@ -120,6 +120,9 @@ async function handleAddGatewayTargetCLI(options: AddGatewayTargetOptions): Prom
   const result = await handleAddGatewayTarget({
     name: options.name!,
     description: options.description,
+    type: options.type,
+    source: options.source as 'existing-endpoint' | 'create-new' | undefined,
+    endpoint: options.endpoint,
     language: options.language! as 'Python' | 'TypeScript',
     gateway: options.gateway,
     host: options.host,

--- a/src/cli/commands/add/validate.ts
+++ b/src/cli/commands/add/validate.ts
@@ -205,8 +205,8 @@ export async function validateAddGatewayTargetOptions(options: AddGatewayTargetO
     return { valid: false, error: 'Invalid type. Valid options: mcpServer, lambda' };
   }
 
-  if (options.source && options.source !== 'existing-endpoint' && options.source !== 'create-new') {
-    return { valid: false, error: 'Invalid source. Valid options: existing-endpoint, create-new' };
+  if (options.source && options.source !== 'existing-endpoint') {
+    return { valid: false, error: "Only 'existing-endpoint' source is currently supported" };
   }
 
   // Gateway is required — a gateway target must be attached to a gateway
@@ -233,38 +233,10 @@ export async function validateAddGatewayTargetOptions(options: AddGatewayTargetO
     };
   }
 
-  if (options.source === 'existing-endpoint') {
-    if (options.host) {
-      return { valid: false, error: '--host is not applicable for existing endpoint targets' };
-    }
-    if (!options.endpoint) {
-      return { valid: false, error: '--endpoint is required when source is existing-endpoint' };
-    }
+  // Default to existing-endpoint (only supported source for now)
+  options.source ??= 'existing-endpoint';
 
-    try {
-      const url = new URL(options.endpoint);
-      if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-        return { valid: false, error: 'Endpoint must use http:// or https:// protocol' };
-      }
-    } catch {
-      return { valid: false, error: 'Endpoint must be a valid URL (e.g. https://example.com/mcp)' };
-    }
-
-    // Populate defaults for fields skipped by external endpoint flow
-    options.language ??= 'Other';
-
-    return { valid: true };
-  }
-
-  if (!options.language) {
-    return { valid: false, error: '--language is required' };
-  }
-
-  if (options.language !== 'Python' && options.language !== 'TypeScript' && options.language !== 'Other') {
-    return { valid: false, error: 'Invalid language. Valid options: Python, TypeScript, Other' };
-  }
-
-  // Validate outbound auth configuration
+  // Validate outbound auth configuration (applies to all source types)
   if (options.outboundAuthType && options.outboundAuthType !== 'NONE') {
     const hasInlineOAuth = !!(options.oauthClientId ?? options.oauthClientSecret ?? options.oauthDiscoveryUrl);
 
@@ -308,6 +280,37 @@ export async function validateAddGatewayTargetOptions(options: AddGatewayTargetO
         return credentialValidation;
       }
     }
+  }
+
+  if (options.source === 'existing-endpoint') {
+    if (options.host) {
+      return { valid: false, error: '--host is not applicable for existing endpoint targets' };
+    }
+    if (!options.endpoint) {
+      return { valid: false, error: '--endpoint is required when source is existing-endpoint' };
+    }
+
+    try {
+      const url = new URL(options.endpoint);
+      if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+        return { valid: false, error: 'Endpoint must use http:// or https:// protocol' };
+      }
+    } catch {
+      return { valid: false, error: 'Endpoint must be a valid URL (e.g. https://example.com/mcp)' };
+    }
+
+    // Populate defaults for fields skipped by external endpoint flow
+    options.language ??= 'Other';
+
+    return { valid: true };
+  }
+
+  if (!options.language) {
+    return { valid: false, error: '--language is required' };
+  }
+
+  if (options.language !== 'Python' && options.language !== 'TypeScript' && options.language !== 'Other') {
+    return { valid: false, error: 'Invalid language. Valid options: Python, TypeScript, Other' };
   }
 
   return { valid: true };


### PR DESCRIPTION
## Description

Fixes three bugs in the gateway-target CLI non-interactive path that made agentcore add gateway-target non-functional from the CLI:

Source code fixes:
- `command.tsx`: Wire `source`, `type`, and `endpoint` options through to the handler (were silently dropped, making `--source existing-endpoint --endpoint <url>` non-functional from CLI)
- `validate.ts`: Default `source` to `'existing-endpoint'` when not provided, matching TUI behavior (only supported path currently)
- `validate.ts`: Reject `--source create-new` with a clear error message instead of falling through to unimplemented code
- `validate.ts`: Move outbound auth validation before source-specific branching so credential/OAuth checks apply to existing-endpoint targets (was unreachable due to early return)

After this fix, agentcore `add gateway-target --name foo --endpoint https://example.com/mcp --gateway bar --json` works as expected. Test coverage follows in a separate PR.

## Related Issue

Closes #

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran npm run test:unit and npm run test:integ
- [x] I ran npm run typecheck
- [x] I ran npm run lint
- [ ] If I modified src/assets/, I ran npm run test:update-snapshots and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.