### PR TITLE
feat: add /strands test command for TUI testing

### DIFF
--- a/.github/agent-sops/task-tester.sop.md
+++ b/.github/agent-sops/task-tester.sop.md
@@ -98,4 +98,4 @@ Do not rely solely on what the TUI displays. Confirm the CLI actually did what i
 - Do NOT run git commands (add, commit, push)
 - Do NOT create or update branches
 - Do NOT approve or merge the pull request
-- Do NOT deploy or create AWS resources
+- Do NOT deploy or create AWS resources unless the test flow explicitly requires it

--- a/.github/agent-sops/task-tester.sop.md
+++ b/.github/agent-sops/task-tester.sop.md
@@ -14,6 +14,9 @@ You have TUI harness MCP tools: `tui_launch`, `tui_send_keys`, `tui_action`, `tu
 
 You also have `shell` for setup commands and GitHub tools for posting comments.
 
+**Important:** Always use `aws/agentcore-cli` as the repository for all GitHub API calls (get PR, post comments, etc.),
+not the fork repository.
+
 ## Steps
 
 ### 1. Setup

--- a/.github/agent-sops/task-tester.sop.md
+++ b/.github/agent-sops/task-tester.sop.md
@@ -19,9 +19,18 @@ not the fork repository.
 
 ## Steps
 
-### 1. Setup
+### 1. Determine Mode
 
-- Read the test spec file at `.github/agent-sops/tui-test-flows.md`
+Check the command text in the prompt:
+
+- If the command is just `test` (no additional text): run **all predefined flows** from
+  `.github/agent-sops/tui-test-flows.md`
+- If the command is `test <description>` (has text after "test"): run **only the described ad-hoc flow**. The text after
+  "test" describes what to test. Design the flow yourself using the TUI harness tools, following the same patterns as
+  the predefined flows.
+
+### 2. Setup
+
 - The CLI is installed globally as `agentcore`. Launch TUI sessions using `tui_launch` with `command: "agentcore"` and
   the appropriate `args`.
 - For non-interactive commands (e.g., `--json` output), prefer `shell` over `tui_launch`.

--- a/.github/agent-sops/task-tester.sop.md
+++ b/.github/agent-sops/task-tester.sop.md
@@ -66,14 +66,31 @@ Post a single PR comment:
 **Expected:** what should have happened **Actual:** what happened
 
 <details>
-<summary>Screenshot</summary>
+<summary>Terminal output</summary>
+```
 
-(paste screen text here)
+(paste tui_read_screen text output here)
+
+```
 
 </details>
 ```
 
 If all flows pass, omit the Failed section.
+
+For failures, use `tui_read_screen` to capture the terminal text and paste it in the comment. SVG screenshots are
+uploaded as workflow artifacts separately — do not try to embed them in the comment.
+
+## Verification
+
+After each flow completes, verify the side effects — not just the TUI output:
+
+- If a project was created: use `shell` to check the directory exists and contains expected files (e.g.
+  `agentcore.json`)
+- If a resource was added: use `shell` to check the config file was updated
+- If a command produced output: verify the output matches expectations
+
+Do not rely solely on what the TUI displays. Confirm the CLI actually did what it claimed.
 
 ## Forbidden Actions
 

--- a/.github/agent-sops/task-tester.sop.md
+++ b/.github/agent-sops/task-tester.sop.md
@@ -1,0 +1,88 @@
+# Task Tester SOP
+
+## Role
+
+You are a TUI Tester. Your goal is to verify the AgentCore CLI's interactive TUI behavior by driving it through
+predefined test flows using the TUI harness MCP tools. You post results as PR comments.
+
+You MUST NOT modify any code, create branches, or push commits. Your only output is test result comments.
+
+## Tools Available
+
+You have TUI harness MCP tools: `tui_launch`, `tui_send_keys`, `tui_action`, `tui_wait_for`, `tui_screenshot`,
+`tui_read_screen`, `tui_close`, `tui_list_sessions`.
+
+You also have `shell` for setup commands and GitHub tools for posting comments.
+
+## Steps
+
+### 1. Setup
+
+- Read the test spec file at `.github/agent-sops/tui-test-flows.md`
+- The CLI is installed globally as `agentcore`. Launch TUI sessions using `tui_launch` with `command: "agentcore"` and
+  the appropriate `args`.
+- For non-interactive commands (e.g., `--json` output), prefer `shell` over `tui_launch`.
+
+### 2. Run Test Flows
+
+For each flow in the test spec:
+
+1. Create any required setup (e.g., temp directories, minimal projects) using `shell`
+2. Use `tui_launch` to start the CLI with the specified arguments and `cwd`
+3. Follow the flow steps: use `tui_action` (preferred — combines send + wait + read in one call) or `tui_wait_for` +
+   `tui_send_keys` for multi-step interactions
+4. Verify each expectation against the screen content
+5. On **pass**: record the flow name as passed
+6. On **failure**: use `tui_screenshot` to capture the terminal state, record the flow name, expected behavior, actual
+   behavior, and the screenshot text
+7. Always `tui_close` the session when done, even on failure
+
+**Constraints:**
+
+- Use `timeoutMs: 10000` (10 seconds) minimum for all `tui_wait_for` and `tui_action` pattern waits
+- Use small terminal dimensions: `cols: 100, rows: 24`
+- If a wait times out, retry once before declaring failure
+- Use text format screenshots only (not SVG)
+- Keep terminal dimensions consistent across all flows
+
+### 3. Post Results
+
+Post a single summary comment on the PR with this format:
+
+```markdown
+## 🧪 TUI Test Results
+
+**X/Y flows passed**
+
+### ✅ Passed
+
+- Flow name 1
+- Flow name 2
+
+### ❌ Failed
+
+#### Flow name 3
+
+**Expected:** description of what should have happened **Actual:** description of what happened
+
+<details>
+<summary>Screenshot</summary>
+```
+
+(terminal screenshot here)
+
+```
+
+</details>
+```
+
+If all flows pass, omit the Failed section.
+
+## Forbidden Actions
+
+- You MUST NOT modify, create, or delete any source files
+- You MUST NOT run git add, git commit, or git push
+- You MUST NOT create or update branches
+- You MUST NOT approve or merge the pull request
+- You MUST NOT run deploy, invoke, or any command that creates AWS resources
+- Your ONLY output is test result comments on the pull request

--- a/.github/agent-sops/task-tester.sop.md
+++ b/.github/agent-sops/task-tester.sop.md
@@ -2,78 +2,52 @@
 
 ## Role
 
-You are a TUI Tester. Your goal is to verify the AgentCore CLI's interactive TUI behavior by driving it through
-predefined test flows using the TUI harness MCP tools. You post results as PR comments.
+You are a CLI and TUI tester for the AgentCore CLI. You verify both interactive TUI behavior and non-interactive CLI
+commands. You drive the CLI using TUI harness tools and shell commands, then post results as PR comments.
 
 You MUST NOT modify any code, create branches, or push commits. Your only output is test result comments.
 
-## Tools Available
+## Tools
 
-You have TUI harness MCP tools: `tui_launch`, `tui_send_keys`, `tui_action`, `tui_wait_for`, `tui_screenshot`,
-`tui_read_screen`, `tui_close`, `tui_list_sessions`.
+- **TUI harness** (MCP tools): `tui_launch`, `tui_send_keys`, `tui_action`, `tui_wait_for`, `tui_screenshot`,
+  `tui_read_screen`, `tui_close`, `tui_list_sessions` — for interactive TUI testing
+- **`shell`** — for non-interactive CLI commands, setup (temp dirs, project scaffolding), and verification
+- **GitHub tools** — for posting PR comments. Always use `aws/agentcore-cli` as the repository, not the fork.
 
-You also have `shell` for setup commands and GitHub tools for posting comments.
-
-**Important:** Always use `aws/agentcore-cli` as the repository for all GitHub API calls (get PR, post comments, etc.),
-not the fork repository.
-
-## Steps
-
-### 1. Determine Mode
+## What to Test
 
 Check the command text in the prompt:
 
-- If the command is just `test` (no additional text): run **all predefined flows** from
-  `.github/agent-sops/tui-test-flows.md`
-- If the command is `test <description>` (has text after "test"): run **only the described ad-hoc flow**. The text after
-  "test" describes what to test. Design the flow yourself using the TUI harness tools, following the same patterns as
-  the predefined flows.
+- `Run all predefined test flows` → read and execute every flow from `.github/agent-sops/tui-test-flows.md`
+- `Run this ad-hoc test flow: <description>` → design and execute a single flow matching the description
 
-### 2. Setup
+## General Rules
 
-- The CLI is installed globally as `agentcore`. Launch TUI sessions using `tui_launch` with `command: "agentcore"` and
-  the appropriate `args`.
-- For non-interactive commands (e.g., `--json` output), prefer `shell` over `tui_launch`.
+- The CLI is installed globally as `agentcore`
+- Use `tui_launch` with `command: "agentcore"` for interactive commands. Use `shell` for non-interactive ones.
+- Terminal dimensions: `cols: 100, rows: 24` for all TUI sessions
+- Use `timeoutMs: 10000` minimum for all `tui_wait_for` and `tui_action` calls
+- If a wait times out, retry once before declaring failure
+- Always `tui_close` sessions when done, even on failure
+- Run `mkdir -p /tmp/tui-screenshots` via `shell` as your very first action
 
-### 3. Run Test Flows
-
-For each flow:
-
-1. Create any required setup (e.g., temp directories, minimal projects) using `shell`
-2. Use `tui_launch` to start the CLI with the specified arguments and `cwd`
-3. Follow the flow steps: use `tui_action` (preferred — combines send + wait + read in one call) or `tui_wait_for` +
-   `tui_send_keys` for multi-step interactions
-4. Verify each expectation against the screen content
-5. Take a screenshot — see Screenshot Rules below
-6. On **failure**: also read the screen text for the PR comment body. Record the flow name, expected behavior, actual
-   behavior, and the screen text.
-7. Always `tui_close` the session when done, even on failure
-
-### Screenshot Rules
+## Screenshot Rules
 
 **NEVER save .txt files. ONLY save .svg files.**
 
-Every flow MUST produce exactly one SVG screenshot saved to `/tmp/tui-screenshots/`. Use this exact tool call pattern:
+Use this exact tool call pattern for every flow:
 
 ```
 tui_screenshot(sessionId=<id>, format="svg", savePath="/tmp/tui-screenshots/<flow-name>.svg")
 ```
 
-- File extension MUST be `.svg`, NEVER `.txt` or `.png`
-- The `format` parameter MUST be `"svg"`, NEVER `"text"`
-- Take the screenshot WHILE the TUI session is still alive (before the process exits)
-- For commands that exit immediately (like `--help`): take the screenshot right after `tui_wait_for` succeeds
-- For interactive wizards: take the screenshot at the most interesting step before pressing the final Enter
-- If a session has already exited, that flow's screenshot is skipped — do NOT save a text file as a substitute
+- `format` MUST be `"svg"`, NEVER `"text"`
+- Take the screenshot WHILE the session is still alive (before the process exits)
+- If a session has already exited, skip the screenshot — do NOT save a text file as a substitute
 
-**Constraints:**
+## Post Results
 
-- Run `mkdir -p /tmp/tui-screenshots` via `shell` as your very first action
-- Use `timeoutMs: 10000` (10 seconds) minimum for all `tui_wait_for` and `tui_action` pattern waits
-
-### 3. Post Results
-
-Post a single summary comment on the PR with this format:
+Post a single PR comment:
 
 ```markdown
 ## 🧪 TUI Test Results
@@ -89,15 +63,12 @@ Post a single summary comment on the PR with this format:
 
 #### Flow name 3
 
-**Expected:** description of what should have happened **Actual:** description of what happened
+**Expected:** what should have happened **Actual:** what happened
 
 <details>
 <summary>Screenshot</summary>
-```
 
-(terminal screenshot here)
-
-```
+(paste screen text here)
 
 </details>
 ```
@@ -106,9 +77,8 @@ If all flows pass, omit the Failed section.
 
 ## Forbidden Actions
 
-- You MUST NOT modify, create, or delete any source files
-- You MUST NOT run git add, git commit, or git push
-- You MUST NOT create or update branches
-- You MUST NOT approve or merge the pull request
-- You MUST NOT run deploy, invoke, or any command that creates AWS resources
-- Your ONLY output is test result comments on the pull request
+- Do NOT modify, create, or delete source files
+- Do NOT run git commands (add, commit, push)
+- Do NOT create or update branches
+- Do NOT approve or merge the pull request
+- Do NOT deploy or create AWS resources

--- a/.github/agent-sops/task-tester.sop.md
+++ b/.github/agent-sops/task-tester.sop.md
@@ -35,13 +35,16 @@ For each flow in the test spec:
 3. Follow the flow steps: use `tui_action` (preferred — combines send + wait + read in one call) or `tui_wait_for` +
    `tui_send_keys` for multi-step interactions
 4. Verify each expectation against the screen content
-5. On **pass**: record the flow name as passed
-6. On **failure**: use `tui_screenshot` to capture the terminal state, record the flow name, expected behavior, actual
-   behavior, and the screenshot text
+5. On **pass**: use `tui_screenshot` with `format: "svg"` and `savePath: "/tmp/tui-screenshots/<flow-name>-pass.svg"` to
+   capture the final state, then record the flow name as passed
+6. On **failure**: use `tui_screenshot` with `format: "svg"` and `savePath: "/tmp/tui-screenshots/<flow-name>-fail.svg"`
+   to capture the terminal state, also take a text screenshot for the PR comment, record the flow name, expected
+   behavior, actual behavior, and the screenshot text
 7. Always `tui_close` the session when done, even on failure
 
 **Constraints:**
 
+- Create `/tmp/tui-screenshots/` at the start before running any flows
 - Use `timeoutMs: 10000` (10 seconds) minimum for all `tui_wait_for` and `tui_action` pattern waits
 - Use small terminal dimensions: `cols: 100, rows: 24`
 - If a wait times out, retry once before declaring failure

--- a/.github/agent-sops/task-tester.sop.md
+++ b/.github/agent-sops/task-tester.sop.md
@@ -35,21 +35,19 @@ For each flow in the test spec:
 3. Follow the flow steps: use `tui_action` (preferred — combines send + wait + read in one call) or `tui_wait_for` +
    `tui_send_keys` for multi-step interactions
 4. Verify each expectation against the screen content
-5. On **pass**: use `tui_screenshot` with `format: "svg"` and `savePath: "/tmp/tui-screenshots/<flow-name>-pass.svg"` to
-   capture the final state, then record the flow name as passed
-6. On **failure**: use `tui_screenshot` with `format: "svg"` and `savePath: "/tmp/tui-screenshots/<flow-name>-fail.svg"`
-   to capture the terminal state, also take a text screenshot for the PR comment, record the flow name, expected
-   behavior, actual behavior, and the screenshot text
+5. **MUST** take a screenshot before closing every session: call `tui_screenshot` with `sessionId`, `format: "svg"`, and
+   `savePath: "/tmp/tui-screenshots/<flow-name>.svg"` (use kebab-case for flow names, e.g. `help-text.svg`,
+   `create-wizard.svg`). This is required for both pass and fail.
+6. On **failure**: also take a text-format screenshot for the PR comment body. Record the flow name, expected behavior,
+   actual behavior, and the text screenshot.
 7. Always `tui_close` the session when done, even on failure
 
 **Constraints:**
 
-- Create `/tmp/tui-screenshots/` at the start before running any flows
+- Run `mkdir -p /tmp/tui-screenshots` via `shell` as your very first action
+- Every flow MUST produce an SVG file in `/tmp/tui-screenshots/` — if a flow has no screenshot, it is considered
+  incomplete
 - Use `timeoutMs: 10000` (10 seconds) minimum for all `tui_wait_for` and `tui_action` pattern waits
-- Use small terminal dimensions: `cols: 100, rows: 24`
-- If a wait times out, retry once before declaring failure
-- Use text format screenshots only (not SVG)
-- Keep terminal dimensions consistent across all flows
 
 ### 3. Post Results
 

--- a/.github/agent-sops/task-tester.sop.md
+++ b/.github/agent-sops/task-tester.sop.md
@@ -35,27 +35,40 @@ Check the command text in the prompt:
   the appropriate `args`.
 - For non-interactive commands (e.g., `--json` output), prefer `shell` over `tui_launch`.
 
-### 2. Run Test Flows
+### 3. Run Test Flows
 
-For each flow in the test spec:
+For each flow:
 
 1. Create any required setup (e.g., temp directories, minimal projects) using `shell`
 2. Use `tui_launch` to start the CLI with the specified arguments and `cwd`
 3. Follow the flow steps: use `tui_action` (preferred — combines send + wait + read in one call) or `tui_wait_for` +
    `tui_send_keys` for multi-step interactions
 4. Verify each expectation against the screen content
-5. **MUST** take a screenshot before closing every session: call `tui_screenshot` with `sessionId`, `format: "svg"`, and
-   `savePath: "/tmp/tui-screenshots/<flow-name>.svg"` (use kebab-case for flow names, e.g. `help-text.svg`,
-   `create-wizard.svg`). This is required for both pass and fail.
-6. On **failure**: also take a text-format screenshot for the PR comment body. Record the flow name, expected behavior,
-   actual behavior, and the text screenshot.
+5. Take a screenshot — see Screenshot Rules below
+6. On **failure**: also read the screen text for the PR comment body. Record the flow name, expected behavior, actual
+   behavior, and the screen text.
 7. Always `tui_close` the session when done, even on failure
+
+### Screenshot Rules
+
+**NEVER save .txt files. ONLY save .svg files.**
+
+Every flow MUST produce exactly one SVG screenshot saved to `/tmp/tui-screenshots/`. Use this exact tool call pattern:
+
+```
+tui_screenshot(sessionId=<id>, format="svg", savePath="/tmp/tui-screenshots/<flow-name>.svg")
+```
+
+- File extension MUST be `.svg`, NEVER `.txt` or `.png`
+- The `format` parameter MUST be `"svg"`, NEVER `"text"`
+- Take the screenshot WHILE the TUI session is still alive (before the process exits)
+- For commands that exit immediately (like `--help`): take the screenshot right after `tui_wait_for` succeeds
+- For interactive wizards: take the screenshot at the most interesting step before pressing the final Enter
+- If a session has already exited, that flow's screenshot is skipped — do NOT save a text file as a substitute
 
 **Constraints:**
 
 - Run `mkdir -p /tmp/tui-screenshots` via `shell` as your very first action
-- Every flow MUST produce an SVG file in `/tmp/tui-screenshots/` — if a flow has no screenshot, it is considered
-  incomplete
 - Use `timeoutMs: 10000` (10 seconds) minimum for all `tui_wait_for` and `tui_action` pattern waits
 
 ### 3. Post Results

--- a/.github/agent-sops/tui-test-flows.md
+++ b/.github/agent-sops/tui-test-flows.md
@@ -2,24 +2,38 @@
 
 Each flow describes a user interaction to verify. The tester agent drives these using the TUI harness MCP tools.
 
+All flows use `tui_launch` with `command: "agentcore"` and the appropriate `args`. Use `cols: 100, rows: 24`.
+
 ---
 
 ## Flow: Help text lists all commands
 
-1. Launch: `agentcore --help` (use `tui_launch` with `command: "agentcore"`, `args: ["--help"]`)
+1. Launch: `agentcore --help`
 2. Wait for: "Usage:" on screen
 3. Expect all of these commands visible: `create`, `deploy`, `invoke`, `status`, `add`, `remove`, `dev`, `logs`
 4. Close session
 
 ---
 
-## Flow: Add agent then verify status shows local-only
+## Flow: Create project with agent via TUI wizard
 
-1. Create a project via shell: `agentcore create --name TestStatus --no-agent --json` (in a temp directory)
-2. Add an agent via shell:
-   `agentcore add agent --name MyAgent --language Python --framework Strands --model-provider Bedrock --json` (in the
-   project directory)
-3. Launch: `agentcore status` in the project directory (use `tui_launch`)
-4. Wait for: the status table to render (look for "MyAgent" or "agent" on screen)
-5. Expect: "MyAgent" appears with a "local-only" state
-6. Close session
+This flow drives the full interactive create wizard — no `--json` flags.
+
+1. Create a temp directory via `shell`: `mktemp -d`
+2. Launch: `agentcore create` with `cwd` set to the temp directory
+3. Wait for: "Project name" prompt
+4. Type a project name (e.g. `TuiTest`), press Enter
+5. Wait for: "Would you like to add an agent" selection
+6. Expect: "Yes, add an agent" is visible and selected (has `❯` marker)
+7. Press Enter to select "Yes, add an agent"
+8. Wait for: "Agent name" prompt inside the Add Agent wizard
+9. Accept the default name or type one, press Enter
+10. Wait for: "Select agent type" selection
+11. Expect: "Create new agent" is visible
+12. Press Enter to select it
+13. Wait for: "Language" step with "Python" visible
+14. Press Enter to select Python
+15. Continue pressing Enter through remaining steps (Build, Protocol, Framework, Model) accepting defaults until you
+    reach a "Confirm" or completion screen
+16. Expect: the wizard completes — look for a success message or the process exits
+17. Close session

--- a/.github/agent-sops/tui-test-flows.md
+++ b/.github/agent-sops/tui-test-flows.md
@@ -4,14 +4,21 @@ Each flow describes a user interaction to verify. The tester agent drives these 
 
 All flows use `tui_launch` with `command: "agentcore"` and the appropriate `args`. Use `cols: 100, rows: 24`.
 
+**Important screenshot rule:** Take the SVG screenshot BEFORE the process exits. For commands that exit immediately
+(like `--help`), use `tui_wait_for` to wait for expected content, then immediately take the screenshot while the session
+is still alive. For interactive wizards, take the screenshot at the most interesting step (e.g. the final confirmation
+screen) before pressing the last Enter.
+
 ---
 
 ## Flow: Help text lists all commands
 
 1. Launch: `agentcore --help`
-2. Wait for: "Usage:" on screen
-3. Expect all of these commands visible: `create`, `deploy`, `invoke`, `status`, `add`, `remove`, `dev`, `logs`
-4. Close session
+2. Use `tui_wait_for` to wait for "Usage:" on screen
+3. Immediately take SVG screenshot (the session may still be alive briefly after output)
+4. Read the screen content
+5. Expect all of these commands visible: `create`, `deploy`, `invoke`, `status`, `add`, `remove`, `dev`, `logs`
+6. Close session
 
 ---
 
@@ -24,16 +31,16 @@ This flow drives the full interactive create wizard — no `--json` flags.
 3. Wait for: "Project name" prompt
 4. Type a project name (e.g. `TuiTest`), press Enter
 5. Wait for: "Would you like to add an agent" selection
-6. Expect: "Yes, add an agent" is visible and selected (has `❯` marker)
+6. Expect: "Yes, add an agent" is visible
 7. Press Enter to select "Yes, add an agent"
 8. Wait for: "Agent name" prompt inside the Add Agent wizard
-9. Accept the default name or type one, press Enter
-10. Wait for: "Select agent type" selection
-11. Expect: "Create new agent" is visible
-12. Press Enter to select it
-13. Wait for: "Language" step with "Python" visible
-14. Press Enter to select Python
-15. Continue pressing Enter through remaining steps (Build, Protocol, Framework, Model) accepting defaults until you
-    reach a "Confirm" or completion screen
-16. Expect: the wizard completes — look for a success message or the process exits
-17. Close session
+9. Accept the default name, press Enter
+10. Wait for: "Select agent type" — expect "Create new agent" visible
+11. Press Enter to select it
+12. Wait for: "Language" step with "Python" visible
+13. Press Enter to select Python
+14. Continue pressing Enter through remaining steps (Build, Protocol, Framework, Model) accepting defaults
+15. When you reach the "Confirm" step, take the SVG screenshot BEFORE pressing the final Enter
+16. Press Enter to confirm
+17. Wait for the process to exit or a success message
+18. Close session

--- a/.github/agent-sops/tui-test-flows.md
+++ b/.github/agent-sops/tui-test-flows.md
@@ -1,0 +1,50 @@
+# TUI Test Flows
+
+Each flow describes a user interaction to verify. The tester agent drives these using the TUI harness MCP tools.
+
+---
+
+## Flow: Help text lists all subcommands
+
+1. Launch: `agentcore --help` (use `tui_launch` with `command: "agentcore"`, `args: ["--help"]`)
+2. Wait for: "Usage:" on screen
+3. Expect all of these subcommands visible: `create`, `deploy`, `invoke`, `status`, `logs`, `add`, `remove`
+4. Close session
+
+---
+
+## Flow: Create wizard prompts for project name
+
+1. Launch: `agentcore create` (no flags, in a temp directory)
+2. Wait for: a prompt asking for the project name (look for "name" or "project")
+3. Expect: an input field or prompt is visible
+4. Close session (Ctrl+C)
+
+---
+
+## Flow: Create with --json produces valid JSON
+
+1. In a temp directory, run via shell:
+   `agentcore create --name TestProj --language Python --framework Strands --model-provider Bedrock --memory none --json`
+2. Expect: stdout contains valid JSON with `"success": true` and `"projectPath"`
+3. Verify the project directory was created
+
+---
+
+## Flow: Add agent shows framework selection
+
+1. First create a project via shell: `agentcore create --name AgentTest --no-agent --json` (in a temp directory)
+2. Launch: `agentcore add agent` in the created project directory
+3. Wait for: agent name prompt
+4. Type a name, press Enter
+5. Wait for: framework or language selection to appear
+6. Expect: at least "Strands" and "LangChain_LangGraph" visible as options
+7. Close session (Ctrl+C)
+
+---
+
+## Flow: Invalid project name shows error
+
+1. In a temp directory, run via shell:
+   `agentcore create --name "123invalid" --language Python --framework Strands --model-provider Bedrock --memory none --json`
+2. Expect: exit code is non-zero OR output contains an error about the project name (must start with a letter)

--- a/.github/agent-sops/tui-test-flows.md
+++ b/.github/agent-sops/tui-test-flows.md
@@ -1,46 +1,27 @@
 # TUI Test Flows
 
-Each flow describes a user interaction to verify. The tester agent drives these using the TUI harness MCP tools.
-
-All flows use `tui_launch` with `command: "agentcore"` and the appropriate `args`. Use `cols: 100, rows: 24`.
-
-**Important screenshot rule:** Take the SVG screenshot BEFORE the process exits. For commands that exit immediately
-(like `--help`), use `tui_wait_for` to wait for expected content, then immediately take the screenshot while the session
-is still alive. For interactive wizards, take the screenshot at the most interesting step (e.g. the final confirmation
-screen) before pressing the last Enter.
-
 ---
 
 ## Flow: Help text lists all commands
 
 1. Launch: `agentcore --help`
-2. Use `tui_wait_for` to wait for "Usage:" on screen
-3. Immediately take SVG screenshot (the session may still be alive briefly after output)
-4. Read the screen content
-5. Expect all of these commands visible: `create`, `deploy`, `invoke`, `status`, `add`, `remove`, `dev`, `logs`
-6. Close session
+2. Wait for "Usage:" on screen
+3. Take SVG screenshot immediately (before the process exits)
+4. Verify these commands are visible: `create`, `deploy`, `invoke`, `status`, `add`, `remove`, `dev`, `logs`
+5. Close session
 
 ---
 
 ## Flow: Create project with agent via TUI wizard
 
-This flow drives the full interactive create wizard — no `--json` flags.
-
 1. Create a temp directory via `shell`: `mktemp -d`
 2. Launch: `agentcore create` with `cwd` set to the temp directory
-3. Wait for: "Project name" prompt
-4. Type a project name (e.g. `TuiTest`), press Enter
-5. Wait for: "Would you like to add an agent" selection
-6. Expect: "Yes, add an agent" is visible
-7. Press Enter to select "Yes, add an agent"
-8. Wait for: "Agent name" prompt inside the Add Agent wizard
-9. Accept the default name, press Enter
-10. Wait for: "Select agent type" — expect "Create new agent" visible
-11. Press Enter to select it
-12. Wait for: "Language" step with "Python" visible
-13. Press Enter to select Python
-14. Continue pressing Enter through remaining steps (Build, Protocol, Framework, Model) accepting defaults
-15. When you reach the "Confirm" step, take the SVG screenshot BEFORE pressing the final Enter
-16. Press Enter to confirm
-17. Wait for the process to exit or a success message
-18. Close session
+3. Wait for "Project name" prompt, type `TuiTest`, press Enter
+4. Wait for "Would you like to add an agent" — expect "Yes, add an agent" visible, press Enter
+5. Wait for "Agent name" prompt, accept the default, press Enter
+6. Wait for "Select agent type" — expect "Create new agent" visible, press Enter
+7. Wait for "Language" step — expect "Python" visible, press Enter
+8. Continue pressing Enter through remaining steps (Build, Protocol, Framework, Model) accepting defaults
+9. At the "Confirm" step, take SVG screenshot, then press Enter
+10. Wait for the process to exit or a success message
+11. Close session

--- a/.github/agent-sops/tui-test-flows.md
+++ b/.github/agent-sops/tui-test-flows.md
@@ -4,47 +4,22 @@ Each flow describes a user interaction to verify. The tester agent drives these 
 
 ---
 
-## Flow: Help text lists all subcommands
+## Flow: Help text lists all commands
 
 1. Launch: `agentcore --help` (use `tui_launch` with `command: "agentcore"`, `args: ["--help"]`)
 2. Wait for: "Usage:" on screen
-3. Expect all of these subcommands visible: `create`, `deploy`, `invoke`, `status`, `logs`, `add`, `remove`
+3. Expect all of these commands visible: `create`, `deploy`, `invoke`, `status`, `add`, `remove`, `dev`, `logs`
 4. Close session
 
 ---
 
-## Flow: Create wizard prompts for project name
+## Flow: Add agent then verify status shows local-only
 
-1. Launch: `agentcore create` (no flags, in a temp directory)
-2. Wait for: a prompt asking for the project name (look for "name" or "project")
-3. Expect: an input field or prompt is visible
-4. Close session (Ctrl+C)
-
----
-
-## Flow: Create with --json produces valid JSON
-
-1. In a temp directory, run via shell:
-   `agentcore create --name TestProj --language Python --framework Strands --model-provider Bedrock --memory none --json`
-2. Expect: stdout contains valid JSON with `"success": true` and `"projectPath"`
-3. Verify the project directory was created
-
----
-
-## Flow: Add agent shows framework selection
-
-1. First create a project via shell: `agentcore create --name AgentTest --no-agent --json` (in a temp directory)
-2. Launch: `agentcore add agent` in the created project directory
-3. Wait for: agent name prompt
-4. Type a name, press Enter
-5. Wait for: framework or language selection to appear
-6. Expect: at least "Strands" and "LangChain_LangGraph" visible as options
-7. Close session (Ctrl+C)
-
----
-
-## Flow: Invalid project name shows error
-
-1. In a temp directory, run via shell:
-   `agentcore create --name "123invalid" --language Python --framework Strands --model-provider Bedrock --memory none --json`
-2. Expect: exit code is non-zero OR output contains an error about the project name (must start with a letter)
+1. Create a project via shell: `agentcore create --name TestStatus --no-agent --json` (in a temp directory)
+2. Add an agent via shell:
+   `agentcore add agent --name MyAgent --language Python --framework Strands --model-provider Bedrock --json` (in the
+   project directory)
+3. Launch: `agentcore status` in the project directory (use `tui_launch`)
+4. Wait for: the status table to render (look for "MyAgent" or "agent" on screen)
+5. Expect: "MyAgent" appears with a "local-only" state
+6. Close session

--- a/.github/scripts/javascript/process-inputs.cjs
+++ b/.github/scripts/javascript/process-inputs.cjs
@@ -108,13 +108,11 @@ module.exports = async (context, github, core, inputs) => {
     const { issueId, command, issue } = await getIssueInfo(github, context, inputs);
 
     const isPullRequest = !!issue.data.pull_request;
-    const mode = command.startsWith('test')
-      ? 'tester'
-      : command.startsWith('review')
-        ? 'reviewer'
-        : isPullRequest || command.startsWith('implement')
-          ? 'implementer'
-          : 'refiner';
+
+    const COMMAND_MODES = { test: 'tester', review: 'reviewer', implement: 'implementer' };
+    const mode =
+      Object.entries(COMMAND_MODES).find(([prefix]) => command.startsWith(prefix))?.[1] ??
+      (isPullRequest ? 'implementer' : 'refiner');
     console.log(`Is PR: ${isPullRequest}, Mode: ${mode}`);
 
     const branchName = await determineBranch(github, context, issueId, mode, isPullRequest);

--- a/.github/scripts/javascript/process-inputs.cjs
+++ b/.github/scripts/javascript/process-inputs.cjs
@@ -87,7 +87,18 @@ function buildPrompts(mode, issueId, isPullRequest, command, branchName, inputs)
   let prompt = isPullRequest ? 'The pull request id is:' : 'The issue id is:';
   prompt += `${issueId}\n`;
   prompt += `The repository is: aws/agentcore-cli\n`;
-  prompt += `${command}\nreview and continue`;
+
+  if (mode === 'tester') {
+    const flowDescription = command.replace(/^test\s*/, '').trim();
+    if (flowDescription) {
+      prompt += `Run this ad-hoc test flow: ${flowDescription}\n`;
+    } else {
+      prompt += `Run all predefined test flows from .github/agent-sops/tui-test-flows.md\n`;
+    }
+  } else {
+    prompt += `${command}\n`;
+  }
+  prompt += 'review and continue';
 
   return { sessionId, systemPrompt, prompt };
 }

--- a/.github/scripts/javascript/process-inputs.cjs
+++ b/.github/scripts/javascript/process-inputs.cjs
@@ -4,48 +4,48 @@
 
 const fs = require('fs');
 
-async function getIssueInfo(github, context, inputs) {
+async function getIssueInfo(github, repo, inputs, eventName, payload) {
   let issueId;
 
-  if (context.eventName === 'workflow_dispatch') {
+  if (eventName === 'workflow_dispatch') {
     issueId = inputs.issue_id;
   } else {
     // Handle both issue comments and PR comments
-    issueId = (context.payload.issue?.number || context.payload.pull_request?.number)?.toString();
+    issueId = (payload.issue?.number || payload.pull_request?.number)?.toString();
   }
 
   const command =
-    context.eventName === 'workflow_dispatch'
+    eventName === 'workflow_dispatch'
       ? inputs.command
-      : context.payload.comment.body.match(/^\/strands\s*(.*)$/)?.[1]?.trim() || '';
+      : payload.comment.body.match(/^\/strands\s*(.*)$/)?.[1]?.trim() || '';
 
-  console.log(`Event: ${context.eventName}, Issue ID: ${issueId}, Command: "${command}"`);
+  console.log(`Event: ${eventName}, Issue ID: ${issueId}, Command: "${command}"`);
 
   const issue = await github.rest.issues.get({
-    owner: context.repo.owner,
-    repo: context.repo.repo,
+    owner: repo.owner,
+    repo: repo.repo,
     issue_number: issueId,
   });
 
   return { issueId, command, issue };
 }
 
-async function determineBranch(github, context, issueId, mode, isPullRequest) {
+async function determineBranch(github, repo, issueId, mode, isPullRequest) {
   let branchName = 'main';
 
   if (mode === 'implementer' && !isPullRequest) {
     branchName = `agent-tasks/${issueId}`;
 
     const mainRef = await github.rest.git.getRef({
-      owner: context.repo.owner,
-      repo: context.repo.repo,
+      owner: repo.owner,
+      repo: repo.repo,
       ref: 'heads/main',
     });
 
     try {
       await github.rest.git.createRef({
-        owner: context.repo.owner,
-        repo: context.repo.repo,
+        owner: repo.owner,
+        repo: repo.repo,
         ref: `refs/heads/${branchName}`,
         sha: mainRef.data.object.sha,
       });
@@ -59,8 +59,8 @@ async function determineBranch(github, context, issueId, mode, isPullRequest) {
     }
   } else if (isPullRequest) {
     const pr = await github.rest.pulls.get({
-      owner: context.repo.owner,
-      repo: context.repo.repo,
+      owner: repo.owner,
+      repo: repo.repo,
       pull_number: issueId,
     });
     branchName = pr.data.head.ref;
@@ -69,7 +69,7 @@ async function determineBranch(github, context, issueId, mode, isPullRequest) {
   return branchName;
 }
 
-function buildPrompts(mode, issueId, isPullRequest, command, branchName, inputs) {
+function buildPrompts(mode, issueId, isPullRequest, command, branchName, inputs, repo) {
   const sessionId =
     inputs.session_id ||
     (mode === 'implementer' ? `${mode}-${branchName}`.replace(/[\/\\]/g, '-') : `${mode}-${issueId}`);
@@ -86,7 +86,7 @@ function buildPrompts(mode, issueId, isPullRequest, command, branchName, inputs)
 
   let prompt = isPullRequest ? 'The pull request id is:' : 'The issue id is:';
   prompt += `${issueId}\n`;
-  prompt += `The repository is: aws/agentcore-cli\n`;
+  prompt += `The repository is: ${repo.owner}/${repo.repo}\n`;
 
   if (mode === 'tester') {
     const flowDescription = command.replace(/^test\s*/, '').trim();
@@ -105,7 +105,9 @@ function buildPrompts(mode, issueId, isPullRequest, command, branchName, inputs)
 
 module.exports = async (context, github, core, inputs) => {
   try {
-    const { issueId, command, issue } = await getIssueInfo(github, context, inputs);
+    const repo = inputs.target_repo || { owner: context.repo.owner, repo: context.repo.repo };
+
+    const { issueId, command, issue } = await getIssueInfo(github, repo, inputs, context.eventName, context.payload);
 
     const isPullRequest = !!issue.data.pull_request;
 
@@ -115,10 +117,18 @@ module.exports = async (context, github, core, inputs) => {
       (isPullRequest ? 'implementer' : 'refiner');
     console.log(`Is PR: ${isPullRequest}, Mode: ${mode}`);
 
-    const branchName = await determineBranch(github, context, issueId, mode, isPullRequest);
+    const branchName = await determineBranch(github, repo, issueId, mode, isPullRequest);
     console.log(`Building prompts - mode: ${mode}, issue: ${issueId}, is PR: ${isPullRequest}`);
 
-    const { sessionId, systemPrompt, prompt } = buildPrompts(mode, issueId, isPullRequest, command, branchName, inputs);
+    const { sessionId, systemPrompt, prompt } = buildPrompts(
+      mode,
+      issueId,
+      isPullRequest,
+      command,
+      branchName,
+      inputs,
+      repo
+    );
 
     console.log(`Session ID: ${sessionId}`);
     console.log(`Task prompt: "${prompt}"`);

--- a/.github/scripts/javascript/process-inputs.cjs
+++ b/.github/scripts/javascript/process-inputs.cjs
@@ -85,7 +85,9 @@ function buildPrompts(mode, issueId, isPullRequest, command, branchName, inputs)
   const systemPrompt = fs.readFileSync(scriptFile, 'utf8');
 
   let prompt = isPullRequest ? 'The pull request id is:' : 'The issue id is:';
-  prompt += `${issueId}\n${command}\nreview and continue`;
+  prompt += `${issueId}\n`;
+  prompt += `The repository is: aws/agentcore-cli\n`;
+  prompt += `${command}\nreview and continue`;
 
   return { sessionId, systemPrompt, prompt };
 }

--- a/.github/scripts/javascript/process-inputs.cjs
+++ b/.github/scripts/javascript/process-inputs.cjs
@@ -78,6 +78,7 @@ function buildPrompts(mode, issueId, isPullRequest, command, branchName, inputs)
     implementer: '.github/agent-sops/task-implementer.sop.md',
     reviewer: '.github/agent-sops/task-reviewer.sop.md',
     refiner: '.github/agent-sops/task-refiner.sop.md',
+    tester: '.github/agent-sops/task-tester.sop.md',
   };
   const scriptFile = sopFiles[mode] || sopFiles.refiner;
 
@@ -94,11 +95,13 @@ module.exports = async (context, github, core, inputs) => {
     const { issueId, command, issue } = await getIssueInfo(github, context, inputs);
 
     const isPullRequest = !!issue.data.pull_request;
-    const mode = command.startsWith('review')
-      ? 'reviewer'
-      : isPullRequest || command.startsWith('implement')
-        ? 'implementer'
-        : 'refiner';
+    const mode = command.startsWith('test')
+      ? 'tester'
+      : command.startsWith('review')
+        ? 'reviewer'
+        : isPullRequest || command.startsWith('implement')
+          ? 'implementer'
+          : 'refiner';
     console.log(`Is PR: ${isPullRequest}, Mode: ${mode}`);
 
     const branchName = await determineBranch(github, context, issueId, mode, isPullRequest);
@@ -113,6 +116,7 @@ module.exports = async (context, github, core, inputs) => {
     core.setOutput('session_id', sessionId);
     core.setOutput('system_prompt', systemPrompt);
     core.setOutput('prompt', prompt);
+    core.setOutput('mode', mode);
   } catch (error) {
     const errorMsg = `Failed: ${error.message}`;
     console.error(errorMsg);

--- a/.github/workflows/strands-command.yml
+++ b/.github/workflows/strands-command.yml
@@ -70,6 +70,7 @@ jobs:
           fetch-depth: 0
 
       - name: Add strands-running label
+        continue-on-error: true
         uses: actions/github-script@v8
         with:
           script: |
@@ -86,6 +87,10 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
+            // When dispatched from a fork, point API calls at the upstream repo
+            if (context.eventName === 'workflow_dispatch' && context.repo.owner !== 'aws') {
+              context.repo = { owner: 'aws', repo: 'agentcore-cli' };
+            }
             const processInputs = require('./.github/scripts/javascript/process-inputs.cjs');
             const inputs = {
               issue_id: '${{ inputs.issue_id }}',

--- a/.github/workflows/strands-command.yml
+++ b/.github/workflows/strands-command.yml
@@ -94,6 +94,21 @@ jobs:
             };
             await processInputs(context, github, core, inputs);
 
+      - name: Setup Node.js (tester mode)
+        if: steps.process-inputs.outputs.mode == 'tester'
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20.x
+          cache: 'npm'
+
+      - name: Build CLI and TUI harness (tester mode)
+        if: steps.process-inputs.outputs.mode == 'tester'
+        run: |
+          npm ci
+          npm run build
+          npm run build:harness
+          npm install -g "$(npm pack | tail -1)"
+
       - name: Run Strands Agent
         uses: ./.github/actions/strands-action
         with:
@@ -102,6 +117,9 @@ jobs:
           provider: 'bedrock'
           model: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0'
           tools: 'strands_tools:shell,retrieve'
+          mcp_servers:
+            ${{ steps.process-inputs.outputs.mode == 'tester' &&
+            '{"mcpServers":{"tui-harness":{"command":"node","args":["dist/mcp-harness/index.mjs"]}}}' || '' }}
           aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
           aws_region: 'us-west-2'
           pat_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/strands-command.yml
+++ b/.github/workflows/strands-command.yml
@@ -122,7 +122,10 @@ jobs:
       - name: Set MCP harness path
         if: steps.process-inputs.outputs.mode == 'tester'
         id: mcp-config
-        run: echo "mcp_servers={\"mcpServers\":{\"tui-harness\":{\"command\":\"node\",\"args\":[\"/tmp/mcp-harness/index.mjs\"]}}}" >> "$GITHUB_OUTPUT"
+        run:
+          echo
+          "mcp_servers={\"mcpServers\":{\"tui-harness\":{\"command\":\"node\",\"args\":[\"/tmp/mcp-harness/index.mjs\"]}}}"
+          >> "$GITHUB_OUTPUT"
 
       - name: Run Strands Agent
         uses: ./.github/actions/strands-action

--- a/.github/workflows/strands-command.yml
+++ b/.github/workflows/strands-command.yml
@@ -87,9 +87,11 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            // When dispatched from a fork, point API calls at the upstream repo
+            // When dispatched from a fork, override the repo getter to point at upstream
             if (context.eventName === 'workflow_dispatch' && context.repo.owner !== 'aws') {
-              context.repo = { owner: 'aws', repo: 'agentcore-cli' };
+              Object.defineProperty(context, 'repo', {
+                get: () => ({ owner: 'aws', repo: 'agentcore-cli' })
+              });
             }
             const processInputs = require('./.github/scripts/javascript/process-inputs.cjs');
             const inputs = {

--- a/.github/workflows/strands-command.yml
+++ b/.github/workflows/strands-command.yml
@@ -70,6 +70,8 @@ jobs:
           fetch-depth: 0
 
       - name: Add strands-running label
+        # continue-on-error: workflow_dispatch from a fork targets the fork repo
+        # where the upstream issue/PR doesn't exist, causing a 404.
         continue-on-error: true
         uses: actions/github-script@v8
         with:
@@ -87,17 +89,15 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            // When dispatched from a fork, override the repo getter to point at upstream
-            if (context.eventName === 'workflow_dispatch' && context.repo.owner !== 'aws') {
-              Object.defineProperty(context, 'repo', {
-                get: () => ({ owner: 'aws', repo: 'agentcore-cli' })
-              });
-            }
             const processInputs = require('./.github/scripts/javascript/process-inputs.cjs');
             const inputs = {
               issue_id: '${{ inputs.issue_id }}',
               command: '${{ inputs.command }}',
-              session_id: '${{ inputs.session_id }}'
+              session_id: '${{ inputs.session_id }}',
+              // When dispatched from a fork, target the upstream repo for API calls
+              ...(context.eventName === 'workflow_dispatch' && context.repo.owner !== 'aws'
+                ? { target_repo: { owner: 'aws', repo: 'agentcore-cli' } }
+                : {}),
             };
             await processInputs(context, github, core, inputs);
 

--- a/.github/workflows/strands-command.yml
+++ b/.github/workflows/strands-command.yml
@@ -126,7 +126,7 @@ jobs:
           tools: 'strands_tools:shell,retrieve'
           mcp_servers:
             ${{ steps.process-inputs.outputs.mode == 'tester' &&
-            '{"mcpServers":{"tui-harness":{"command":"node","args":["dist/mcp-harness/index.mjs"]}}}' || '' }}
+            format('{"mcpServers":{"tui-harness":{"command":"node","args":["{0}/dist/mcp-harness/index.mjs"]}}}', github.workspace) || '' }}
           aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
           aws_region: 'us-west-2'
           pat_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/strands-command.yml
+++ b/.github/workflows/strands-command.yml
@@ -115,14 +115,12 @@ jobs:
           npm run build
           npm run build:harness
           npm install -g "$(npm pack | tail -1)"
-          echo "--- Verifying harness exists ---"
-          ls -la dist/mcp-harness/index.mjs
-          node -e "require('fs').accessSync('${{ github.workspace }}/dist/mcp-harness/index.mjs'); console.log('File accessible')"
+          cp dist/mcp-harness/index.mjs /tmp/mcp-harness.mjs
 
       - name: Set MCP harness path
         if: steps.process-inputs.outputs.mode == 'tester'
         id: mcp-config
-        run: echo "mcp_servers={\"mcpServers\":{\"tui-harness\":{\"command\":\"node\",\"args\":[\"${{ github.workspace }}/dist/mcp-harness/index.mjs\"]}}}" >> "$GITHUB_OUTPUT"
+        run: echo "mcp_servers={\"mcpServers\":{\"tui-harness\":{\"command\":\"node\",\"args\":[\"/tmp/mcp-harness.mjs\"]}}}" >> "$GITHUB_OUTPUT"
 
       - name: Run Strands Agent
         uses: ./.github/actions/strands-action

--- a/.github/workflows/strands-command.yml
+++ b/.github/workflows/strands-command.yml
@@ -115,12 +115,14 @@ jobs:
           npm run build
           npm run build:harness
           npm install -g "$(npm pack | tail -1)"
-          cp dist/mcp-harness/index.mjs /tmp/mcp-harness.mjs
+          mkdir -p /tmp/mcp-harness
+          cp dist/mcp-harness/index.mjs /tmp/mcp-harness/index.mjs
+          cd /tmp/mcp-harness && npm init -y && npm install node-pty @xterm/headless express
 
       - name: Set MCP harness path
         if: steps.process-inputs.outputs.mode == 'tester'
         id: mcp-config
-        run: echo "mcp_servers={\"mcpServers\":{\"tui-harness\":{\"command\":\"node\",\"args\":[\"/tmp/mcp-harness.mjs\"]}}}" >> "$GITHUB_OUTPUT"
+        run: echo "mcp_servers={\"mcpServers\":{\"tui-harness\":{\"command\":\"node\",\"args\":[\"/tmp/mcp-harness/index.mjs\"]}}}" >> "$GITHUB_OUTPUT"
 
       - name: Run Strands Agent
         uses: ./.github/actions/strands-action

--- a/.github/workflows/strands-command.yml
+++ b/.github/workflows/strands-command.yml
@@ -115,6 +115,9 @@ jobs:
           npm run build
           npm run build:harness
           npm install -g "$(npm pack | tail -1)"
+          echo "--- Verifying harness exists ---"
+          ls -la dist/mcp-harness/index.mjs
+          node -e "require('fs').accessSync('${{ github.workspace }}/dist/mcp-harness/index.mjs'); console.log('File accessible')"
 
       - name: Set MCP harness path
         if: steps.process-inputs.outputs.mode == 'tester'

--- a/.github/workflows/strands-command.yml
+++ b/.github/workflows/strands-command.yml
@@ -116,6 +116,11 @@ jobs:
           npm run build:harness
           npm install -g "$(npm pack | tail -1)"
 
+      - name: Set MCP harness path
+        if: steps.process-inputs.outputs.mode == 'tester'
+        id: mcp-config
+        run: echo "mcp_servers={\"mcpServers\":{\"tui-harness\":{\"command\":\"node\",\"args\":[\"${{ github.workspace }}/dist/mcp-harness/index.mjs\"]}}}" >> "$GITHUB_OUTPUT"
+
       - name: Run Strands Agent
         uses: ./.github/actions/strands-action
         with:
@@ -124,9 +129,7 @@ jobs:
           provider: 'bedrock'
           model: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0'
           tools: 'strands_tools:shell,retrieve'
-          mcp_servers:
-            ${{ steps.process-inputs.outputs.mode == 'tester' &&
-            format('{"mcpServers":{"tui-harness":{"command":"node","args":["{0}/dist/mcp-harness/index.mjs"]}}}', github.workspace) || '' }}
+          mcp_servers: ${{ steps.mcp-config.outputs.mcp_servers || '' }}
           aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
           aws_region: 'us-west-2'
           pat_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/strands-command.yml
+++ b/.github/workflows/strands-command.yml
@@ -141,6 +141,14 @@ jobs:
           S3_SESSION_BUCKET: ${{ secrets.AGENT_SESSIONS_BUCKET }}
           BRANCH_NAME: ${{ steps.process-inputs.outputs.branch_name }}
 
+      - name: Upload TUI screenshots
+        if: always() && steps.process-inputs.outputs.mode == 'tester'
+        uses: actions/upload-artifact@v4
+        with:
+          name: tui-screenshots
+          path: /tmp/tui-screenshots/
+          if-no-files-found: ignore
+
       - name: Remove strands-running label
         if: always()
         uses: actions/github-script@v8


### PR DESCRIPTION
## Description

Adds a `/strands test` command that uses the existing TUI harness MCP server to drive the CLI interactively and verify behavior on PRs. The Strands agent launches the CLI in pseudo-terminals, interacts with it, verifies expectations, and posts results as PR comments with screenshots of any failures.

### How it works
There are two modes: predefined flows, and dynamic flows. 

Commenting `/strands test {prompt}` on a PR will trigger the agent in "tester" mode. If a prompt is specified after the test, it will only run the specified flow (dynamic), otherwise it will run all predefined flows. Results are posted as a PR comment with pass/fail counts and failure screenshots. Successes are also verified with screenshots as artifacts on the GH actions run. 

Ex. 
```
/strands test verify that when creating a new project in the TUI, there is a prompt for creating an agent too
```
--> https://github.com/Hweinstock/agentcore-cli/actions/runs/23949720694
(see attached screenshots, not able to post comment since its running in my fork). 

## Related Issue

Closes #

## Documentation PR

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing
- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots
See example run for testing. 

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.