### PR TITLE
ci: run full e2e suite on every push to main

### DIFF
--- a/.github/workflows/e2e-tests-full.yml
+++ b/.github/workflows/e2e-tests-full.yml
@@ -1,4 +1,4 @@
-name: E2E Tests (Weekly Full Suite)
+name: E2E Tests (Full Suite)
 on:
   workflow_dispatch:
     inputs:
@@ -7,6 +7,8 @@ on:
         default: 'us-east-1'
   schedule:
     - cron: '0 14 * * 1' # Every Monday at 9 AM EST (14:00 UTC)
+  push:
+    branches: [main]
 
 concurrency:
   group: e2e-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Description

Run the full E2E test suite on every push to main, not just weekly. This catches regressions before release instead of discovering them on the next Monday scheduled run.

The change adds a `push: branches: [main]` trigger to the existing `e2e-tests-weekly.yml` workflow. No other changes needed — the workflow already checks out `main`, has no auth gate, and uses a 60-minute timeout suitable for the full suite.

## Related Issue

N/A — CI improvement

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe): CI workflow improvement

## Testing

- The workflow change is a single trigger addition. Validated that the YAML is well-formed via pre-commit (prettier + secretlint passed).
- The concurrency group (`e2e-${{ github.ref }}`) ensures push-to-main runs queue sequentially rather than canceling each other.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes generate no new warnings
