### PR TITLE
feat(templates): add conversation history persistence to HTTP agent templates

### DIFF
--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -3417,21 +3417,39 @@ agent = Agent(
 )
 
 
-# Session and Runner
-async def setup_session_and_runner(user_id, session_id):
-    ensure_credentials_loaded()
-    session_service = InMemorySessionService()
-    session = await session_service.create_session(
+# Module-level session service and runner (preserves history across invocations)
+_session_service = InMemorySessionService()
+_runner = None
+
+
+def get_or_create_runner():
+    global _runner
+    if _runner is None:
+        ensure_credentials_loaded()
+        _runner = Runner(
+            agent=agent,
+            app_name=APP_NAME,
+            session_service=_session_service,
+        )
+    return _runner
+
+
+async def get_or_create_session(user_id, session_id):
+    session = await _session_service.get_session(
         app_name=APP_NAME, user_id=user_id, session_id=session_id
     )
-    runner = Runner(agent=agent, app_name=APP_NAME, session_service=session_service)
-    return session, runner
+    if session is None:
+        session = await _session_service.create_session(
+            app_name=APP_NAME, user_id=user_id, session_id=session_id
+        )
+    return session
 
 
 # Agent Interaction
 async def call_agent_async(query, user_id, session_id):
     content = types.Content(role="user", parts=[types.Part(text=query)])
-    session, runner = await setup_session_and_runner(user_id, session_id)
+    runner = get_or_create_runner()
+    session = await get_or_create_session(user_id, session_id)
     events = runner.run_async(
         user_id=user_id, session_id=session.id, new_message=content
     )
@@ -3718,6 +3736,7 @@ exports[`Assets Directory Snapshots > Python framework assets > python/python/ht
 from typing import Any
 
 from langchain_core.messages import HumanMessage{{#if hasConfigBundle}}, SystemMessage{{/if}}
+from langgraph.checkpoint.memory import InMemorySaver
 from langgraph.prebuilt import create_react_agent
 from langchain.tools import tool
 {{#if hasConfigBundle}}
@@ -3764,6 +3783,9 @@ def add_numbers(a: int, b: int) -> int:
 
 # Define a collection of tools used by the model
 tools = [add_numbers]
+
+# Module-level checkpointer preserves conversation history across invocations
+_checkpointer = InMemorySaver()
 
 {{#if sessionStorageMountPath}}
 SESSION_STORAGE_PATH = "{{sessionStorageMountPath}}"
@@ -3857,29 +3879,44 @@ async def invoke(payload, context):
     if mcp_client:
         mcp_tools = await mcp_client.get_tools()
 
-    # Define the agent using create_react_agent
+    # Define the agent using create_react_agent (checkpointer is shared across invocations)
 {{#if hasConfigBundle}}
-    graph = create_react_agent(get_or_create_model(), tools=mcp_tools + tools, prompt=DEFAULT_SYSTEM_PROMPT)
+    graph = create_react_agent(
+        get_or_create_model(),
+        tools=mcp_tools + tools,
+        prompt=DEFAULT_SYSTEM_PROMPT,
+        checkpointer=_checkpointer,
+    )
     callback = ConfigBundleCallback()
 
     # Process the user prompt
     prompt = payload.get("prompt", "What can you help me with?")
+    session_id = getattr(context, "session_id", "default-session")
     log.info(f"Agent input: {prompt}")
 
-    # Run the agent with config bundle callback
+    # Run the agent with config bundle callback (checkpointer auto-loads/saves history per session)
     result = await graph.ainvoke(
         {"messages": [HumanMessage(content=prompt)]},
-        config={"callbacks": [callback]},
+        config={"callbacks": [callback], "configurable": {"thread_id": session_id}},
     )
 {{else}}
-    graph = create_react_agent(get_or_create_model(), tools=mcp_tools + tools, prompt=DEFAULT_SYSTEM_PROMPT)
+    graph = create_react_agent(
+        get_or_create_model(),
+        tools=mcp_tools + tools,
+        prompt=DEFAULT_SYSTEM_PROMPT,
+        checkpointer=_checkpointer,
+    )
 
     # Process the user prompt
     prompt = payload.get("prompt", "What can you help me with?")
+    session_id = getattr(context, "session_id", "default-session")
     log.info(f"Agent input: {prompt}")
 
-    # Run the agent
-    result = await graph.ainvoke({"messages": [HumanMessage(content=prompt)]})
+    # Run the agent (checkpointer auto-loads/saves history per session)
+    result = await graph.ainvoke(
+        {"messages": [HumanMessage(content=prompt)]},
+        config={"configurable": {"thread_id": session_id}},
+    )
 {{/if}}
 
     # Return result
@@ -4242,7 +4279,8 @@ Thumbs.db
 
 exports[`Assets Directory Snapshots > Python framework assets > python/python/http/openaiagents/base/main.py should match snapshot 1`] = `
 "import os
-from agents import Agent, Runner, function_tool
+from functools import lru_cache
+from agents import Agent, Runner, SQLiteSession, function_tool
 from bedrock_agentcore.runtime import BedrockAgentCoreApp
 from model.load import load_model
 {{#if hasGateway}}
@@ -4340,8 +4378,14 @@ You have persistent storage at {{sessionStorageMountPath}}. Use file tools to re
 {{/if}}
 """
 
+
+@lru_cache(maxsize=128)
+def get_session(session_id):
+    return SQLiteSession(session_id)
+
+
 # Define the agent execution
-async def main(query):
+async def main(query, session):
     ensure_credentials_loaded()
     try:
         {{#if hasGateway}}
@@ -4353,7 +4397,7 @@ async def main(query):
                 mcp_servers=mcp_servers,
                 tools=tools
             )
-            result = await Runner.run(agent, query)
+            result = await Runner.run(agent, query, session=session)
             return result
         else:
             agent = Agent(
@@ -4363,7 +4407,7 @@ async def main(query):
                 mcp_servers=[],
                 tools=tools
             )
-            result = await Runner.run(agent, query)
+            result = await Runner.run(agent, query, session=session)
             return result
         {{else}}
         if mcp_servers:
@@ -4376,7 +4420,7 @@ async def main(query):
                     mcp_servers=active_servers,
                     tools=tools
                 )
-                result = await Runner.run(agent, query)
+                result = await Runner.run(agent, query, session=session)
                 return result
         else:
             agent = Agent(
@@ -4386,7 +4430,7 @@ async def main(query):
                 mcp_servers=[],
                 tools=tools
             )
-            result = await Runner.run(agent, query)
+            result = await Runner.run(agent, query, session=session)
             return result
         {{/if}}
     except Exception as e:
@@ -4400,9 +4444,11 @@ async def invoke(payload, context):
 
     # Process the user prompt
     prompt = payload.get("prompt", "What can you help me with?")
+    session_id = getattr(context, "session_id", "default-session")
+    session = get_session(session_id)
 
-    # Run the agent
-    result = await main(prompt)
+    # Run the agent (session automatically loads/saves conversation history)
+    result = await main(prompt, session)
 
     # Return result
     return {"result": result.final_output}
@@ -4655,7 +4701,8 @@ Thumbs.db"
 `;
 
 exports[`Assets Directory Snapshots > Python framework assets > python/python/http/strands/base/main.py should match snapshot 1`] = `
-"from typing import Any
+"from functools import lru_cache
+from typing import Any
 
 from strands import Agent, tool
 {{#if hasConfigBundle}}
@@ -4830,17 +4877,13 @@ def create_agent():
         hooks=[ConfigBundleHook()],
     )
 {{else}}
-_agent = None
-
-def get_or_create_agent():
-    global _agent
-    if _agent is None:
-        _agent = Agent(
-            model=load_model(),
-            system_prompt=DEFAULT_SYSTEM_PROMPT,
-            tools=tools
-        )
-    return _agent
+@lru_cache(maxsize=128)
+def get_or_create_agent(session_id):
+    return Agent(
+        model=load_model(),
+        system_prompt=DEFAULT_SYSTEM_PROMPT,
+        tools=tools
+    )
 {{/if}}
 {{/if}}
 
@@ -4857,7 +4900,8 @@ async def invoke(payload, context):
 {{#if hasConfigBundle}}
     agent = create_agent()
 {{else}}
-    agent = get_or_create_agent()
+    session_id = getattr(context, 'session_id', 'default-session')
+    agent = get_or_create_agent(session_id)
 {{/if}}
 {{/if}}
 

--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -4379,6 +4379,9 @@ You have persistent storage at {{sessionStorageMountPath}}. Use file tools to re
 """
 
 
+# Caches up to 128 active sessions; LRU eviction silently resets history for
+# the oldest session. For production use, replace with a durable session store
+# (e.g. SQLiteSession with a file path).
 @lru_cache(maxsize=128)
 def get_session(session_id):
     return SQLiteSession(session_id)
@@ -4868,8 +4871,12 @@ def agent_factory():
     return get_or_create_agent
 get_or_create_agent = agent_factory()
 {{else}}
+# Caches up to 128 active sessions; LRU eviction silently resets history for
+# the oldest session. For production use, replace with a durable session store
+# (e.g. Strands FileSessionManager).
 {{#if hasConfigBundle}}
-def create_agent():
+@lru_cache(maxsize=128)
+def get_or_create_agent(session_id):
     return Agent(
         model=load_model(),
         system_prompt=DEFAULT_SYSTEM_PROMPT,
@@ -4897,12 +4904,8 @@ async def invoke(payload, context):
     user_id = getattr(context, 'user_id', 'default-user')
     agent = get_or_create_agent(session_id, user_id)
 {{else}}
-{{#if hasConfigBundle}}
-    agent = create_agent()
-{{else}}
     session_id = getattr(context, 'session_id', 'default-session')
     agent = get_or_create_agent(session_id)
-{{/if}}
 {{/if}}
 
     # Execute and format response

--- a/src/assets/python/http/googleadk/base/main.py
+++ b/src/assets/python/http/googleadk/base/main.py
@@ -113,21 +113,39 @@ agent = Agent(
 )
 
 
-# Session and Runner
-async def setup_session_and_runner(user_id, session_id):
-    ensure_credentials_loaded()
-    session_service = InMemorySessionService()
-    session = await session_service.create_session(
+# Module-level session service and runner (preserves history across invocations)
+_session_service = InMemorySessionService()
+_runner = None
+
+
+def get_or_create_runner():
+    global _runner
+    if _runner is None:
+        ensure_credentials_loaded()
+        _runner = Runner(
+            agent=agent,
+            app_name=APP_NAME,
+            session_service=_session_service,
+        )
+    return _runner
+
+
+async def get_or_create_session(user_id, session_id):
+    session = await _session_service.get_session(
         app_name=APP_NAME, user_id=user_id, session_id=session_id
     )
-    runner = Runner(agent=agent, app_name=APP_NAME, session_service=session_service)
-    return session, runner
+    if session is None:
+        session = await _session_service.create_session(
+            app_name=APP_NAME, user_id=user_id, session_id=session_id
+        )
+    return session
 
 
 # Agent Interaction
 async def call_agent_async(query, user_id, session_id):
     content = types.Content(role="user", parts=[types.Part(text=query)])
-    session, runner = await setup_session_and_runner(user_id, session_id)
+    runner = get_or_create_runner()
+    session = await get_or_create_session(user_id, session_id)
     events = runner.run_async(
         user_id=user_id, session_id=session.id, new_message=content
     )

--- a/src/assets/python/http/langchain_langgraph/base/main.py
+++ b/src/assets/python/http/langchain_langgraph/base/main.py
@@ -2,6 +2,7 @@ import os
 from typing import Any
 
 from langchain_core.messages import HumanMessage{{#if hasConfigBundle}}, SystemMessage{{/if}}
+from langgraph.checkpoint.memory import InMemorySaver
 from langgraph.prebuilt import create_react_agent
 from langchain.tools import tool
 {{#if hasConfigBundle}}
@@ -48,6 +49,9 @@ def add_numbers(a: int, b: int) -> int:
 
 # Define a collection of tools used by the model
 tools = [add_numbers]
+
+# Module-level checkpointer preserves conversation history across invocations
+_checkpointer = InMemorySaver()
 
 {{#if sessionStorageMountPath}}
 SESSION_STORAGE_PATH = "{{sessionStorageMountPath}}"
@@ -141,29 +145,44 @@ async def invoke(payload, context):
     if mcp_client:
         mcp_tools = await mcp_client.get_tools()
 
-    # Define the agent using create_react_agent
+    # Define the agent using create_react_agent (checkpointer is shared across invocations)
 {{#if hasConfigBundle}}
-    graph = create_react_agent(get_or_create_model(), tools=mcp_tools + tools, prompt=DEFAULT_SYSTEM_PROMPT)
+    graph = create_react_agent(
+        get_or_create_model(),
+        tools=mcp_tools + tools,
+        prompt=DEFAULT_SYSTEM_PROMPT,
+        checkpointer=_checkpointer,
+    )
     callback = ConfigBundleCallback()
 
     # Process the user prompt
     prompt = payload.get("prompt", "What can you help me with?")
+    session_id = getattr(context, "session_id", "default-session")
     log.info(f"Agent input: {prompt}")
 
-    # Run the agent with config bundle callback
+    # Run the agent with config bundle callback (checkpointer auto-loads/saves history per session)
     result = await graph.ainvoke(
         {"messages": [HumanMessage(content=prompt)]},
-        config={"callbacks": [callback]},
+        config={"callbacks": [callback], "configurable": {"thread_id": session_id}},
     )
 {{else}}
-    graph = create_react_agent(get_or_create_model(), tools=mcp_tools + tools, prompt=DEFAULT_SYSTEM_PROMPT)
+    graph = create_react_agent(
+        get_or_create_model(),
+        tools=mcp_tools + tools,
+        prompt=DEFAULT_SYSTEM_PROMPT,
+        checkpointer=_checkpointer,
+    )
 
     # Process the user prompt
     prompt = payload.get("prompt", "What can you help me with?")
+    session_id = getattr(context, "session_id", "default-session")
     log.info(f"Agent input: {prompt}")
 
-    # Run the agent
-    result = await graph.ainvoke({"messages": [HumanMessage(content=prompt)]})
+    # Run the agent (checkpointer auto-loads/saves history per session)
+    result = await graph.ainvoke(
+        {"messages": [HumanMessage(content=prompt)]},
+        config={"configurable": {"thread_id": session_id}},
+    )
 {{/if}}
 
     # Return result

--- a/src/assets/python/http/openaiagents/base/main.py
+++ b/src/assets/python/http/openaiagents/base/main.py
@@ -99,6 +99,9 @@ You have persistent storage at {{sessionStorageMountPath}}. Use file tools to re
 """
 
 
+# Caches up to 128 active sessions; LRU eviction silently resets history for
+# the oldest session. For production use, replace with a durable session store
+# (e.g. SQLiteSession with a file path).
 @lru_cache(maxsize=128)
 def get_session(session_id):
     return SQLiteSession(session_id)

--- a/src/assets/python/http/openaiagents/base/main.py
+++ b/src/assets/python/http/openaiagents/base/main.py
@@ -1,5 +1,6 @@
 import os
-from agents import Agent, Runner, function_tool
+from functools import lru_cache
+from agents import Agent, Runner, SQLiteSession, function_tool
 from bedrock_agentcore.runtime import BedrockAgentCoreApp
 from model.load import load_model
 {{#if hasGateway}}
@@ -97,8 +98,14 @@ You have persistent storage at {{sessionStorageMountPath}}. Use file tools to re
 {{/if}}
 """
 
+
+@lru_cache(maxsize=128)
+def get_session(session_id):
+    return SQLiteSession(session_id)
+
+
 # Define the agent execution
-async def main(query):
+async def main(query, session):
     ensure_credentials_loaded()
     try:
         {{#if hasGateway}}
@@ -110,7 +117,7 @@ async def main(query):
                 mcp_servers=mcp_servers,
                 tools=tools
             )
-            result = await Runner.run(agent, query)
+            result = await Runner.run(agent, query, session=session)
             return result
         else:
             agent = Agent(
@@ -120,7 +127,7 @@ async def main(query):
                 mcp_servers=[],
                 tools=tools
             )
-            result = await Runner.run(agent, query)
+            result = await Runner.run(agent, query, session=session)
             return result
         {{else}}
         if mcp_servers:
@@ -133,7 +140,7 @@ async def main(query):
                     mcp_servers=active_servers,
                     tools=tools
                 )
-                result = await Runner.run(agent, query)
+                result = await Runner.run(agent, query, session=session)
                 return result
         else:
             agent = Agent(
@@ -143,7 +150,7 @@ async def main(query):
                 mcp_servers=[],
                 tools=tools
             )
-            result = await Runner.run(agent, query)
+            result = await Runner.run(agent, query, session=session)
             return result
         {{/if}}
     except Exception as e:
@@ -157,9 +164,11 @@ async def invoke(payload, context):
 
     # Process the user prompt
     prompt = payload.get("prompt", "What can you help me with?")
+    session_id = getattr(context, "session_id", "default-session")
+    session = get_session(session_id)
 
-    # Run the agent
-    result = await main(prompt)
+    # Run the agent (session automatically loads/saves conversation history)
+    result = await main(prompt, session)
 
     # Return result
     return {"result": result.final_output}

--- a/src/assets/python/http/strands/base/main.py
+++ b/src/assets/python/http/strands/base/main.py
@@ -165,8 +165,12 @@ def agent_factory():
     return get_or_create_agent
 get_or_create_agent = agent_factory()
 {{else}}
+# Caches up to 128 active sessions; LRU eviction silently resets history for
+# the oldest session. For production use, replace with a durable session store
+# (e.g. Strands FileSessionManager).
 {{#if hasConfigBundle}}
-def create_agent():
+@lru_cache(maxsize=128)
+def get_or_create_agent(session_id):
     return Agent(
         model=load_model(),
         system_prompt=DEFAULT_SYSTEM_PROMPT,
@@ -194,12 +198,8 @@ async def invoke(payload, context):
     user_id = getattr(context, 'user_id', 'default-user')
     agent = get_or_create_agent(session_id, user_id)
 {{else}}
-{{#if hasConfigBundle}}
-    agent = create_agent()
-{{else}}
     session_id = getattr(context, 'session_id', 'default-session')
     agent = get_or_create_agent(session_id)
-{{/if}}
 {{/if}}
 
     # Execute and format response

--- a/src/assets/python/http/strands/base/main.py
+++ b/src/assets/python/http/strands/base/main.py
@@ -1,3 +1,4 @@
+from functools import lru_cache
 from typing import Any
 
 from strands import Agent, tool
@@ -173,17 +174,13 @@ def create_agent():
         hooks=[ConfigBundleHook()],
     )
 {{else}}
-_agent = None
-
-def get_or_create_agent():
-    global _agent
-    if _agent is None:
-        _agent = Agent(
-            model=load_model(),
-            system_prompt=DEFAULT_SYSTEM_PROMPT,
-            tools=tools
-        )
-    return _agent
+@lru_cache(maxsize=128)
+def get_or_create_agent(session_id):
+    return Agent(
+        model=load_model(),
+        system_prompt=DEFAULT_SYSTEM_PROMPT,
+        tools=tools
+    )
 {{/if}}
 {{/if}}
 
@@ -200,7 +197,8 @@ async def invoke(payload, context):
 {{#if hasConfigBundle}}
     agent = create_agent()
 {{else}}
-    agent = get_or_create_agent()
+    session_id = getattr(context, 'session_id', 'default-session')
+    agent = get_or_create_agent(session_id)
 {{/if}}
 {{/if}}
 


### PR DESCRIPTION
## Description

All four HTTP agent templates (Strands, OpenAI Agents, Google ADK, LangGraph) were stateless per-invocation — each call started with zero conversation context, so multi-turn recall within a session didn't work. Strands additionally had a session-bleed risk because all invocations sharing a Python process used a single global `_agent` whose `Agent.messages` accumulated across calls.

### Note on Strands and Runtime session isolation

AgentCore Runtime isolates each `session_id` to its own dedicated microVM (terminated and memory-sanitized at session end), so the Strands cross-session bleed cannot manifest in a deployed AgentCore Runtime agent. The bleed is real, however, in:
- `agentcore dev` (one local process serving multiple sessions — the exact reproduction in #809)
- Any deployment of the template outside AgentCore Runtime (Lambda, ECS, FastAPI, etc.) where one process may serve multiple sessions

Keying the agent by `session_id` makes the template correct independent of the runtime's isolation guarantee, costs the same memory profile as the previous global, and aligns Strands with the per-session pattern the other three templates use.

### Per-template fixes

- **Strands**: replace global `_agent` with `@lru_cache(maxsize=128) get_or_create_agent(session_id)`. Strands `Agent` accumulates messages internally across `stream_async()` calls, so reusing the per-session instance gives natural multi-turn memory and isolates sessions. Bound at 128 entries to cap process memory; evicted sessions silently start fresh on their next invoke (documented in a code comment, suggesting durable session stores for production). Applied to both the no-memory/no-config-bundle branch and the no-memory/config-bundle branch — `hasMemory` already keys per `(session_id, user_id)`. The `ConfigBundleHook` callbacks re-read bundle state at invocation time, so caching the agent is safe and consistent with how `hasMemory` already attaches the hook.
- **OpenAI Agents**: `@lru_cache(maxsize=128) get_session(session_id)` returning `SQLiteSession`, threaded via `session=` on `Runner.run()`. Auto-loads/saves prior history in-process. Same 128-session cap and documentation comment as Strands.
- **Google ADK**: module-level `_session_service` + `_runner` with a `get_or_create_session()` helper that calls `get_session()` then `create_session()` if missing — avoids `AlreadyExistsError` on repeat calls. ADK's `InMemorySessionService` is itself a single instance retained across invocations, so no per-session cache cap is needed.
- **LangGraph**: module-level `_checkpointer = InMemorySaver()` passed to `create_react_agent()`. `thread_id` mapped to `context.session_id` via `configurable` on `graph.ainvoke()`. `InMemorySaver` retains all checkpoints in process memory.

All conversation state is in-memory (best-effort) — persists across invocations within the runtime process and resets on cold starts. This is the correct default for starter templates; users can swap to durable backends (Strands `FileSessionManager`, OpenAI `SQLiteSession` with file path, ADK `DatabaseSessionService`, LangGraph persistent checkpointers) when they need durability.

Note: #810 (missing system prompts on OpenAI Agents and LangGraph) was already addressed by other PRs that landed on `main` after this PR was opened — both templates now ship `INSTRUCTIONS` / `DEFAULT_SYSTEM_PROMPT` constants. This PR's scope is therefore #808 + #809.

## Related Issue

Closes #808
Closes #809

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test:unit` (275 test files passing)
- [x] `npm run test:update-snapshots`

**End-to-end deploy + invoke testing (from earlier iteration of this branch):**
- Strands (Bedrock): Deployed, invoked 3x — recall ✅, session isolation ✅
- OpenAI Agents (OpenAI): Deployed, invoked 3x — recall ✅, session isolation ✅
- LangGraph (Bedrock): Deployed, invoked 3x — recall ✅, session isolation ✅
- Google ADK (Gemini): Deployed, code structurally verified — Gemini API quota prevented live invocation testing

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.