### PR TITLE
fix: make add command description consistent with remove

### DIFF
--- a/src/cli/tui/copy.ts
+++ b/src/cli/tui/copy.ts
@@ -31,7 +31,7 @@ export const COMMAND_DESCRIPTIONS = {
   /** Main program description */
   program: 'Build and deploy Agentic AI applications on AgentCore',
   /** Command descriptions */
-  add: 'Add resources (agent, evaluator, online-eval, memory, credential, target)',
+  add: 'Add resources to project config.',
   create: 'Create a new AgentCore project',
   deploy: 'Deploy project infrastructure to AWS via CDK.',
   dev: 'Launch local dev server, or invoke an agent locally.',


### PR DESCRIPTION
## Description

The `add` command description enumerates resource types in a parenthetical:

```
Add resources (agent, evaluator, online-eval, memory, credential, target)
```

This list is stale — it is missing `gateway`, `gateway-target`, `policy-engine`, and `policy`, and uses `target` instead of `gateway-target`. Rather than updating the list (which will go stale again), this changes the description to be consistent with the `remove` command:

| Command | Before | After |
|---------|--------|-------|
| `remove` | `Remove resources from project config.` | *(no change)* |
| `add` | `Add resources (agent, evaluator, online-eval, memory, credential, target)` | `Add resources to project config.` |

The subcommand list directly below the description already serves as the authoritative enumeration.

## Related Issue

N/A — found during bug bash.

## Type of Change

- [x] Bug fix

## Testing

- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`

String-only change — no behavioral impact.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes generate no new warnings