### PR TITLE
fix: prevent account override for post-deploy commands

### DIFF
--- a/src/lib/schemas/io/config-io.ts
+++ b/src/lib/schemas/io/config-io.ts
@@ -115,12 +115,18 @@ export class ConfigIO {
 
   /**
    * Read and validate the AWS configuration file.
-   * Region is preserved as saved. Use resolveAWSDeploymentTargets() for environment/profile overrides.
-   * TODO: Account is still overridden via AWS_PROFILE — consider moving to resolveAWSDeploymentTargets() for consistency.
+   * Use resolveAWSDeploymentTargets() for environment/profile overrides.
    */
   async readAWSDeploymentTargets(): Promise<AwsDeploymentTarget[]> {
     const filePath = this.pathResolver.getAWSTargetsConfigPath();
-    let targets = await this.readAndValidate(filePath, 'AWS Targets', AwsDeploymentTargetsSchema);
+    return this.readAndValidate(filePath, 'AWS Targets', AwsDeploymentTargetsSchema);
+  }
+
+  /**
+   * Read AWS deployment targets with environment/profile overrides for deploy-time operations.
+   */
+  async resolveAWSDeploymentTargets(): Promise<AwsDeploymentTarget[]> {
+    let targets = await this.readAWSDeploymentTargets();
 
     // Override account from credentials if AWS_PROFILE is set
     if (process.env.AWS_PROFILE) {
@@ -129,16 +135,6 @@ export class ConfigIO {
         targets = targets.map(t => ({ ...t, account }));
       }
     }
-
-    return targets;
-  }
-
-  /**
-   * Read AWS deployment targets with region overrides from environment/profile.
-   * Region precedence: AWS_REGION > AWS_DEFAULT_REGION > profile config > saved value.
-   */
-  async resolveAWSDeploymentTargets(): Promise<AwsDeploymentTarget[]> {
-    const targets = await this.readAWSDeploymentTargets();
 
     // Override region from env vars
     const envRegion = process.env.AWS_REGION ?? process.env.AWS_DEFAULT_REGION;


### PR DESCRIPTION
## Description

Follow-up to #595 . `readAWSDeploymentTargets()` still overrode the saved account via `AWS_PROFILE`, which meant post-deploy commands (invoke, status, etc.) could resolve a different account than the one used at deploy time. This moves the account override to `resolveAWSDeploymentTargets()` alongside the existing region override, so `readAWSDeploymentTargets()` now returns saved targets completely as-is.

## Related Issue

Follow-up to #595 

## Documentation PR

`N/A`

## Type of Change

<!-- Check all that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
