### PR TITLE
fix: add missing MCP fields to vended CDK test spec

### DIFF
--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -381,6 +381,9 @@ test('AgentCoreStack synthesizes with empty spec', () => {
       evaluators: [],
       onlineEvalConfigs: [],
       policyEngines: [],
+      agentCoreGateways: [],
+      mcpRuntimeTools: [],
+      unassignedTargets: [],
     },
   });
   const template = Template.fromStack(stack);

--- a/src/assets/cdk/test/cdk.test.ts
+++ b/src/assets/cdk/test/cdk.test.ts
@@ -14,6 +14,9 @@ test('AgentCoreStack synthesizes with empty spec', () => {
       evaluators: [],
       onlineEvalConfigs: [],
       policyEngines: [],
+      agentCoreGateways: [],
+      mcpRuntimeTools: [],
+      unassignedTargets: [],
     },
   });
   const template = Template.fromStack(stack);


### PR DESCRIPTION
## Summary

- Adds `agentCoreGateways`, `mcpRuntimeTools`, and `unassignedTargets` to the mock spec in the vended `cdk.test.ts` template
- These fields became required in CDK constructs after aws/agentcore-l3-cdk-constructs#99 merged, causing the e2e (CDK main) CI job to fail for all PRs

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] Snapshot updated