### PR TITLE
fix: remove dead --agents flag from add gateway

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -265,7 +265,6 @@ agentcore add gateway \
 | `--allowed-scopes <scopes>`      | Comma-separated allowed scopes (optional for CUSTOM_JWT)     |
 | `--agent-client-id <id>`         | Agent OAuth client ID for Bearer token auth (CUSTOM_JWT)     |
 | `--agent-client-secret <secret>` | Agent OAuth client secret (CUSTOM_JWT)                       |
-| `--agents <agents>`              | Comma-separated agent names                                  |
 | `--no-semantic-search`           | Disable semantic search for tool discovery                   |
 | `--exception-level <level>`      | Exception verbosity level (default: `NONE`)                  |
 | `--json`                         | JSON output                                                  |

--- a/src/cli/commands/add/__tests__/add-gateway.test.ts
+++ b/src/cli/commands/add/__tests__/add-gateway.test.ts
@@ -78,6 +78,13 @@ describe('add gateway command', () => {
     });
   });
 
+  describe('rejected flags', () => {
+    it('rejects unknown --agents flag', async () => {
+      const result = await runCLI(['add', 'gateway', '--name', 'agents-test', '--agents', 'foo', '--json'], projectDir);
+      expect(result.exitCode).toBe(1);
+    });
+  });
+
   describe('JWT authorizer', () => {
     it('creates gateway with CUSTOM_JWT authorizer', async () => {
       const gatewayName = `jwt-gw-${Date.now()}`;

--- a/src/cli/commands/add/types.ts
+++ b/src/cli/commands/add/types.ts
@@ -57,7 +57,6 @@ export interface AddGatewayOptions {
   customClaims?: string;
   clientId?: string;
   clientSecret?: string;
-  agents?: string;
   semanticSearch?: boolean;
   exceptionLevel?: string;
   policyEngine?: string;

--- a/src/cli/primitives/GatewayPrimitive.ts
+++ b/src/cli/primitives/GatewayPrimitive.ts
@@ -33,7 +33,6 @@ export interface AddGatewayOptions {
   customClaims?: CustomClaimValidation[];
   clientId?: string;
   clientSecret?: string;
-  agents?: string;
   enableSemanticSearch?: boolean;
   exceptionLevel?: string;
   policyEngine?: string;
@@ -161,7 +160,6 @@ export class GatewayPrimitive extends BasePrimitive<AddGatewayOptions, Removable
       .description('Add an API gateway that routes requests to agent targets')
       .option('--name <name>', 'Gateway name [non-interactive]')
       .option('--description <desc>', 'Gateway description [non-interactive]')
-      .option('--agents <agents>', 'Comma-separated agent names to expose through this gateway [non-interactive]')
       .option('--authorizer-type <type>', 'Authorizer type: NONE or CUSTOM_JWT [non-interactive]')
       .option('--discovery-url <url>', 'OIDC discovery URL (for CUSTOM_JWT) [non-interactive]')
       .option('--allowed-audience <audience>', 'Comma-separated allowed audiences (for CUSTOM_JWT) [non-interactive]')
@@ -213,7 +211,6 @@ export class GatewayPrimitive extends BasePrimitive<AddGatewayOptions, Removable
             customClaims: parsedCustomClaims,
             clientId: cliOptions.clientId,
             clientSecret: cliOptions.clientSecret,
-            agents: cliOptions.agents,
             enableSemanticSearch: cliOptions.semanticSearch !== false,
             exceptionLevel: cliOptions.exceptionLevel,
             policyEngine: cliOptions.policyEngine,


### PR DESCRIPTION
## Description

Remove the dead `--agents` CLI flag from `agentcore add gateway`. The flag was registered on the Commander command, included in type definitions, and passed through the action handler, but was never consumed by `buildGatewayConfig()`, never validated by `validateAddGatewayOptions()`, and the `AddGatewayConfig` type had no `agents` field. A user passing `--agents my-agent1,my-agent2` would have their input silently discarded.

This was a leftover from an earlier design where gateways were associated with specific agents. The current architecture wires all gateways to all agents via `wireGatewayUrlsToAgents()` in the CDK constructs — there is no per-gateway agent association.

**Changes:**
- Removed `--agents` option registration from Commander (`GatewayPrimitive.ts`)
- Removed `agents?: string` from both `AddGatewayOptions` interfaces (primitive + CLI types)
- Removed `agents: cliOptions.agents` passthrough in the action handler
- Removed `--agents` documentation row from `commands.md`
- Added regression test confirming `--agents` is now properly rejected

## Related Issue

N/A — dead code cleanup discovered during code review

## Documentation PR

N/A — only removed a doc row for a non-functional flag

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

**Test results:** 216/218 test files pass. 2 pre-existing failures in `tui-harness/__tests__/proof-of-concept.test.ts` (PTY/xterm wiring — unrelated). All 9 gateway-specific tests pass including the new regression guard.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.