### PR TITLE
ci: add package install sanity check to build-and-test

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -50,6 +50,15 @@ jobs:
       - name: Pack tarball
         if: matrix.node-version == '20.x'
         run: npm pack
+      - name: Install from tarball
+        if: matrix.node-version == '20.x'
+        run: npm install -g aws-agentcore-*.tgz
+      - name: Verify packaged CLI runs
+        if: matrix.node-version == '20.x'
+        run: |
+          agentcore --version
+          agentcore create --name sanitytest --language Python --framework Strands --model-provider Bedrock --memory none --json
+          test -f sanitytest/agentcore/agentcore.json
       - name: Upload tarball artifact
         if: matrix.node-version == '20.x'
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Description

Add a package install sanity check to the build-and-test workflow. After `npm pack`, the CI now installs the tarball globally and verifies the CLI boots and can scaffold a project. Catches packaging regressions (missing files, broken bin shims, miscategorized deps) before merge.

## Related Issue

Closes #591

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe): CI improvement

## Testing

The workflow itself is the test — it verifies the packaged tarball installs and runs correctly (`agentcore --version`, `agentcore create`).

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.