### PR TITLE
ci: use draft releases for PR tarballs to avoid notifying watchers

### DIFF
--- a/.github/workflows/pr-tarball.yml
+++ b/.github/workflows/pr-tarball.yml
@@ -67,7 +67,7 @@ jobs:
             "${TARBALL_NAME}" \
             --title "PR #${PR_NUMBER} Tarball" \
             --notes "Auto-generated tarball for PR #${PR_NUMBER}." \
-            --prerelease \
+            --draft \
             --target "${{ github.event.pull_request.head.sha }}"
 
           DOWNLOAD_URL="https://github.com/${{ github.repository }}/releases/download/${TAG}/${TARBALL_NAME}"


### PR DESCRIPTION
## Description

Switch PR tarball releases from `--prerelease` to `--draft` so that watchers/stargazers of the repo do not receive notifications every time a PR tarball is created or updated.

Published releases (including prereleases) trigger notifications to anyone watching the repo with release notifications enabled. Draft releases are unpublished and do not trigger any notifications and are only visible to collaborators with write access. 

docs: https://cli.github.com/manual/gh_release_create

## Related Issue

N/A — operational improvement.

## Type of Change

- [x] Other (please describe): CI workflow change to reduce notification noise for repo watchers.

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes generate no new warnings
