### PR TITLE
fix: conditionally show invoke in deploy next steps only when agents exist

### DIFF
--- a/src/cli/tui/screens/deploy/DeployScreen.tsx
+++ b/src/cli/tui/screens/deploy/DeployScreen.tsx
@@ -32,10 +32,18 @@ interface DeployScreenProps {
 }
 
 /** Next steps shown after successful deployment */
-const DEPLOY_NEXT_STEPS: NextStep[] = [
-  { command: 'invoke', label: 'Test your agent' },
-  { command: 'status', label: 'View deployment status' },
-];
+function getDeployNextSteps(hasAgents: boolean): NextStep[] {
+  if (hasAgents) {
+    return [
+      { command: 'invoke', label: 'Test your agent' },
+      { command: 'status', label: 'View deployment status' },
+    ];
+  }
+  return [
+    { command: 'add', label: 'Add an agent' },
+    { command: 'status', label: 'View deployment status' },
+  ];
+}
 
 export function DeployScreen({ isInteractive, onExit, autoConfirm, onNavigate, preSynthesized }: DeployScreenProps) {
   const awsConfig = useAwsTargetConfig();
@@ -287,7 +295,7 @@ export function DeployScreen({ isInteractive, onExit, autoConfirm, onNavigate, p
 
       {allSuccess && (
         <NextSteps
-          steps={DEPLOY_NEXT_STEPS}
+          steps={getDeployNextSteps((context?.projectSpec.agents.length ?? 0) > 0)}
           isInteractive={isInteractive}
           onSelect={step => {
             if (step.command === 'invoke') {


### PR DESCRIPTION
## Description

The TUI deploy screen always showed `invoke` as a next step after deployment, even when no agents were configured (e.g., memory-only projects). This was misleading since there's nothing to invoke without an agent.

Changed `DEPLOY_NEXT_STEPS` from a static constant to a function `getDeployNextSteps(hasAgents)` that checks `context.projectSpec.agents` to determine the appropriate next steps. When no agents exist, it now shows "Add an agent" instead of "invoke". This aligns TUI behavior with the CLI deploy path (`actions.ts`) which already handled this correctly.

## Related Issue

Closes #507

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.