### PR TITLE
test: add post-deploy e2e tests for status, logs, and traces

### DIFF
--- a/e2e-tests/e2e-helper.ts
+++ b/e2e-tests/e2e-helper.ts
@@ -3,6 +3,7 @@ import {
   hasAwsCredentials,
   parseJsonOutput,
   prereqs,
+  retry,
   spawnAndCollect,
 } from '../src/test-utils/index.js';
 import {
@@ -32,24 +33,6 @@ interface E2EConfig {
   modelProvider: string;
   requiredEnvVar?: string;
   build?: string;
-}
-
-/**
- * Retry an async function up to `times` attempts with a delay between retries.
- */
-async function retry<T>(fn: () => Promise<T>, times: number, delayMs: number): Promise<T> {
-  let lastError: unknown;
-  for (let i = 0; i < times; i++) {
-    try {
-      return await fn();
-    } catch (err) {
-      lastError = err;
-      if (i < times - 1) {
-        await new Promise(resolve => setTimeout(resolve, delayMs));
-      }
-    }
-  }
-  throw lastError;
 }
 
 export function createE2ESuite(cfg: E2EConfig) {

--- a/e2e-tests/e2e-helper.ts
+++ b/e2e-tests/e2e-helper.ts
@@ -203,5 +203,79 @@ export function createE2ESuite(cfg: E2EConfig) {
       },
       180000
     );
+
+    // ── Post-deploy observability tests ──────────────────────────────
+    it.skipIf(!canRun)(
+      'status shows the deployed agent',
+      async () => {
+        const result = await runCLI(['status', '--json'], projectPath, false);
+
+        expect(result.exitCode, `Status failed: ${result.stderr}`).toBe(0);
+
+        const json = parseJsonOutput(result.stdout) as {
+          success: boolean;
+          resources: {
+            resourceType: string;
+            name: string;
+            deploymentState: string;
+            identifier?: string;
+          }[];
+        };
+        expect(json.success).toBe(true);
+
+        const agent = json.resources.find(r => r.resourceType === 'agent' && r.name === agentName);
+        expect(agent, `Agent "${agentName}" should appear in status`).toBeDefined();
+        expect(agent!.deploymentState).toBe('deployed');
+        expect(agent!.identifier, 'Deployed agent should have a runtime ARN').toBeTruthy();
+      },
+      120000
+    );
+
+    it.skipIf(!canRun)(
+      'logs returns entries from the invocation',
+      async () => {
+        await retry(
+          async () => {
+            // --since 1h triggers search mode (avoids live tail)
+            const result = await runCLI(['logs', '--agent', agentName, '--since', '1h', '--json'], projectPath, false);
+
+            expect(result.exitCode, `Logs failed: ${result.stderr}`).toBe(0);
+
+            // logs --json outputs JSON Lines (one {timestamp, message} per line)
+            const lines: { timestamp: string; message: string }[] = result.stdout
+              .split('\n')
+              .filter((l: string) => l.trim())
+              .map((l: string) => JSON.parse(l) as { timestamp: string; message: string });
+
+            expect(lines.length, 'Should have at least one log entry').toBeGreaterThan(0);
+            for (const line of lines) {
+              expect(line.timestamp, 'Each log entry should have a timestamp').toBeTruthy();
+              expect(line.message, 'Each log entry should have a message').toBeTruthy();
+            }
+          },
+          3,
+          15000
+        );
+      },
+      120000
+    );
+
+    it.skipIf(!canRun)(
+      'traces list succeeds after invocation',
+      async () => {
+        // traces list has no --json flag — verify exit code and non-empty output
+        await retry(
+          async () => {
+            const result = await runCLI(['traces', 'list', '--agent', agentName, '--since', '1h'], projectPath, false);
+
+            expect(result.exitCode, `Traces list failed (stderr: ${result.stderr})`).toBe(0);
+            expect(result.stdout.length, 'Traces list should produce output').toBeGreaterThan(0);
+          },
+          3,
+          15000
+        );
+      },
+      120000
+    );
   });
 }

--- a/e2e-tests/e2e-helper.ts
+++ b/e2e-tests/e2e-helper.ts
@@ -205,10 +205,17 @@ export function createE2ESuite(cfg: E2EConfig) {
     );
 
     // ── Post-deploy observability tests ──────────────────────────────
+    // Use spawnAndCollect directly to avoid TypeScript inference depth limits
+    // in the describe.sequential callback.
+    const run = (args: string[]) => spawnAndCollect('agentcore', args, projectPath);
+
+    // Track the runtime ID across status tests
+    let runtimeId: string;
+
     it.skipIf(!canRun)(
       'status shows the deployed agent',
       async () => {
-        const result = await runCLI(['status', '--json'], projectPath, false);
+        const result = await run(['status', '--json']);
 
         expect(result.exitCode, `Status failed: ${result.stderr}`).toBe(0);
 
@@ -227,6 +234,30 @@ export function createE2ESuite(cfg: E2EConfig) {
         expect(agent, `Agent "${agentName}" should appear in status`).toBeDefined();
         expect(agent!.deploymentState).toBe('deployed');
         expect(agent!.identifier, 'Deployed agent should have a runtime ARN').toBeTruthy();
+
+        // Extract runtime ID from ARN (e.g. arn:aws:...:agent-runtime/XXXXX → XXXXX)
+        runtimeId = agent!.identifier!.split('/').pop()!;
+      },
+      120000
+    );
+
+    it.skipIf(!canRun)(
+      'status looks up agent runtime by ID',
+      async () => {
+        expect(runtimeId, 'Runtime ID should have been extracted from status').toBeTruthy();
+
+        const result = await run(['status', '--agent-runtime-id', runtimeId, '--json']);
+
+        expect(result.exitCode, `Runtime lookup failed: ${result.stderr}`).toBe(0);
+
+        const json = parseJsonOutput(result.stdout) as {
+          success: boolean;
+          runtimeId?: string;
+          runtimeStatus?: string;
+        };
+        expect(json.success).toBe(true);
+        expect(json.runtimeId).toBe(runtimeId);
+        expect(json.runtimeStatus).toBeTruthy();
       },
       120000
     );
@@ -237,7 +268,7 @@ export function createE2ESuite(cfg: E2EConfig) {
         await retry(
           async () => {
             // --since 1h triggers search mode (avoids live tail)
-            const result = await runCLI(['logs', '--agent', agentName, '--since', '1h', '--json'], projectPath, false);
+            const result = await run(['logs', '--agent', agentName, '--since', '1h', '--json']);
 
             expect(result.exitCode, `Logs failed: ${result.stderr}`).toBe(0);
 
@@ -261,12 +292,23 @@ export function createE2ESuite(cfg: E2EConfig) {
     );
 
     it.skipIf(!canRun)(
+      'logs supports level filtering',
+      async () => {
+        // --level error should succeed even if no error-level logs exist
+        const result = await run(['logs', '--agent', agentName, '--since', '1h', '--level', 'error', '--json']);
+
+        expect(result.exitCode, `Logs --level failed: ${result.stderr}`).toBe(0);
+      },
+      120000
+    );
+
+    it.skipIf(!canRun)(
       'traces list succeeds after invocation',
       async () => {
         // traces list has no --json flag — verify exit code and non-empty output
         await retry(
           async () => {
-            const result = await runCLI(['traces', 'list', '--agent', agentName, '--since', '1h'], projectPath, false);
+            const result = await run(['traces', 'list', '--agent', agentName, '--since', '1h']);
 
             expect(result.exitCode, `Traces list failed (stderr: ${result.stderr})`).toBe(0);
             expect(result.stdout.length, 'Traces list should produce output').toBeGreaterThan(0);

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -10,6 +10,24 @@ export { createTestProject, type TestProject, type CreateTestProjectOptions } fr
 export { readProjectConfig } from './config-reader.js';
 
 /**
+ * Retry an async function up to `times` attempts with a delay between retries.
+ */
+export async function retry<T>(fn: () => Promise<T>, times: number, delayMs: number): Promise<T> {
+  let lastError: unknown;
+  for (let i = 0; i < times; i++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err;
+      if (i < times - 1) {
+        await new Promise(resolve => setTimeout(resolve, delayMs));
+      }
+    }
+  }
+  throw lastError;
+}
+
+/**
  * Strip ANSI escape codes from a string.
  */
 export function stripAnsi(str: string): string {


### PR DESCRIPTION
## Description

The e2e test suite only validates `create → deploy → invoke`. After a successful invoke, the tests stop — no observability commands are exercised. This means `status`, `logs`, and `traces` have zero e2e coverage. 

This PR adds 5 sequential test blocks to `e2e-helper.ts` after the existing invoke test. 

### Known gaps for follow-up
- `traces get` — no `--json` flag on `traces list`, no reliable way to extract trace ID programmatically

## Related Issue

Closes #

## Documentation PR

N/A — test-only change.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe): e2e test coverage for observability commands (status, logs, traces)

## Testing

How have you tested the change?

- [ ] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

Ran in my dev account. 

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
