### PR TITLE
refactor(schema): remove type fields from resource schemas and rename credential discriminator

### DIFF
--- a/integ-tests/add-agent-auth.test.ts
+++ b/integ-tests/add-agent-auth.test.ts
@@ -116,7 +116,7 @@ describe('integration: add BYO agent with CUSTOM_JWT auth', () => {
     // Verify OAuth credential was auto-created
     const oauthCred = config.credentials.find(c => c.name === `${agent2}-oauth`);
     expect(oauthCred, 'OAuth credential should be auto-created').toBeTruthy();
-    expect(oauthCred!.type).toBe('OAuthCredentialProvider');
+    expect(oauthCred!.authorizerType).toBe('OAuthCredentialProvider');
     expect((oauthCred as { managed?: boolean }).managed).toBe(true);
 
     // Verify .env.local has client secrets (namespaced per credential)

--- a/schemas/agentcore.schema.v1.json
+++ b/schemas/agentcore.schema.v1.json
@@ -41,10 +41,6 @@
       "items": {
         "type": "object",
         "properties": {
-          "type": {
-            "type": "string",
-            "const": "AgentCoreRuntime"
-          },
           "name": {
             "type": "string",
             "minLength": 1,
@@ -133,10 +129,6 @@
               }
             },
             "additionalProperties": false
-          },
-          "modelProvider": {
-            "type": "string",
-            "enum": ["Bedrock", "Gemini", "OpenAI", "Anthropic"]
           },
           "protocol": {
             "type": "string",
@@ -277,7 +269,7 @@
             "additionalProperties": false
           }
         },
-        "required": ["type", "name", "build", "entrypoint", "codeLocation", "runtimeVersion"],
+        "required": ["name", "build", "entrypoint", "codeLocation", "runtimeVersion"],
         "additionalProperties": false
       }
     },
@@ -287,10 +279,6 @@
       "items": {
         "type": "object",
         "properties": {
-          "type": {
-            "type": "string",
-            "const": "AgentCoreMemory"
-          },
           "name": {
             "type": "string",
             "minLength": 1,
@@ -310,7 +298,7 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": ["SEMANTIC", "SUMMARIZATION", "USER_PREFERENCE", "EPISODIC"]
+                  "enum": ["SEMANTIC", "SUMMARIZATION", "USER_PREFERENCE", "EPISODIC", "CUSTOM"]
                 },
                 "name": {
                   "type": "string",
@@ -332,6 +320,44 @@
                   "items": {
                     "type": "string"
                   }
+                },
+                "semanticOverride": {
+                  "type": "object",
+                  "properties": {
+                    "extraction": {
+                      "type": "object",
+                      "properties": {
+                        "appendToPrompt": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 30000
+                        },
+                        "modelId": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "required": ["appendToPrompt", "modelId"],
+                      "additionalProperties": false
+                    },
+                    "consolidation": {
+                      "type": "object",
+                      "properties": {
+                        "appendToPrompt": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 30000
+                        },
+                        "modelId": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "required": ["appendToPrompt", "modelId"],
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
                 }
               },
               "required": ["type"],
@@ -353,7 +379,7 @@
             }
           }
         },
-        "required": ["type", "name", "eventExpiryDuration"],
+        "required": ["name", "eventExpiryDuration"],
         "additionalProperties": false
       }
     },
@@ -365,32 +391,32 @@
           {
             "type": "object",
             "properties": {
-              "type": {
+              "authorizerType": {
                 "type": "string",
                 "const": "ApiKeyCredentialProvider"
               },
               "name": {
                 "type": "string",
-                "minLength": 3,
-                "maxLength": 255,
-                "pattern": "^[A-Za-z0-9_.-]+$"
+                "minLength": 1,
+                "maxLength": 128,
+                "pattern": "^[a-zA-Z0-9\\-_]+$"
               }
             },
-            "required": ["type", "name"],
+            "required": ["authorizerType", "name"],
             "additionalProperties": false
           },
           {
             "type": "object",
             "properties": {
-              "type": {
+              "authorizerType": {
                 "type": "string",
                 "const": "OAuthCredentialProvider"
               },
               "name": {
                 "type": "string",
-                "minLength": 3,
-                "maxLength": 255,
-                "pattern": "^[A-Za-z0-9_.-]+$"
+                "minLength": 1,
+                "maxLength": 128,
+                "pattern": "^[a-zA-Z0-9\\-_]+$"
               },
               "discoveryUrl": {
                 "type": "string",
@@ -414,7 +440,7 @@
                 "enum": ["inbound", "outbound"]
               }
             },
-            "required": ["type", "name"],
+            "required": ["authorizerType", "name"],
             "additionalProperties": false
           }
         ]
@@ -426,10 +452,6 @@
       "items": {
         "type": "object",
         "properties": {
-          "type": {
-            "type": "string",
-            "const": "CustomEvaluator"
-          },
           "name": {
             "type": "string",
             "minLength": 1,
@@ -527,7 +549,7 @@
             }
           }
         },
-        "required": ["type", "name", "level", "config"],
+        "required": ["name", "level", "config"],
         "additionalProperties": false
       }
     },
@@ -537,10 +559,6 @@
       "items": {
         "type": "object",
         "properties": {
-          "type": {
-            "type": "string",
-            "const": "OnlineEvaluationConfig"
-          },
           "name": {
             "type": "string",
             "minLength": 1,
@@ -586,7 +604,7 @@
             }
           }
         },
-        "required": ["type", "name", "agent", "evaluators", "samplingRate"],
+        "required": ["name", "agent", "evaluators", "samplingRate"],
         "additionalProperties": false
       }
     },

--- a/src/cli/commands/add/__tests__/add-gateway.test.ts
+++ b/src/cli/commands/add/__tests__/add-gateway.test.ts
@@ -190,7 +190,7 @@ describe('add gateway command', () => {
       // Verify managed OAuth credential in agentcore.json
       const credential = projectSpec.credentials.find((c: { name: string }) => c.name === `${gatewayName}-oauth`);
       expect(credential, 'Managed OAuth credential should exist').toBeTruthy();
-      expect(credential.type).toBe('OAuthCredentialProvider');
+      expect(credential.authorizerType).toBe('OAuthCredentialProvider');
       expect(credential.managed).toBe(true);
       expect(credential.usage).toBe('inbound');
     });

--- a/src/cli/commands/add/__tests__/add-identity.test.ts
+++ b/src/cli/commands/add/__tests__/add-identity.test.ts
@@ -61,7 +61,7 @@ describe('add credential command', () => {
       const projectSpec = JSON.parse(await readFile(join(projectDir, 'agentcore/agentcore.json'), 'utf-8'));
       const credential = projectSpec.credentials.find((c: { name: string }) => c.name === identityName);
       expect(credential, 'Credential should be in project credentials').toBeTruthy();
-      expect(credential.type).toBe('ApiKeyCredentialProvider');
+      expect(credential.authorizerType).toBe('ApiKeyCredentialProvider');
     });
   });
 
@@ -98,7 +98,7 @@ describe('add credential command', () => {
       const projectSpec = JSON.parse(await readFile(join(projectDir, 'agentcore/agentcore.json'), 'utf-8'));
       const credential = projectSpec.credentials.find((c: { name: string }) => c.name === identityName);
       expect(credential, 'Credential should be in project credentials').toBeTruthy();
-      expect(credential.type).toBe('OAuthCredentialProvider');
+      expect(credential.authorizerType).toBe('OAuthCredentialProvider');
       expect(credential.discoveryUrl).toBe('https://idp.example.com/.well-known/openid-configuration');
       expect(credential.vendor).toBe('CustomOauth2');
       expect(credential.scopes).toEqual(['read', 'write']);

--- a/src/cli/commands/add/__tests__/add-memory.test.ts
+++ b/src/cli/commands/add/__tests__/add-memory.test.ts
@@ -82,7 +82,7 @@ describe('add memory command', () => {
       const projectSpec = JSON.parse(await readFile(join(projectDir, 'agentcore/agentcore.json'), 'utf-8'));
       const memory = projectSpec.memories.find((m: { name: string }) => m.name === memoryName);
       expect(memory, 'Memory should be in project memories').toBeTruthy();
-      expect(memory.type).toBe('AgentCoreMemory');
+      expect(memory).toBeTruthy();
     });
 
     it('creates memory with multiple strategies', async () => {

--- a/src/cli/commands/dev/command.tsx
+++ b/src/cli/commands/dev/command.tsx
@@ -183,11 +183,6 @@ export const registerDev = (program: Command) => {
           if (protocol === 'A2A') invokePort = 9000;
           else if (protocol === 'MCP') invokePort = 8000;
 
-          // Show model info if available (not applicable to MCP)
-          if (protocol !== 'MCP' && targetAgent?.modelProvider) {
-            console.log(`Provider: ${targetAgent.modelProvider}`);
-          }
-
           // Protocol-aware dispatch
           if (protocol === 'MCP') {
             await handleMcpInvoke(invokePort, opts.invoke, opts.tool, opts.input, headers);
@@ -270,8 +265,7 @@ export const registerDev = (program: Command) => {
           }
 
           // Get provider info from agent config
-          const targetAgent = project.agents.find(a => a.name === config.agentName);
-          const providerInfo = targetAgent?.modelProvider ?? '(see agent code)';
+          const providerInfo = '(see agent code)';
 
           console.log(`Starting dev server...`);
           console.log(`Agent: ${config.agentName}`);

--- a/src/cli/commands/import/__tests__/fixtures/cli-project-with-agent-and-memory.json
+++ b/src/cli/commands/import/__tests__/fixtures/cli-project-with-agent-and-memory.json
@@ -3,7 +3,6 @@
   "version": 1,
   "agents": [
     {
-      "type": "AgentCoreRuntime",
       "name": "existing_agent",
       "build": "CodeZip",
       "entrypoint": "main.py",
@@ -18,7 +17,6 @@
   ],
   "memories": [
     {
-      "type": "AgentCoreMemory",
       "name": "existing_agent_memory",
       "eventExpiryDuration": 30,
       "strategies": [
@@ -30,7 +28,7 @@
   ],
   "credentials": [
     {
-      "type": "ApiKeyCredentialProvider",
+      "authorizerType": "ApiKeyCredentialProvider",
       "name": "my_api_key"
     }
   ],

--- a/src/cli/commands/import/__tests__/idempotency.test.ts
+++ b/src/cli/commands/import/__tests__/idempotency.test.ts
@@ -176,7 +176,6 @@ function makeProjectSpec(agents: { name: string }[] = [], memories: { name: stri
     name: 'TestProject',
     version: 1,
     agents: agents.map(a => ({
-      type: 'AgentCoreRuntime',
       name: a.name,
       build: 'CodeZip',
       entrypoint: 'main.py',
@@ -187,7 +186,6 @@ function makeProjectSpec(agents: { name: string }[] = [], memories: { name: stri
       instrumentation: { enableOtel: true },
     })),
     memories: memories.map(m => ({
-      type: 'AgentCoreMemory',
       name: m.name,
       eventExpiryDuration: 30,
       strategies: [{ type: 'SEMANTIC' }],
@@ -529,7 +527,7 @@ describe('Import Idempotency (Test Group 7)', () => {
       );
 
       const existingSpec = makeProjectSpec();
-      (existingSpec as any).credentials = [{ type: 'ApiKeyCredentialProvider', name: 'my-cred' }];
+      (existingSpec as any).credentials = [{ authorizerType: 'ApiKeyCredentialProvider', name: 'my-cred' }];
       mockConfigIOInstance.readProjectSpec.mockResolvedValue(existingSpec);
 
       const progressMessages: string[] = [];

--- a/src/cli/commands/import/__tests__/import-memory.test.ts
+++ b/src/cli/commands/import/__tests__/import-memory.test.ts
@@ -37,7 +37,6 @@ function toMemorySpec(mem: ParsedStarterToolkitMemory): Memory {
   }
 
   return {
-    type: 'AgentCoreMemory',
     name: mem.name,
     eventExpiryDuration: Math.max(7, Math.min(365, mem.eventExpiryDays)),
     strategies,
@@ -367,7 +366,6 @@ describe('toMemorySpec', () => {
 
     const result = toMemorySpec(mem);
 
-    expect(result.type).toBe('AgentCoreMemory');
     expect(result.name).toBe('test_memory');
     expect(result.eventExpiryDuration).toBe(30);
     expect(result.strategies).toHaveLength(3);
@@ -384,7 +382,6 @@ describe('toMemorySpec', () => {
 
     const result = toMemorySpec(mem);
 
-    expect(result.type).toBe('AgentCoreMemory');
     expect(result.name).toBe('stm_memory');
     expect(result.eventExpiryDuration).toBe(14);
     expect(result.strategies).toHaveLength(0);
@@ -505,7 +502,6 @@ describe('Memory Merge Logic', () => {
   it('skips existing memories by name', () => {
     const existingMemories: Memory[] = [
       {
-        type: 'AgentCoreMemory',
         name: 'existing_memory',
         eventExpiryDuration: 30,
         strategies: [{ type: 'SEMANTIC' }],

--- a/src/cli/commands/import/__tests__/import-no-deploy.test.ts
+++ b/src/cli/commands/import/__tests__/import-no-deploy.test.ts
@@ -557,7 +557,6 @@ agents:
     const writtenSpec = mockWriteProjectSpec.mock.calls[0]![0];
     expect(writtenSpec.memories).toHaveLength(1);
     expect(writtenSpec.memories[0].name).toBe('test_agent_memory');
-    expect(writtenSpec.memories[0].type).toBe('AgentCoreMemory');
   });
 
   it('does NOT call CDK build/synth operations', async () => {

--- a/src/cli/commands/import/__tests__/merge-logic.test.ts
+++ b/src/cli/commands/import/__tests__/merge-logic.test.ts
@@ -15,7 +15,6 @@ function toAgentEnvSpec(agent: ParsedStarterToolkitConfig['agents'][0]): AgentEn
   const codeLocation = path.join(APP_DIR, agent.name);
   const entrypoint = path.basename(agent.entrypoint);
   const spec: AgentEnvSpec = {
-    type: 'AgentCoreRuntime',
     name: agent.name,
     build: agent.build,
     entrypoint: entrypoint as AgentEnvSpec['entrypoint'],
@@ -39,7 +38,6 @@ function toMemorySpec(mem: ParsedStarterToolkitConfig['memories'][0]): Memory {
     strategies.push({ type: 'USER_PREFERENCE' });
   }
   return {
-    type: 'AgentCoreMemory',
     name: mem.name,
     eventExpiryDuration: Math.max(7, Math.min(365, mem.eventExpiryDays)),
     strategies,
@@ -47,7 +45,7 @@ function toMemorySpec(mem: ParsedStarterToolkitConfig['memories'][0]): Memory {
 }
 
 function toCredentialSpec(cred: ParsedStarterToolkitConfig['credentials'][0]): Credential {
-  return { type: 'ApiKeyCredentialProvider', name: cred.name };
+  return { authorizerType: 'ApiKeyCredentialProvider', name: cred.name };
 }
 
 function simulateMerge(
@@ -159,7 +157,7 @@ describe('merge: credential deduplication', () => {
   });
   it('skips credential with same name', () => {
     const projectSpec = loadCliProjectSpec();
-    projectSpec.credentials.push({ type: 'ApiKeyCredentialProvider', name: 'new_api_key_cred' });
+    projectSpec.credentials.push({ authorizerType: 'ApiKeyCredentialProvider', name: 'new_api_key_cred' });
     const parsed = parseStarterToolkitYaml(DIFFERENT_AGENT_YAML);
     const { messages } = simulateMerge(projectSpec, parsed);
     expect(messages).toContain('Skipping credential "new_api_key_cred" (already exists in project)');

--- a/src/cli/commands/import/__tests__/test1-no-memory-agent.test.ts
+++ b/src/cli/commands/import/__tests__/test1-no-memory-agent.test.ts
@@ -274,7 +274,6 @@ describe('toAgentEnvSpec conversion', () => {
   const APP_DIR = 'app';
   function toAgentEnvSpec(agent: ParsedStarterToolkitAgent) {
     return {
-      type: 'AgentCoreRuntime' as const,
       name: agent.name,
       build: agent.build,
       entrypoint: path.basename(agent.entrypoint),
@@ -298,8 +297,8 @@ describe('toAgentEnvSpec conversion', () => {
     enableOtel: true,
   };
 
-  it('type=AgentCoreRuntime', () => {
-    expect(toAgentEnvSpec(base).type).toBe('AgentCoreRuntime');
+  it('name is set', () => {
+    expect(toAgentEnvSpec(base).name).toBe('my_strands_agent');
   });
   it('build=CodeZip', () => {
     expect(toAgentEnvSpec(base).build).toBe('CodeZip');

--- a/src/cli/commands/import/actions.ts
+++ b/src/cli/commands/import/actions.ts
@@ -46,7 +46,6 @@ function toAgentEnvSpec(agent: ParsedStarterToolkitConfig['agents'][0]): AgentEn
 
   /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any */
   const spec: AgentEnvSpec = {
-    type: 'AgentCoreRuntime',
     name: agent.name,
     build: agent.build,
     entrypoint: entrypoint as any,
@@ -85,7 +84,6 @@ function toMemorySpec(mem: ParsedStarterToolkitConfig['memories'][0]): Memory {
   }
 
   return {
-    type: 'AgentCoreMemory',
     name: mem.name,
     eventExpiryDuration: Math.max(7, Math.min(365, mem.eventExpiryDays)),
     strategies,
@@ -99,13 +97,13 @@ function toMemorySpec(mem: ParsedStarterToolkitConfig['memories'][0]): Memory {
  */
 function toCredentialSpec(cred: ParsedStarterToolkitConfig['credentials'][0]): Credential {
   if (cred.providerType === 'api_key') {
-    return { type: 'ApiKeyCredentialProvider', name: cred.name };
+    return { authorizerType: 'ApiKeyCredentialProvider', name: cred.name };
   }
   // OAuth providers already exist in Identity service. We map them as OAuthCredentialProvider
   // so the CLI correctly wires CLIENT_ID/CLIENT_SECRET env vars (not API_KEY).
   // discoveryUrl is omitted since it's not available from the YAML and the provider
   // already exists — pre-deploy will skip if no credentials are in .env.local.
-  return { type: 'OAuthCredentialProvider', name: cred.name, vendor: 'CustomOauth2' };
+  return { authorizerType: 'OAuthCredentialProvider', name: cred.name, vendor: 'CustomOauth2' };
 }
 
 export async function handleImport(options: ImportOptions): Promise<ImportResult> {

--- a/src/cli/commands/invoke/action.ts
+++ b/src/cli/commands/invoke/action.ts
@@ -214,8 +214,8 @@ export async function handleInvoke(context: InvokeContext, options: InvokeOption
     }
   }
 
-  // Get provider info if available
-  const providerInfo = agentSpec.modelProvider;
+  // modelProvider has been removed from schema
+  const providerInfo = undefined;
 
   // Create logger for this invocation
   const logger = new InvokeLogger({

--- a/src/cli/commands/logs/__tests__/action.test.ts
+++ b/src/cli/commands/logs/__tests__/action.test.ts
@@ -46,7 +46,6 @@ describe('resolveAgentContext', () => {
       managedBy: 'CDK' as const,
       agents: [
         {
-          type: 'AgentCoreRuntime' as const,
           name: 'MyAgent',
           build: 'CodeZip' as const,
           entrypoint: 'main.py' as any,
@@ -100,7 +99,6 @@ describe('resolveAgentContext', () => {
         managedBy: 'CDK' as const,
         agents: [
           {
-            type: 'AgentCoreRuntime' as const,
             name: 'AgentA',
             build: 'CodeZip' as const,
             entrypoint: 'main.py' as any,
@@ -109,7 +107,6 @@ describe('resolveAgentContext', () => {
             protocol: 'HTTP' as const,
           },
           {
-            type: 'AgentCoreRuntime' as const,
             name: 'AgentB',
             build: 'CodeZip' as const,
             entrypoint: 'main.py' as any,
@@ -143,7 +140,6 @@ describe('resolveAgentContext', () => {
         managedBy: 'CDK' as const,
         agents: [
           {
-            type: 'AgentCoreRuntime' as const,
             name: 'AgentA',
             build: 'CodeZip' as const,
             entrypoint: 'main.py' as any,
@@ -152,7 +148,6 @@ describe('resolveAgentContext', () => {
             protocol: 'HTTP' as const,
           },
           {
-            type: 'AgentCoreRuntime' as const,
             name: 'AgentB',
             build: 'CodeZip' as const,
             entrypoint: 'main.py' as any,

--- a/src/cli/commands/status/__tests__/action.test.ts
+++ b/src/cli/commands/status/__tests__/action.test.ts
@@ -103,7 +103,7 @@ describe('computeResourceStatuses', () => {
   it('marks credential as deployed when in both local and deployed state', () => {
     const project = {
       ...baseProject,
-      credentials: [{ name: 'my-cred', type: 'OAuthCredentialProvider' }],
+      credentials: [{ name: 'my-cred', authorizerType: 'OAuthCredentialProvider' }],
     } as unknown as AgentCoreProjectSpec;
 
     const resources: DeployedResourceState = {
@@ -126,7 +126,7 @@ describe('computeResourceStatuses', () => {
   it('marks credential as local-only when not in deployed state', () => {
     const project = {
       ...baseProject,
-      credentials: [{ name: 'my-cred', type: 'ApiKeyCredentialProvider' }],
+      credentials: [{ name: 'my-cred', authorizerType: 'ApiKeyCredentialProvider' }],
     } as unknown as AgentCoreProjectSpec;
 
     const result = computeResourceStatuses(project, undefined);
@@ -215,7 +215,7 @@ describe('computeResourceStatuses', () => {
       ...baseProject,
       agents: [{ name: 'agent-a' }],
       memories: [{ name: 'mem-a', strategies: [] }],
-      credentials: [{ name: 'cred-a', type: 'ApiKeyCredentialProvider' }],
+      credentials: [{ name: 'cred-a', authorizerType: 'ApiKeyCredentialProvider' }],
     } as unknown as AgentCoreProjectSpec;
 
     const result = computeResourceStatuses(project, undefined);
@@ -398,7 +398,7 @@ describe('computeResourceStatuses', () => {
     const project = {
       ...baseProject,
       agents: [{ name: 'deployed-agent' }, { name: 'new-agent' }],
-      credentials: [{ name: 'deployed-cred', type: 'OAuthCredentialProvider' }],
+      credentials: [{ name: 'deployed-cred', authorizerType: 'OAuthCredentialProvider' }],
     } as unknown as AgentCoreProjectSpec;
 
     const resources: DeployedResourceState = {

--- a/src/cli/commands/status/action.ts
+++ b/src/cli/commands/status/action.ts
@@ -130,7 +130,7 @@ export function computeResourceStatuses(
     localItems: project.credentials,
     deployedRecord: resources?.credentials ?? {},
     getIdentifier: deployed => deployed.credentialProviderArn,
-    getLocalDetail: item => item.type?.replace('CredentialProvider', ''),
+    getLocalDetail: item => item.authorizerType?.replace('CredentialProvider', ''),
   });
 
   const memories = diffResourceSet({

--- a/src/cli/commands/tag/__tests__/action.test.ts
+++ b/src/cli/commands/tag/__tests__/action.test.ts
@@ -27,7 +27,6 @@ const baseSpec = () => ({
   tags: { 'agentcore:created-by': 'agentcore-cli' },
   agents: [
     {
-      type: 'AgentCoreRuntime',
       name: 'myAgent',
       build: 'CodeZip',
       entrypoint: 'main.py',
@@ -36,7 +35,7 @@ const baseSpec = () => ({
       protocol: 'HTTP',
     },
   ],
-  memories: [{ type: 'AgentCoreMemory', name: 'myMemory', eventExpiryDuration: 30, strategies: [] }],
+  memories: [{ name: 'myMemory', eventExpiryDuration: 30, strategies: [] }],
   credentials: [],
   agentCoreGateways: [
     {

--- a/src/cli/external-requirements/__tests__/checks-extended.test.ts
+++ b/src/cli/external-requirements/__tests__/checks-extended.test.ts
@@ -39,7 +39,6 @@ describe('requiresUv', () => {
       managedBy: 'CDK' as const,
       agents: [
         {
-          type: 'AgentCoreRuntime',
           name: 'Agent1',
           build: 'CodeZip',
           runtimeVersion: 'PYTHON_3_12',
@@ -65,7 +64,6 @@ describe('requiresUv', () => {
       managedBy: 'CDK' as const,
       agents: [
         {
-          type: 'AgentCoreRuntime',
           name: 'Agent1',
           build: 'Container',
           runtimeVersion: 'PYTHON_3_12',
@@ -109,7 +107,6 @@ describe('requiresContainerRuntime', () => {
       managedBy: 'CDK' as const,
       agents: [
         {
-          type: 'AgentCoreRuntime',
           name: 'Agent1',
           build: 'Container',
           runtimeVersion: 'PYTHON_3_12',
@@ -135,7 +132,6 @@ describe('requiresContainerRuntime', () => {
       managedBy: 'CDK' as const,
       agents: [
         {
-          type: 'AgentCoreRuntime',
           name: 'Agent1',
           build: 'CodeZip',
           runtimeVersion: 'PYTHON_3_12',
@@ -177,7 +173,6 @@ describe('requiresContainerRuntime', () => {
       managedBy: 'CDK' as const,
       agents: [
         {
-          type: 'AgentCoreRuntime',
           name: 'Agent1',
           build: 'CodeZip',
           runtimeVersion: 'PYTHON_3_12',
@@ -186,7 +181,6 @@ describe('requiresContainerRuntime', () => {
           protocol: 'HTTP',
         },
         {
-          type: 'AgentCoreRuntime',
           name: 'Agent2',
           build: 'Container',
           runtimeVersion: 'PYTHON_3_12',
@@ -302,7 +296,6 @@ describe('checkDependencyVersions', () => {
       managedBy: 'CDK' as const,
       agents: [
         {
-          type: 'AgentCoreRuntime',
           name: 'Agent1',
           build: 'CodeZip',
           runtimeVersion: 'PYTHON_3_12',

--- a/src/cli/operations/agent/generate/__tests__/schema-mapper.test.ts
+++ b/src/cli/operations/agent/generate/__tests__/schema-mapper.test.ts
@@ -30,7 +30,6 @@ describe('mapGenerateInputToMemories', () => {
   it('returns memory with no strategies for "shortTerm"', () => {
     const result = mapGenerateInputToMemories('shortTerm', 'Proj');
     expect(result).toHaveLength(1);
-    expect(result[0]!.type).toBe('AgentCoreMemory');
     expect(result[0]!.name).toBe('ProjMemory');
     expect(result[0]!.eventExpiryDuration).toBe(30);
     expect(result[0]!.strategies).toEqual([]);
@@ -57,7 +56,6 @@ describe('mapGenerateInputToMemories', () => {
   it('returns memory with single CUSTOM strategy for "custom"', () => {
     const result = mapGenerateInputToMemories('custom', 'Proj');
     expect(result).toHaveLength(1);
-    expect(result[0]!.type).toBe('AgentCoreMemory');
     expect(result[0]!.name).toBe('ProjMemory');
     expect(result[0]!.eventExpiryDuration).toBe(30);
     const strategies = result[0]!.strategies;
@@ -87,7 +85,7 @@ describe('mapModelProviderToCredentials', () => {
   it('returns credential for Anthropic', () => {
     const result = mapModelProviderToCredentials('Anthropic', 'Proj');
     expect(result).toHaveLength(1);
-    expect(result[0]!.type).toBe('ApiKeyCredentialProvider');
+    expect(result[0]!.authorizerType).toBe('ApiKeyCredentialProvider');
     expect(result[0]!.name).toBe('ProjAnthropic');
   });
 
@@ -105,7 +103,6 @@ describe('mapModelProviderToCredentials', () => {
 describe('mapGenerateConfigToAgent', () => {
   it('creates AgentCoreRuntime agent spec', () => {
     const result = mapGenerateConfigToAgent(baseConfig);
-    expect(result.type).toBe('AgentCoreRuntime');
     expect(result.name).toBe('TestProject');
     expect(result.build).toBe('CodeZip');
     expect(result.entrypoint).toBe('main.py');
@@ -235,7 +232,6 @@ describe('mapGenerateConfigToRenderConfig', () => {
   it('includes existing memories in memoryProviders', async () => {
     const existingMemories = [
       {
-        type: 'AgentCoreMemory' as const,
         name: 'SharedMemory',
         eventExpiryDuration: 30,
         strategies: [{ type: 'SEMANTIC' as const, namespaces: ['/users/{actorId}/facts'] }],
@@ -253,7 +249,6 @@ describe('mapGenerateConfigToRenderConfig', () => {
     const config: GenerateConfig = { ...baseConfig, memory: 'shortTerm' };
     const existingMemories = [
       {
-        type: 'AgentCoreMemory' as const,
         name: 'TestProjectMemory',
         eventExpiryDuration: 30,
         strategies: [{ type: 'SEMANTIC' as const, namespaces: ['/users/{actorId}/facts'] }],
@@ -269,7 +264,6 @@ describe('mapGenerateConfigToRenderConfig', () => {
   it('sets hasMemory true from existing memories even when memory option is "none"', async () => {
     const existingMemories = [
       {
-        type: 'AgentCoreMemory' as const,
         name: 'ProjectMemory',
         eventExpiryDuration: 30,
         strategies: [],
@@ -285,7 +279,6 @@ describe('mapGenerateConfigToRenderConfig', () => {
     const config: GenerateConfig = { ...baseConfig, memory: 'custom', projectName: 'NewAgent' };
     const existingMemories = [
       {
-        type: 'AgentCoreMemory' as const,
         name: 'SharedMemory',
         eventExpiryDuration: 30,
         strategies: [{ type: 'SEMANTIC' as const, namespaces: ['/users/{actorId}/facts'] }],
@@ -303,7 +296,6 @@ describe('mapExistingMemoriesToProviders', () => {
   it('maps memories to providers with correct envVarName and strategies', () => {
     const memories = [
       {
-        type: 'AgentCoreMemory' as const,
         name: 'MyMemory',
         eventExpiryDuration: 30,
         strategies: [
@@ -322,7 +314,6 @@ describe('mapExistingMemoriesToProviders', () => {
   it('handles memory with CUSTOM strategy (no namespaces)', () => {
     const memories = [
       {
-        type: 'AgentCoreMemory' as const,
         name: 'CustomMem',
         eventExpiryDuration: 30,
         strategies: [{ type: 'CUSTOM' as const }],
@@ -336,7 +327,6 @@ describe('mapExistingMemoriesToProviders', () => {
   it('handles memory with empty strategies (short-term memory)', () => {
     const memories = [
       {
-        type: 'AgentCoreMemory' as const,
         name: 'ShortTermMem',
         eventExpiryDuration: 30,
         strategies: [],
@@ -351,13 +341,11 @@ describe('mapExistingMemoriesToProviders', () => {
   it('maps multiple memories', () => {
     const memories = [
       {
-        type: 'AgentCoreMemory' as const,
         name: 'MemOne',
         eventExpiryDuration: 30,
         strategies: [{ type: 'SEMANTIC' as const, namespaces: ['/users/{actorId}/facts'] }],
       },
       {
-        type: 'AgentCoreMemory' as const,
         name: 'MemTwo',
         eventExpiryDuration: 60,
         strategies: [{ type: 'CUSTOM' as const }],
@@ -394,7 +382,6 @@ describe('mapGenerateConfigToAgent protocol mode', () => {
     };
     const result = mapGenerateConfigToAgent(httpConfig);
     expect(result.protocol).toBe('HTTP');
-    expect(result.modelProvider).toBe('Bedrock');
   });
 
   it('sets protocol for A2A', () => {
@@ -404,7 +391,6 @@ describe('mapGenerateConfigToAgent protocol mode', () => {
     };
     const result = mapGenerateConfigToAgent(a2aConfig);
     expect(result.protocol).toBe('A2A');
-    expect(result.modelProvider).toBe('Bedrock');
   });
 });
 

--- a/src/cli/operations/agent/generate/schema-mapper.ts
+++ b/src/cli/operations/agent/generate/schema-mapper.ts
@@ -83,7 +83,6 @@ export function mapGenerateInputToMemories(memory: MemoryOption, projectName: st
 
   return [
     {
-      type: 'AgentCoreMemory',
       name: `${projectName}Memory`,
       eventExpiryDuration: DEFAULT_MEMORY_EXPIRY_DAYS,
       strategies,
@@ -102,7 +101,7 @@ export function mapModelProviderToCredentials(modelProvider: ModelProvider, proj
 
   return [
     {
-      type: 'ApiKeyCredentialProvider',
+      authorizerType: 'ApiKeyCredentialProvider',
       name: computeCredentialName(projectName, modelProvider),
     },
   ];
@@ -117,7 +116,6 @@ export function mapGenerateConfigToAgent(config: GenerateConfig): AgentEnvSpec {
   const networkMode = config.networkMode ?? DEFAULT_NETWORK_MODE;
 
   return {
-    type: 'AgentCoreRuntime',
     name: config.projectName,
     build: config.buildType ?? 'CodeZip',
     entrypoint: DEFAULT_PYTHON_ENTRYPOINT as FilePath,
@@ -151,7 +149,6 @@ export function mapGenerateConfigToAgent(config: GenerateConfig): AgentEnvSpec {
           },
         }
       : {}),
-    ...(protocol !== 'MCP' && { modelProvider: config.modelProvider }),
     // MCP uses mcp.run() which is incompatible with the opentelemetry-instrument wrapper
     ...(protocol === 'MCP' && { instrumentation: { enableOtel: false } }),
   };

--- a/src/cli/operations/deploy/__tests__/pre-deploy-identity.test.ts
+++ b/src/cli/operations/deploy/__tests__/pre-deploy-identity.test.ts
@@ -203,8 +203,8 @@ describe('hasIdentityOAuthProviders', () => {
   it('returns true when OAuthCredentialProvider exists', () => {
     const projectSpec = {
       credentials: [
-        { name: 'oauth-cred', type: 'OAuthCredentialProvider' },
-        { name: 'api-cred', type: 'ApiKeyCredentialProvider' },
+        { name: 'oauth-cred', authorizerType: 'OAuthCredentialProvider' },
+        { name: 'api-cred', authorizerType: 'ApiKeyCredentialProvider' },
       ],
     };
     expect(hasIdentityOAuthProviders(projectSpec as any)).toBe(true);
@@ -212,7 +212,7 @@ describe('hasIdentityOAuthProviders', () => {
 
   it('returns false when only ApiKey credentials exist', () => {
     const projectSpec = {
-      credentials: [{ name: 'api-cred', type: 'ApiKeyCredentialProvider' }],
+      credentials: [{ name: 'api-cred', authorizerType: 'ApiKeyCredentialProvider' }],
     };
     expect(hasIdentityOAuthProviders(projectSpec as any)).toBe(false);
   });
@@ -226,7 +226,7 @@ describe('hasIdentityOAuthProviders', () => {
 describe('getAllCredentials', () => {
   it('returns API key env var for ApiKeyCredentialProvider', () => {
     const projectSpec = {
-      credentials: [{ name: 'test-api', type: 'ApiKeyCredentialProvider' }],
+      credentials: [{ name: 'test-api', authorizerType: 'ApiKeyCredentialProvider' }],
     };
     const result = getAllCredentials(projectSpec as any);
     expect(result).toEqual([{ providerName: 'test-api', envVarName: 'AGENTCORE_CREDENTIAL_TEST_API' }]);
@@ -234,7 +234,7 @@ describe('getAllCredentials', () => {
 
   it('returns CLIENT_ID and CLIENT_SECRET vars for OAuthCredentialProvider', () => {
     const projectSpec = {
-      credentials: [{ name: 'oauth-provider', type: 'OAuthCredentialProvider' }],
+      credentials: [{ name: 'oauth-provider', authorizerType: 'OAuthCredentialProvider' }],
     };
     const result = getAllCredentials(projectSpec as any);
     expect(result).toEqual([
@@ -246,8 +246,8 @@ describe('getAllCredentials', () => {
   it('handles both credential types together', () => {
     const projectSpec = {
       credentials: [
-        { name: 'api-key', type: 'ApiKeyCredentialProvider' },
-        { name: 'oauth-cred', type: 'OAuthCredentialProvider' },
+        { name: 'api-key', authorizerType: 'ApiKeyCredentialProvider' },
+        { name: 'oauth-cred', authorizerType: 'OAuthCredentialProvider' },
       ],
     };
     const result = getAllCredentials(projectSpec as any);
@@ -260,7 +260,7 @@ describe('getAllCredentials', () => {
 
   it('uppercases and replaces hyphens with underscores', () => {
     const projectSpec = {
-      credentials: [{ name: 'my-oauth-provider', type: 'OAuthCredentialProvider' }],
+      credentials: [{ name: 'my-oauth-provider', authorizerType: 'OAuthCredentialProvider' }],
     };
     const result = getAllCredentials(projectSpec as any);
     expect(result[0]!.envVarName).toBe('AGENTCORE_CREDENTIAL_MY_OAUTH_PROVIDER_CLIENT_ID');
@@ -288,7 +288,7 @@ describe('setupOAuth2Providers', () => {
       credentials: [
         {
           name: 'test-oauth',
-          type: 'OAuthCredentialProvider',
+          authorizerType: 'OAuthCredentialProvider',
           vendor: 'Google',
           discoveryUrl: 'https://accounts.google.com/.well-known/openid_configuration',
         },
@@ -325,7 +325,7 @@ describe('setupOAuth2Providers', () => {
       credentials: [
         {
           name: 'test-oauth',
-          type: 'OAuthCredentialProvider',
+          authorizerType: 'OAuthCredentialProvider',
           discoveryUrl: 'https://accounts.google.com/.well-known/openid_configuration',
         },
       ],
@@ -347,7 +347,7 @@ describe('setupOAuth2Providers', () => {
     mockReadEnvFile.mockResolvedValue({});
 
     const projectSpec = {
-      credentials: [{ name: 'test-oauth', type: 'OAuthCredentialProvider' }],
+      credentials: [{ name: 'test-oauth', authorizerType: 'OAuthCredentialProvider' }],
     };
 
     const result = await setupOAuth2Providers({
@@ -374,7 +374,7 @@ describe('setupOAuth2Providers', () => {
       credentials: [
         {
           name: 'test-oauth',
-          type: 'OAuthCredentialProvider',
+          authorizerType: 'OAuthCredentialProvider',
           discoveryUrl: 'https://accounts.google.com/.well-known/openid_configuration',
         },
       ],

--- a/src/cli/operations/deploy/pre-deploy-identity.ts
+++ b/src/cli/operations/deploy/pre-deploy-identity.ts
@@ -85,7 +85,7 @@ export async function setupApiKeyProviders(options: SetupApiKeyProvidersOptions)
 
   // Set up each credential in the project
   for (const credential of projectSpec.credentials) {
-    if (credential.type === 'ApiKeyCredentialProvider') {
+    if (credential.authorizerType === 'ApiKeyCredentialProvider') {
       const result = await setupApiKeyCredentialProvider(client, credential, allCredentials);
       results.push(result);
     }
@@ -200,7 +200,7 @@ async function setupApiKeyCredentialProvider(
  * Check if the project has any API key credentials that need setup.
  */
 export function hasIdentityApiProviders(projectSpec: AgentCoreProjectSpec): boolean {
-  return projectSpec.credentials.some(c => c.type === 'ApiKeyCredentialProvider');
+  return projectSpec.credentials.some(c => c.authorizerType === 'ApiKeyCredentialProvider');
 }
 
 export interface MissingCredential {
@@ -219,7 +219,7 @@ export async function getMissingCredentials(
   const missing: MissingCredential[] = [];
 
   for (const credential of projectSpec.credentials) {
-    if (credential.type === 'ApiKeyCredentialProvider') {
+    if (credential.authorizerType === 'ApiKeyCredentialProvider') {
       const envVarName = computeDefaultCredentialEnvVarName(credential.name);
       if (!envVars[envVarName]) {
         missing.push({
@@ -240,12 +240,12 @@ export function getAllCredentials(projectSpec: AgentCoreProjectSpec): MissingCre
   const credentials: MissingCredential[] = [];
 
   for (const credential of projectSpec.credentials) {
-    if (credential.type === 'ApiKeyCredentialProvider') {
+    if (credential.authorizerType === 'ApiKeyCredentialProvider') {
       credentials.push({
         providerName: credential.name,
         envVarName: computeDefaultCredentialEnvVarName(credential.name),
       });
-    } else if (credential.type === 'OAuthCredentialProvider') {
+    } else if (credential.authorizerType === 'OAuthCredentialProvider') {
       const nameKey = credential.name.toUpperCase().replace(/-/g, '_');
       credentials.push(
         { providerName: credential.name, envVarName: `AGENTCORE_CREDENTIAL_${nameKey}_CLIENT_ID` },
@@ -298,7 +298,7 @@ export async function setupOAuth2Providers(options: SetupOAuth2ProvidersOptions)
   const client = new BedrockAgentCoreControlClient({ region, credentials });
 
   for (const credential of projectSpec.credentials) {
-    if (credential.type === 'OAuthCredentialProvider') {
+    if (credential.authorizerType === 'OAuthCredentialProvider') {
       const result = await setupSingleOAuth2Provider(client, credential, allCredentials);
       results.push(result);
     }
@@ -314,7 +314,7 @@ export async function setupOAuth2Providers(options: SetupOAuth2ProvidersOptions)
  * Check if the project has any OAuth credentials that need setup.
  */
 export function hasIdentityOAuthProviders(projectSpec: AgentCoreProjectSpec): boolean {
-  return projectSpec.credentials.some(c => c.type === 'OAuthCredentialProvider');
+  return projectSpec.credentials.some(c => c.authorizerType === 'OAuthCredentialProvider');
 }
 
 async function setupSingleOAuth2Provider(
@@ -322,7 +322,7 @@ async function setupSingleOAuth2Provider(
   credential: Credential,
   credentials: SecureCredentials
 ): Promise<OAuth2ProviderSetupResult> {
-  if (credential.type !== 'OAuthCredentialProvider') {
+  if (credential.authorizerType !== 'OAuthCredentialProvider') {
     return { providerName: credential.name, status: 'error', error: 'Invalid credential type' };
   }
 

--- a/src/cli/operations/dev/__tests__/config.test.ts
+++ b/src/cli/operations/dev/__tests__/config.test.ts
@@ -34,7 +34,6 @@ describe('getDevConfig', () => {
       managedBy: 'CDK' as const,
       agents: [
         {
-          type: 'AgentCoreRuntime',
           name: 'NodeAgent',
           build: 'CodeZip',
           runtimeVersion: 'NODE_20',
@@ -62,7 +61,6 @@ describe('getDevConfig', () => {
       managedBy: 'CDK' as const,
       agents: [
         {
-          type: 'AgentCoreRuntime',
           name: 'PythonAgent',
           build: 'CodeZip',
           runtimeVersion: 'PYTHON_3_12',
@@ -96,7 +94,6 @@ describe('getDevConfig', () => {
       managedBy: 'CDK' as const,
       agents: [
         {
-          type: 'AgentCoreRuntime',
           name: 'PythonAgent',
           build: 'CodeZip',
           runtimeVersion: 'PYTHON_3_12',
@@ -125,7 +122,6 @@ describe('getDevConfig', () => {
       managedBy: 'CDK' as const,
       agents: [
         {
-          type: 'AgentCoreRuntime',
           name: 'NodeAgent',
           build: 'CodeZip',
           runtimeVersion: 'NODE_20',
@@ -152,7 +148,6 @@ describe('getDevConfig', () => {
       managedBy: 'CDK' as const,
       agents: [
         {
-          type: 'AgentCoreRuntime',
           name: 'PythonAgent',
           build: 'CodeZip',
           runtimeVersion: 'PYTHON_3_12',
@@ -182,7 +177,6 @@ describe('getDevConfig', () => {
       managedBy: 'CDK' as const,
       agents: [
         {
-          type: 'AgentCoreRuntime',
           name: 'PythonAgent',
           build: 'CodeZip',
           runtimeVersion: 'PYTHON_3_12',
@@ -212,7 +206,6 @@ describe('getDevConfig', () => {
       managedBy: 'CDK' as const,
       agents: [
         {
-          type: 'AgentCoreRuntime',
           name: 'ContainerAgent',
           build: 'Container',
           runtimeVersion: 'PYTHON_3_12',
@@ -242,7 +235,6 @@ describe('getDevConfig', () => {
       managedBy: 'CDK' as const,
       agents: [
         {
-          type: 'AgentCoreRuntime',
           name: 'ContainerAgent',
           build: 'Container',
           runtimeVersion: 'NODE_20',
@@ -272,7 +264,6 @@ describe('getDevConfig', () => {
       managedBy: 'CDK' as const,
       agents: [
         {
-          type: 'AgentCoreRuntime',
           name: 'PythonAgent',
           build: 'CodeZip',
           runtimeVersion: 'PYTHON_3_12',
@@ -300,7 +291,6 @@ describe('getDevConfig', () => {
       managedBy: 'CDK' as const,
       agents: [
         {
-          type: 'AgentCoreRuntime',
           name: 'McpAgent',
           build: 'CodeZip',
           runtimeVersion: 'PYTHON_3_12',
@@ -329,7 +319,6 @@ describe('getDevConfig', () => {
       managedBy: 'CDK' as const,
       agents: [
         {
-          type: 'AgentCoreRuntime',
           name: 'A2aAgent',
           build: 'CodeZip',
           runtimeVersion: 'PYTHON_3_12',
@@ -358,7 +347,6 @@ describe('getDevConfig', () => {
       managedBy: 'CDK' as const,
       agents: [
         {
-          type: 'AgentCoreRuntime',
           name: 'FastAPIAgent',
           build: 'CodeZip',
           runtimeVersion: 'PYTHON_3_12',
@@ -393,7 +381,6 @@ describe('getAgentPort', () => {
       managedBy: 'CDK' as const,
       agents: [
         {
-          type: 'AgentCoreRuntime',
           name: 'Agent1',
           build: 'CodeZip',
           runtimeVersion: 'PYTHON_3_12',
@@ -402,7 +389,6 @@ describe('getAgentPort', () => {
           protocol: 'HTTP',
         },
         {
-          type: 'AgentCoreRuntime',
           name: 'Agent2',
           build: 'CodeZip',
           runtimeVersion: 'PYTHON_3_12',
@@ -470,7 +456,6 @@ describe('getDevSupportedAgents', () => {
       managedBy: 'CDK' as const,
       agents: [
         {
-          type: 'AgentCoreRuntime',
           name: 'NodeAgent',
           build: 'CodeZip',
           runtimeVersion: 'NODE_20',
@@ -497,7 +482,6 @@ describe('getDevSupportedAgents', () => {
       managedBy: 'CDK' as const,
       agents: [
         {
-          type: 'AgentCoreRuntime',
           name: 'PythonAgent',
           build: 'CodeZip',
           runtimeVersion: 'PYTHON_3_12',
@@ -506,7 +490,6 @@ describe('getDevSupportedAgents', () => {
           protocol: 'HTTP',
         },
         {
-          type: 'AgentCoreRuntime',
           name: 'NodeAgent',
           build: 'CodeZip',
           runtimeVersion: 'NODE_20',
@@ -535,7 +518,6 @@ describe('getDevSupportedAgents', () => {
       managedBy: 'CDK' as const,
       agents: [
         {
-          type: 'AgentCoreRuntime',
           name: 'ContainerAgent',
           build: 'Container',
           runtimeVersion: 'PYTHON_3_12',
@@ -564,7 +546,6 @@ describe('getDevSupportedAgents', () => {
       managedBy: 'CDK' as const,
       agents: [
         {
-          type: 'AgentCoreRuntime',
           name: 'PythonAgent',
           build: 'CodeZip',
           runtimeVersion: 'PYTHON_3_12',
@@ -573,7 +554,6 @@ describe('getDevSupportedAgents', () => {
           protocol: 'HTTP',
         },
         {
-          type: 'AgentCoreRuntime',
           name: 'ContainerAgent',
           build: 'Container',
           runtimeVersion: 'PYTHON_3_12',

--- a/src/cli/operations/fetch-access/__tests__/fetch-gateway-token.test.ts
+++ b/src/cli/operations/fetch-access/__tests__/fetch-gateway-token.test.ts
@@ -37,7 +37,7 @@ const baseProjectSpec = {
   version: 1,
   credentials: [
     {
-      type: 'OAuthCredentialProvider',
+      authorizerType: 'OAuthCredentialProvider',
       name: 'myGateway-oauth',
       discoveryUrl: DISCOVERY_URL,
     },

--- a/src/cli/operations/fetch-access/fetch-runtime-token.ts
+++ b/src/cli/operations/fetch-access/fetch-runtime-token.ts
@@ -23,7 +23,7 @@ export async function canFetchRuntimeToken(agentName: string, options: { configI
 
     const credName = computeManagedOAuthCredentialName(agentName);
     const hasCredential = projectSpec.credentials.some(
-      c => c.type === 'OAuthCredentialProvider' && c.name === credName
+      c => c.authorizerType === 'OAuthCredentialProvider' && c.name === credName
     );
     if (!hasCredential) return false;
 

--- a/src/cli/operations/fetch-access/oauth-token.ts
+++ b/src/cli/operations/fetch-access/oauth-token.ts
@@ -30,14 +30,14 @@ export async function fetchOAuthToken(opts: {
   /** Target name within deployed state */
   targetName: string;
   /** Project credentials list */
-  credentials: { type: string; name: string }[];
+  credentials: { authorizerType: string; name: string }[];
 }): Promise<OAuthTokenResult> {
   const { resourceName, jwtConfig, deployedState, targetName, credentials } = opts;
 
   const credName = computeManagedOAuthCredentialName(resourceName);
 
   // Validate credential exists in project spec
-  const credential = credentials.find(c => c.type === 'OAuthCredentialProvider' && c.name === credName);
+  const credential = credentials.find(c => c.authorizerType === 'OAuthCredentialProvider' && c.name === credName);
   if (!credential) {
     throw new Error(
       `No managed OAuth credential found for '${resourceName}'. Expected credential '${credName}'. ` +

--- a/src/cli/operations/identity/__tests__/credential-ops.test.ts
+++ b/src/cli/operations/identity/__tests__/credential-ops.test.ts
@@ -48,7 +48,11 @@ describe('createCredential', () => {
     mockWriteProjectSpec.mockResolvedValue(undefined);
     mockSetEnvVar.mockResolvedValue(undefined);
 
-    const result = await primitive.add({ type: 'ApiKeyCredentialProvider', name: 'NewCred', apiKey: 'key123' });
+    const result = await primitive.add({
+      authorizerType: 'ApiKeyCredentialProvider',
+      name: 'NewCred',
+      apiKey: 'key123',
+    });
 
     expect(result).toEqual(expect.objectContaining({ success: true, credentialName: 'NewCred' }));
     expect(mockWriteProjectSpec).toHaveBeenCalled();
@@ -56,11 +60,15 @@ describe('createCredential', () => {
   });
 
   it('reuses existing credential without writing project', async () => {
-    const existing = { name: 'ExistCred', type: 'ApiKeyCredentialProvider' };
+    const existing = { name: 'ExistCred', authorizerType: 'ApiKeyCredentialProvider' };
     mockReadProjectSpec.mockResolvedValue({ credentials: [existing] });
     mockSetEnvVar.mockResolvedValue(undefined);
 
-    const result = await primitive.add({ type: 'ApiKeyCredentialProvider', name: 'ExistCred', apiKey: 'newkey' });
+    const result = await primitive.add({
+      authorizerType: 'ApiKeyCredentialProvider',
+      name: 'ExistCred',
+      apiKey: 'newkey',
+    });
 
     expect(result).toEqual(expect.objectContaining({ success: true, credentialName: 'ExistCred' }));
     expect(mockWriteProjectSpec).not.toHaveBeenCalled();
@@ -91,7 +99,7 @@ describe('resolveCredentialStrategy', () => {
 
   it('reuses existing credential with matching key', async () => {
     mockGetEnvVar.mockResolvedValue('my-api-key');
-    const creds = [{ name: 'ProjAnthropic', type: 'ApiKeyCredentialProvider' as const }];
+    const creds = [{ name: 'ProjAnthropic', authorizerType: 'ApiKeyCredentialProvider' as const }];
 
     const result = await primitive.resolveCredentialStrategy(
       'Proj',
@@ -123,7 +131,7 @@ describe('resolveCredentialStrategy', () => {
 
   it('creates agent-scoped credential when project-scoped exists with different key', async () => {
     mockGetEnvVar.mockResolvedValue('different-key');
-    const creds = [{ name: 'ProjAnthropic', type: 'ApiKeyCredentialProvider' as const }];
+    const creds = [{ name: 'ProjAnthropic', authorizerType: 'ApiKeyCredentialProvider' as const }];
 
     const result = await primitive.resolveCredentialStrategy(
       'Proj',

--- a/src/cli/operations/identity/__tests__/resolve-credential-strategy.test.ts
+++ b/src/cli/operations/identity/__tests__/resolve-credential-strategy.test.ts
@@ -131,7 +131,7 @@ describe('resolveCredentialStrategy', () => {
   });
 
   describe('credential exists - key comparison', () => {
-    const existingCredentials: Credential[] = [{ name: 'MyProjectGemini', type: 'ApiKeyCredentialProvider' }];
+    const existingCredentials: Credential[] = [{ name: 'MyProjectGemini', authorizerType: 'ApiKeyCredentialProvider' }];
 
     it('reuses credential when API keys match', async () => {
       mockGetEnvVar.mockResolvedValue('same-key');
@@ -201,8 +201,8 @@ describe('resolveCredentialStrategy', () => {
       // Scenario: agent1 uses mainKey (project-scoped), agent2 uses secondaryKey (agent-scoped)
       // agent3 also uses secondaryKey - should reuse agent2's credential
       const existingCredentials: Credential[] = [
-        { name: 'MyProjectGemini', type: 'ApiKeyCredentialProvider' },
-        { name: 'MyProjectAgent2Gemini', type: 'ApiKeyCredentialProvider' },
+        { name: 'MyProjectGemini', authorizerType: 'ApiKeyCredentialProvider' },
+        { name: 'MyProjectAgent2Gemini', authorizerType: 'ApiKeyCredentialProvider' },
       ];
 
       mockGetEnvVar.mockImplementation((envVar: string) => {
@@ -230,8 +230,8 @@ describe('resolveCredentialStrategy', () => {
 
     it('agent3 reuses project-scoped credential when using main key', async () => {
       const existingCredentials: Credential[] = [
-        { name: 'MyProjectGemini', type: 'ApiKeyCredentialProvider' },
-        { name: 'MyProjectAgent2Gemini', type: 'ApiKeyCredentialProvider' },
+        { name: 'MyProjectGemini', authorizerType: 'ApiKeyCredentialProvider' },
+        { name: 'MyProjectAgent2Gemini', authorizerType: 'ApiKeyCredentialProvider' },
       ];
 
       mockGetEnvVar.mockImplementation((envVar: string) => {
@@ -259,8 +259,8 @@ describe('resolveCredentialStrategy', () => {
 
     it('creates new agent-scoped credential when key matches no existing credential', async () => {
       const existingCredentials: Credential[] = [
-        { name: 'MyProjectGemini', type: 'ApiKeyCredentialProvider' },
-        { name: 'MyProjectAgent2Gemini', type: 'ApiKeyCredentialProvider' },
+        { name: 'MyProjectGemini', authorizerType: 'ApiKeyCredentialProvider' },
+        { name: 'MyProjectAgent2Gemini', authorizerType: 'ApiKeyCredentialProvider' },
       ];
 
       mockGetEnvVar.mockImplementation((envVar: string) => {
@@ -297,7 +297,7 @@ describe('resolveCredentialStrategy', () => {
         'OpenAI',
         'new-key',
         configBaseDir,
-        [{ name: 'TestProjectOpenAI', type: 'ApiKeyCredentialProvider' }]
+        [{ name: 'TestProjectOpenAI', authorizerType: 'ApiKeyCredentialProvider' }]
       );
 
       expect(result.credentialName).toBe('TestProjectMyAgentOpenAI');

--- a/src/cli/operations/memory/__tests__/create-memory.test.ts
+++ b/src/cli/operations/memory/__tests__/create-memory.test.ts
@@ -24,7 +24,7 @@ const makeProject = (memoryNames: string[]) => ({
   agents: [],
   memories: memoryNames.map(name => ({
     name,
-    type: 'AgentCoreMemory',
+
     eventExpiryDuration: 30,
     strategies: [],
   })),
@@ -70,7 +70,7 @@ describe('add', () => {
     const writtenSpec = mockWriteProjectSpec.mock.calls[0]![0];
     const addedMemory = writtenSpec.memories.find((m: { name: string }) => m.name === 'NewMem');
     expect(addedMemory).toBeDefined();
-    expect(addedMemory.type).toBe('AgentCoreMemory');
+    expect(addedMemory).toBeDefined();
     expect(addedMemory.eventExpiryDuration).toBe(60);
     expect(addedMemory.strategies[0]!.type).toBe('SEMANTIC');
     expect(addedMemory.strategies[0]!.namespaces).toEqual(['/users/{actorId}/facts']);

--- a/src/cli/operations/remove/__tests__/get-agent-scoped-credentials.test.ts
+++ b/src/cli/operations/remove/__tests__/get-agent-scoped-credentials.test.ts
@@ -14,7 +14,7 @@ const getAgentScopedCredentials = (...args: Parameters<typeof AgentPrimitive.get
 describe('getAgentScopedCredentials', () => {
   const projectName = 'MyProject';
 
-  const makeCredential = (name: string): Credential => ({ name, type: 'ApiKeyCredentialProvider' });
+  const makeCredential = (name: string): Credential => ({ name, authorizerType: 'ApiKeyCredentialProvider' });
 
   describe('matches agent-scoped credentials', () => {
     it('matches credential for the specified agent', () => {

--- a/src/cli/operations/remove/__tests__/remove-agent-ops.test.ts
+++ b/src/cli/operations/remove/__tests__/remove-agent-ops.test.ts
@@ -21,7 +21,7 @@ const makeProject = (agentNames: string[]) => ({
   name: 'TestProject',
   version: 1,
   managedBy: 'CDK' as const,
-  agents: agentNames.map(name => ({ name, type: 'AgentCoreRuntime' })),
+  agents: agentNames.map(name => ({ name })),
   memories: [],
   credentials: [],
 });

--- a/src/cli/operations/remove/__tests__/remove-identity-ops.test.ts
+++ b/src/cli/operations/remove/__tests__/remove-identity-ops.test.ts
@@ -27,7 +27,7 @@ const makeProject = (
   managedBy: 'CDK' as const,
   agents: [],
   memories: [],
-  credentials: credNames.map(name => ({ name, type: 'ApiKeyCredentialProvider' })),
+  credentials: credNames.map(name => ({ name, authorizerType: 'ApiKeyCredentialProvider' })),
   agentCoreGateways,
 });
 
@@ -42,8 +42,8 @@ describe('getRemovable', () => {
     const result = await primitive.getRemovable();
 
     expect(result).toEqual([
-      { name: 'Cred1', type: 'ApiKeyCredentialProvider' },
-      { name: 'Cred2', type: 'ApiKeyCredentialProvider' },
+      { name: 'Cred1', authorizerType: 'ApiKeyCredentialProvider' },
+      { name: 'Cred2', authorizerType: 'ApiKeyCredentialProvider' },
     ]);
   });
 

--- a/src/cli/operations/remove/__tests__/remove-memory-ops.test.ts
+++ b/src/cli/operations/remove/__tests__/remove-memory-ops.test.ts
@@ -22,7 +22,7 @@ const makeProject = (memoryNames: string[]) => ({
   version: 1,
   managedBy: 'CDK' as const,
   agents: [],
-  memories: memoryNames.map(name => ({ name, type: 'AgentCoreMemory', eventExpiryDuration: 30, strategies: [] })),
+  memories: memoryNames.map(name => ({ name, eventExpiryDuration: 30, strategies: [] })),
   credentials: [],
 });
 

--- a/src/cli/primitives/AgentPrimitive.tsx
+++ b/src/cli/primitives/AgentPrimitive.tsx
@@ -508,7 +508,6 @@ export class AgentPrimitive extends BasePrimitive<AddAgentOptions, RemovableReso
     const lifecycleConfiguration = this.buildLifecycleConfig(options);
 
     const agent: AgentEnvSpec = {
-      type: 'AgentCoreRuntime',
       name: options.name,
       build: options.buildType,
       entrypoint: (options.entrypoint ?? 'main.py') as FilePath,

--- a/src/cli/primitives/CredentialPrimitive.tsx
+++ b/src/cli/primitives/CredentialPrimitive.tsx
@@ -13,7 +13,7 @@ import type { Command } from '@commander-js/extra-typings';
  * Options for adding an API Key credential.
  */
 export interface AddApiKeyCredentialOptions {
-  type: 'ApiKeyCredentialProvider';
+  authorizerType: 'ApiKeyCredentialProvider';
   name: string;
   apiKey: string;
 }
@@ -22,7 +22,7 @@ export interface AddApiKeyCredentialOptions {
  * Options for adding an OAuth credential.
  */
 export interface AddOAuthCredentialOptions {
-  type: 'OAuthCredentialProvider';
+  authorizerType: 'OAuthCredentialProvider';
   name: string;
   discoveryUrl: string;
   clientId: string;
@@ -41,7 +41,7 @@ export type AddCredentialOptions = AddApiKeyCredentialOptions | AddOAuthCredenti
  */
 export interface RemovableCredential extends RemovableResource {
   name: string;
-  type: string;
+  authorizerType: string;
 }
 
 /**
@@ -127,7 +127,7 @@ export class CredentialPrimitive extends BasePrimitive<AddCredentialOptions, Rem
 
     const summary: string[] = [
       `Removing credential: ${credentialName}`,
-      `Type: ${credential.type}`,
+      `Type: ${credential.authorizerType}`,
       `Note: .env file will not be modified`,
     ];
 
@@ -162,7 +162,7 @@ export class CredentialPrimitive extends BasePrimitive<AddCredentialOptions, Rem
   async getRemovable(): Promise<RemovableCredential[]> {
     try {
       const project = await this.readProjectSpec();
-      return project.credentials.map(c => ({ name: c.name, type: c.type }));
+      return project.credentials.map(c => ({ name: c.name, authorizerType: c.authorizerType }));
     } catch {
       return [];
     }
@@ -311,7 +311,7 @@ export class CredentialPrimitive extends BasePrimitive<AddCredentialOptions, Rem
               const addOptions =
                 cliOptions.type === 'oauth'
                   ? {
-                      type: 'OAuthCredentialProvider' as const,
+                      authorizerType: 'OAuthCredentialProvider' as const,
                       name: cliOptions.name!,
                       discoveryUrl: cliOptions.discoveryUrl!,
                       clientId: cliOptions.clientId!,
@@ -322,7 +322,7 @@ export class CredentialPrimitive extends BasePrimitive<AddCredentialOptions, Rem
                         .filter(Boolean),
                     }
                   : {
-                      type: 'ApiKeyCredentialProvider' as const,
+                      authorizerType: 'ApiKeyCredentialProvider' as const,
                       name: cliOptions.name!,
                       apiKey: cliOptions.apiKey!,
                     };
@@ -386,9 +386,9 @@ export class CredentialPrimitive extends BasePrimitive<AddCredentialOptions, Rem
     let credential: Credential;
     if (existingCredential) {
       credential = existingCredential;
-    } else if (config.type === 'OAuthCredentialProvider') {
+    } else if (config.authorizerType === 'OAuthCredentialProvider') {
       credential = {
-        type: 'OAuthCredentialProvider',
+        authorizerType: 'OAuthCredentialProvider',
         name: config.name,
         discoveryUrl: config.discoveryUrl,
         vendor: 'CustomOauth2',
@@ -398,7 +398,7 @@ export class CredentialPrimitive extends BasePrimitive<AddCredentialOptions, Rem
       await this.writeProjectSpec(project);
     } else {
       credential = {
-        type: 'ApiKeyCredentialProvider',
+        authorizerType: 'ApiKeyCredentialProvider',
         name: config.name,
       };
       project.credentials.push(credential);
@@ -406,7 +406,7 @@ export class CredentialPrimitive extends BasePrimitive<AddCredentialOptions, Rem
     }
 
     // Write secrets to .env file
-    if (config.type === 'OAuthCredentialProvider') {
+    if (config.authorizerType === 'OAuthCredentialProvider') {
       const clientIdEnvVar = `${CredentialPrimitive.computeDefaultCredentialEnvVarName(config.name)}_CLIENT_ID`;
       const clientSecretEnvVar = `${CredentialPrimitive.computeDefaultCredentialEnvVarName(config.name)}_CLIENT_SECRET`;
       await setEnvVar(clientIdEnvVar, config.clientId);

--- a/src/cli/primitives/EvaluatorPrimitive.ts
+++ b/src/cli/primitives/EvaluatorPrimitive.ts
@@ -286,7 +286,6 @@ export class EvaluatorPrimitive extends BasePrimitive<AddEvaluatorOptions, Remov
     this.checkDuplicate(project.evaluators, options.name);
 
     const evaluator: Evaluator = {
-      type: 'CustomEvaluator',
       name: options.name,
       level: options.level,
       ...(options.description && { description: options.description }),

--- a/src/cli/primitives/MemoryPrimitive.tsx
+++ b/src/cli/primitives/MemoryPrimitive.tsx
@@ -233,7 +233,6 @@ export class MemoryPrimitive extends BasePrimitive<AddMemoryOptions, RemovableMe
     });
 
     const memory: Memory = {
-      type: 'AgentCoreMemory',
       name: config.name,
       eventExpiryDuration: config.eventExpiryDuration,
       strategies,

--- a/src/cli/primitives/OnlineEvalConfigPrimitive.ts
+++ b/src/cli/primitives/OnlineEvalConfigPrimitive.ts
@@ -211,7 +211,6 @@ export class OnlineEvalConfigPrimitive extends BasePrimitive<AddOnlineEvalConfig
     this.checkDuplicate(project.onlineEvalConfigs, options.name, 'Online eval config');
 
     const config: OnlineEvalConfig = {
-      type: 'OnlineEvaluationConfig',
       name: options.name,
       agent: options.agent,
       evaluators: options.evaluators,

--- a/src/cli/primitives/__tests__/EvaluatorPrimitive.test.ts
+++ b/src/cli/primitives/__tests__/EvaluatorPrimitive.test.ts
@@ -71,7 +71,6 @@ describe('EvaluatorPrimitive', () => {
       const writtenSpec = mockWriteProjectSpec.mock.calls[0]![0];
       expect(writtenSpec.evaluators).toHaveLength(1);
       expect(writtenSpec.evaluators[0].name).toBe('MyEval');
-      expect(writtenSpec.evaluators[0].type).toBe('CustomEvaluator');
       expect(writtenSpec.evaluators[0].level).toBe('SESSION');
     });
 

--- a/src/cli/primitives/__tests__/OnlineEvalConfigPrimitive.test.ts
+++ b/src/cli/primitives/__tests__/OnlineEvalConfigPrimitive.test.ts
@@ -58,7 +58,6 @@ describe('OnlineEvalConfigPrimitive', () => {
       const writtenSpec = mockWriteProjectSpec.mock.calls[0]![0];
       expect(writtenSpec.onlineEvalConfigs).toHaveLength(1);
       const config = writtenSpec.onlineEvalConfigs[0];
-      expect(config.type).toBe('OnlineEvaluationConfig');
       expect(config.name).toBe('MyConfig');
       expect(config.evaluators).toEqual(['Builtin.GoalSuccessRate']);
       expect(config.samplingRate).toBe(10);

--- a/src/cli/primitives/__tests__/auth-utils.test.ts
+++ b/src/cli/primitives/__tests__/auth-utils.test.ts
@@ -117,7 +117,7 @@ describe('createManagedOAuthCredential', () => {
     const writtenSpec = writeSpy.mock.calls[0]![0] as AgentCoreProjectSpec;
     const cred = writtenSpec.credentials.find(c => c.name === 'my-gateway-oauth');
     expect(cred).toEqual({
-      type: 'OAuthCredentialProvider',
+      authorizerType: 'OAuthCredentialProvider',
       name: 'my-gateway-oauth',
       discoveryUrl: 'https://idp.example.com/.well-known/openid-configuration',
       vendor: 'CustomOauth2',
@@ -143,7 +143,7 @@ describe('createManagedOAuthCredential', () => {
       ...baseProject,
       credentials: [
         {
-          type: 'OAuthCredentialProvider',
+          authorizerType: 'OAuthCredentialProvider',
           name: 'my-gateway-oauth',
           discoveryUrl: 'https://idp.example.com/.well-known/openid-configuration',
           vendor: 'CustomOauth2',

--- a/src/cli/primitives/auth-utils.ts
+++ b/src/cli/primitives/auth-utils.ts
@@ -43,7 +43,7 @@ export async function createManagedOAuthCredential(
   if (project.credentials.some(c => c.name === credentialName)) return;
 
   project.credentials.push({
-    type: 'OAuthCredentialProvider',
+    authorizerType: 'OAuthCredentialProvider',
     name: credentialName,
     discoveryUrl: jwtConfig.discoveryUrl,
     vendor: 'CustomOauth2',

--- a/src/cli/tui/components/ResourceGraph.tsx
+++ b/src/cli/tui/components/ResourceGraph.tsx
@@ -222,7 +222,7 @@ export function ResourceGraph({ project, mcp, agentName, resourceStatuses }: Res
                 icon={ICONS.credential}
                 color="yellow"
                 name={credential.name}
-                detail={rsEntry?.detail ?? credential.type.replace('CredentialProvider', '')}
+                detail={rsEntry?.detail ?? credential.authorizerType.replace('CredentialProvider', '')}
                 deploymentState={rsEntry?.deploymentState}
                 identifier={rsEntry?.identifier}
               />

--- a/src/cli/tui/components/__tests__/ResourceGraph.test.tsx
+++ b/src/cli/tui/components/__tests__/ResourceGraph.test.tsx
@@ -53,7 +53,7 @@ describe('ResourceGraph', () => {
   it('renders credentials section', () => {
     const project = {
       ...baseProject,
-      credentials: [{ name: 'my-cred', type: 'OAuthCredentialProvider' }],
+      credentials: [{ name: 'my-cred', authorizerType: 'OAuthCredentialProvider' }],
     } as unknown as AgentCoreProjectSpec;
 
     const { lastFrame } = render(<ResourceGraph project={project} />);

--- a/src/cli/tui/hooks/useDevServer.ts
+++ b/src/cli/tui/hooks/useDevServer.ts
@@ -433,7 +433,7 @@ export function useDevServer(options: {
     logFilePath: loggerRef.current?.getRelativeLogPath(),
     hasMemory: (project?.memories?.length ?? 0) > 0,
     hasVpc: project?.agents.find(a => a.name === config?.agentName)?.networkMode === 'VPC',
-    modelProvider: project?.agents.find(a => a.name === config?.agentName)?.modelProvider,
+    modelProvider: undefined,
     protocol,
     mcpTools,
     fetchMcpTools,

--- a/src/cli/tui/screens/agent/useAddAgent.ts
+++ b/src/cli/tui/screens/agent/useAddAgent.ts
@@ -56,7 +56,6 @@ export type AddAgentOutcome = AddAgentCreateResult | AddAgentByoResult | AddAgen
 export function mapByoConfigToAgent(config: AddAgentConfig): AgentEnvSpec {
   const networkMode = config.networkMode ?? 'PUBLIC';
   return {
-    type: 'AgentCoreRuntime',
     name: config.name,
     build: config.buildType,
     entrypoint: config.entrypoint as FilePath,

--- a/src/cli/tui/screens/identity/AddIdentityFlow.tsx
+++ b/src/cli/tui/screens/identity/AddIdentityFlow.tsx
@@ -38,7 +38,7 @@ export function AddIdentityFlow({ isInteractive = true, onExit, onBack, onDev, o
       const createConfig =
         config.identityType === 'OAuthCredentialProvider'
           ? {
-              type: 'OAuthCredentialProvider' as const,
+              authorizerType: 'OAuthCredentialProvider' as const,
               name: config.name,
               discoveryUrl: config.discoveryUrl!,
               clientId: config.clientId!,
@@ -49,7 +49,7 @@ export function AddIdentityFlow({ isInteractive = true, onExit, onBack, onDev, o
                 .filter(Boolean),
             }
           : {
-              type: 'ApiKeyCredentialProvider' as const,
+              authorizerType: 'ApiKeyCredentialProvider' as const,
               name: config.name,
               apiKey: config.apiKey,
             };

--- a/src/cli/tui/screens/invoke/InvokeScreen.tsx
+++ b/src/cli/tui/screens/invoke/InvokeScreen.tsx
@@ -372,12 +372,6 @@ export function InvokeScreen({
           <Text color="cyan">{agentProtocol}</Text>
         </Box>
       )}
-      {mode !== 'select-agent' && agent?.modelProvider && (
-        <Box>
-          <Text>Provider: </Text>
-          <Text color="cyan">{agent.modelProvider}</Text>
-        </Box>
-      )}
       <Box>
         <Text>Target: </Text>
         <Text color="yellow">{config.target.region}</Text>

--- a/src/cli/tui/screens/invoke/useInvokeFlow.ts
+++ b/src/cli/tui/screens/invoke/useInvokeFlow.ts
@@ -128,7 +128,7 @@ export function useInvokeFlow(options: InvokeFlowOptions = {}): InvokeFlowState 
           agents.push({
             name: agent.name,
             state,
-            modelProvider: agent.modelProvider,
+            modelProvider: undefined,
             networkMode: agent.networkMode,
             protocol: agent.protocol,
             authorizerType: agent.authorizerType,

--- a/src/cli/tui/screens/mcp/AddGatewayTargetFlow.tsx
+++ b/src/cli/tui/screens/mcp/AddGatewayTargetFlow.tsx
@@ -41,12 +41,12 @@ export function AddGatewayTargetFlow({
   const [flow, setFlow] = useState<FlowState>({ name: 'create-wizard' });
 
   const oauthCredentialNames = useMemo(
-    () => credentials.filter(c => c.type === 'OAuthCredentialProvider').map(c => c.name),
+    () => credentials.filter(c => c.authorizerType === 'OAuthCredentialProvider').map(c => c.name),
     [credentials]
   );
 
   const apiKeyCredentialNames = useMemo(
-    () => credentials.filter(c => c.type === 'ApiKeyCredentialProvider').map(c => c.name),
+    () => credentials.filter(c => c.authorizerType === 'ApiKeyCredentialProvider').map(c => c.name),
     [credentials]
   );
 
@@ -116,7 +116,7 @@ export function AddGatewayTargetFlow({
       const createConfig =
         identityConfig.identityType === 'OAuthCredentialProvider'
           ? {
-              type: 'OAuthCredentialProvider' as const,
+              authorizerType: 'OAuthCredentialProvider' as const,
               name: identityConfig.name,
               discoveryUrl: identityConfig.discoveryUrl!,
               clientId: identityConfig.clientId!,
@@ -127,7 +127,7 @@ export function AddGatewayTargetFlow({
                 .filter(Boolean),
             }
           : {
-              type: 'ApiKeyCredentialProvider' as const,
+              authorizerType: 'ApiKeyCredentialProvider' as const,
               name: identityConfig.name,
               apiKey: identityConfig.apiKey,
             };

--- a/src/cli/tui/screens/remove/RemoveIdentityScreen.tsx
+++ b/src/cli/tui/screens/remove/RemoveIdentityScreen.tsx
@@ -15,7 +15,7 @@ export function RemoveIdentityScreen({ identities, onSelect, onExit }: RemoveIde
   const items = identities.map(identity => ({
     id: identity.name,
     title: identity.name,
-    description: identity.type,
+    description: identity.authorizerType,
   }));
 
   return (

--- a/src/lib/schemas/io/__tests__/config-io.test.ts
+++ b/src/lib/schemas/io/__tests__/config-io.test.ts
@@ -182,7 +182,6 @@ describe('ConfigIO', () => {
         managedBy: 'CDK' as const,
         agents: [
           {
-            type: 'AgentCoreRuntime',
             name: 'myagent',
             build: 'CodeZip',
             entrypoint: 'main.py',

--- a/src/lib/utils/__tests__/zod.test.ts
+++ b/src/lib/utils/__tests__/zod.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from 'vitest';
 
 describe('validateAgentSchema', () => {
   const validAgent = {
-    type: 'AgentCoreRuntime',
     name: 'TestAgent',
     build: 'CodeZip',
     entrypoint: 'main.py',
@@ -64,7 +63,6 @@ describe('validateProjectSchema', () => {
 
   it('throws for duplicate agent names', () => {
     const agent = {
-      type: 'AgentCoreRuntime',
       name: 'Same',
       build: 'CodeZip',
       entrypoint: 'main.py',

--- a/src/schema/llm-compacted/agentcore.ts
+++ b/src/schema/llm-compacted/agentcore.ts
@@ -35,14 +35,11 @@ interface NetworkConfig {
 }
 
 type MemoryStrategyType = 'SEMANTIC' | 'SUMMARIZATION' | 'USER_PREFERENCE' | 'EPISODIC' | 'CUSTOM';
-type ModelProvider = 'Bedrock' | 'Gemini' | 'OpenAI' | 'Anthropic';
-
 // ─────────────────────────────────────────────────────────────────────────────
 // AGENT
 // ─────────────────────────────────────────────────────────────────────────────
 
 interface AgentEnvSpec {
-  type: 'AgentCoreRuntime';
   name: string; // @regex ^[a-zA-Z][a-zA-Z0-9_]{0,47}$ @max 48
   build: BuildType;
   entrypoint: string; // @regex ^[a-zA-Z0-9_][a-zA-Z0-9_/.-]*\.(py|ts|js)(:[a-zA-Z_][a-zA-Z0-9_]*)?$ e.g. "main.py:handler" or "index.ts"
@@ -52,7 +49,6 @@ interface AgentEnvSpec {
   networkMode?: NetworkMode; // default 'PUBLIC'
   networkConfig?: NetworkConfig; // Required when networkMode is 'VPC'
   instrumentation?: Instrumentation; // OTel settings
-  modelProvider?: ModelProvider; // Model provider used by this agent
   tags?: Record<string, string>;
 }
 
@@ -70,7 +66,6 @@ interface EnvVar {
 // ─────────────────────────────────────────────────────────────────────────────
 
 interface Memory {
-  type: 'AgentCoreMemory';
   name: string; // @regex ^[a-zA-Z][a-zA-Z0-9_]{0,47}$ @max 48
   eventExpiryDuration: number; // @min 7 @max 365 (days)
   strategies: MemoryStrategy[]; // @min 1, unique by type
@@ -95,6 +90,6 @@ interface MemoryStrategy {
 // ─────────────────────────────────────────────────────────────────────────────
 
 interface Credential {
-  type: 'ApiKeyCredentialProvider';
+  authorizerType: 'ApiKeyCredentialProvider' | 'OAuthCredentialProvider';
   name: string; // @regex ^[a-zA-Z0-9\-_]+$ @min 1 @max 128
 }

--- a/src/schema/schemas/__tests__/agent-env.test.ts
+++ b/src/schema/schemas/__tests__/agent-env.test.ts
@@ -183,7 +183,6 @@ describe('InstrumentationSchema', () => {
 
 describe('AgentEnvSpecSchema', () => {
   const validPythonAgent = {
-    type: 'AgentCoreRuntime',
     name: 'TestAgent',
     build: 'CodeZip',
     entrypoint: 'main.py:handler',
@@ -193,7 +192,6 @@ describe('AgentEnvSpecSchema', () => {
   };
 
   const validNodeAgent = {
-    type: 'AgentCoreRuntime',
     name: 'NodeAgent',
     build: 'CodeZip',
     entrypoint: 'index.ts',
@@ -282,12 +280,8 @@ describe('AgentEnvSpecSchema', () => {
     expect(result.success).toBe(true);
   });
 
-  it('rejects invalid type literal', () => {
-    expect(AgentEnvSpecSchema.safeParse({ ...validPythonAgent, type: 'Lambda' }).success).toBe(false);
-  });
-
   it('rejects missing required fields', () => {
-    expect(AgentEnvSpecSchema.safeParse({ type: 'AgentCoreRuntime' }).success).toBe(false);
+    expect(AgentEnvSpecSchema.safeParse({}).success).toBe(false);
     expect(AgentEnvSpecSchema.safeParse({ ...validPythonAgent, name: undefined }).success).toBe(false);
   });
 
@@ -413,7 +407,6 @@ describe('LifecycleConfigurationSchema', () => {
 
 describe('AgentEnvSpecSchema - lifecycleConfiguration', () => {
   const validAgent = {
-    type: 'AgentCoreRuntime',
     name: 'TestAgent',
     build: 'CodeZip',
     entrypoint: 'main.py',

--- a/src/schema/schemas/__tests__/agentcore-project.test.ts
+++ b/src/schema/schemas/__tests__/agentcore-project.test.ts
@@ -110,7 +110,6 @@ describe('MemoryNameSchema', () => {
 describe('MemorySchema', () => {
   it('accepts valid memory with strategies', () => {
     const result = MemorySchema.safeParse({
-      type: 'AgentCoreMemory',
       name: 'TestMemory',
       eventExpiryDuration: 30,
       strategies: [{ type: 'SEMANTIC' }],
@@ -120,7 +119,6 @@ describe('MemorySchema', () => {
 
   it('accepts memory with empty strategies (short-term only)', () => {
     const result = MemorySchema.safeParse({
-      type: 'AgentCoreMemory',
       name: 'ShortTermOnly',
       eventExpiryDuration: 7,
       strategies: [],
@@ -130,7 +128,6 @@ describe('MemorySchema', () => {
 
   it('defaults strategies to empty array', () => {
     const result = MemorySchema.safeParse({
-      type: 'AgentCoreMemory',
       name: 'NoStrategies',
       eventExpiryDuration: 30,
     });
@@ -142,7 +139,6 @@ describe('MemorySchema', () => {
 
   it('rejects eventExpiryDuration below 7', () => {
     const result = MemorySchema.safeParse({
-      type: 'AgentCoreMemory',
       name: 'Test',
       eventExpiryDuration: 6,
       strategies: [],
@@ -152,7 +148,6 @@ describe('MemorySchema', () => {
 
   it('rejects eventExpiryDuration above 365', () => {
     const result = MemorySchema.safeParse({
-      type: 'AgentCoreMemory',
       name: 'Test',
       eventExpiryDuration: 366,
       strategies: [],
@@ -163,7 +158,6 @@ describe('MemorySchema', () => {
   it('accepts eventExpiryDuration boundary values (7 and 365)', () => {
     expect(
       MemorySchema.safeParse({
-        type: 'AgentCoreMemory',
         name: 'Min',
         eventExpiryDuration: 7,
         strategies: [],
@@ -172,7 +166,6 @@ describe('MemorySchema', () => {
 
     expect(
       MemorySchema.safeParse({
-        type: 'AgentCoreMemory',
         name: 'Max',
         eventExpiryDuration: 365,
         strategies: [],
@@ -182,7 +175,6 @@ describe('MemorySchema', () => {
 
   it('rejects non-integer eventExpiryDuration', () => {
     const result = MemorySchema.safeParse({
-      type: 'AgentCoreMemory',
       name: 'Test',
       eventExpiryDuration: 30.5,
       strategies: [],
@@ -192,7 +184,6 @@ describe('MemorySchema', () => {
 
   it('rejects duplicate strategy types', () => {
     const result = MemorySchema.safeParse({
-      type: 'AgentCoreMemory',
       name: 'Test',
       eventExpiryDuration: 30,
       strategies: [{ type: 'SEMANTIC' }, { type: 'SEMANTIC' }],
@@ -202,22 +193,11 @@ describe('MemorySchema', () => {
 
   it('accepts multiple different strategy types', () => {
     const result = MemorySchema.safeParse({
-      type: 'AgentCoreMemory',
       name: 'Test',
       eventExpiryDuration: 30,
       strategies: [{ type: 'SEMANTIC' }, { type: 'SUMMARIZATION' }, { type: 'USER_PREFERENCE' }],
     });
     expect(result.success).toBe(true);
-  });
-
-  it('rejects invalid type literal', () => {
-    const result = MemorySchema.safeParse({
-      type: 'InvalidType',
-      name: 'Test',
-      eventExpiryDuration: 30,
-      strategies: [],
-    });
-    expect(result.success).toBe(false);
   });
 });
 
@@ -258,7 +238,7 @@ describe('CredentialNameSchema', () => {
 describe('CredentialSchema', () => {
   it('accepts valid credential', () => {
     const result = CredentialSchema.safeParse({
-      type: 'ApiKeyCredentialProvider',
+      authorizerType: 'ApiKeyCredentialProvider',
       name: 'MyCredential',
     });
     expect(result.success).toBe(true);
@@ -266,7 +246,7 @@ describe('CredentialSchema', () => {
 
   it('rejects invalid type', () => {
     const result = CredentialSchema.safeParse({
-      type: 'OAuthProvider',
+      authorizerType: 'OAuthProvider',
       name: 'MyCredential',
     });
     expect(result.success).toBe(false);
@@ -274,7 +254,7 @@ describe('CredentialSchema', () => {
 
   it('ApiKeyCredentialProvider with name passes', () => {
     const result = CredentialSchema.safeParse({
-      type: 'ApiKeyCredentialProvider',
+      authorizerType: 'ApiKeyCredentialProvider',
       name: 'MyApiKey',
     });
     expect(result.success).toBe(true);
@@ -282,7 +262,7 @@ describe('CredentialSchema', () => {
 
   it('OAuthCredentialProvider with name and discoveryUrl passes', () => {
     const result = CredentialSchema.safeParse({
-      type: 'OAuthCredentialProvider',
+      authorizerType: 'OAuthCredentialProvider',
       name: 'MyOAuth',
       discoveryUrl: 'https://example.com/.well-known/openid-configuration',
     });
@@ -291,7 +271,7 @@ describe('CredentialSchema', () => {
 
   it('OAuthCredentialProvider with scopes omitted passes', () => {
     const result = CredentialSchema.safeParse({
-      type: 'OAuthCredentialProvider',
+      authorizerType: 'OAuthCredentialProvider',
       name: 'MyOAuth',
       discoveryUrl: 'https://example.com/.well-known/openid-configuration',
     });
@@ -300,7 +280,7 @@ describe('CredentialSchema', () => {
 
   it('OAuthCredentialProvider without discoveryUrl succeeds (optional for imported providers)', () => {
     const result = CredentialSchema.safeParse({
-      type: 'OAuthCredentialProvider',
+      authorizerType: 'OAuthCredentialProvider',
       name: 'MyOAuth',
     });
     expect(result.success).toBe(true);
@@ -308,7 +288,7 @@ describe('CredentialSchema', () => {
 
   it('invalid type fails discriminated union', () => {
     const result = CredentialSchema.safeParse({
-      type: 'InvalidCredentialType',
+      authorizerType: 'InvalidCredentialType',
       name: 'MyCred',
     });
     expect(result.success).toBe(false);
@@ -316,12 +296,12 @@ describe('CredentialSchema', () => {
 
   it('vendor defaults to CustomOauth2', () => {
     const result = CredentialSchema.safeParse({
-      type: 'OAuthCredentialProvider',
+      authorizerType: 'OAuthCredentialProvider',
       name: 'MyOAuth',
       discoveryUrl: 'https://example.com/.well-known/openid-configuration',
     });
     expect(result.success).toBe(true);
-    if (result.success && result.data.type === 'OAuthCredentialProvider') {
+    if (result.success && result.data.authorizerType === 'OAuthCredentialProvider') {
       expect(result.data.vendor).toBe('CustomOauth2');
     }
   });
@@ -348,7 +328,6 @@ describe('AgentCoreProjectSpecSchema', () => {
       ...minimalProject,
       agents: [
         {
-          type: 'AgentCoreRuntime',
           name: 'MyAgent',
           build: 'CodeZip',
           entrypoint: 'main.py',
@@ -363,7 +342,6 @@ describe('AgentCoreProjectSpecSchema', () => {
 
   it('rejects duplicate agent names', () => {
     const agent = {
-      type: 'AgentCoreRuntime',
       name: 'MyAgent',
       build: 'CodeZip',
       entrypoint: 'main.py',
@@ -383,7 +361,6 @@ describe('AgentCoreProjectSpecSchema', () => {
 
   it('rejects duplicate memory names', () => {
     const memory = {
-      type: 'AgentCoreMemory',
       name: 'SharedMemory',
       eventExpiryDuration: 30,
       strategies: [],
@@ -400,7 +377,7 @@ describe('AgentCoreProjectSpecSchema', () => {
 
   it('rejects duplicate credential names', () => {
     const cred = {
-      type: 'ApiKeyCredentialProvider',
+      authorizerType: 'ApiKeyCredentialProvider',
       name: 'MyCred',
     };
     const result = AgentCoreProjectSpecSchema.safeParse({
@@ -419,7 +396,6 @@ describe('AgentCoreProjectSpecSchema', () => {
       version: 1,
       agents: [
         {
-          type: 'AgentCoreRuntime',
           name: 'Agent1',
           build: 'CodeZip',
           entrypoint: 'main.py',
@@ -428,7 +404,6 @@ describe('AgentCoreProjectSpecSchema', () => {
           protocol: 'HTTP',
         },
         {
-          type: 'AgentCoreRuntime',
           name: 'Agent2',
           build: 'Container',
           entrypoint: 'index.ts',
@@ -439,15 +414,14 @@ describe('AgentCoreProjectSpecSchema', () => {
       ],
       memories: [
         {
-          type: 'AgentCoreMemory',
           name: 'Memory1',
           eventExpiryDuration: 30,
           strategies: [{ type: 'SEMANTIC' }],
         },
       ],
       credentials: [
-        { type: 'ApiKeyCredentialProvider', name: 'Cred1' },
-        { type: 'ApiKeyCredentialProvider', name: 'Cred2' },
+        { authorizerType: 'ApiKeyCredentialProvider', name: 'Cred1' },
+        { authorizerType: 'ApiKeyCredentialProvider', name: 'Cred2' },
       ],
     });
     expect(result.success).toBe(true);
@@ -484,7 +458,6 @@ describe('AgentCoreProjectSpecSchema', () => {
       ...minimalProject,
       memories: [
         {
-          type: 'AgentCoreMemory',
           name: 'TestMemory',
           eventExpiryDuration: 30,
           strategies: [
@@ -510,7 +483,6 @@ describe('AgentCoreProjectSpecSchema', () => {
       ...minimalProject,
       memories: [
         {
-          type: 'AgentCoreMemory',
           name: 'TestMemory',
           eventExpiryDuration: 30,
           strategies: [

--- a/src/schema/schemas/agent-env.ts
+++ b/src/schema/schemas/agent-env.ts
@@ -4,7 +4,6 @@
  * @module agent-env
  */
 import {
-  ModelProviderSchema,
   NetworkModeSchema,
   ProtocolModeSchema,
   RuntimeVersionSchema as RuntimeVersionSchemaFromConstants,
@@ -178,7 +177,6 @@ export type LifecycleConfiguration = z.infer<typeof LifecycleConfigurationSchema
  */
 export const AgentEnvSpecSchema = z
   .object({
-    type: AgentTypeSchema,
     name: AgentNameSchema,
     build: BuildTypeSchema,
     entrypoint: EntrypointSchema,
@@ -192,8 +190,6 @@ export const AgentEnvSpecSchema = z
     networkConfig: NetworkConfigSchema.optional(),
     /** Instrumentation settings for observability. Defaults to OTel enabled. */
     instrumentation: InstrumentationSchema.optional(),
-    /** Model provider used by this agent. Optional for backwards compatibility. */
-    modelProvider: ModelProviderSchema.optional(),
     /** Protocol for the runtime (HTTP, MCP, A2A). */
     protocol: ProtocolModeSchema.optional(),
     /** Allowed request headers forwarded to the runtime at invocation time. */

--- a/src/schema/schemas/agentcore-project.ts
+++ b/src/schema/schemas/agentcore-project.ts
@@ -95,7 +95,6 @@ export const MemoryNameSchema = z
   );
 
 export const MemorySchema = z.object({
-  type: MemoryTypeSchema,
   name: MemoryNameSchema,
   eventExpiryDuration: z.number().int().min(7).max(365),
   // Strategies array can be empty for short-term memory (just base memory with expiration)
@@ -129,14 +128,14 @@ export const CredentialTypeSchema = z.enum(['ApiKeyCredentialProvider', 'OAuthCr
 export type CredentialType = z.infer<typeof CredentialTypeSchema>;
 
 export const ApiKeyCredentialSchema = z.object({
-  type: z.literal('ApiKeyCredentialProvider'),
+  authorizerType: z.literal('ApiKeyCredentialProvider'),
   name: CredentialNameSchema,
 });
 
 export type ApiKeyCredential = z.infer<typeof ApiKeyCredentialSchema>;
 
 export const OAuthCredentialSchema = z.object({
-  type: z.literal('OAuthCredentialProvider'),
+  authorizerType: z.literal('OAuthCredentialProvider'),
   name: CredentialNameSchema,
   /** OIDC discovery URL for the OAuth provider (optional for imported providers that already exist in Identity service) */
   discoveryUrl: z.string().url().optional(),
@@ -152,7 +151,7 @@ export const OAuthCredentialSchema = z.object({
 
 export type OAuthCredential = z.infer<typeof OAuthCredentialSchema>;
 
-export const CredentialSchema = z.discriminatedUnion('type', [ApiKeyCredentialSchema, OAuthCredentialSchema]);
+export const CredentialSchema = z.discriminatedUnion('authorizerType', [ApiKeyCredentialSchema, OAuthCredentialSchema]);
 
 export type Credential = z.infer<typeof CredentialSchema>;
 
@@ -164,7 +163,6 @@ export const EvaluatorTypeSchema = z.literal('CustomEvaluator');
 export type EvaluatorType = z.infer<typeof EvaluatorTypeSchema>;
 
 export const EvaluatorSchema = z.object({
-  type: EvaluatorTypeSchema,
   name: EvaluatorNameSchema,
   level: EvaluationLevelSchema,
   description: z.string().optional(),

--- a/src/schema/schemas/primitives/__tests__/online-eval-config.test.ts
+++ b/src/schema/schemas/primitives/__tests__/online-eval-config.test.ts
@@ -27,7 +27,6 @@ describe('OnlineEvalConfigNameSchema', () => {
 
 describe('OnlineEvalConfigSchema', () => {
   const validConfig = {
-    type: 'OnlineEvaluationConfig' as const,
     name: 'TestConfig',
     agent: 'MyAgent',
     evaluators: ['Builtin.GoalSuccessRate'],
@@ -49,11 +48,6 @@ describe('OnlineEvalConfigSchema', () => {
       evaluators: ['arn:aws:bedrock:us-east-1:123456:evaluator/MyEval-abc'],
     };
     expect(OnlineEvalConfigSchema.safeParse(config).success).toBe(true);
-  });
-
-  it('rejects wrong type literal', () => {
-    const config = { ...validConfig, type: 'WrongType' };
-    expect(OnlineEvalConfigSchema.safeParse(config).success).toBe(false);
   });
 
   it('rejects empty evaluators array', () => {

--- a/src/schema/schemas/primitives/online-eval-config.ts
+++ b/src/schema/schemas/primitives/online-eval-config.ts
@@ -15,7 +15,6 @@ export const OnlineEvalConfigNameSchema = z
   );
 
 export const OnlineEvalConfigSchema = z.object({
-  type: z.literal('OnlineEvaluationConfig'),
   name: OnlineEvalConfigNameSchema,
   /** Agent name to monitor (must match a project agent) */
   agent: z.string().min(1, 'Agent name is required'),

--- a/src/tui-harness/helpers.ts
+++ b/src/tui-harness/helpers.ts
@@ -99,7 +99,6 @@ export async function createMinimalProjectDir(
   // Optionally add a sample agent.
   if (hasAgents) {
     (config.agents as unknown[]).push({
-      type: 'AgentCoreRuntime',
       name: 'TestAgent',
       build: 'CodeZip',
       entrypoint: 'main.py:handler',


### PR DESCRIPTION
## Description

Remove redundant `type` fields from all resource schemas and rename the credential discriminator from `type` to `authorizerType`.

**Changes:**
- Remove `type` field from agent (`AgentEnvSpecSchema`), memory, evaluator, and online-eval-config schemas
- Rename credential discriminated union key from `type` to `authorizerType` (values `ApiKeyCredentialProvider` and `OAuthCredentialProvider` unchanged)
- Remove `modelProvider` from agent env schema (`AgentEnvSpecSchema`)
- Update all consuming source files, primitives, operations, TUI components, and CLI commands
- Regenerate `agentcore.schema.v1.json`
- Update LLM-compacted schema documentation

**Companion PR:** aws/agentcore-l3-cdk-constructs (same branch name)

## Related Issue

N/A — schema cleanup task

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

**TypeScript compilation:** Both packages compile clean (`tsc --noEmit` passes)

**Unit tests (CLI):** 217/218 test files pass, 3112/3114 tests pass
- 2 pre-existing PTY test failures (unrelated to this change)

**Unit tests (CDK):** 11/11 test files pass, 132/132 tests pass

**JSON schema regeneration:** `node scripts/generate-schema.mjs` succeeds, output committed

**Specific test evidence:**
- Schema validation tests updated and passing for all resource types
- Credential discriminated union tests verify `authorizerType` as discriminator
- `OnlineEvalConfigSchema` tests pass without `type` field
- `AgentEnvSpecSchema` tests pass without `type` and `modelProvider`
- `MemorySchema` tests pass without `type` field
- All credential operation tests (`credential-ops`, `resolve-credential-strategy`, `pre-deploy-identity`, `fetch-gateway-token`) pass with `authorizerType`
- ResourceGraph component tests pass with updated credential rendering
- Import/merge tests pass with updated schemas
- Status command tests pass with `authorizerType` references

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.