### PR TITLE
fix: improve CLI UX — memory docs, standardize flags, fix deploy alias

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -9,7 +9,7 @@ Run `agentcore` without arguments to launch the interactive TUI. Flags marked `[
 
 | Command   | Alias |
 | --------- | ----- |
-| `deploy`  | `p`   |
+| `deploy`  | `dp`  |
 | `dev`     | `d`   |
 | `invoke`  | `i`   |
 | `status`  | `s`   |
@@ -65,30 +65,30 @@ agentcore create \
   --memory none
 ```
 
-| Flag                      | Description                                                                      |
-| ------------------------- | -------------------------------------------------------------------------------- |
-| `--name <name>`           | Project name (alphanumeric, starts with letter, max 23 chars)                    |
-| `--defaults`              | Use defaults (Python, Strands, Bedrock, no memory)                               |
-| `--no-agent`              | Skip agent creation                                                              |
-| `--type <type>`           | `create` (default) or `import`                                                   |
-| `--language <lang>`       | `Python` (default)                                                               |
-| `--framework <fw>`        | `Strands`, `LangChain_LangGraph`, `CrewAI`, `GoogleADK`, `OpenAIAgents`          |
-| `--model-provider <p>`    | `Bedrock`, `Anthropic`, `OpenAI`, `Gemini`                                       |
-| `--build <type>`          | `CodeZip` (default) or `Container` (see [Container Builds](container-builds.md)) |
-| `--api-key <key>`         | API key for non-Bedrock providers                                                |
-| `--memory <opt>`          | `none`, `shortTerm`, `longAndShortTerm`                                          |
-| `--protocol <protocol>`   | `HTTP` (default), `MCP`, `A2A`                                                   |
-| `--network-mode <mode>`   | `PUBLIC` (default) or `VPC`                                                      |
-| `--subnets <ids>`         | Comma-separated subnet IDs (required for VPC mode)                               |
-| `--security-groups <ids>` | Comma-separated security group IDs (required for VPC mode)                       |
-| `--agent-id <id>`         | Bedrock Agent ID (import only)                                                   |
-| `--agent-alias-id <id>`   | Bedrock Agent Alias ID (import only)                                             |
-| `--region <region>`       | AWS region for Bedrock Agent (import only)                                       |
-| `--output-dir <dir>`      | Output directory                                                                 |
-| `--skip-git`              | Skip git initialization                                                          |
-| `--skip-python-setup`     | Skip venv setup                                                                  |
-| `--dry-run`               | Preview without creating                                                         |
-| `--json`                  | JSON output                                                                      |
+| Flag                      | Description                                                                                                    |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `--name <name>`           | Project name (alphanumeric, starts with letter, max 23 chars)                                                  |
+| `--defaults`              | Use defaults (Python, Strands, Bedrock, no memory)                                                             |
+| `--no-agent`              | Skip agent creation                                                                                            |
+| `--type <type>`           | `create` (default) or `import`                                                                                 |
+| `--language <lang>`       | `Python` (default)                                                                                             |
+| `--framework <fw>`        | `Strands`, `LangChain_LangGraph`, `CrewAI`, `GoogleADK`, `OpenAIAgents`                                        |
+| `--model-provider <p>`    | `Bedrock`, `Anthropic`, `OpenAI`, `Gemini`                                                                     |
+| `--build <type>`          | `CodeZip` (default) or `Container` (see [Container Builds](container-builds.md))                               |
+| `--api-key <key>`         | API key for non-Bedrock providers                                                                              |
+| `--memory <opt>`          | `none`, `shortTerm`, `longAndShortTerm` (see [Memory Shorthand Mapping](memory.md#--memory-shorthand-mapping)) |
+| `--protocol <protocol>`   | `HTTP` (default), `MCP`, `A2A`                                                                                 |
+| `--network-mode <mode>`   | `PUBLIC` (default) or `VPC`                                                                                    |
+| `--subnets <ids>`         | Comma-separated subnet IDs (required for VPC mode)                                                             |
+| `--security-groups <ids>` | Comma-separated security group IDs (required for VPC mode)                                                     |
+| `--agent-id <id>`         | Bedrock Agent ID (import only)                                                                                 |
+| `--agent-alias-id <id>`   | Bedrock Agent Alias ID (import only)                                                                           |
+| `--region <region>`       | AWS region for Bedrock Agent (import only)                                                                     |
+| `--output-dir <dir>`      | Output directory                                                                                               |
+| `--skip-git`              | Skip git initialization                                                                                        |
+| `--skip-python-setup`     | Skip venv setup                                                                                                |
+| `--dry-run`               | Preview without creating                                                                                       |
+| `--json`                  | JSON output                                                                                                    |
 
 ### deploy
 
@@ -193,26 +193,26 @@ agentcore add agent \
   --memory none
 ```
 
-| Flag                      | Description                                                                      |
-| ------------------------- | -------------------------------------------------------------------------------- |
-| `--name <name>`           | Agent name (alphanumeric, starts with letter, max 64 chars)                      |
-| `--type <type>`           | `create` (default), `byo`, or `import`                                           |
-| `--build <type>`          | `CodeZip` (default) or `Container` (see [Container Builds](container-builds.md)) |
-| `--language <lang>`       | `Python` (create); `Python`, `TypeScript`, `Other` (BYO)                         |
-| `--framework <fw>`        | `Strands`, `LangChain_LangGraph`, `CrewAI`, `GoogleADK`, `OpenAIAgents`          |
-| `--model-provider <p>`    | `Bedrock`, `Anthropic`, `OpenAI`, `Gemini`                                       |
-| `--api-key <key>`         | API key for non-Bedrock providers                                                |
-| `--memory <opt>`          | `none`, `shortTerm`, `longAndShortTerm` (create and import)                      |
-| `--protocol <protocol>`   | `HTTP` (default), `MCP`, `A2A`                                                   |
-| `--code-location <path>`  | Path to existing code (BYO only)                                                 |
-| `--entrypoint <file>`     | Entry file relative to code-location (BYO, default: `main.py`)                   |
-| `--network-mode <mode>`   | `PUBLIC` (default) or `VPC`                                                      |
-| `--subnets <ids>`         | Comma-separated subnet IDs (required for VPC mode)                               |
-| `--security-groups <ids>` | Comma-separated security group IDs (required for VPC mode)                       |
-| `--agent-id <id>`         | Bedrock Agent ID (import only)                                                   |
-| `--agent-alias-id <id>`   | Bedrock Agent Alias ID (import only)                                             |
-| `--region <region>`       | AWS region for Bedrock Agent (import only)                                       |
-| `--json`                  | JSON output                                                                      |
+| Flag                      | Description                                                                                                                       |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `--name <name>`           | Agent name (alphanumeric, starts with letter, max 64 chars)                                                                       |
+| `--type <type>`           | `create` (default), `byo`, or `import`                                                                                            |
+| `--build <type>`          | `CodeZip` (default) or `Container` (see [Container Builds](container-builds.md))                                                  |
+| `--language <lang>`       | `Python` (create); `Python`, `TypeScript`, `Other` (BYO)                                                                          |
+| `--framework <fw>`        | `Strands`, `LangChain_LangGraph`, `CrewAI`, `GoogleADK`, `OpenAIAgents`                                                           |
+| `--model-provider <p>`    | `Bedrock`, `Anthropic`, `OpenAI`, `Gemini`                                                                                        |
+| `--api-key <key>`         | API key for non-Bedrock providers                                                                                                 |
+| `--memory <opt>`          | `none`, `shortTerm`, `longAndShortTerm` (create and import; see [Memory Shorthand Mapping](memory.md#--memory-shorthand-mapping)) |
+| `--protocol <protocol>`   | `HTTP` (default), `MCP`, `A2A`                                                                                                    |
+| `--code-location <path>`  | Path to existing code (BYO only)                                                                                                  |
+| `--entrypoint <file>`     | Entry file relative to code-location (BYO, default: `main.py`)                                                                    |
+| `--network-mode <mode>`   | `PUBLIC` (default) or `VPC`                                                                                                       |
+| `--subnets <ids>`         | Comma-separated subnet IDs (required for VPC mode)                                                                                |
+| `--security-groups <ids>` | Comma-separated security group IDs (required for VPC mode)                                                                        |
+| `--agent-id <id>`         | Bedrock Agent ID (import only)                                                                                                    |
+| `--agent-alias-id <id>`   | Bedrock Agent Alias ID (import only)                                                                                              |
+| `--region <region>`       | AWS region for Bedrock Agent (import only)                                                                                        |
+| `--json`                  | JSON output                                                                                                                       |
 
 ### add memory
 
@@ -542,7 +542,7 @@ agentcore logs --json                            # JSON Lines output
 | `--since <time>`  | Start time (defaults to 1h ago in search mode; e.g. `1h`, `30m`, `2d`, ISO 8601) |
 | `--until <time>`  | End time (defaults to now in search mode; e.g. `now`, ISO 8601)                  |
 | `--level <level>` | Filter by log level: `error`, `warn`, `info`, `debug`                            |
-| `-n, --lines <n>` | Maximum number of log lines to return                                            |
+| `-n, --limit <n>` | Maximum number of log lines to return                                            |
 | `--query <text>`  | Server-side text filter                                                          |
 | `--json`          | Output as JSON Lines                                                             |
 
@@ -675,7 +675,7 @@ agentcore logs evals --follow --json
 | `-a, --agent <name>`  | Filter by agent                               |
 | `--since <time>`      | Start time (e.g. `1h`, `30m`, `2d`, ISO 8601) |
 | `--until <time>`      | End time                                      |
-| `-n, --lines <count>` | Maximum log lines                             |
+| `-n, --limit <count>` | Maximum log lines                             |
 | `-f, --follow`        | Stream in real-time                           |
 | `--json`              | JSON Lines output                             |
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -149,6 +149,23 @@ async def invoke(payload, context):
     agentcore deploy
    ```
 
+## `--memory` Shorthand Mapping
+
+The `create` and `add agent` commands accept a `--memory` flag with one of three shorthand values. Each maps to a
+specific memory configuration:
+
+| Shorthand          | Strategies Created                                                                                                                                                                                                                                              |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `none`             | No memory resource created                                                                                                                                                                                                                                      |
+| `shortTerm`        | Memory with no strategies (session context via event expiry only, default 30 days)                                                                                                                                                                              |
+| `longAndShortTerm` | Memory with four strategies: `SEMANTIC` (`/users/{actorId}/facts`), `USER_PREFERENCE` (`/users/{actorId}/preferences`), `SUMMARIZATION` (`/summaries/{actorId}/{sessionId}`), `EPISODIC` (`/episodes/{actorId}/{sessionId}`, reflection: `/episodes/{actorId}`) |
+
+**Short-term memory** provides basic conversation context within a session — events are stored and expire after the
+configured duration, but no long-term extraction or search is performed.
+
+**Long-and-short-term memory** adds persistent strategies that extract facts, preferences, summaries, and episodes from
+conversations, enabling cross-session recall via semantic search.
+
 ## Memory Strategies
 
 | Strategy          | Description                                            |

--- a/src/cli/commands/deploy/command.tsx
+++ b/src/cli/commands/deploy/command.tsx
@@ -130,7 +130,7 @@ async function handleDeployCLI(options: DeployOptions): Promise<void> {
 export const registerDeploy = (program: Command) => {
   program
     .command('deploy')
-    .alias('p')
+    .alias('dp')
     .description(COMMAND_DESCRIPTIONS.deploy)
     .option('--target <target>', 'Deployment target name (default: "default") [non-interactive]')
     .option('-y, --yes', 'Auto-confirm prompts, read credentials from env [non-interactive]')

--- a/src/cli/commands/logs/action.ts
+++ b/src/cli/commands/logs/action.ts
@@ -110,7 +110,7 @@ export async function handleLogs(options: LogsOptions): Promise<LogsResult> {
     if (mode === 'search') {
       const startTimeMs = options.since ? parseTimeString(options.since) : Date.now() - 3_600_000;
       const endTimeMs = options.until ? parseTimeString(options.until) : Date.now();
-      const limit = options.lines ? parseInt(options.lines, 10) : undefined;
+      const limit = options.limit ? parseInt(options.limit, 10) : undefined;
 
       for await (const event of searchLogs({
         logGroupName: agentContext.logGroupName,

--- a/src/cli/commands/logs/command.tsx
+++ b/src/cli/commands/logs/command.tsx
@@ -24,7 +24,7 @@ export const registerLogs = (program: Command) => {
     .option('--since <time>', 'Start time — defaults to 1h ago in search mode (e.g. "1h", "30m", "2d", ISO 8601)')
     .option('--until <time>', 'End time — defaults to now in search mode (e.g. "now", ISO 8601)')
     .option('--level <level>', 'Filter by log level (error, warn, info, debug)')
-    .option('-n, --lines <count>', 'Maximum number of log lines to return')
+    .option('-n, --limit <count>', 'Maximum number of log lines to return')
     .option('--query <text>', 'Server-side text filter')
     .option('--json', 'Output as JSON Lines')
     .action(async (cliOptions: LogsOptions) => {
@@ -49,7 +49,7 @@ export const registerLogs = (program: Command) => {
     .option('-a, --agent <name>', 'Select specific agent')
     .option('--since <time>', 'Start time (e.g. "1h", "30m", "2d", ISO 8601)')
     .option('--until <time>', 'End time (e.g. "now", ISO 8601)')
-    .option('-n, --lines <count>', 'Maximum number of log lines')
+    .option('-n, --limit <count>', 'Maximum number of log lines')
     .option('-f, --follow', 'Stream logs in real-time (default when no --since/--until)')
     .option('--json', 'Output as JSON Lines')
     .action(async (cliOptions: LogsEvalOptions) => {

--- a/src/cli/commands/logs/types.ts
+++ b/src/cli/commands/logs/types.ts
@@ -3,7 +3,7 @@ export interface LogsOptions {
   since?: string;
   until?: string;
   level?: string;
-  lines?: string;
+  limit?: string;
   query?: string;
   json?: boolean;
 }

--- a/src/cli/operations/eval/logs-eval.ts
+++ b/src/cli/operations/eval/logs-eval.ts
@@ -8,7 +8,7 @@ export interface LogsEvalOptions {
   agent?: string;
   since?: string;
   until?: string;
-  lines?: string;
+  limit?: string;
   json?: boolean;
   follow?: boolean;
 }
@@ -109,7 +109,7 @@ export async function handleLogsEval(options: LogsEvalOptions): Promise<LogsEval
       if (!isFollow) {
         const startTimeMs = options.since ? parseTimeString(options.since) : Date.now() - 3_600_000;
         const endTimeMs = options.until ? parseTimeString(options.until) : Date.now();
-        const limit = options.lines ? parseInt(options.lines, 10) : undefined;
+        const limit = options.limit ? parseInt(options.limit, 10) : undefined;
 
         try {
           for await (const event of searchLogs({


### PR DESCRIPTION
## Summary

- **Document `--memory` shorthand mapping**: Added a mapping table to `docs/memory.md` showing what `none`, `shortTerm`, and `longAndShortTerm` actually create (strategies, namespaces). Added cross-references from `--memory` flag descriptions in `docs/commands.md`.
- **Standardize max-results flags**: `logs` and `logs evals` now use `-n, --limit` (matching `traces list` and `evals history`) instead of `-n, --lines`.
- **Fix deploy alias**: Changed from `p` (confusable with `package`/`publish`) to `dp`.

## Test plan

- [x] `npm run build` — compiles with no TypeScript errors
- [x] `npm test` — all 217 test files pass (3076 tests, 0 failures)
- [x] No snapshot updates needed
- [x] Prettier and ESLint pass via pre-commit hooks
- [x] **E2E validation** (per `clitest.md` instructions):
  - Built and packed both `@aws/agentcore` and `@aws/agentcore-cdk` with e2e timestamp versions
  - Installed CLI tarball locally (not globally) — `npx agentcore --version` returns correct version
  - `agentcore create --name testE2Eproject --no-agent --skip-git --skip-python-setup --defaults` succeeds
  - Installed L3 CDK constructs tarball in created project's `agentcore/cdk/` — `npm ls @aws/agentcore-cdk` confirms correct version