### PR TITLE
fix: use correct article 'an' for agent in help text

### DIFF
--- a/src/cli/primitives/AgentPrimitive.tsx
+++ b/src/cli/primitives/AgentPrimitive.tsx
@@ -75,6 +75,7 @@ export interface AddAgentOptions extends VpcOptions {
 export class AgentPrimitive extends BasePrimitive<AddAgentOptions, RemovableResource> {
   readonly kind = 'agent';
   readonly label = 'Agent';
+  override readonly article = 'an';
   readonly primitiveSchema = AgentEnvSpecSchema;
 
   /** Local instance to avoid circular dependency with registry. */


### PR DESCRIPTION
## Description

AgentPrimitive does not override the default article (`"a"`) from BasePrimitive, resulting in grammatically incorrect help text: "Add a agent", "Remove a agent". This adds `override readonly article = 'an'` to AgentPrimitive, matching the pattern used by EvaluatorPrimitive and OnlineEvalConfigPrimitive.

## Related Issue

N/A

## Documentation PR

N/A

## Type of Change

- [x] Bug fix

## Testing

- Built the project and verified `agentcore add agent --help` shows "Add an agent" and `agentcore remove agent --help` shows "Remove an agent".
- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes generate no new warnings

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.