### PR TITLE
feat: add e2e tests for dev server lifecycle

### DIFF
--- a/e2e-tests/dev-lifecycle.test.ts
+++ b/e2e-tests/dev-lifecycle.test.ts
@@ -1,0 +1,110 @@
+import { waitForServerReady } from '../src/cli/operations/dev/utils.js';
+import { cleanSpawnEnv, parseJsonOutput, spawnAndCollect } from '../src/test-utils/index.js';
+import { baseCanRun as canRun, runAgentCoreCLI } from './e2e-helper.js';
+import { type ChildProcess, spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { mkdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+const DEV_SERVER_PORT = 18080;
+const DEV_SERVER_PORT_STR = String(DEV_SERVER_PORT);
+
+describe.sequential('e2e: dev server lifecycle', () => {
+  let testDir: string;
+  let projectPath: string;
+  let serverProcess: ChildProcess | null = null;
+
+  beforeAll(async () => {
+    if (!canRun) return;
+
+    testDir = join(tmpdir(), `agentcore-e2e-dev-${randomUUID()}`);
+    await mkdir(testDir, { recursive: true });
+
+    const result = await runAgentCoreCLI(
+      [
+        'create',
+        '--name',
+        'DevTest',
+        '--language',
+        'Python',
+        '--framework',
+        'Strands',
+        '--model-provider',
+        'Bedrock',
+        '--memory',
+        'none',
+        '--json',
+      ],
+      testDir
+    );
+    expect(result.exitCode, `Create failed: ${result.stderr}`).toBe(0);
+    projectPath = z.object({ projectPath: z.string() }).parse(parseJsonOutput(result.stdout)).projectPath;
+  }, 120000);
+
+  afterAll(async () => {
+    if (serverProcess?.pid) {
+      try {
+        process.kill(-serverProcess.pid, 'SIGTERM');
+      } catch {
+        // Process group already exited
+      }
+      await new Promise<void>(resolve => {
+        serverProcess?.on('exit', () => resolve());
+        setTimeout(resolve, 5000);
+      });
+      serverProcess = null;
+    }
+    if (testDir) {
+      await rm(testDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 1000 });
+    }
+  }, 30000);
+
+  it.skipIf(!canRun)(
+    'dev --logs starts the server and accepts connections',
+    async () => {
+      serverProcess = spawn('agentcore', ['dev', '--logs', '--port', DEV_SERVER_PORT_STR], {
+        cwd: projectPath,
+        stdio: 'pipe',
+        detached: true,
+        env: cleanSpawnEnv(),
+      });
+
+      const ready = await waitForServerReady(DEV_SERVER_PORT, 90000);
+      expect(ready, 'Dev server should accept connections').toBe(true);
+    },
+    120000
+  );
+
+  it.skipIf(!canRun)(
+    'dev invokes the running server and returns a response',
+    async () => {
+      const result = await spawnAndCollect(
+        'agentcore',
+        ['dev', 'What is 2 plus 2? Reply with just the number.', '--port', DEV_SERVER_PORT_STR],
+        projectPath
+      );
+
+      expect(result.exitCode, `Invoke failed (exit ${result.exitCode}): ${result.stderr}`).toBe(0);
+      expect(result.stdout.length, 'Should produce a response').toBeGreaterThan(0);
+    },
+    60000
+  );
+
+  it.skipIf(!canRun)(
+    'dev --stream returns a response',
+    async () => {
+      const result = await spawnAndCollect(
+        'agentcore',
+        ['dev', 'Say hello', '--stream', '--port', DEV_SERVER_PORT_STR],
+        projectPath
+      );
+
+      expect(result.exitCode, `Stream invoke failed (exit ${result.exitCode}): ${result.stderr}`).toBe(0);
+      expect(result.stdout.length, 'Should produce output').toBeGreaterThan(0);
+    },
+    60000
+  );
+});

--- a/src/test-utils/cli-runner.ts
+++ b/src/test-utils/cli-runner.ts
@@ -14,6 +14,16 @@ export interface RunResult {
 }
 
 /**
+ * Build a clean env for spawned CLI processes.
+ * Strips INIT_CWD which npm/npx sets to the runner's directory — without this,
+ * the CLI resolves the working directory from INIT_CWD instead of the spawn's cwd.
+ * @see https://docs.npmjs.com/cli/v10/commands/npm-run-script
+ */
+export function cleanSpawnEnv(extraEnv: Record<string, string> = {}): NodeJS.ProcessEnv {
+  return { ...process.env, INIT_CWD: undefined, ...extraEnv };
+}
+
+/**
  * Spawn a command, collect output, and strip ANSI codes.
  */
 export function spawnAndCollect(
@@ -25,7 +35,7 @@ export function spawnAndCollect(
   return new Promise(resolve => {
     const proc = spawn(command, args, {
       cwd,
-      env: { ...process.env, INIT_CWD: undefined, ...extraEnv },
+      env: cleanSpawnEnv(extraEnv),
     });
 
     let stdout = '';

--- a/src/test-utils/index.ts
+++ b/src/test-utils/index.ts
@@ -3,7 +3,7 @@
  * Import these helpers instead of duplicating code in each test file.
  */
 
-export { runCLI, spawnAndCollect, type RunResult } from './cli-runner.js';
+export { runCLI, spawnAndCollect, cleanSpawnEnv, type RunResult } from './cli-runner.js';
 export { exists } from './fs-helpers.js';
 export { hasCommand, hasAwsCredentials, prereqs } from './prereqs.js';
 export { createTestProject, type TestProject, type CreateTestProjectOptions } from './project-factory.js';


### PR DESCRIPTION
## Description

Add e2e tests for the `dev` command lifecycle: create a project, start the dev server, invoke it, and verify responses.

Three tests covering the core dev workflow:
- **Server startup**: `dev --logs` starts server and accepts connections
- **Invoke**: `dev "prompt"` sends a prompt to the running server and gets a non-empty response
- **Stream invoke**: `dev "prompt" --stream` streams a response from the running server (or at least returns a response). 

Note: `INIT_CWD` must be stripped from the spawned process environment, otherwise `agentcore` resolves the working directory to the test runner root instead of the project directory. `spawnAndCollect` already handles this, but the raw `spawn` used for the background server process needed the same treatment. Therefore we moved this into a shared utility for future cases. 

docs: https://docs.npmjs.com/cli/v10/commands/npm-run-script

Tests run in ~20s (no AWS deploy needed — dev server runs locally) and use Strands/Bedrock with a Python agent.

## Related Issue

Closes #

## Documentation PR

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

All 3 tests pass locally against dev account. 

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
