### PR TITLE
fix(tui): prevent screen flicker in policy creation flow

### DIFF
--- a/src/cli/tui/screens/policy/AddPolicyFlow.tsx
+++ b/src/cli/tui/screens/policy/AddPolicyFlow.tsx
@@ -112,6 +112,7 @@ export function AddPolicyFlow({ isInteractive = true, onExit, onBack, onDev, onD
     if (item.id === '__create_new__') {
       setFlow({ name: 'engine-wizard' });
     } else {
+      setFlow({ name: 'loading' });
       const [deployedId, deployedGateways] = await Promise.all([
         policyEnginePrimitive.getDeployedEngineId(item.id),
         policyEnginePrimitive.getDeployedGateways(),
@@ -161,6 +162,7 @@ export function AddPolicyFlow({ isInteractive = true, onExit, onBack, onDev, onD
   }, []);
 
   const handleAddPolicyToNewEngine = useCallback(async (engineName: string) => {
+    setFlow({ name: 'loading' });
     const [deployedId, deployedGateways] = await Promise.all([
       policyEnginePrimitive.getDeployedEngineId(engineName),
       policyEnginePrimitive.getDeployedGateways(),
@@ -177,7 +179,7 @@ export function AddPolicyFlow({ isInteractive = true, onExit, onBack, onDev, onD
   if (flow.name === 'loading') {
     return (
       <Box>
-        <Text dimColor>Loading policy engines...</Text>
+        <Text dimColor>Loading...</Text>
       </Box>
     );
   }


### PR DESCRIPTION
## Description

Fixes a UI flicker in the policy creation flow where, after selecting a policy engine, the gateway selection step briefly shows "No items available" before the actual gateways appear.

**Root cause:** `handleSelectEngine` and `handleAddPolicyToNewEngine` perform async gateway lookups (`getDeployedEngineId` + `getDeployedGateways`) without transitioning to a loading state first. This leaves the select screen interactive during the await, which can cause the handler to fire multiple times (race condition). When both resolve, the flow state is set twice in quick succession, remounting `AddPolicyScreen` — causing the gateway list to briefly render as empty before being populated.

**Fix:** Set the flow state to `loading` before the async calls. This replaces the interactive select screen with a loading indicator, preventing duplicate firings and ensuring a clean single transition to the policy wizard with gateway data already resolved.

Also updated the loading message from "Loading policy engines..." to the generic "Loading..." since it is now reused for both initial load and engine-to-policy transitions.

## Related Issue

Closes #

## Documentation PR

N/A — no user-facing docs changes needed.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

Additionally, manually tested the policy creation flow end-to-end by running the CLI, selecting an engine, choosing the Generate source method, and verifying that the gateway selection step renders cleanly without briefly showing "No items available" before the gateways appear.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.