### PR TITLE
fix: update lockfile for @aws-cdk/cloud-assembly-schema peer dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -216,9 +216,9 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "53.4.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.4.0.tgz",
-      "integrity": "sha512-UPZi7XA2hOB7OfvMR2kgy7wX1zUu3LGx/eKrykZcFdrwEEny4RvycB0UyqbkzUeIZzuT2t//UpuhPyIGVXqD0w==",
+      "version": "53.8.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.8.0.tgz",
+      "integrity": "sha512-AICSjQCYJrJrMNtN5bW6Zpgyz3Jjtj0Os0qIqEvoX6TS1GjW8idaAxocElDl4/NhnBKWw3ogW36vyHOAYeI36g==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -6728,44 +6728,10 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "52.2.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-52.2.0.tgz",
       "integrity": "sha512-ourZjixQ/UfsZc7gdk3vt1eHBODMUjQTYYYCY3ZX8fiXyHtWNDAYZPrXUK96jpCC2fLP+tfHTJrBjZ563pmcEw==",
-      "bundleDependencies": [
-        "jsonschema",
-        "semver"
-      ],
       "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.3"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.7.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
+      "inBundle": true
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
       "version": "1.0.2",


### PR DESCRIPTION
## Description

`@aws-cdk/toolkit-lib@1.19.2` introduced `@aws-cdk/cloud-assembly-api@2.2.1` which requires `@aws-cdk/cloud-assembly-schema@>=53.8.0` as a peer dependency. The lockfile had `53.4.0`, causing `npm install -g` from tarball to fail with `ETARGET` in CI.

## Related Issues

N/A

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes generate no new warnings

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.