### PR TITLE
fix(gateway): write both CLIENT_ID and CLIENT_SECRET env vars for managed OAuth

### DIFF
--- a/src/cli/primitives/GatewayPrimitive.ts
+++ b/src/cli/primitives/GatewayPrimitive.ts
@@ -386,7 +386,7 @@ export class GatewayPrimitive extends BasePrimitive<AddGatewayOptions, Removable
 
   /**
    * Auto-create a managed OAuth credential for gateway inbound auth.
-   * Stores the credential in agentcore.json and writes the client secret to .env.
+   * Stores the credential in agentcore.json and writes the client ID and client secret to .env.
    */
   private async createManagedOAuthCredential(
     gatewayName: string,
@@ -410,9 +410,10 @@ export class GatewayPrimitive extends BasePrimitive<AddGatewayOptions, Removable
     });
     await this.writeProjectSpec(project);
 
-    // Write client secret to .env
-    const envVarName = computeDefaultCredentialEnvVarName(credentialName);
-    await setEnvVar(envVarName, jwtConfig.clientSecret!);
+    // Write client ID and client secret to .env
+    const envVarPrefix = computeDefaultCredentialEnvVarName(credentialName);
+    await setEnvVar(`${envVarPrefix}_CLIENT_ID`, jwtConfig.clientId!);
+    await setEnvVar(`${envVarPrefix}_CLIENT_SECRET`, jwtConfig.clientSecret!);
   }
 
   /**


### PR DESCRIPTION
## Summary

- **Bug**: `createManagedOAuthCredential` in `GatewayPrimitive.ts` wrote a single env var (`AGENTCORE_CREDENTIAL_<NAME>`) with only the client secret value
- **Expected**: The deploy step (`pre-deploy-identity.ts` → `setupSingleOAuth2Provider`) reads two separate env vars: `AGENTCORE_CREDENTIAL_<NAME>_CLIENT_ID` and `AGENTCORE_CREDENTIAL_<NAME>_CLIENT_SECRET`
- **Fix**: Write both `_CLIENT_ID` and `_CLIENT_SECRET` suffixed env vars so OAuth2 credential providers are correctly registered during deploy

## Impact

Without this fix, managed OAuth credentials created via `agentcore add gateway` with CUSTOM_JWT auth are silently skipped during `agentcore deploy`, because the expected env vars are missing. This results in the runtime getting 401 Unauthorized errors when attempting to fetch OAuth access tokens via `@requires_access_token`.

## Test plan

- [x] Existing `GatewayPrimitive` tests pass (3/3)
- [x] Existing `pre-deploy-identity` tests pass (16/16 + 8 skipped)
- [x] Verified end-to-end: deployed agent with managed OAuth gateway successfully fetches tokens and invokes MCP tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)