### PR TITLE
ci: use packaged CLI tarball for e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -96,6 +96,8 @@ jobs:
 
       - run: npm ci
       - run: npm run build
+      - name: Install CLI globally
+        run: npm install -g "$(npm pack | tail -1)"
       - name: Run E2E tests (${{ matrix.cdk-source }})
         env:
           AWS_ACCOUNT_ID: ${{ steps.aws.outputs.account_id }}

--- a/e2e-tests/e2e-helper.ts
+++ b/e2e-tests/e2e-helper.ts
@@ -1,4 +1,10 @@
-import { hasAwsCredentials, parseJsonOutput, prereqs, runCLI } from '../src/test-utils/index.js';
+import {
+  type RunResult,
+  hasAwsCredentials,
+  parseJsonOutput,
+  prereqs,
+  spawnAndCollect,
+} from '../src/test-utils/index.js';
 import {
   BedrockAgentCoreControlClient,
   DeleteApiKeyCredentialProviderCommand,
@@ -12,6 +18,14 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 const hasAws = hasAwsCredentials();
 const baseCanRun = prereqs.npm && prereqs.git && prereqs.uv && hasAws;
+
+/**
+ * Run the globally installed `agentcore` CLI.
+ * E2E tests use the packaged binary to validate the published artifact.
+ */
+async function runAgentCore(args: string[], cwd: string): Promise<RunResult> {
+  return spawnAndCollect('agentcore', args, cwd);
+}
 
 interface E2EConfig {
   framework: string;
@@ -79,7 +93,7 @@ export function createE2ESuite(cfg: E2EConfig) {
         createArgs.push('--api-key', apiKey);
       }
 
-      const result = await runCLI(createArgs, testDir, false);
+      const result = await runAgentCore(createArgs, testDir);
 
       expect(result.exitCode, `Create failed: ${result.stderr}`).toBe(0);
       const json = parseJsonOutput(result.stdout) as { projectPath: string };
@@ -104,8 +118,8 @@ export function createE2ESuite(cfg: E2EConfig) {
 
     afterAll(async () => {
       if (projectPath && hasAws) {
-        await runCLI(['remove', 'all', '--json'], projectPath, false);
-        const result = await runCLI(['deploy', '--yes', '--json'], projectPath, false);
+        await runAgentCore(['remove', 'all', '--json'], projectPath);
+        const result = await runAgentCore(['deploy', '--yes', '--json'], projectPath);
 
         if (result.exitCode !== 0) {
           console.log('Teardown stdout:', result.stdout);
@@ -141,7 +155,7 @@ export function createE2ESuite(cfg: E2EConfig) {
 
         await retry(
           async () => {
-            const result = await runCLI(['deploy', '--yes', '--json'], projectPath, false);
+            const result = await runAgentCore(['deploy', '--yes', '--json'], projectPath);
 
             if (result.exitCode !== 0) {
               console.log('Deploy stdout:', result.stdout);
@@ -168,10 +182,9 @@ export function createE2ESuite(cfg: E2EConfig) {
         // Retry invoke to handle cold-start / runtime initialization delays
         await retry(
           async () => {
-            const result = await runCLI(
+            const result = await runAgentCore(
               ['invoke', '--prompt', 'Say hello', '--agent', agentName, '--json'],
-              projectPath,
-              false
+              projectPath
             );
 
             if (result.exitCode !== 0) {

--- a/src/test-utils/cli-runner.ts
+++ b/src/test-utils/cli-runner.ts
@@ -14,34 +14,18 @@ export interface RunResult {
 }
 
 /**
- * Get the path to the CLI entry point.
- * Uses the built bundle - run `npm run build` before tests.
+ * Spawn a command, collect output, and strip ANSI codes.
  */
-function getCLIPath(): string {
-  // Navigate from src/test-utils to dist/cli/index.mjs
-  return join(__dirname, '..', '..', 'dist', 'cli', 'index.mjs');
-}
-
-/**
- * Run the AgentCore CLI with the given arguments.
- *
- * @param args - CLI arguments to pass
- * @param cwd - Working directory to run the command in
- * @returns Promise resolving to the command result
- *
- * @example
- * ```ts
- * const result = await runCLI(['create', '--name', 'MyProject', '--json'], testDir);
- * assert.strictEqual(result.exitCode, 0);
- * ```
- */
-export async function runCLI(args: string[], cwd: string, skipInstall = true): Promise<RunResult> {
-  const cliPath = getCLIPath();
-
+export function spawnAndCollect(
+  command: string,
+  args: string[],
+  cwd: string,
+  extraEnv: Record<string, string> = {}
+): Promise<RunResult> {
   return new Promise(resolve => {
-    const proc = spawn('node', [cliPath, ...args], {
+    const proc = spawn(command, args, {
       cwd,
-      env: { ...process.env, INIT_CWD: undefined, ...(skipInstall ? { AGENTCORE_SKIP_INSTALL: '1' } : {}) },
+      env: { ...process.env, INIT_CWD: undefined, ...extraEnv },
     });
 
     let stdout = '';
@@ -62,4 +46,21 @@ export async function runCLI(args: string[], cwd: string, skipInstall = true): P
       resolve({ stdout, stderr, exitCode: code ?? 1 });
     });
   });
+}
+
+/**
+ * Get the path to the CLI entry point.
+ * Uses the built bundle - run `npm run build` before tests.
+ */
+function getCLIPath(): string {
+  // Navigate from src/test-utils to dist/cli/index.mjs
+  return join(__dirname, '..', '..', 'dist', 'cli', 'index.mjs');
+}
+
+/**
+ * Run the AgentCore CLI via the local build (unit/integ tests).
+ * Skips dependency installation by default for speed.
+ */
+export async function runCLI(args: string[], cwd: string, skipInstall = true): Promise<RunResult> {
+  return spawnAndCollect('node', [getCLIPath(), ...args], cwd, skipInstall ? { AGENTCORE_SKIP_INSTALL: '1' } : {});
 }

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -3,7 +3,7 @@
  * Import these helpers instead of duplicating code in each test file.
  */
 
-export { runCLI, type RunResult } from './cli-runner.js';
+export { runCLI, spawnAndCollect, type RunResult } from './cli-runner.js';
 export { exists } from './fs-helpers.js';
 export { hasCommand, hasAwsCredentials, prereqs } from './prereqs.js';
 export { createTestProject, type TestProject, type CreateTestProjectOptions } from './project-factory.js';


### PR DESCRIPTION
## Description

E2E tests previously invoked the CLI via `node dist/cli/index.mjs`, bypassing the packaging and bin-linking that real users go through. This means issues like missing files in the tarball, broken bin entries, or incorrect `package.json` `files` globs would not be caught until after publishing.

This PR adds an `npm pack` + `npm install -g` step in the e2e workflow so `agentcore` is on PATH as a globally installed package, and simplifies `cli-runner.ts` to spawn `agentcore` directly.

## Related Issue

https://github.com/aws/agentcore-cli/issues/618

## Documentation PR

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

Ran the full strands-bedrock e2e suite locally and manually adjusted the trigger to run in CI: https://github.com/aws/agentcore-cli/actions/runs/23497058334/job/68381062269. 

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.