### PR TITLE
feat: unhide gateway and gateway-target CLI commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,10 +47,6 @@ Note: CDK L3 constructs are in a separate package `@aws/agentcore-cdk`.
 - **Container**: Agent is built as a Docker container image, deployed via ECR and CodeBuild. Requires a `Dockerfile` in
   the agent's code directory. Supported container runtimes: Docker, Podman, Finch.
 
-### Coming Soon
-
-- MCP gateway and tool support (`add gateway`, `add mcp-tool`) - currently hidden
-
 ## Primitives Architecture
 
 All resource types (agent, memory, identity, gateway, mcp-tool) are modeled as **primitives** — self-contained classes
@@ -64,8 +60,8 @@ Current primitives:
 - `AgentPrimitive` — agent creation (template + BYO), removal, credential resolution
 - `MemoryPrimitive` — memory creation with strategies, removal
 - `CredentialPrimitive` — credential/identity creation, .env management, removal
-- `GatewayPrimitive` — MCP gateway creation/removal (hidden, coming soon)
-- `GatewayTargetPrimitive` — MCP tool creation/removal with code generation (hidden, coming soon)
+- `GatewayPrimitive` — MCP gateway creation/removal
+- `GatewayTargetPrimitive` — MCP tool creation/removal with code generation
 
 Singletons are created in `registry.ts` and wired into CLI commands via `cli.ts`. See `src/cli/AGENTS.md` for details on
 adding new primitives.

--- a/src/cli/primitives/GatewayPrimitive.ts
+++ b/src/cli/primitives/GatewayPrimitive.ts
@@ -146,7 +146,7 @@ export class GatewayPrimitive extends BasePrimitive<AddGatewayOptions, Removable
 
   registerCommands(addCmd: Command, removeCmd: Command): void {
     addCmd
-      .command('gateway', { hidden: true })
+      .command('gateway')
       .description('Add a gateway to the project')
       .option('--name <name>', 'Gateway name')
       .option('--description <desc>', 'Gateway description')
@@ -214,7 +214,7 @@ export class GatewayPrimitive extends BasePrimitive<AddGatewayOptions, Removable
       });
 
     removeCmd
-      .command('gateway', { hidden: true })
+      .command('gateway')
       .description('Remove a gateway from the project')
       .option('--name <name>', 'Name of resource to remove')
       .option('--force', 'Skip confirmation prompt')

--- a/src/cli/primitives/GatewayTargetPrimitive.ts
+++ b/src/cli/primitives/GatewayTargetPrimitive.ts
@@ -239,7 +239,7 @@ export class GatewayTargetPrimitive extends BasePrimitive<AddGatewayTargetOption
 
   registerCommands(addCmd: Command, removeCmd: Command): void {
     addCmd
-      .command('gateway-target', { hidden: true })
+      .command('gateway-target')
       .description('Add a gateway target to the project')
       .option('--name <name>', 'Target name')
       .option('--description <desc>', 'Target description')
@@ -457,7 +457,7 @@ export class GatewayTargetPrimitive extends BasePrimitive<AddGatewayTargetOption
       });
 
     removeCmd
-      .command('gateway-target', { hidden: true })
+      .command('gateway-target')
       .description('Remove a gateway target from the project')
       .option('--name <name>', 'Name of resource to remove')
       .option('--force', 'Skip confirmation prompt')


### PR DESCRIPTION
## Description

Remove `{ hidden: true }` from the `gateway` and `gateway-target` Commander subcommand registrations in `GatewayPrimitive.ts` and `GatewayTargetPrimitive.ts`. This makes both commands visible in `agentcore add --help` and `agentcore remove --help` output. Updates `AGENTS.md` to reflect that these primitives are no longer hidden/coming soon.

## Related Issue

Closes #

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

Verified manually:
```
$ agentcore add --help
Commands:
  agent [options]           Add an agent to the project
  memory [options]          Add a memory to the project
  identity [options]        Add an identity (credential) to the project
  gateway [options]         Add a gateway to the project
  gateway-target [options]  Add a gateway target to the project
```

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.