### PR TITLE
docs: update help text and docs for all gateway target types

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -188,21 +188,21 @@ agentcore add gateway \
 
 ### add gateway-target
 
-Add a gateway target to the project. Targets are backend tools exposed through a gateway as an external MCP server
-endpoint.
+Add a gateway target to the project. Targets are backend tools exposed through a gateway. Supports five target types:
+`mcp-server`, `api-gateway`, `open-api-schema`, `smithy-model`, and `lambda-function-arn`.
 
 ```bash
 # Interactive mode (select 'Gateway Target' from the menu)
 agentcore add
 
-# External MCP server endpoint
+# MCP Server endpoint
 agentcore add gateway-target \
   --name WeatherTools \
   --type mcp-server \
   --endpoint https://mcp.example.com/mcp \
   --gateway MyGateway
 
-# External endpoint with OAuth outbound auth
+# MCP Server with OAuth outbound auth
 agentcore add gateway-target \
   --name SecureTools \
   --type mcp-server \
@@ -212,22 +212,70 @@ agentcore add gateway-target \
   --oauth-client-id my-client \
   --oauth-client-secret my-secret \
   --oauth-discovery-url https://auth.example.com/.well-known/openid-configuration
+
+# API Gateway REST API
+agentcore add gateway-target \
+  --name PetStore \
+  --type api-gateway \
+  --rest-api-id abc123 \
+  --stage prod \
+  --tool-filter-path '/pets/*' \
+  --tool-filter-methods GET,POST \
+  --gateway MyGateway
+
+# OpenAPI Schema (auto-derive tools from spec)
+agentcore add gateway-target \
+  --name PetStoreAPI \
+  --type open-api-schema \
+  --schema specs/petstore.json \
+  --gateway MyGateway \
+  --outbound-auth oauth \
+  --credential-name MyOAuth
+
+# Smithy Model (auto-derive tools from model)
+agentcore add gateway-target \
+  --name MyService \
+  --type smithy-model \
+  --schema models/service.json \
+  --gateway MyGateway
+
+# Lambda Function ARN
+agentcore add gateway-target \
+  --name MyLambdaTools \
+  --type lambda-function-arn \
+  --lambda-arn arn:aws:lambda:us-east-1:123456789012:function:my-func \
+  --tool-schema-file tools.json \
+  --gateway MyGateway
 ```
 
-| Flag                             | Description                                     |
-| -------------------------------- | ----------------------------------------------- |
-| `--name <name>`                  | Target name                                     |
-| `--description <desc>`           | Target description                              |
-| `--type <type>`                  | Target type (required): `mcp-server`            |
-| `--endpoint <url>`               | MCP server endpoint URL                         |
-| `--gateway <name>`               | Gateway to attach target to                     |
-| `--outbound-auth <type>`         | `oauth`, `api-key`, or `none`                   |
-| `--credential-name <name>`       | Existing credential name for outbound auth      |
-| `--oauth-client-id <id>`         | OAuth client ID (creates credential inline)     |
-| `--oauth-client-secret <secret>` | OAuth client secret (creates credential inline) |
-| `--oauth-discovery-url <url>`    | OAuth discovery URL (creates credential inline) |
-| `--oauth-scopes <scopes>`        | OAuth scopes, comma-separated                   |
-| `--json`                         | JSON output                                     |
+| Flag                              | Description                                                                                                   |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `--name <name>`                   | Target name                                                                                                   |
+| `--description <desc>`            | Target description                                                                                            |
+| `--type <type>`                   | Target type (required): `mcp-server`, `api-gateway`, `open-api-schema`, `smithy-model`, `lambda-function-arn` |
+| `--endpoint <url>`                | MCP server endpoint URL (mcp-server)                                                                          |
+| `--language <lang>`               | Implementation language: Python, TypeScript, Other (mcp-server)                                               |
+| `--host <host>`                   | Compute host: Lambda or AgentCoreRuntime (mcp-server)                                                         |
+| `--gateway <name>`                | Gateway to attach target to                                                                                   |
+| `--outbound-auth <type>`          | `oauth`, `api-key`, or `none` (varies by target type)                                                         |
+| `--credential-name <name>`        | Existing credential name for outbound auth                                                                    |
+| `--oauth-client-id <id>`          | OAuth client ID (creates credential inline)                                                                   |
+| `--oauth-client-secret <secret>`  | OAuth client secret (creates credential inline)                                                               |
+| `--oauth-discovery-url <url>`     | OAuth discovery URL (creates credential inline)                                                               |
+| `--oauth-scopes <scopes>`         | OAuth scopes, comma-separated                                                                                 |
+| `--rest-api-id <id>`              | API Gateway REST API ID (api-gateway)                                                                         |
+| `--stage <stage>`                 | API Gateway stage name (api-gateway)                                                                          |
+| `--tool-filter-path <path>`       | Filter API paths, supports wildcards (api-gateway)                                                            |
+| `--tool-filter-methods <methods>` | Comma-separated HTTP methods to expose (api-gateway)                                                          |
+| `--schema <path>`                 | Path to schema file, relative to project root (open-api-schema, smithy-model)                                 |
+| `--schema-s3-account <account>`   | AWS account for S3-hosted schema (open-api-schema, smithy-model)                                              |
+| `--lambda-arn <arn>`              | Lambda function ARN (lambda-function-arn)                                                                     |
+| `--tool-schema-file <path>`       | Tool schema file, relative to project root or absolute path (lambda-function-arn)                             |
+| `--json`                          | JSON output                                                                                                   |
+
+> **Note**: `smithy-model` and `lambda-function-arn` use IAM role auth and do not support `--outbound-auth`.
+> `open-api-schema` requires `--outbound-auth` (`oauth` or `api-key`). `api-gateway` supports `api-key` or `none`.
+> `mcp-server` supports `oauth` or `none`.
 
 ### add identity
 

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -34,8 +34,13 @@ The generated agent code includes gateway client setup, authentication, and envi
 
 ## Gateway Targets
 
-A gateway target is a backend tool exposed through a gateway — an external MCP server endpoint that the gateway proxies
-requests to.
+A gateway target is a backend tool source exposed through a gateway. The gateway proxies requests to the target and
+handles tool discovery and authentication. There are five target types.
+
+### MCP Server (`mcp-server`)
+
+Connect to an external MCP server endpoint, or deploy a managed MCP server on Lambda/AgentCoreRuntime
+(Python/TypeScript).
 
 ```bash
 agentcore add gateway-target \
@@ -44,6 +49,72 @@ agentcore add gateway-target \
   --endpoint https://mcp.example.com/mcp \
   --gateway my-gateway
 ```
+
+Supports outbound auth: `oauth`, `api-key`, or `none`.
+
+### API Gateway REST API (`api-gateway`)
+
+Connect to an existing Amazon API Gateway REST API. The gateway auto-discovers tools from API routes.
+
+```bash
+agentcore add gateway-target \
+  --type api-gateway \
+  --name PetStore \
+  --rest-api-id abc123 \
+  --stage prod \
+  --tool-filter-path '/pets/*' \
+  --tool-filter-methods GET,POST \
+  --gateway my-gateway
+```
+
+Supports outbound auth: `api-key` or `none`. OAuth is not supported for API Gateway targets.
+
+### OpenAPI Schema (`open-api-schema`)
+
+Auto-derive tools from an OpenAPI JSON specification file.
+
+```bash
+agentcore add gateway-target \
+  --type open-api-schema \
+  --name PetStoreAPI \
+  --schema specs/petstore.json \
+  --gateway my-gateway \
+  --outbound-auth oauth \
+  --credential-name MyOAuth
+```
+
+Outbound auth is required (`oauth` or `api-key`). Schema path is relative to project root.
+
+### Smithy Model (`smithy-model`)
+
+Auto-derive tools from a Smithy JSON model file.
+
+```bash
+agentcore add gateway-target \
+  --type smithy-model \
+  --name MyService \
+  --schema models/service.json \
+  --gateway my-gateway
+```
+
+Uses IAM role auth — no outbound auth needed. Schema path is relative to project root.
+
+### Lambda Function ARN (`lambda-function-arn`)
+
+Connect to an existing AWS Lambda function by ARN. Tools are defined via a JSON schema file rather than code
+scaffolding.
+
+```bash
+agentcore add gateway-target \
+  --type lambda-function-arn \
+  --name MyLambdaTools \
+  --lambda-arn arn:aws:lambda:us-east-1:123456789012:function:my-func \
+  --tool-schema-file tools.json \
+  --gateway my-gateway
+```
+
+Uses IAM role auth exclusively — no outbound auth is allowed. The tool schema file path is relative to project root (or
+an absolute path) and is uploaded to S3 during deployment.
 
 ## Authentication
 
@@ -75,13 +146,14 @@ credential that your agent uses to obtain Bearer tokens at runtime.
 
 ### Outbound Authentication
 
-Controls how the gateway authenticates with upstream MCP servers. Configured per target.
+Controls how the gateway authenticates with upstream targets. Configured per target.
 
-| Type      | Description                    |
-| --------- | ------------------------------ |
-| `none`    | No outbound authentication     |
-| `oauth`   | OAuth2 client credentials flow |
-| `api-key` | API key passed to upstream     |
+| Type      | Description                    | Supported Target Types                        |
+| --------- | ------------------------------ | --------------------------------------------- |
+| `none`    | No outbound authentication     | mcp-server, api-gateway                       |
+| `oauth`   | OAuth2 client credentials flow | mcp-server, open-api-schema                   |
+| `api-key` | API key passed to upstream     | api-gateway, open-api-schema                  |
+| IAM role  | Automatic IAM role auth        | smithy-model, lambda-function-arn (exclusive) |
 
 #### OAuth Outbound Auth
 

--- a/src/cli/primitives/GatewayTargetPrimitive.ts
+++ b/src/cli/primitives/GatewayTargetPrimitive.ts
@@ -243,7 +243,10 @@ export class GatewayTargetPrimitive extends BasePrimitive<AddGatewayTargetOption
       .description('Add a gateway target to the project')
       .option('--name <name>', 'Target name')
       .option('--description <desc>', 'Target description')
-      .option('--type <type>', 'Target type (required): mcp-server, api-gateway, lambda-function-arn')
+      .option(
+        '--type <type>',
+        'Target type (required): mcp-server, api-gateway, open-api-schema, smithy-model, lambda-function-arn'
+      )
       .option('--endpoint <url>', 'MCP server endpoint URL')
       .option('--language <lang>', 'Language: Python, TypeScript, Other')
       .option('--gateway <name>', 'Gateway name')


### PR DESCRIPTION
## Description

Update CLI help text and documentation to cover all 5 gateway target types that are now supported:

- `mcp-server` — external MCP server endpoints
- `api-gateway` — existing Amazon API Gateway REST APIs
- `open-api-schema` — auto-derive tools from OpenAPI JSON specs
- `smithy-model` — auto-derive tools from Smithy JSON models
- `lambda-function-arn` — connect to existing Lambda functions by ARN

Changes:
- Fix `--type` help text in `GatewayTargetPrimitive.ts` to list all 5 types (was missing `open-api-schema` and `smithy-model`)
- Update `docs/commands.md`: add CLI examples for all target types, complete flags table (22 flags) with per-type applicability notes, auth compatibility note
- Update `docs/gateway.md`: add subsections for each target type with CLI examples, auth support notes, and path resolution details. Update outbound auth table with "Supported Target Types" column including IAM role row.

## Related Issue


## Type of Change

- [x] Documentation update

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published