### PR TITLE
chore: remove dead AutoGenRenderer code

### DIFF
--- a/src/cli/templates/AutoGenRenderer.ts
+++ b/src/cli/templates/AutoGenRenderer.ts
@@ -1,9 +1,0 @@
-import { BaseRenderer } from './BaseRenderer';
-import { TEMPLATE_ROOT } from './templateRoot';
-import type { AgentRenderConfig } from './types';
-
-export class AutoGenRenderer extends BaseRenderer {
-  constructor(config: AgentRenderConfig) {
-    super(config, 'autogen', TEMPLATE_ROOT, config.protocol ?? 'http');
-  }
-}


### PR DESCRIPTION
## Description

`AutoGenRenderer` in `src/cli/templates/AutoGenRenderer.ts` is dead code — not imported or referenced anywhere in the codebase. This removes it.

## Related Issue

N/A

## Documentation PR

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe): Dead code removal

## Testing
Grep confirms zero imports/references to `AutoGenRenderer` outside its own file
- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.