### PR TITLE
fix: align aws-cdk-lib peer dependency with @aws/agentcore-cdk ^2.243.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "zod": "^4.3.5"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.234.1",
+    "aws-cdk-lib": "^2.243.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
@@ -108,7 +108,7 @@
     "@typescript-eslint/parser": "^8.50.0",
     "@vitest/coverage-v8": "^4.0.18",
     "@xterm/headless": "^6.0.0",
-    "aws-cdk-lib": "^2.240.0",
+    "aws-cdk-lib": "^2.243.0",
     "constructs": "^10.4.4",
     "esbuild": "^0.27.2",
     "eslint": "^9.39.4",


### PR DESCRIPTION
## Summary
- Bumps `aws-cdk-lib` peer dependency from `^2.234.1` to `^2.243.0` to match `@aws/agentcore-cdk`
- Bumps `aws-cdk-lib` dev dependency from `^2.240.0` to `^2.243.0` for consistency
- Fixes unresolvable dependency conflicts customers hit when installing both `@aws/agentcore` and `@aws/agentcore-cdk`

## Problem
`@aws/agentcore-cdk` requires `aws-cdk-lib ^2.243.0` (for the `aws-bedrockagentcore` CloudFormation module), but the CLI declared `^2.234.1`. A customer with e.g. `aws-cdk-lib@2.240.0` would satisfy the CLI's constraint but fail the CDK constructs package — npm cannot resolve both, producing an unresolvable peer dependency error.

## Test plan
- [x] `npm run typecheck` passes
- [x] `prettier --check` passes
- [ ] Verify `npm install` resolves cleanly in a fresh project depending on both `@aws/agentcore` and `@aws/agentcore-cdk`