### PR TITLE
fix: correct managed OAuth credential name lookup for gateway MCP clients

### DIFF
--- a/src/cli/operations/agent/generate/__tests__/schema-mapper.test.ts
+++ b/src/cli/operations/agent/generate/__tests__/schema-mapper.test.ts
@@ -1,3 +1,4 @@
+import { computeManagedOAuthCredentialName } from '../../../../primitives/credential-utils.js';
 import type { GenerateConfig } from '../../../../tui/screens/generate/types.js';
 import {
   mapGenerateConfigToAgent,
@@ -192,21 +193,11 @@ describe('mapGenerateConfigToRenderConfig', () => {
 });
 
 describe('gateway credential provider name mapping', () => {
-  it('uses the correct credential name suffix (-oauth) matching GatewayPrimitive creation', async () => {
-    // Regression test: credential is created as `${gatewayName}-oauth` by GatewayPrimitive,
-    // so the lookup in mapGatewaysToGatewayProviders must use the same suffix.
-    // Previously used '-agent-oauth' which caused provider_name="" in generated code.
-    //
-    // We verify this by checking the source code directly since ConfigIO requires
-    // a full build environment to import.
-
-    const fs = await import('node:fs');
-    const path = await import('node:path');
-    const schemaMapperPath = path.resolve(import.meta.dirname ?? __dirname, '../schema-mapper.ts');
-    const source = fs.readFileSync(schemaMapperPath, 'utf-8');
-
-    // The credential lookup must use `${gateway.name}-oauth` (not `-agent-oauth`)
-    expect(source).toContain('`${gateway.name}-oauth`');
-    expect(source).not.toContain('-agent-oauth');
+  it('computeManagedOAuthCredentialName produces the correct suffix', () => {
+    // Regression test: the managed credential name must use '-oauth' suffix.
+    // GatewayPrimitive creates it, schema-mapper looks it up, AddGatewayScreen displays it.
+    // All three now use computeManagedOAuthCredentialName to stay in sync.
+    expect(computeManagedOAuthCredentialName('my-gateway')).toBe('my-gateway-oauth');
+    expect(computeManagedOAuthCredentialName('test')).toBe('test-oauth');
   });
 });

--- a/src/cli/operations/agent/generate/schema-mapper.ts
+++ b/src/cli/operations/agent/generate/schema-mapper.ts
@@ -11,7 +11,10 @@ import type {
 } from '../../../../schema';
 import { DEFAULT_STRATEGY_NAMESPACES } from '../../../../schema';
 import { GatewayPrimitive } from '../../../primitives/GatewayPrimitive';
-import { computeDefaultCredentialEnvVarName } from '../../../primitives/credential-utils';
+import {
+  computeDefaultCredentialEnvVarName,
+  computeManagedOAuthCredentialName,
+} from '../../../primitives/credential-utils';
 import type {
   AgentRenderConfig,
   GatewayProviderRenderConfig,
@@ -199,7 +202,7 @@ async function mapGatewaysToGatewayProviders(): Promise<GatewayProviderRenderCon
 
       if (gateway.authorizerType === 'CUSTOM_JWT' && gateway.authorizerConfiguration?.customJwtAuthorizer) {
         const jwtConfig = gateway.authorizerConfiguration.customJwtAuthorizer;
-        const credName = `${gateway.name}-oauth`;
+        const credName = computeManagedOAuthCredentialName(gateway.name);
         const credential = project.credentials.find(c => c.name === credName);
 
         if (credential) {

--- a/src/cli/primitives/GatewayPrimitive.ts
+++ b/src/cli/primitives/GatewayPrimitive.ts
@@ -8,7 +8,7 @@ import type { RemovalPreview, RemovalResult, SchemaChange } from '../operations/
 import type { AddGatewayConfig } from '../tui/screens/mcp/types';
 import { BasePrimitive } from './BasePrimitive';
 import { SOURCE_CODE_NOTE } from './constants';
-import { computeDefaultCredentialEnvVarName } from './credential-utils';
+import { computeDefaultCredentialEnvVarName, computeManagedOAuthCredentialName } from './credential-utils';
 import type { AddResult, AddScreenComponent, RemovableResource } from './types';
 import type { Command } from '@commander-js/extra-typings';
 
@@ -379,7 +379,7 @@ export class GatewayPrimitive extends BasePrimitive<AddGatewayOptions, Removable
     gatewayName: string,
     jwtConfig: NonNullable<AddGatewayConfig['jwtConfig']>
   ): Promise<void> {
-    const credentialName = `${gatewayName}-oauth`;
+    const credentialName = computeManagedOAuthCredentialName(gatewayName);
     const project = await this.readProjectSpec();
 
     // Skip if credential already exists

--- a/src/cli/primitives/credential-utils.ts
+++ b/src/cli/primitives/credential-utils.ts
@@ -6,3 +6,12 @@
 export function computeDefaultCredentialEnvVarName(credentialName: string): string {
   return `AGENTCORE_CREDENTIAL_${credentialName.replace(/-/g, '_').toUpperCase()}`;
 }
+
+/**
+ * Compute the managed OAuth credential name for a gateway.
+ * Used when creating the credential (GatewayPrimitive) and when
+ * looking it up for code generation (schema-mapper).
+ */
+export function computeManagedOAuthCredentialName(gatewayName: string): string {
+  return `${gatewayName}-oauth`;
+}

--- a/src/cli/tui/screens/mcp/AddGatewayScreen.tsx
+++ b/src/cli/tui/screens/mcp/AddGatewayScreen.tsx
@@ -1,5 +1,6 @@
 import type { GatewayAuthorizerType } from '../../../../schema';
 import { GatewayNameSchema } from '../../../../schema';
+import { computeManagedOAuthCredentialName } from '../../../primitives/credential-utils';
 import {
   ConfirmReview,
   Panel,
@@ -272,7 +273,7 @@ export function AddGatewayScreen({ onComplete, onExit, existingGateways, unassig
                       ? [{ label: 'Allowed Scopes', value: wizard.config.jwtConfig.allowedScopes.join(', ') }]
                       : []),
                     ...(wizard.config.jwtConfig.agentClientId
-                      ? [{ label: 'Agent Credential', value: `${wizard.config.name}-oauth` }]
+                      ? [{ label: 'Agent Credential', value: computeManagedOAuthCredentialName(wizard.config.name) }]
                       : []),
                   ]
                 : []),


### PR DESCRIPTION
## Description

Fixed a credential name mismatch that caused agent runtimes to crash when connecting to gateways with CUSTOM_JWT auth.

When a gateway with CUSTOM_JWT auth is created, the CLI creates a managed OAuth credential with the suffix `-oauth` (e.g. `my-gateway-oauth`). However, when generating the MCP client code for the agent, `schema-mapper.ts` looked up the credential using the suffix `-agent-oauth` (e.g. `my-gateway-agent-oauth`). This lookup failed silently, resulting in an empty `provider_name` in the generated `@requires_access_token` decorator.

At runtime, the agent crashed with:

botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid length for parameter resourceCredentialProviderName, value: 0, valid min length: 1

The fix aligns the lookup suffix in `schema-mapper.ts` and the UI preview in `AddGatewayScreen.tsx` to match the creation suffix (`-oauth`). Added a regression test to prevent future naming drift.

## Related Issue

Closes #544

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.