### PR TITLE
fix: delete credential provider before stack teardown in e2e tests

### DIFF
--- a/e2e-tests/e2e-helper.ts
+++ b/e2e-tests/e2e-helper.ts
@@ -292,20 +292,23 @@ export function installCdkTarball(projectPath: string): void {
 }
 
 export async function teardownE2EProject(projectPath: string, agentName: string, modelProvider: string): Promise<void> {
-  await spawnAndCollect('agentcore', ['remove', 'all', '--json'], projectPath);
-  const result = await spawnAndCollect('agentcore', ['deploy', '--yes', '--json'], projectPath);
-  if (result.exitCode !== 0) {
-    console.log('Teardown stdout:', result.stdout);
-    console.log('Teardown stderr:', result.stderr);
-  }
+  // Delete credential provider first — it's not a CFN resource, so deleting it
+  // before stack teardown is safe and avoids leaking providers when stack
+  // destruction times out or fails.
   if (modelProvider !== 'Bedrock' && agentName) {
     const providerName = `${agentName}${modelProvider}`;
     const region = process.env.AWS_REGION ?? 'us-east-1';
     try {
       const client = new BedrockAgentCoreControlClient({ region });
       await client.send(new DeleteApiKeyCredentialProviderCommand({ name: providerName }));
-    } catch {
-      // Best-effort cleanup
+    } catch (err) {
+      console.warn(`Failed to delete credential provider ${providerName}:`, err);
     }
+  }
+  await spawnAndCollect('agentcore', ['remove', 'all', '--json'], projectPath);
+  const result = await spawnAndCollect('agentcore', ['deploy', '--yes', '--json'], projectPath);
+  if (result.exitCode !== 0) {
+    console.log('Teardown stdout:', result.stdout);
+    console.log('Teardown stderr:', result.stderr);
   }
 }


### PR DESCRIPTION
## Description

E2E tests for non-Bedrock model providers (OpenAI, Anthropic, Gemini) create API key credential providers during setup. The cleanup in `afterAll` deleted them *after* stack teardown, but if the stack destruction timed out or failed, the delete never ran — leaking providers until the account hit the 50-provider limit.

Also add some logging to see when clean up fails. 

## Related Issue

N/A

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

Verified that credential providers are not CFN resources and have no stack dependency. The delete call is safe to run before stack teardown.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.