### PR TITLE
fix: add @aws-sdk/xml-builder override to resolve entity expansion limit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "@typescript-eslint/parser": "^8.50.0",
         "@vitest/coverage-v8": "^4.0.18",
         "@xterm/headless": "^6.0.0",
-        "aws-cdk-lib": "^2.240.0",
+        "aws-cdk-lib": "^2.243.0",
         "constructs": "^10.4.4",
         "esbuild": "^0.27.2",
         "eslint": "^9.39.4",
@@ -73,7 +73,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.234.1",
+        "aws-cdk-lib": "^2.243.0",
         "constructs": "^10.0.0"
       }
     },
@@ -2671,13 +2671,13 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.10.tgz",
-      "integrity": "sha512-OnejAIVD+CxzyAUrVic7lG+3QRltyja9LoNqCE/1YVs8ichoTbJlVSaZ9iSMcnHLyzrSNtvaOGjSDRP+d/ouFA==",
+      "version": "3.972.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.15.tgz",
+      "integrity": "sha512-PxMRlCFNiQnke9YR29vjFQwz4jq+6Q04rOVFeTDR2K7Qpv9h9FOWOxG+zJjageimYbWqE3bTuLjmryWHAWbvaA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
-        "fast-xml-parser": "5.4.1",
+        "@smithy/types": "^4.13.1",
+        "fast-xml-parser": "5.5.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4986,9 +4986,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
-      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
+      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"

--- a/package.json
+++ b/package.json
@@ -132,11 +132,13 @@
   },
   "overridesComments": {
     "minimatch": "GHSA-7r86-cg39-jmmj, GHSA-23c5-xmqv-rm74: minimatch 10.0.0-10.2.2 has ReDoS vulnerabilities. Multiple transitive deps (eslint, typescript-eslint, eslint-plugin-import, eslint-plugin-react, prettier-plugin-sort-imports, aws-cdk-lib) pin older versions. Remove this override once upstream packages update their minimatch dependency to >=10.2.3.",
-    "fast-xml-parser": "GHSA-8gc5-j5rx-235r, GHSA-jp2q-39xq-3w4g: fast-xml-parser <=5.5.6 has entity expansion bypass (CVE-2026-33036, CVE-2026-33349). Transitive via @aws-sdk/xml-builder. Remove once @aws-sdk updates to fast-xml-parser >=5.5.7."
+    "fast-xml-parser": "GHSA-8gc5-j5rx-235r, GHSA-jp2q-39xq-3w4g: fast-xml-parser <=5.5.6 has entity expansion bypass (CVE-2026-33036, CVE-2026-33349). Transitive via @aws-sdk/xml-builder. Remove once @aws-sdk updates to fast-xml-parser >=5.5.7.",
+    "@aws-sdk/xml-builder": "aws/aws-sdk-js-v3#7867: @aws-sdk/xml-builder <3.972.14 does not configure maxTotalExpansions on fast-xml-parser, causing 'Entity expansion limit exceeded' on large CloudFormation responses. Remove once @aws-sdk/client-* deps are bumped past 3.972.14."
   },
   "overrides": {
     "minimatch": "10.2.4",
-    "fast-xml-parser": "5.5.7"
+    "fast-xml-parser": "5.5.7",
+    "@aws-sdk/xml-builder": "3.972.15"
   },
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
## Description

The `container-strands-bedrock` e2e test fails with `Entity expansion limit exceeded: 1015 > 1000` during CDK deploy. This is caused by `fast-xml-parser` 5.5.7 introducing a default `maxTotalExpansions: 1000` limit (as part of CVE-2026-33036 / CVE-2026-33349 fixes), while `@aws-sdk/xml-builder@3.972.10` does not configure this parameter. Standard XML entity escaping (`&quot;`, `&amp;`, etc.) in CloudFormation API responses counts toward this limit, and the container deploy template exceeds it.

The AWS SDK team fixed this in `@aws-sdk/xml-builder@3.972.14` ([aws/aws-sdk-js-v3#7867](https://github.com/aws/aws-sdk-js-v3/issues/7867)) by setting `maxTotalExpansions: Infinity` for trusted API responses. This PR adds an npm override to pull in the fixed version.

## Related Issue

Closes #600

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

Manually triggered workflow on this branch, temporarily adding this test to non-full version, https://github.com/aws/agentcore-cli/actions/runs/23438632117/job/68183188908. 

In the future we should make this easier. 

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.