### PR TITLE
fix: prevent CI runs from cancelling each other on main

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,17 +2,17 @@ name: Build and Test
 
 on:
   push:
-    branches: ['main', 'feat/gateway-integration']
+    branches: ['main']
   pull_request:
-    branches: ['main', 'feat/gateway-integration']
+    branches: ['main']
 
 permissions:
   contents: read
 
-# Cancel in-progress runs when a new commit is pushed
+# Cancel in-progress runs for PRs; never cancel runs on main (merges should not abort each other)
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   build:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,16 +2,16 @@ name: CodeQL
 
 on:
   push:
-    branches: ['main', 'feat/gateway-integration']
+    branches: ['main']
   pull_request:
-    branches: ['main', 'feat/gateway-integration']
+    branches: ['main']
   pull_request_target:
-    branches: ['main', 'feat/gateway-integration']
+    branches: ['main']
 
-# Cancel in-progress runs when a new commit is pushed
+# Cancel in-progress runs for PRs; never cancel runs on main (merges should not abort each other)
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   analyze:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -6,7 +6,7 @@ on:
         description: 'AWS region for deployment'
         default: 'us-east-1'
   pull_request_target:
-    branches: [main, feat/gateway-integration]
+    branches: [main]
 
 concurrency:
   group: e2e-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,17 +2,17 @@ name: Quality and Safety Checks
 
 on:
   push:
-    branches: ['main', 'feat/gateway-integration']
+    branches: ['main']
   pull_request:
-    branches: ['main', 'feat/gateway-integration']
+    branches: ['main']
 
 permissions:
   contents: read
 
-# Cancel in-progress runs when a new commit is pushed
+# Cancel in-progress runs for PRs; never cancel runs on main (merges should not abort each other)
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   setup:

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -4,7 +4,7 @@ name: PR Size Check and Label
 # Safe because this workflow only reads PR metadata — it never checks out untrusted code.
 on:
   pull_request_target:
-    branches: [main, feat/gateway-integration]
+    branches: [main]
 
 jobs:
   label-size:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -2,7 +2,7 @@ name: Validate PR Title
 
 on:
   pull_request_target:
-    branches: [main, feat/gateway-integration]
+    branches: [main]
     types: [opened, edited, synchronize, reopened]
 
 permissions:


### PR DESCRIPTION
## Summary

- Change `cancel-in-progress` from unconditional `true` to `${{ github.ref != 'refs/heads/main' }}` in **codeql**, **build-and-test**, and **lint** workflows
- Remove stale `feat/gateway-integration` branch from all 6 workflow triggers (branch was merged and deleted)

**Root cause**: When two PRs merge to main in quick succession, both trigger push events with the same concurrency group (`workflow-refs/heads/main`). With `cancel-in-progress: true`, the second run cancels the first — causing CodeQL (or build/lint) to show as cancelled/failed.

The fix preserves cancellation for PR branches (where it's useful to skip superseded commits) while letting main branch runs complete independently.

## Test plan

- [x] Pre-commit hooks pass (prettier, secretlint, typecheck)
- [ ] Merge two PRs back-to-back and verify both CI runs complete on main