### PR TITLE
ci: add cross-package e2e matrix testing against CDK constructs main

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -47,6 +47,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: e2e-testing
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        cdk-source: [npm, main]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -74,13 +78,30 @@ jobs:
           secret-ids: |
             E2E,${{ secrets.E2E_SECRET_ARN }}
           parse-json-secrets: true
+
+      # Build @aws/agentcore-cdk from source for cross-package testing.
+      # Requires secrets: CDK_REPO_NAME (org/repo), CDK_REPO_TOKEN (fine-grained PAT)
+      - name: Build CDK package from main
+        if: matrix.cdk-source == 'main'
+        run: |
+          git clone --depth 1 "https://x-access-token:${CDK_REPO_TOKEN}@github.com/${CDK_REPO}.git" /tmp/cdk-repo
+          cd /tmp/cdk-repo
+          npm ci
+          npm run build
+          TARBALL=$(npm pack --pack-destination "$RUNNER_TEMP" | tail -1)
+          echo "CDK_TARBALL=$RUNNER_TEMP/$TARBALL" >> "$GITHUB_ENV"
+        env:
+          CDK_REPO_TOKEN: ${{ secrets.CDK_REPO_TOKEN }}
+          CDK_REPO: ${{ secrets.CDK_REPO_NAME }}
+
       - run: npm ci
       - run: npm run build
-      - name: Run E2E tests
+      - name: Run E2E tests (${{ matrix.cdk-source }})
         env:
           AWS_ACCOUNT_ID: ${{ steps.aws.outputs.account_id }}
           AWS_REGION: ${{ inputs.aws_region || 'us-east-1' }}
           ANTHROPIC_API_KEY: ${{ env.E2E_ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ env.E2E_OPENAI_API_KEY }}
           GEMINI_API_KEY: ${{ env.E2E_GEMINI_API_KEY }}
+          CDK_TARBALL: ${{ env.CDK_TARBALL }}
         run: npx vitest run --project e2e strands-bedrock strands-openai langgraph-bedrock googleadk-gemini

--- a/e2e-tests/e2e-helper.ts
+++ b/e2e-tests/e2e-helper.ts
@@ -92,6 +92,14 @@ export function createE2ESuite(cfg: E2EConfig) {
       const region = process.env.AWS_REGION ?? 'us-east-1';
       const awsTargetsPath = join(projectPath, 'agentcore', 'aws-targets.json');
       await writeFile(awsTargetsPath, JSON.stringify([{ name: 'default', account, region }]));
+
+      // Override @aws/agentcore-cdk with a local tarball if provided (for cross-package testing)
+      if (process.env.CDK_TARBALL) {
+        execSync(`npm install -f ${process.env.CDK_TARBALL}`, {
+          cwd: join(projectPath, 'agentcore', 'cdk'),
+          stdio: 'pipe',
+        });
+      }
     }, 300000);
 
     afterAll(async () => {


### PR DESCRIPTION
## Description

Add a matrix dimension to the e2e workflow (`cdk-source: [npm, main]`) to catch cross-package issues before releasing the cdk package. 

- **npm**: runs e2e tests against the published `@aws/agentcore-cdk` from npm (existing behavior, what customers get)
- **main**: clones the CDK constructs repo, builds it from source, packs a tarball, and overrides the template dependency before running e2e tests

Requires two repo secrets:
- `CROSS_REPO_TOKEN`: fine-grained PAT with read access to the CDK constructs repo
- `CDK_CONSTRUCTS_REPO`: org/repo identifier for the CDK constructs repo

## Related Issue

Closes #

## Documentation PR

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

Manually adjusted trigger conditions, and ran: https://github.com/aws/agentcore-cli/actions/runs/23462628966. 

Also verified that the override was successful by logging the version number before running the tests. 

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly [TODO: write instructions for rotating token]
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.