### PR TITLE
fix(eval): filter scopeless spans in CloudWatch query

### DIFF
--- a/src/cli/operations/eval/run-eval.ts
+++ b/src/cli/operations/eval/run-eval.ts
@@ -446,7 +446,8 @@ async function fetchSessionSpans(opts: FetchSpansOptions): Promise<SessionSpans[
   // 1. Query proper OTel spans from the aws/spans log group
   let spanQuery = `fields @message, attributes.session.id as sessionId, traceId
      | parse resource.attributes.cloud.resource_id "runtime/*/" as parsedAgentId
-     | filter parsedAgentId = '${sanitizeQueryValue(runtimeId)}'`;
+     | filter parsedAgentId = '${sanitizeQueryValue(runtimeId)}'
+     | filter ispresent(scope.name)`;
 
   if (opts.sessionId) {
     spanQuery += `\n     | filter attributes.session.id = '${sanitizeQueryValue(opts.sessionId)}'`;


### PR DESCRIPTION
## Summary
- Adds `ispresent(scope.name)` filter to the CloudWatch Insights span query in `fetchSessionSpans()`
- Spans without a `scope` field were being sent to the Evaluate API, which rejects them with: `Failed to parse span data for entry at index [0] with validation errors: [Field 'scope': Field required (type: missing)]`
- Aligns with the Python SDK's `CloudWatchAgentSpanCollector` which already filters for `scope.name`

## Test plan
- [x] All 39 existing `run-eval` unit tests pass
- [x] Manual test: `agentcore run eval --runtime-arn ... --evaluator-arn "Builtin.Correctness"` succeeds
- [x] Manual test: same command with `--expected-response` ground truth succeeds