### PR TITLE
fix: hide logs and traces commands from TUI

### DIFF
--- a/src/cli/tui/utils/commands.ts
+++ b/src/cli/tui/utils/commands.ts
@@ -11,7 +11,7 @@ export interface CommandMeta {
 /**
  * Commands hidden from TUI help but still available via CLI.
  */
-const HIDDEN_FROM_TUI = ['help', 'update', 'package'] as const;
+const HIDDEN_FROM_TUI = ['help', 'update', 'package', 'logs', 'traces'] as const;
 
 /**
  * Commands hidden from TUI when inside an existing project.


### PR DESCRIPTION
## Description

Hide the `logs` and `traces` commands from the TUI interactive experience. Both commands currently render a `PlaceholderScreen` with a "TODO: implement" message, which is not useful for users. They remain fully accessible via the CLI (`agentcore logs`, `agentcore traces`).

The change adds `'logs'` and `'traces'` to the `HIDDEN_FROM_TUI` list in `src/cli/tui/utils/commands.ts`, which filters them from `getCommandsForUI()`.

## Related Issue

N/A

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.