### PR TITLE
ci: block schema changes in PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -100,3 +100,20 @@ jobs:
           path: node_modules
           key: node-modules-${{ hashFiles('package-lock.json') }}
       - run: npm run typecheck
+
+  schema-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Reject schema changes outside release PRs
+        run: |
+          if git diff --name-only origin/main...HEAD | grep -q '^schemas/agentcore\.schema\.v[0-9]*\.json$'; then
+            echo ""
+            echo "❌ schemas/ must not be modified directly."
+            echo "The JSON schema is served live from the repo — changes are released automatically."
+            echo "Schema regeneration happens during the release workflow."
+            exit 1
+          fi
+          echo "✓ No schema changes detected"


### PR DESCRIPTION
## Description

The JSON schema (`schemas/agentcore.schema.v1.json`) is served live from the repo via GitHub Pages. Any commit to main that modifies it is effectively a public release. PRs should not modify the schema directly — regeneration happens during the release workflow (#710).

This adds a `schema-check` job to the Quality and Safety Checks workflow that fails if a PR touches `schemas/`. 

## Related Issue

Closes #

## Documentation PR

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe): CI quality gate

## Testing

Verified locally: PRs that modify `schemas/` fail the check, PRs that don't pass cleanly. Release PRs (created by the release workflow) bypass this since they merge directly.

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.