### PR TITLE
fix(e2e): limit PR tests to Bedrock-only and improve credential cleanup

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -106,4 +106,6 @@ jobs:
           OPENAI_API_KEY: ${{ env.E2E_OPENAI_API_KEY }}
           GEMINI_API_KEY: ${{ env.E2E_GEMINI_API_KEY }}
           CDK_TARBALL: ${{ env.CDK_TARBALL }}
-        run: npx vitest run --project e2e strands-bedrock strands-openai langgraph-bedrock googleadk-gemini
+        # Only run Bedrock tests on PRs to avoid creating ApiKeyCredentialProviders,
+        # which have a 50-resource account limit and accumulate from interrupted runs.
+        run: npx vitest run --project e2e strands-bedrock langgraph-bedrock

--- a/e2e-tests/e2e-helper.ts
+++ b/e2e-tests/e2e-helper.ts
@@ -332,12 +332,22 @@ export function installCdkTarball(projectPath: string): void {
   }
 }
 
+async function deleteCredentialProvider(client: BedrockAgentCoreControlClient, name: string): Promise<void> {
+  try {
+    await client.send(new DeleteApiKeyCredentialProviderCommand({ name }));
+    console.log(`Deleted credential provider: ${name}`);
+  } catch (error) {
+    const code = (error as { name?: string }).name ?? 'Unknown';
+    console.warn(`Failed to delete credential provider ${name}: [${code}]`);
+  }
+}
+
 /**
  * Delete stale E2e* credential providers older than the given max age.
  * Runs in beforeAll to prevent accumulation from previous runs that
  * crashed or timed out before their afterAll teardown could execute.
  */
-export async function cleanupStaleCredentialProviders(maxAgeMs: number = 60 * 60 * 1000): Promise<void> {
+export async function cleanupStaleCredentialProviders(maxAgeMs: number = 30 * 60 * 1000): Promise<void> {
   const region = process.env.AWS_REGION ?? 'us-east-1';
   const client = new BedrockAgentCoreControlClient({ region });
   const cutoff = new Date(Date.now() - maxAgeMs);
@@ -348,16 +358,7 @@ export async function cleanupStaleCredentialProviders(maxAgeMs: number = 60 * 60
     const providers = response.credentialProviders ?? [];
     const stale = providers.filter(p => p.name?.startsWith('E2e') && p.createdTime && p.createdTime < cutoff);
 
-    await Promise.all(
-      stale.map(async p => {
-        try {
-          await client.send(new DeleteApiKeyCredentialProviderCommand({ name: p.name! }));
-          console.log(`Cleaned up stale credential provider: ${p.name}`);
-        } catch {
-          console.warn(`Failed to clean up stale credential provider: ${p.name}`);
-        }
-      })
-    );
+    await Promise.all(stale.map(p => deleteCredentialProvider(client, p.name!)));
 
     nextToken = response.nextToken;
   } while (nextToken);
@@ -371,13 +372,8 @@ export async function teardownE2EProject(projectPath: string, agentName: string,
     console.log('Teardown stderr:', result.stderr);
   }
   if (modelProvider !== 'Bedrock' && agentName) {
-    const providerName = `${agentName}${modelProvider}`;
     const region = process.env.AWS_REGION ?? 'us-east-1';
-    try {
-      const client = new BedrockAgentCoreControlClient({ region });
-      await client.send(new DeleteApiKeyCredentialProviderCommand({ name: providerName }));
-    } catch {
-      // Best-effort cleanup
-    }
+    const client = new BedrockAgentCoreControlClient({ region });
+    await deleteCredentialProvider(client, `${agentName}${modelProvider}`);
   }
 }


### PR DESCRIPTION
## Description

PR e2e runs create ApiKeyCredentialProviders for non-Bedrock tests (OpenAI, Gemini). These have a 50-resource account limit and accumulate from interrupted runs where teardown never executes. This causes e2e tests on mainline to fail, resulting in a lack of trust in CI when it matters (releases). 

Changes:
- Limit PR e2e tests triggered by PRs to Bedrock-only (`strands-bedrock`, `langgraph-bedrock`) which don't create credential providers
- Lower the stale credential provider cleanup threshold from 1 hour to 30 minutes to match test timeout. 
- Log error codes when credential provider cleanup fails. 


From adding the logging, also noticed the cleanup was failing due to missing `secretsmanager:DeleteSecret` permissions, since under the hood its storing the api keys in secrets manager. This is now fixed. 

Note: these workflows run from `pull_request_target` so the e2e tests on this PR are still running all versions. 

## Related Issue

N/A

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes generate no new warnings
