### PR TITLE
fix(e2e): prevent API key credential provider quota exhaustion

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -98,6 +98,18 @@ jobs:
       - run: npm run build
       - name: Install CLI globally
         run: npm install -g "$(npm pack | tail -1)"
+      - name: Clean up stale credential providers
+        run: |
+          # Delete leaked E2e* API key credential providers from previous CI runs
+          # to prevent account quota exhaustion
+          for name in $(aws bedrock-agentcore-control list-api-key-credential-providers \
+            --region ${{ inputs.aws_region || 'us-east-1' }} \
+            --query 'credentialProviders[?starts_with(name, `E2e`)].name' \
+            --output text); do
+              echo "Deleting stale provider: $name"
+              aws bedrock-agentcore-control delete-api-key-credential-provider \
+                --name "$name" --region ${{ inputs.aws_region || 'us-east-1' }} || true
+          done
       - name: Run E2E tests (${{ matrix.cdk-source }})
         env:
           AWS_ACCOUNT_ID: ${{ steps.aws.outputs.account_id }}

--- a/e2e-tests/e2e-helper.ts
+++ b/e2e-tests/e2e-helper.ts
@@ -9,6 +9,7 @@ import {
 import {
   BedrockAgentCoreControlClient,
   DeleteApiKeyCredentialProviderCommand,
+  ListApiKeyCredentialProvidersCommand,
 } from '@aws-sdk/client-bedrock-agentcore-control';
 import { execSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
@@ -38,6 +39,9 @@ export function createE2ESuite(cfg: E2EConfig) {
 
     beforeAll(async () => {
       if (!canRun) return;
+
+      // Purge leaked credential providers from prior CI runs to avoid quota limits
+      await cleanupStaleCredentialProviders();
 
       testDir = join(tmpdir(), `agentcore-e2e-${randomUUID()}`);
       await mkdir(testDir, { recursive: true });
@@ -292,20 +296,53 @@ export function installCdkTarball(projectPath: string): void {
 }
 
 export async function teardownE2EProject(projectPath: string, agentName: string, modelProvider: string): Promise<void> {
-  await spawnAndCollect('agentcore', ['remove', 'all', '--json'], projectPath);
-  const result = await spawnAndCollect('agentcore', ['deploy', '--yes', '--json'], projectPath);
-  if (result.exitCode !== 0) {
-    console.log('Teardown stdout:', result.stdout);
-    console.log('Teardown stderr:', result.stderr);
-  }
+  // Delete the API key credential provider FIRST — CFN teardown may fail,
+  // and leaked providers accumulate until the account hits its quota limit.
   if (modelProvider !== 'Bedrock' && agentName) {
     const providerName = `${agentName}${modelProvider}`;
     const region = process.env.AWS_REGION ?? 'us-east-1';
     try {
       const client = new BedrockAgentCoreControlClient({ region });
       await client.send(new DeleteApiKeyCredentialProviderCommand({ name: providerName }));
-    } catch {
-      // Best-effort cleanup
+      console.log(`Deleted credential provider: ${providerName}`);
+    } catch (err) {
+      console.warn(`Failed to delete credential provider ${providerName}:`, err);
     }
+  }
+
+  await spawnAndCollect('agentcore', ['remove', 'all', '--json'], projectPath);
+  const result = await spawnAndCollect('agentcore', ['deploy', '--yes', '--json'], projectPath);
+  if (result.exitCode !== 0) {
+    console.log('Teardown stdout:', result.stdout);
+    console.log('Teardown stderr:', result.stderr);
+  }
+}
+
+/**
+ * Delete stale E2e* API key credential providers left behind by previous
+ * CI runs whose teardown failed. Call this before tests to prevent quota
+ * exhaustion in the shared test account.
+ */
+export async function cleanupStaleCredentialProviders(): Promise<void> {
+  const region = process.env.AWS_REGION ?? 'us-east-1';
+  try {
+    const client = new BedrockAgentCoreControlClient({ region });
+    const response = await client.send(new ListApiKeyCredentialProvidersCommand({}));
+    const providers = response.credentialProviders ?? [];
+    const stale = providers.filter(p => p.name?.startsWith('E2e'));
+
+    if (stale.length === 0) return;
+
+    console.log(`Cleaning up ${stale.length} stale E2e* credential provider(s)...`);
+    for (const provider of stale) {
+      try {
+        await client.send(new DeleteApiKeyCredentialProviderCommand({ name: provider.name! }));
+        console.log(`  Deleted: ${provider.name}`);
+      } catch (err) {
+        console.warn(`  Failed to delete ${provider.name}:`, err);
+      }
+    }
+  } catch (err) {
+    console.warn('Failed to list credential providers for cleanup:', err);
   }
 }


### PR DESCRIPTION
## Summary

- E2E tests for non-Bedrock model providers (OpenAI, Gemini, Anthropic) were failing because the test account hit its API key credential provider quota limit
- Stale providers accumulated across CI runs because teardown deleted providers **after** CFN stack teardown, which frequently fails when the original deploy never succeeded
- This has been broken on `main` for all recent runs — not caused by any specific PR

## Changes

### `e2e-tests/e2e-helper.ts`
- **Move credential provider deletion before CFN teardown** in `teardownE2EProject()` — ensures cleanup runs even if `remove all` + `deploy` fails
- **Add `cleanupStaleCredentialProviders()`** called in `beforeAll` — purges any leaked `E2e*` providers from prior runs before tests start
- **Add error logging** instead of silently swallowing deletion failures

### `.github/workflows/e2e-tests.yml`
- **Add "Clean up stale credential providers" step** before running tests — belt-and-suspenders defense using AWS CLI directly

## Root Cause

1. E2E creates API key credential providers during `agentcore deploy` (pre-deploy identity step)
2. Teardown runs: `remove all` → `deploy --yes` (to destroy CFN stack) → `DeleteApiKeyCredentialProviderCommand`
3. When the CFN teardown fails (common when deploy itself never succeeded), the credential provider deletion at the end still runs but is **best-effort with a silent catch**
4. Over many CI runs, providers accumulate → account quota hit → all non-Bedrock deploys fail → more providers leak (snowball)

## Test plan

- [x] TypeScript typecheck passes
- [x] ESLint passes
- [x] Prettier passes
- [x] Secretlint passes
- [x] `ListApiKeyCredentialProvidersCommand` import verified in SDK
- [ ] E2E tests pass after manual cleanup of 50 stale providers (re-run triggered on PR #620)

🤖 Generated with [Claude Code](https://claude.com/claude-code)