### PR TITLE
fix: bump fast-xml-parser override to 5.5.7 (CVE-2026-33036, CVE-2026-33349)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,6 @@
         "zod": "^4.3.5"
       },
       "bin": {
-        "agent-tui-harness": "dist/mcp-harness/index.mjs",
         "agentcore": "dist/cli/index.mjs"
       },
       "devDependencies": {
@@ -72,9 +71,6 @@
       },
       "engines": {
         "node": ">=20"
-      },
-      "optionalDependencies": {
-        "node-pty": "^1.1.0"
       },
       "peerDependencies": {
         "aws-cdk-lib": "^2.234.1",
@@ -8874,10 +8870,10 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/fast-xml-parser": {
-      "version": "5.3.9",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.9.tgz",
-      "integrity": "sha512-zU0KUuO9U+fLGduTDdxQ6qsQLIxRg4EK5AMduwBNGNCSfCGRSbNS7OpH343NFQlLDg1jxoH68JSbOPAGksIGvg==",
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
       "funding": [
         {
           "type": "github",
@@ -8886,7 +8882,24 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^2.1.2"
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.5.7",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.7.tgz",
+      "integrity": "sha512-LteOsISQ2GEiDHZch6L9hB0+MLoYVLToR7xotrzU0opCICBkxOPgHAy1HxAvtxfJNXDJpgAsQN30mkrfpO2Prg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.1.3",
+        "strnum": "^2.2.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -11622,6 +11635,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.1.3.tgz",
+      "integrity": "sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/path-key": {

--- a/package.json
+++ b/package.json
@@ -132,11 +132,11 @@
   },
   "overridesComments": {
     "minimatch": "GHSA-7r86-cg39-jmmj, GHSA-23c5-xmqv-rm74: minimatch 10.0.0-10.2.2 has ReDoS vulnerabilities. Multiple transitive deps (eslint, typescript-eslint, eslint-plugin-import, eslint-plugin-react, prettier-plugin-sort-imports, aws-cdk-lib) pin older versions. Remove this override once upstream packages update their minimatch dependency to >=10.2.3.",
-    "fast-xml-parser": "GHSA-fj3w-jwp8-x2g3: fast-xml-parser <5.3.8 has stack overflow in XMLBuilder. Transitive via @aws-sdk/xml-builder. Remove this override once @aws-sdk updates to fast-xml-parser >=5.3.8."
+    "fast-xml-parser": "GHSA-8gc5-j5rx-235r, GHSA-jp2q-39xq-3w4g: fast-xml-parser <=5.5.6 has entity expansion bypass (CVE-2026-33036, CVE-2026-33349). Transitive via @aws-sdk/xml-builder. Remove once @aws-sdk updates to fast-xml-parser >=5.5.7."
   },
   "overrides": {
     "minimatch": "10.2.4",
-    "fast-xml-parser": "5.3.9"
+    "fast-xml-parser": "5.5.7"
   },
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
## Description

CI `security:audit` step fails due to two high-severity CVEs in `fast-xml-parser`:
- [GHSA-8gc5-j5rx-235r](https://github.com/advisories/GHSA-8gc5-j5rx-235r) (CVE-2026-33036): numeric entity expansion bypasses all entity expansion limits (affects `<= 5.5.5`)
- [GHSA-jp2q-39xq-3w4g](https://github.com/advisories/GHSA-jp2q-39xq-3w4g) (CVE-2026-33349): entity expansion limits bypassed when set to zero due to JavaScript falsy evaluation (affects `<= 5.5.6`)

The existing npm override pins `fast-xml-parser` to `5.3.9`, which is in the vulnerable range. The override is needed because `@aws-sdk/xml-builder` hasn't updated its `fast-xml-parser` dependency yet. Bumps the override from `5.3.9` → `5.5.7` (the patched version). The repo doesn't use `fast-xml-parser` directly — it's purely a transitive dependency of `@aws-sdk/xml-builder`. No breaking API changes in the `5.3 → 5.5` range.

## Related Issue

N/A — CI security audit failure, no tracking issue.

## Documentation PR

N/A

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:unit` and `npm run test:integ`
- [X] I ran `npm run typecheck`
- [X] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

`npm run security:audit` (`npm audit --audit-level=high --omit=dev`) passes with 0 vulnerabilities.

## Checklist

- [X] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.