### PR TITLE
test: add e2e test for evaluations lifecycle

### DIFF
--- a/e2e-tests/e2e-helper.ts
+++ b/e2e-tests/e2e-helper.ts
@@ -3,6 +3,7 @@ import {
   hasAwsCredentials,
   parseJsonOutput,
   prereqs,
+  retry,
   spawnAndCollect,
 } from '../src/test-utils/index.js';
 import {
@@ -19,37 +20,11 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 const hasAws = hasAwsCredentials();
 const baseCanRun = prereqs.npm && prereqs.git && prereqs.uv && hasAws;
 
-/**
- * Run the globally installed `agentcore` CLI.
- * E2E tests use the packaged binary to validate the published artifact.
- */
-async function runAgentCore(args: string[], cwd: string): Promise<RunResult> {
-  return spawnAndCollect('agentcore', args, cwd);
-}
-
 interface E2EConfig {
   framework: string;
   modelProvider: string;
   requiredEnvVar?: string;
   build?: string;
-}
-
-/**
- * Retry an async function up to `times` attempts with a delay between retries.
- */
-async function retry<T>(fn: () => Promise<T>, times: number, delayMs: number): Promise<T> {
-  let lastError: unknown;
-  for (let i = 0; i < times; i++) {
-    try {
-      return await fn();
-    } catch (err) {
-      lastError = err;
-      if (i < times - 1) {
-        await new Promise(resolve => setTimeout(resolve, delayMs));
-      }
-    }
-  }
-  throw lastError;
 }
 
 export function createE2ESuite(cfg: E2EConfig) {
@@ -93,52 +68,19 @@ export function createE2ESuite(cfg: E2EConfig) {
         createArgs.push('--api-key', apiKey);
       }
 
-      const result = await runAgentCore(createArgs, testDir);
+      const result = await runAgentCoreCLI(createArgs, testDir);
 
       expect(result.exitCode, `Create failed: ${result.stderr}`).toBe(0);
       const json = parseJsonOutput(result.stdout) as { projectPath: string };
       projectPath = json.projectPath;
 
-      // TODO: Replace with `agentcore add target` once the CLI command is re-introduced
-      const account =
-        process.env.AWS_ACCOUNT_ID ??
-        execSync('aws sts get-caller-identity --query Account --output text').toString().trim();
-      const region = process.env.AWS_REGION ?? 'us-east-1';
-      const awsTargetsPath = join(projectPath, 'agentcore', 'aws-targets.json');
-      await writeFile(awsTargetsPath, JSON.stringify([{ name: 'default', account, region }]));
-
-      // Override @aws/agentcore-cdk with a local tarball if provided (for cross-package testing)
-      if (process.env.CDK_TARBALL) {
-        execSync(`npm install -f ${process.env.CDK_TARBALL}`, {
-          cwd: join(projectPath, 'agentcore', 'cdk'),
-          stdio: 'pipe',
-        });
-      }
+      await writeAwsTargets(projectPath);
+      installCdkTarball(projectPath);
     }, 300000);
 
     afterAll(async () => {
       if (projectPath && hasAws) {
-        await runAgentCore(['remove', 'all', '--json'], projectPath);
-        const result = await runAgentCore(['deploy', '--yes', '--json'], projectPath);
-
-        if (result.exitCode !== 0) {
-          console.log('Teardown stdout:', result.stdout);
-          console.log('Teardown stderr:', result.stderr);
-        }
-
-        // Delete the API key credential provider from the account.
-        // These are created as a pre-deploy step outside CDK and are not
-        // cleaned up by stack teardown, so we must delete them explicitly.
-        if (cfg.modelProvider !== 'Bedrock' && agentName) {
-          const providerName = `${agentName}${cfg.modelProvider}`;
-          const region = process.env.AWS_REGION ?? 'us-east-1';
-          try {
-            const client = new BedrockAgentCoreControlClient({ region });
-            await client.send(new DeleteApiKeyCredentialProviderCommand({ name: providerName }));
-          } catch {
-            // Best-effort cleanup — don't fail the test if deletion fails
-          }
-        }
+        await teardownE2EProject(projectPath, agentName, cfg.modelProvider);
       }
       if (testDir) await rm(testDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 1000 });
     }, 600000);
@@ -155,7 +97,7 @@ export function createE2ESuite(cfg: E2EConfig) {
 
         await retry(
           async () => {
-            const result = await runAgentCore(['deploy', '--yes', '--json'], projectPath);
+            const result = await runAgentCoreCLI(['deploy', '--yes', '--json'], projectPath);
 
             if (result.exitCode !== 0) {
               console.log('Deploy stdout:', result.stdout);
@@ -182,7 +124,7 @@ export function createE2ESuite(cfg: E2EConfig) {
         // Retry invoke to handle cold-start / runtime initialization delays
         await retry(
           async () => {
-            const result = await runAgentCore(
+            const result = await runAgentCoreCLI(
               ['invoke', '--prompt', 'Say hello', '--agent', agentName, '--json'],
               projectPath
             );
@@ -204,4 +146,50 @@ export function createE2ESuite(cfg: E2EConfig) {
       180000
     );
   });
+}
+
+export { hasAws, baseCanRun };
+
+export function runAgentCoreCLI(args: string[], cwd: string): Promise<RunResult> {
+  return spawnAndCollect('agentcore', args, cwd);
+}
+
+// TODO: Replace with `agentcore add target` once the CLI command is re-introduced
+export async function writeAwsTargets(projectPath: string): Promise<void> {
+  const account =
+    process.env.AWS_ACCOUNT_ID ??
+    execSync('aws sts get-caller-identity --query Account --output text').toString().trim();
+  const region = process.env.AWS_REGION ?? 'us-east-1';
+  await writeFile(
+    join(projectPath, 'agentcore', 'aws-targets.json'),
+    JSON.stringify([{ name: 'default', account, region }])
+  );
+}
+
+export function installCdkTarball(projectPath: string): void {
+  if (process.env.CDK_TARBALL) {
+    execSync(`npm install -f ${process.env.CDK_TARBALL}`, {
+      cwd: join(projectPath, 'agentcore', 'cdk'),
+      stdio: 'pipe',
+    });
+  }
+}
+
+export async function teardownE2EProject(projectPath: string, agentName: string, modelProvider: string): Promise<void> {
+  await spawnAndCollect('agentcore', ['remove', 'all', '--json'], projectPath);
+  const result = await spawnAndCollect('agentcore', ['deploy', '--yes', '--json'], projectPath);
+  if (result.exitCode !== 0) {
+    console.log('Teardown stdout:', result.stdout);
+    console.log('Teardown stderr:', result.stderr);
+  }
+  if (modelProvider !== 'Bedrock' && agentName) {
+    const providerName = `${agentName}${modelProvider}`;
+    const region = process.env.AWS_REGION ?? 'us-east-1';
+    try {
+      const client = new BedrockAgentCoreControlClient({ region });
+      await client.send(new DeleteApiKeyCredentialProviderCommand({ name: providerName }));
+    } catch {
+      // Best-effort cleanup
+    }
+  }
 }

--- a/e2e-tests/evals-lifecycle.test.ts
+++ b/e2e-tests/evals-lifecycle.test.ts
@@ -1,0 +1,197 @@
+import { parseJsonOutput, retry } from '../src/test-utils/index.js';
+import {
+  baseCanRun,
+  hasAws,
+  installCdkTarball,
+  runAgentCoreCLI,
+  teardownE2EProject,
+  writeAwsTargets,
+} from './e2e-helper.js';
+import { randomUUID } from 'node:crypto';
+import { mkdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const canRun = baseCanRun && hasAws;
+
+describe.sequential('e2e: evaluations lifecycle', () => {
+  let testDir: string;
+  let projectPath: string;
+  const agentName = `E2eEval${String(Date.now()).slice(-8)}`;
+  const evalName = 'E2eEvaluator';
+  const onlineEvalName = 'E2eOnlineEval';
+
+  beforeAll(async () => {
+    if (!canRun) return;
+
+    testDir = join(tmpdir(), `agentcore-e2e-evals-${randomUUID()}`);
+    await mkdir(testDir, { recursive: true });
+
+    const result = await runAgentCoreCLI(
+      [
+        'create',
+        '--name',
+        agentName,
+        '--language',
+        'Python',
+        '--framework',
+        'Strands',
+        '--model-provider',
+        'Bedrock',
+        '--memory',
+        'none',
+        '--json',
+      ],
+      testDir
+    );
+    expect(result.exitCode, `Create failed: ${result.stderr}`).toBe(0);
+    projectPath = (parseJsonOutput(result.stdout) as { projectPath: string }).projectPath;
+
+    await writeAwsTargets(projectPath);
+    installCdkTarball(projectPath);
+  }, 300000);
+
+  afterAll(async () => {
+    if (projectPath && hasAws) {
+      await teardownE2EProject(projectPath, agentName, 'Bedrock');
+    }
+    if (testDir) await rm(testDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 1000 });
+  }, 600000);
+
+  const run = (args: string[]) => runAgentCoreCLI(args, projectPath);
+
+  it.skipIf(!canRun)(
+    'configures evaluator and online eval before deploy',
+    async () => {
+      let result = await run([
+        'add',
+        'evaluator',
+        '--name',
+        evalName,
+        '--level',
+        'SESSION',
+        '--model',
+        'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+        '--instructions',
+        'Evaluate the overall quality of this session. Context: {context}',
+        '--json',
+      ]);
+      expect(result.exitCode, `Add evaluator failed: ${result.stdout}`).toBe(0);
+
+      result = await run([
+        'add',
+        'online-eval',
+        '--name',
+        onlineEvalName,
+        '--agent',
+        agentName,
+        '--evaluator',
+        evalName,
+        '--sampling-rate',
+        '100',
+        '--enable-on-create',
+        '--json',
+      ]);
+      expect(result.exitCode, `Add online-eval failed: ${result.stdout}`).toBe(0);
+    },
+    60000
+  );
+
+  it.skipIf(!canRun)(
+    'deploys agent with evaluator and online eval config',
+    async () => {
+      const result = await run(['deploy', '--yes', '--json']);
+      if (result.exitCode !== 0) {
+        console.log('Deploy stdout:', result.stdout);
+        console.log('Deploy stderr:', result.stderr);
+      }
+      expect(result.exitCode, 'Deploy failed').toBe(0);
+      const json = parseJsonOutput(result.stdout) as { success: boolean };
+      expect(json.success).toBe(true);
+    },
+    600000
+  );
+
+  it.skipIf(!canRun)(
+    'invokes the deployed agent',
+    async () => {
+      await retry(
+        async () => {
+          const result = await run(['invoke', '--prompt', 'Say hello', '--agent', agentName, '--json']);
+          expect(result.exitCode, `Invoke failed: ${result.stderr}`).toBe(0);
+          const json = parseJsonOutput(result.stdout) as { success: boolean };
+          expect(json.success).toBe(true);
+        },
+        3,
+        15000
+      );
+    },
+    180000
+  );
+
+  it.skipIf(!canRun)(
+    'runs on-demand evaluation against agent traces',
+    async () => {
+      await retry(
+        async () => {
+          const result = await run([
+            'run',
+            'evals',
+            '--agent',
+            agentName,
+            '--evaluator',
+            'Builtin.Faithfulness',
+            '--days',
+            '1',
+            '--json',
+          ]);
+          expect(result.exitCode, `Run evals failed (stdout: ${result.stdout}, stderr: ${result.stderr})`).toBe(0);
+          const json = parseJsonOutput(result.stdout) as Record<string, unknown>;
+          expect(json).toHaveProperty('success', true);
+          expect(json).toHaveProperty('run');
+          expect(json).toHaveProperty('filePath');
+        },
+        18,
+        10000
+      );
+    },
+    300000
+  );
+
+  it.skipIf(!canRun)(
+    'eval history shows the completed run',
+    async () => {
+      const result = await run(['evals', 'history', '--agent', agentName, '--json']);
+      expect(result.exitCode, `Evals history failed: ${result.stderr}`).toBe(0);
+      const json = parseJsonOutput(result.stdout) as Record<string, unknown> & { runs: unknown[] };
+      expect(json).toHaveProperty('success', true);
+      expect(json.runs.length, 'Should have at least one eval run').toBeGreaterThan(0);
+    },
+    120000
+  );
+
+  it.skipIf(!canRun)(
+    'pauses the online eval config',
+    async () => {
+      const result = await run(['pause', 'online-eval', onlineEvalName, '--json']);
+      expect(result.exitCode, `Pause failed: ${result.stderr}`).toBe(0);
+      const json = parseJsonOutput(result.stdout) as Record<string, unknown>;
+      expect(json).toHaveProperty('success', true);
+      expect(json).toHaveProperty('executionStatus', 'DISABLED');
+    },
+    120000
+  );
+
+  it.skipIf(!canRun)(
+    'resumes the online eval config',
+    async () => {
+      const result = await run(['resume', 'online-eval', onlineEvalName, '--json']);
+      expect(result.exitCode, `Resume failed: ${result.stderr}`).toBe(0);
+      const json = parseJsonOutput(result.stdout) as Record<string, unknown>;
+      expect(json).toHaveProperty('success', true);
+      expect(json).toHaveProperty('executionStatus', 'ENABLED');
+    },
+    120000
+  );
+});

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -10,6 +10,24 @@ export { createTestProject, type TestProject, type CreateTestProjectOptions } fr
 export { readProjectConfig } from './config-reader.js';
 
 /**
+ * Retry an async function up to `times` attempts with a delay between retries.
+ */
+export async function retry<T>(fn: () => Promise<T>, times: number, delayMs: number): Promise<T> {
+  let lastError: unknown;
+  for (let i = 0; i < times; i++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err;
+      if (i < times - 1) {
+        await new Promise(resolve => setTimeout(resolve, delayMs));
+      }
+    }
+  }
+  throw lastError;
+}
+
+/**
  * Strip ANSI escape codes from a string.
  */
 export function stripAnsi(str: string): string {


### PR DESCRIPTION
## Description

The evaluations feature (custom evaluators, online eval configs, on-demand evals, pause/resume) is missing e2e test coverage. This PR adds a standalone e2e suite that tests the full lifecycle against real AWS infrastructure.

Also refactor e2e test setup to be build consumable utility functions rather than a single mono-function. 

### Known limitation: `logs evals` not included

Online eval log processing is async and the CloudWatch log group (`/aws/bedrock-agentcore/evaluations/results/{configId}`) was not populated within 8+ minutes of polling across multiple test runs. This makes `logs evals` assertions unreliable for e2e testing.

## Related Issue

Closes #

## Documentation PR

N/A — test-only change.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe): e2e test coverage for evaluations lifecycle (user stories 2.4, 2.5, 10.1, 10.3, 10.4)

## Testing

How have you tested the change?

- [ ] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

Verified against dev account (us-east-1). All 6 tests pass in ~4 minutes:

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
