### PR TITLE
ci: auto-run E2E tests for authorized team members

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -17,7 +17,33 @@ permissions:
   contents: read
 
 jobs:
+  authorize:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request_target'
+    outputs:
+      is_authorized: ${{ steps.check.outputs.is_authorized }}
+    steps:
+      - name: Check authorization
+        id: check
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "✅ Manual workflow dispatch — authorized"
+            echo "is_authorized=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          AUTHORIZED_USERS="${{ secrets.AUTHORIZED_USERS }}"
+          if [[ ",$AUTHORIZED_USERS," == *",${{ github.actor }},"* ]]; then
+            echo "✅ User ${{ github.actor }} is authorized"
+            echo "is_authorized=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "⏭️ User ${{ github.actor }} is not in AUTHORIZED_USERS — skipping E2E tests."
+            echo "ℹ️ External contributors: ask a maintainer to run the E2E tests manually via workflow_dispatch."
+            echo "is_authorized=false" >> "$GITHUB_OUTPUT"
+          fi
+
   e2e:
+    needs: authorize
+    if: needs.authorize.outputs.is_authorized == 'true'
     runs-on: ubuntu-latest
     environment: e2e-testing
     timeout-minutes: 30


### PR DESCRIPTION
## Summary
- Add an `authorize` job to the E2E test workflow that checks `github.actor` against the `AUTHORIZED_USERS` secret (reusing the existing pattern from `agent-restricted.yml`)
- Team member PRs to `main` auto-trigger E2E tests without manual approval
- External/unauthorized contributors get a clear skip message directing them to request a manual run via `workflow_dispatch`

## Changes
- **New `authorize` job**: lightweight string check against `AUTHORIZED_USERS` secret (no environment needed — repo-level secret)
- **`e2e` job** now depends on `authorize` via `needs: authorize` and `if: needs.authorize.outputs.is_authorized == 'true'`
- `workflow_dispatch` runs are auto-authorized (they already require repo write access)

## Test plan
- [x] Open a PR from an authorized user → E2E tests should auto-trigger
- [x] Open a PR from an external contributor → workflow should skip E2E with a message
- [x] Manual `workflow_dispatch` → should still work as before