### PR TITLE
chore: bump aws-cdk-lib peer dep to ^2.248.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "@typescript-eslint/parser": "^8.50.0",
         "@vitest/coverage-v8": "^4.0.18",
         "@xterm/headless": "^6.0.0",
-        "aws-cdk-lib": "^2.243.0",
+        "aws-cdk-lib": "^2.248.0",
         "constructs": "^10.4.4",
         "esbuild": "^0.27.2",
         "eslint": "^9.39.4",
@@ -80,7 +80,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.243.0",
+        "aws-cdk-lib": "^2.248.0",
         "constructs": "^10.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "zod": "^4.3.5"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.243.0",
+    "aws-cdk-lib": "^2.248.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
@@ -117,7 +117,7 @@
     "@typescript-eslint/parser": "^8.50.0",
     "@vitest/coverage-v8": "^4.0.18",
     "@xterm/headless": "^6.0.0",
-    "aws-cdk-lib": "^2.243.0",
+    "aws-cdk-lib": "^2.248.0",
     "constructs": "^10.4.4",
     "esbuild": "^0.27.2",
     "eslint": "^9.39.4",


### PR DESCRIPTION
## Summary

- Bumps `aws-cdk-lib` from `^2.243.0` to `^2.248.0` in both `peerDependencies` and `devDependencies`
- Aligns with aws/agentcore-l3-cdk-constructs#143 which now requires `^2.248.0` for the `executionStatus` property on `CfnOnlineEvaluationConfig`
- The vended template (`src/assets/cdk/package.json`) already pins `2.248.0` — this brings the CLI's own deps in sync

Without this bump, the CLI's peer dep range allows `aws-cdk-lib@2.243.0` which lacks the `executionStatus` type, causing TypeScript errors when using the updated CDK construct.

## Test plan

- [x] `npm run typecheck` passes
- [ ] CI passes (typecheck, lint, unit tests)