### PR TITLE
fix(e2e): update --agent to --runtime in e2e tests

### DIFF
--- a/e2e-tests/byo-custom-jwt.test.ts
+++ b/e2e-tests/byo-custom-jwt.test.ts
@@ -239,7 +239,7 @@ describe.sequential('e2e: BYO agent with CUSTOM_JWT auth', () => {
 
       // The CLI uses SigV4 by default — a CUSTOM_JWT runtime should reject it
       const result = await runLocalCLI(
-        ['invoke', '--prompt', 'Say hello', '--agent', agentName, '--json'],
+        ['invoke', '--prompt', 'Say hello', '--runtime', agentName, '--json'],
         projectPath
       );
 

--- a/e2e-tests/e2e-helper.ts
+++ b/e2e-tests/e2e-helper.ts
@@ -142,7 +142,7 @@ export function createE2ESuite(cfg: E2EConfig) {
         await retry(
           async () => {
             const result = await runAgentCoreCLI(
-              ['invoke', '--prompt', 'Say hello', '--agent', agentName, '--json'],
+              ['invoke', '--prompt', 'Say hello', '--runtime', agentName, '--json'],
               projectPath
             );
 
@@ -205,7 +205,7 @@ export function createE2ESuite(cfg: E2EConfig) {
       async () => {
         expect(runtimeId, 'Runtime ID should have been extracted from status').toBeTruthy();
 
-        const result = await run(['status', '--agent-runtime-id', runtimeId, '--json']);
+        const result = await run(['status', '--runtime-id', runtimeId, '--json']);
 
         expect(result.exitCode, `Runtime lookup failed: ${result.stderr}`).toBe(0);
 
@@ -227,7 +227,7 @@ export function createE2ESuite(cfg: E2EConfig) {
         await retry(
           async () => {
             // --since 1h triggers search mode (avoids live tail)
-            const result = await run(['logs', '--agent', agentName, '--since', '1h', '--json']);
+            const result = await run(['logs', '--runtime', agentName, '--since', '1h', '--json']);
 
             expect(result.exitCode, `Logs failed: ${result.stderr}`).toBe(0);
 
@@ -254,7 +254,7 @@ export function createE2ESuite(cfg: E2EConfig) {
       'logs supports level filtering',
       async () => {
         // --level error should succeed even if no error-level logs exist
-        const result = await run(['logs', '--agent', agentName, '--since', '1h', '--level', 'error', '--json']);
+        const result = await run(['logs', '--runtime', agentName, '--since', '1h', '--level', 'error', '--json']);
 
         expect(result.exitCode, `Logs --level failed: ${result.stderr}`).toBe(0);
       },
@@ -267,7 +267,7 @@ export function createE2ESuite(cfg: E2EConfig) {
         // traces list has no --json flag — verify exit code and non-empty output
         await retry(
           async () => {
-            const result = await run(['traces', 'list', '--agent', agentName, '--since', '1h']);
+            const result = await run(['traces', 'list', '--runtime', agentName, '--since', '1h']);
 
             expect(result.exitCode, `Traces list failed (stderr: ${result.stderr})`).toBe(0);
             expect(result.stdout.length, 'Traces list should produce output').toBeGreaterThan(0);

--- a/e2e-tests/evals-lifecycle.test.ts
+++ b/e2e-tests/evals-lifecycle.test.ts
@@ -84,7 +84,7 @@ describe.sequential('e2e: evaluations lifecycle', () => {
         'online-eval',
         '--name',
         onlineEvalName,
-        '--agent',
+        '--runtime',
         agentName,
         '--evaluator',
         evalName,
@@ -118,7 +118,7 @@ describe.sequential('e2e: evaluations lifecycle', () => {
     async () => {
       await retry(
         async () => {
-          const result = await run(['invoke', '--prompt', 'Say hello', '--agent', agentName, '--json']);
+          const result = await run(['invoke', '--prompt', 'Say hello', '--runtime', agentName, '--json']);
           expect(result.exitCode, `Invoke failed: ${result.stderr}`).toBe(0);
           const json = parseJsonOutput(result.stdout) as { success: boolean };
           expect(json.success).toBe(true);
@@ -138,7 +138,7 @@ describe.sequential('e2e: evaluations lifecycle', () => {
           const result = await run([
             'run',
             'eval',
-            '--agent',
+            '--runtime',
             agentName,
             '--evaluator',
             'Builtin.Faithfulness',
@@ -162,7 +162,7 @@ describe.sequential('e2e: evaluations lifecycle', () => {
   it.skipIf(!canRun)(
     'eval history shows the completed run',
     async () => {
-      const result = await run(['evals', 'history', '--agent', agentName, '--json']);
+      const result = await run(['evals', 'history', '--runtime', agentName, '--json']);
       expect(result.exitCode, `Evals history failed: ${result.stderr}`).toBe(0);
       const json = parseJsonOutput(result.stdout) as Record<string, unknown> & { runs: unknown[] };
       expect(json).toHaveProperty('success', true);


### PR DESCRIPTION
## Description

E2e tests were using old CLI option names (`--agent`, `--agent-runtime-id`) that were renamed to `--runtime` and `--runtime-id`. This caused all invoke, status, logs, traces, and evals e2e tests to fail with `error: unknown option '--agent'`.

**Changes:**
- `e2e-helper.ts`: `--agent` → `--runtime` (invoke, logs, traces), `--agent-runtime-id` → `--runtime-id` (status)
- `evals-lifecycle.test.ts`: `--agent` → `--runtime` (add online-eval, invoke, run eval, evals history)
- `byo-custom-jwt.test.ts`: `--agent` → `--runtime` (invoke)

## Related Issue

Closes #

## Type of Change

- [x] Bug fix

## Testing

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.