### PR TITLE
chore: Revert "chore: bump version to 0.3.0-preview.7.0 (#569)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,6 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.3.0-preview.7.0] - 2026-03-19
-
-### Added
-- feat: introduce evaluation feature (#518) (d970e26)
-- feat: add TUI agent harness with MCP server (#548) (c51b1e2)
-- feat: dev and invoke support for MCP and A2A protocols (#554) (c2c646c)
-- feat: unhide gateway and gateway-target CLI commands (#562) (5c8d1b4)
-- feat: add protocol mode support (HTTP, MCP, A2A) (#550) (3aaa062)
-- feat: add VPC network mode support (#545) (a61ebdd)
-
-### Fixed
-- fix: correct managed OAuth credential name lookup for gateway MCP clients (#543) (30e6a74)
-
 ## [0.3.0-preview.5.1] - 2026-03-12
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/agentcore",
-  "version": "0.3.0-preview.7.0",
+  "version": "0.3.0-preview.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/agentcore",
-      "version": "0.3.0-preview.7.0",
+      "version": "0.3.0-preview.5.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws/agentcore",
-  "version": "0.3.0-preview.7.0",
+  "version": "0.3.0-preview.5.1",
   "description": "CLI for Amazon Bedrock AgentCore",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary

- Reverts the version bump from #569 (0.3.0-preview.7.0 → 0.3.0-preview.5.1)
- Removes the auto-generated CHANGELOG entry for 7.0

## Test plan

- [ ] Verify package.json version is back to 0.3.0-preview.5.1
- [ ] CI passes