### PR TITLE
fix: use caret range for aws-cdk-lib in project template

### DIFF
--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -358,7 +358,7 @@ exports[`Assets Directory Snapshots > CDK assets > cdk/cdk/package.json should m
   },
   "dependencies": {
     "@aws/agentcore-cdk": "^0.1.0-alpha.1",
-    "aws-cdk-lib": "2.248.0",
+    "aws-cdk-lib": "^2.248.0",
     "constructs": "^10.0.0"
   }
 }

--- a/src/assets/cdk/package.json
+++ b/src/assets/cdk/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@aws/agentcore-cdk": "^0.1.0-alpha.1",
-    "aws-cdk-lib": "2.248.0",
+    "aws-cdk-lib": "^2.248.0",
     "constructs": "^10.0.0"
   }
 }


### PR DESCRIPTION
## Description

### Problem
When the CDK package bumps its `aws-cdk-lib` required version, the CLI must manually update its version. This can lead to brief periods where there is an incompatibility between releases/fixes.

### Solution
Change `aws-cdk-lib` from a pinned version (`2.243.0`) to a caret range (`^2.248.0`) so npm can auto-resolve peer dep requirements. This prevents future breakage when the constructs package bumps its cdk-lib minimum.

## Related Issue

N/A

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [x] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

- `agentcore create` succeeds after the change (was failing with ERESOLVE before)

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
