### PR TITLE
ci: use AUTHORIZED_USERS for pr-tarball authorization

### DIFF
--- a/.github/workflows/pr-tarball.yml
+++ b/.github/workflows/pr-tarball.yml
@@ -8,10 +8,27 @@ permissions:
   pull-requests: write
 
 jobs:
-  pr-tarball:
+  authorize:
     runs-on: ubuntu-latest
-    if: >-
-      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+    outputs:
+      is_authorized: ${{ steps.check.outputs.is_authorized }}
+    steps:
+      - name: Check authorization
+        id: check
+        run: |
+          AUTHORIZED_USERS="${{ secrets.AUTHORIZED_USERS }}"
+          if [[ ",$AUTHORIZED_USERS," == *",${{ github.actor }},"* ]]; then
+            echo "✅ User ${{ github.actor }} is authorized"
+            echo "is_authorized=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "⏭️ User ${{ github.actor }} is not in AUTHORIZED_USERS — skipping."
+            echo "is_authorized=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  pr-tarball:
+    needs: authorize
+    if: needs.authorize.outputs.is_authorized == 'true'
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Description

The pr-tarball workflow uses `author_association` to gate execution, which is unreliable for fork-based PRs. This replaces it with the same `AUTHORIZED_USERS` secret check used by the e2e workflow.

## Related Issue

N/A

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

The authorize pattern is identical to the e2e workflow which is already proven in CI.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.