### PR TITLE
ci: regenerate JSON schema during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,12 @@ jobs:
           echo "branch=release/v$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "New version: $NEW_VERSION"
 
+      - name: Regenerate JSON schema
+        run: |
+          npm run build
+          node scripts/generate-schema.mjs
+          echo "✓ JSON schema regenerated"
+
       - name: Create release branch and PR
         env:
           NEW_VERSION: ${{ steps.bump.outputs.version }}


### PR DESCRIPTION
## Description

The release workflow does not regenerate `schemas/agentcore.schema.v1.json` from the Zod source schemas. If schema changes are merged between releases, the published JSON schema file can drift from the actual validation logic.

This adds a schema regeneration step to the `prepare-release` job, after the version bump and before the release branch commit. The existing `git add -A` picks up the regenerated file automatically.

## Related Issue

Closes #

## Documentation PR

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe): CI workflow improvement

## Testing

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.