### PR TITLE
feat: add --snapshot flag to npm run package

### DIFF
--- a/.github/workflows/pr-tarball.yml
+++ b/.github/workflows/pr-tarball.yml
@@ -43,8 +43,7 @@ jobs:
           git config --global user.name "CI"
       - uses: astral-sh/setup-uv@v7
       - run: npm ci
-      - run: npm run build --if-present
-      - run: npm pack
+      - run: npm run package -- --snapshot
       - name: Get tarball info
         id: tarball
         run: |

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "lint:fix": "eslint src/ --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "package": "node scripts/package.mjs",
     "secrets:check": "secretlint '**/*'",
     "security:audit": "npm audit --audit-level=high --omit=dev",
     "clean": "node -e \"require('fs').rmSync('dist', {recursive: true, force: true})\"",

--- a/scripts/bundle.mjs
+++ b/scripts/bundle.mjs
@@ -81,17 +81,18 @@ function resolveCdkPath() {
 
 log('Starting bundle process...');
 
-const timestamp = Math.floor(Date.now() / 1000);
-log(`Bundle timestamp: ${timestamp}`);
+function getCommitHash(cwd) {
+  return execFileSync('git', ['rev-parse', '--short=7', 'HEAD'], { cwd, encoding: 'utf-8' }).trim();
+}
 
-// Helper to bump a package version with a unique e2e timestamp tag.
 // Saves the original version so it can be restored after packing.
 function bumpVersion(pkgDir) {
   const pkgJsonPath = path.join(pkgDir, 'package.json');
   const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
   const originalVersion = pkg.version;
   const baseVersion = originalVersion.split('-')[0];
-  pkg.version = `${baseVersion}-${timestamp}`;
+  const hash = getCommitHash(pkgDir);
+  pkg.version = `${baseVersion}-sha.${hash}`;
   fs.writeFileSync(pkgJsonPath, JSON.stringify(pkg, null, 2) + '\n');
   log(`Bumped ${pkg.name} version: ${originalVersion} -> ${pkg.version}`);
   return { pkgJsonPath, originalVersion, bumpedVersion: pkg.version };

--- a/scripts/package.mjs
+++ b/scripts/package.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+
+/**
+ * Build and pack the CLI tarball.
+ *
+ * Usage:
+ *   node scripts/package.mjs [--snapshot]
+ *
+ * --snapshot  Append the short git commit hash to the version (e.g. 0.8.0-sha.abc1234)
+ *             so pre-release tarballs are traceable to a specific commit.
+ */
+
+import { execSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const snapshot = process.argv.includes('--snapshot');
+
+function getCommitHash() {
+  try {
+    return execSync('git rev-parse --short=7 HEAD', { encoding: 'utf-8' }).trim();
+  } catch {
+    throw new Error('Failed to get git commit hash. Is this a git repository?');
+  }
+}
+
+function setVersion(version) {
+  const pkg = JSON.parse(readFileSync('package.json', 'utf-8'));
+  pkg.version = version;
+  writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+
+  const lock = JSON.parse(readFileSync('package-lock.json', 'utf-8'));
+  lock.version = version;
+  if (lock.packages?.['']) lock.packages[''].version = version;
+  writeFileSync('package-lock.json', JSON.stringify(lock, null, 2) + '\n');
+}
+
+let origPkg;
+let origLock;
+
+if (snapshot) {
+  origPkg = readFileSync('package.json', 'utf-8');
+  origLock = readFileSync('package-lock.json', 'utf-8');
+}
+
+try {
+  if (snapshot) {
+    const hash = getCommitHash();
+    const { version } = JSON.parse(origPkg);
+    const snapshotVersion = `${version}-sha.${hash}`;
+    console.log(`Snapshot version: ${snapshotVersion}`);
+    setVersion(snapshotVersion);
+  }
+
+  execSync('npm run build', { stdio: 'inherit' });
+  execSync('npm pack', { stdio: 'inherit' });
+} finally {
+  if (snapshot) {
+    writeFileSync('package.json', origPkg);
+    writeFileSync('package-lock.json', origLock);
+  }
+}

--- a/scripts/package.mjs
+++ b/scripts/package.mjs
@@ -9,7 +9,6 @@
  * --snapshot  Append the short git commit hash to the version (e.g. 0.8.0-sha.abc1234)
  *             so pre-release tarballs are traceable to a specific commit.
  */
-
 import { execSync } from 'node:child_process';
 import { readFileSync, writeFileSync } from 'node:fs';
 


### PR DESCRIPTION
## Description

### Problem
PR tarballs from different commits all have the same version (`0.8.0`), making it impossible to identify which commit a tarball came from once downloaded.

### Solution
Add a `package` npm script (`scripts/package.mjs`) that wraps build + pack. When invoked with `--snapshot`, it appends the short git commit hash to the version (e.g. `0.8.0-sha.abc1234`) so pre-release tarballs are self-documenting. The PR tarball workflow now uses this script.

## Related Issue

N/A

## Documentation PR

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

- `npm run package` produces `aws-agentcore-0.8.0.tgz`
- `npm run package -- --snapshot` produces `aws-agentcore-0.8.0-sha.6e19463.tgz`
- `package.json` version restored correctly after snapshot build

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
