### PR TITLE
fix: default srcDir to project root instead of non-existent src/ subdirectory

### DIFF
--- a/src/lib/packaging/__tests__/helpers.test.ts
+++ b/src/lib/packaging/__tests__/helpers.test.ts
@@ -247,9 +247,9 @@ describe('resolveProjectPaths', () => {
 
   beforeAll(() => {
     root = mkdtempSync(join(tmpdir(), 'helpers-resolve-'));
-    // Create a minimal project structure with pyproject.toml
+    // Create a minimal project structure with pyproject.toml (source files live alongside it)
     writeFileSync(join(root, 'pyproject.toml'), '[project]\nname = "test"');
-    mkdirSync(join(root, 'src'), { recursive: true });
+    writeFileSync(join(root, 'main.py'), 'print("hello")');
   });
 
   afterAll(() => {
@@ -260,7 +260,7 @@ describe('resolveProjectPaths', () => {
     const paths = await resolveProjectPaths({ projectRoot: root });
     expect(paths.projectRoot).toBe(root);
     expect(paths.pyprojectPath).toBe(join(root, 'pyproject.toml'));
-    expect(paths.srcDir).toBe(join(root, 'src'));
+    expect(paths.srcDir).toBe(root);
   });
 
   it('uses agent name for build directory', async () => {

--- a/src/lib/packaging/helpers.ts
+++ b/src/lib/packaging/helpers.ts
@@ -122,7 +122,7 @@ export async function resolveProjectPaths(options: PackageOptions = {}, agentNam
   const pyprojectPath = candidatePyproject;
 
   const projectRoot = options.projectRoot ? resolve(options.projectRoot) : dirname(pyprojectPath);
-  const srcDir = resolve(projectRoot, options.srcDir ?? 'src');
+  const srcDir = resolve(projectRoot, options.srcDir ?? '.');
   const artifactDir = resolve(options.artifactDir ?? join(projectRoot, CONFIG_DIR));
 
   // Simplified staging structure: <artifactDir>/<name>/staging
@@ -261,7 +261,7 @@ export function resolveProjectPathsSync(options: PackageOptions = {}, agentName?
 
   const pyprojectPath = candidatePyproject;
   const projectRoot = options.projectRoot ? resolve(options.projectRoot) : dirname(pyprojectPath);
-  const srcDir = resolve(projectRoot, options.srcDir ?? 'src');
+  const srcDir = resolve(projectRoot, options.srcDir ?? '.');
   const artifactDir = resolve(options.artifactDir ?? join(projectRoot, CONFIG_DIR));
 
   // Simplified staging structure: <artifactDir>/<name>/staging


### PR DESCRIPTION
## Description

The `agentcore package` command fails with `Error: Required project file not found: .../app/MyAgent/src` because `resolveProjectPaths` and `resolveProjectPathsSync` in `helpers.ts` default `srcDir` to `'src'` relative to the agent's code directory. However, all agent templates (Strands, LangChain, CrewAI, GoogleADK, OpenAIAgents) place source files directly in the agent directory (e.g. `app/MyAgent/main.py`), not in a `src/` subdirectory.

The fix changes the default from `'src'` to `'.'` so that `srcDir` correctly resolves to the agent code directory itself. The `srcDir` option in `PackageOptions` still allows callers to override this if needed.

## Related Issue

Closes #311

## Documentation PR

N/A — no documentation changes needed.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

End-to-end manual testing:

- `agentcore create --name TestAgent --defaults` → `agentcore package` → produces valid zip with `main.py`, `model/`, `mcp_client/` at the root
- `agentcore create` with `--framework LangChain_LangGraph` → `agentcore package` → produces valid zip
- Added a second agent via `agentcore add agent` → `agentcore package` → both agents packaged successfully
- `agentcore package --agent <name>` → works for individual agent targeting
- `agentcore validate` → passes on all test projects

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.