### PR TITLE
fix: bump aws-cdk-lib to 2.248.0 in project template

### DIFF
--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -358,7 +358,7 @@ exports[`Assets Directory Snapshots > CDK assets > cdk/cdk/package.json should m
   },
   "dependencies": {
     "@aws/agentcore-cdk": "^0.1.0-alpha.1",
-    "aws-cdk-lib": "2.243.0",
+    "aws-cdk-lib": "2.248.0",
     "constructs": "^10.0.0"
   }
 }

--- a/src/assets/cdk/package.json
+++ b/src/assets/cdk/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@aws/agentcore-cdk": "^0.1.0-alpha.1",
-    "aws-cdk-lib": "2.243.0",
+    "aws-cdk-lib": "2.248.0",
     "constructs": "^10.0.0"
   }
 }


### PR DESCRIPTION
## Description

### Problem
All e2e tests are failing because `agentcore create` exits with code 1. The CDK project template pins `aws-cdk-lib@2.243.0`, but `@aws/agentcore-cdk@0.1.0-alpha.17` (resolved from `^0.1.0-alpha.1`) now requires `aws-cdk-lib@^2.248.0`. This causes `npm install` to fail with `ERESOLVE unable to resolve dependency tree` during project creation.

### Solution
Bump `aws-cdk-lib` from `2.243.0` to `2.248.0` in `src/assets/cdk/package.json`. Updated the asset snapshot accordingly.

## Testing
- Verified `agentcore create` succeeds locally after the fix
- All 3298 unit tests pass including updated snapshot
