### PR TITLE
ci: add global CLI install and CDK matrix to full e2e workflow

### DIFF
--- a/.github/workflows/e2e-tests-full.yml
+++ b/.github/workflows/e2e-tests-full.yml
@@ -23,6 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     environment: e2e-testing
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        cdk-source: [npm, main]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -52,11 +56,26 @@ jobs:
           parse-json-secrets: true
       - run: npm ci
       - run: npm run build
-      - name: Run E2E tests
+      - name: Build CDK package from main
+        if: matrix.cdk-source == 'main'
+        run: |
+          git clone --depth 1 "https://x-access-token:${CDK_REPO_TOKEN}@github.com/${CDK_REPO}.git" /tmp/cdk-repo
+          cd /tmp/cdk-repo
+          npm ci
+          npm run build
+          TARBALL=$(npm pack --pack-destination "$RUNNER_TEMP" | tail -1)
+          echo "CDK_TARBALL=$RUNNER_TEMP/$TARBALL" >> "$GITHUB_ENV"
+        env:
+          CDK_REPO_TOKEN: ${{ secrets.CDK_REPO_TOKEN }}
+          CDK_REPO: ${{ secrets.CDK_REPO_NAME }}
+      - name: Install CLI globally
+        run: npm install -g "$(npm pack | tail -1)"
+      - name: Run E2E tests (${{ matrix.cdk-source }})
         env:
           AWS_ACCOUNT_ID: ${{ steps.aws.outputs.account_id }}
           AWS_REGION: ${{ inputs.aws_region || 'us-east-1' }}
           ANTHROPIC_API_KEY: ${{ env.E2E_ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ env.E2E_OPENAI_API_KEY }}
           GEMINI_API_KEY: ${{ env.E2E_GEMINI_API_KEY }}
+          CDK_TARBALL: ${{ env.CDK_TARBALL }}
         run: npm run test:e2e


### PR DESCRIPTION
## Description

The changes to use the agentcore tarball and test against prerelease versions of the cdk package only applied to the e2e-tests, not e2e-tests-full. 

The missing tarball installation causes e2e tests to fail with `spawn agentcore ENOENT` since it can't find the binary. 

Additionally, we don't test against CDK pre-release. 

### Future Work
- refactor these two workflows to consume a shared definition to avoid drift like this. 

## Related Issue

Closes #

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:unit` and `npm run test:integ`
- [ ] I ran `npm run typecheck`
- [ ] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

One-line CI fix — adds `npm install -g "$(npm pack | tail -1)"` between `npm run build` and the test step, matching the PR workflow.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
