### PR TITLE
ci: format schemas after generation in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,8 @@ jobs:
         run: |
           npm run build
           node scripts/generate-schema.mjs
-          echo "✓ JSON schema regenerated"
+          npx prettier --write schemas/
+          echo "✓ JSON schema regenerated and formatted"
 
       - name: Create release branch and PR
         env:


### PR DESCRIPTION
## Problem

The release workflow regenerates the JSON schema via `generate-schema.mjs` but doesn't run prettier on the output. If the generated schema doesn't match prettier's format, the release PR will fail the format check in Quality and Safety Checks.

## Solution

Add `npx prettier --write schemas/` after schema generation in the release workflow.

## Testing

Verified the current schema passes prettier. The change is a one-line addition to the workflow — no runtime code affected.