### PR TITLE
chore: pin @aws/agentcore-cdk version and auto-sync on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,32 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Sync @aws/agentcore-cdk to latest npm version
+        run: |
+          echo "Fetching latest @aws/agentcore-cdk version from npm..."
+          LATEST_CDK=$(npm view @aws/agentcore-cdk version 2>/dev/null || echo "")
+
+          if [ -z "$LATEST_CDK" ]; then
+            echo "⚠️  Could not fetch @aws/agentcore-cdk version from npm. Skipping sync."
+          else
+            TEMPLATE_PKG="src/assets/cdk/package.json"
+            CURRENT_CDK=$(node -p "require('./$TEMPLATE_PKG').dependencies['@aws/agentcore-cdk']")
+            echo "Current pinned version: $CURRENT_CDK"
+            echo "Latest npm version:     $LATEST_CDK"
+
+            if [ "$CURRENT_CDK" != "$LATEST_CDK" ]; then
+              node -e "
+                const fs = require('fs');
+                const pkg = JSON.parse(fs.readFileSync('$TEMPLATE_PKG', 'utf8'));
+                pkg.dependencies['@aws/agentcore-cdk'] = '$LATEST_CDK';
+                fs.writeFileSync('$TEMPLATE_PKG', JSON.stringify(pkg, null, 2) + '\n');
+              "
+              echo "✅ Updated @aws/agentcore-cdk: $CURRENT_CDK -> $LATEST_CDK"
+            else
+              echo "✅ @aws/agentcore-cdk already at latest ($LATEST_CDK)"
+            fi
+          fi
+
       - name: Get current version
         id: current
         run: |

--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -357,7 +357,7 @@ exports[`Assets Directory Snapshots > CDK assets > cdk/cdk/package.json should m
     "typescript": "~5.9.3"
   },
   "dependencies": {
-    "@aws/agentcore-cdk": "^0.1.0-alpha.1",
+    "@aws/agentcore-cdk": "0.1.0-alpha.17",
     "aws-cdk-lib": "^2.248.0",
     "constructs": "^10.0.0"
   }

--- a/src/assets/cdk/package.json
+++ b/src/assets/cdk/package.json
@@ -23,7 +23,7 @@
     "typescript": "~5.9.3"
   },
   "dependencies": {
-    "@aws/agentcore-cdk": "^0.1.0-alpha.1",
+    "@aws/agentcore-cdk": "0.1.0-alpha.17",
     "aws-cdk-lib": "^2.248.0",
     "constructs": "^10.0.0"
   }


### PR DESCRIPTION
## Summary
- Pins `@aws/agentcore-cdk` in the vended CDK template (`src/assets/cdk/package.json`) to an exact version (`0.1.0-alpha.17`) instead of a caret range (`^0.1.0-alpha.1`)
- Adds an auto-sync step to the release workflow that fetches the latest `@aws/agentcore-cdk` from npm during release prep, so each CLI release PR automatically includes the latest CDK version
- Updates snapshot test to match

## Why
The caret range (`^`) creates a release-ordering race condition: if the CLI is released before the CDK constructs package is published to npm, users running `agentcore create` would get a stale or missing CDK version. Pinning eliminates this entirely.

## How it works
During `prepare-release` in the release workflow (before the version bump), a new step:
1. Runs `npm view @aws/agentcore-cdk version` to get the latest published version
2. If it differs from the pin, updates `src/assets/cdk/package.json`
3. The change is included in the same release commit/PR — no separate PRs needed

## Release flow after this change
```
1. Release CDK constructs → publishes to npm
2. Trigger CLI release → auto-syncs CDK pin → release PR includes the bump
```

## Test plan
- [ ] CI passes (build, lint, typecheck, tests)
- [ ] Snapshot test matches pinned version
- [ ] Verify release workflow YAML is valid