### PR TITLE
fix(schema): add executionRoleArn to JSON schema

### DIFF
--- a/schemas/agentcore.schema.v1.json
+++ b/schemas/agentcore.schema.v1.json
@@ -141,6 +141,10 @@
               "type": "string"
             }
           },
+          "executionRoleArn": {
+            "description": "ARN of an existing IAM execution role to use instead of creating a new one.",
+            "type": "string"
+          },
           "authorizerType": {
             "type": "string",
             "enum": ["AWS_IAM", "CUSTOM_JWT"]


### PR DESCRIPTION
## Description

The `executionRoleArn` field was added to the Zod schema (`AgentEnvSpecSchema`) in #729 but the JSON schema (`agentcore.schema.v1.json`) was not updated to match. This adds the missing `executionRoleArn` string property to the JSON schema, placed between `requestHeaderAllowlist` and `authorizerType` to match the Zod schema order.

## Related Issue

Closes #729 (follow-up)

## Type of Change

- [x] Bug fix

## Testing

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.