### PR TITLE
fix(gateway): add missing validation for custom JWT claim values

### DIFF
--- a/src/cli/operations/fetch-access/fetch-gateway-token.ts
+++ b/src/cli/operations/fetch-access/fetch-gateway-token.ts
@@ -206,7 +206,7 @@ function resolveClientId(
     return envClientId;
   }
 
-  // Tier 3: allowedClients[0] from mcp.json (fallback)
+  // Tier 3: allowedClients[0] from agentcore.json (fallback)
   if (jwtConfig.allowedClients && jwtConfig.allowedClients.length > 0) {
     return jwtConfig.allowedClients[0];
   }

--- a/src/cli/primitives/PolicyEnginePrimitive.ts
+++ b/src/cli/primitives/PolicyEnginePrimitive.ts
@@ -143,7 +143,7 @@ export class PolicyEnginePrimitive extends BasePrimitive<AddPolicyEngineOptions,
   }
 
   /**
-   * Attach a policy engine to the specified gateways in mcp.json.
+   * Attach a policy engine to the specified gateways in agentcore.json.
    */
   async attachToGateways(engineName: string, gatewayNames: string[], mode: 'LOG_ONLY' | 'ENFORCE'): Promise<void> {
     if (gatewayNames.length === 0) return;

--- a/src/cli/tui/screens/mcp/__tests__/finishJwtConfig.test.ts
+++ b/src/cli/tui/screens/mcp/__tests__/finishJwtConfig.test.ts
@@ -58,9 +58,9 @@ describe('finishJwtConfig data mapping', () => {
         },
       ],
     };
-    // Schema accepts this structurally (both fields are optional at schema level)
-    // but the TUI should map STRING_ARRAY to matchValueStringList, not matchValueString
+    // 'admin,dev' contains a comma which violates the API-documented
+    // pattern [A-Za-z0-9_.-]+ — schema now correctly rejects this
     const result = CustomJwtAuthorizerConfigSchema.safeParse(config);
-    expect(result.success).toBe(true);
+    expect(result.success).toBe(false);
   });
 });

--- a/src/schema/schemas/mcp.ts
+++ b/src/schema/schemas/mcp.ts
@@ -46,13 +46,28 @@ const OidcDiscoveryUrlSchema = z
 
 // ── Custom Claims Schemas (matches CFN CustomClaimValidationType) ──
 
+// API-documented patterns (from ClaimMatchValueType and CustomClaimValidationType)
+const MATCH_VALUE_PATTERN = /^[A-Za-z0-9_.-]+$/;
+const CLAIM_NAME_PATTERN = /^[A-Za-z0-9_.:-]+$/;
+// Server-side reserved claim names (not regex-documented; API rejects these at deploy time)
+const RESERVED_CLAIM_NAMES = ['client_id'];
+
 export const ClaimMatchOperatorSchema = z.enum(['EQUALS', 'CONTAINS', 'CONTAINS_ANY']);
 export type ClaimMatchOperator = z.infer<typeof ClaimMatchOperatorSchema>;
 
 export const ClaimMatchValueSchema = z
   .object({
-    matchValueString: z.string().min(1).optional(),
-    matchValueStringList: z.array(z.string().min(1)).min(1).max(255).optional(),
+    matchValueString: z
+      .string()
+      .min(1)
+      .max(255)
+      .regex(MATCH_VALUE_PATTERN, 'Match value must match [A-Za-z0-9_.-]+')
+      .optional(),
+    matchValueStringList: z
+      .array(z.string().min(1).max(255).regex(MATCH_VALUE_PATTERN, 'Each match value must match [A-Za-z0-9_.-]+'))
+      .min(1)
+      .max(255)
+      .optional(),
   })
   .refine(data => data.matchValueString !== undefined || data.matchValueStringList !== undefined, {
     message: 'Either matchValueString or matchValueStringList must be provided',
@@ -70,7 +85,11 @@ export const CustomClaimValidationSchema = z
     inboundTokenClaimName: z
       .string()
       .min(1)
-      .regex(/^[A-Za-z0-9_.\-:]+$/, 'Claim name must match [A-Za-z0-9_.-:]+'),
+      .max(255)
+      .regex(CLAIM_NAME_PATTERN, 'Claim name must match [A-Za-z0-9_.-:]+')
+      .refine(name => !RESERVED_CLAIM_NAMES.includes(name), {
+        message: `Claim name cannot be a reserved name (${RESERVED_CLAIM_NAMES.join(', ')})`,
+      }),
     inboundTokenClaimValueType: InboundTokenClaimValueTypeSchema,
     authorizingClaimMatchValue: z.object({
       claimMatchOperator: ClaimMatchOperatorSchema,


### PR DESCRIPTION
## Description

Add missing Zod validation for custom JWT claim values to catch invalid input at CLI time instead of failing at deploy time.

- **`matchValueString`** and **`matchValueStringList`** items lacked regex validation, allowing characters (e.g. `/`, `:`) that the API rejects. Added `[A-Za-z0-9_.-]+` pattern and `max(255)` per the [ClaimMatchValueType API docs](https://docs.aws.amazon.com/bedrock-agentcore-control/latest/APIReference/API_ClaimMatchValueType.html).
- **`inboundTokenClaimName`**: Added `max(255)` length constraint and a blocklist for `client_id` — a server-side reserved claim name that the API rejects but doesn't document in its schema.
- Fixed stale `mcp.json` comment references → `agentcore.json`.

## Related Issue

<!-- No existing issue — discovered during bug bash -->

## Documentation PR

N/A — no user-facing doc changes needed.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

Companion CDK PR: https://github.com/aws/agentcore-l3-cdk-constructs/pull/107

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.