### PR TITLE
fix: respect aws-targets.json region instead of overriding with AWS_REGION env var

### DIFF
--- a/src/lib/schemas/io/__tests__/config-io.test.ts
+++ b/src/lib/schemas/io/__tests__/config-io.test.ts
@@ -6,7 +6,7 @@ import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { mkdir, rm, unlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 describe('ConfigIO', () => {
   let testDir: string;
@@ -283,6 +283,76 @@ describe('ConfigIO', () => {
 
       const readBack = await configIO.readMcpDefs();
       expect(readBack.tools).toEqual({});
+    });
+  });
+
+  describe('resolveAWSDeploymentTargets region handling (issue #772)', () => {
+    let projectDir: string;
+    let agentcoreDir: string;
+    let configIO: ConfigIO;
+    let savedEnv: Record<string, string | undefined>;
+
+    const validTarget = {
+      name: 'my-target',
+      account: '123456789012',
+      region: 'us-west-2',
+    };
+
+    beforeEach(() => {
+      projectDir = join(testDir, `resolve-targets-${randomUUID()}`);
+      agentcoreDir = join(projectDir, 'agentcore');
+      mkdirSync(agentcoreDir, { recursive: true });
+
+      // Save and clear env vars that affect region resolution
+      savedEnv = {
+        AWS_REGION: process.env.AWS_REGION,
+        AWS_DEFAULT_REGION: process.env.AWS_DEFAULT_REGION,
+        AWS_PROFILE: process.env.AWS_PROFILE,
+      };
+      delete process.env.AWS_REGION;
+      delete process.env.AWS_DEFAULT_REGION;
+      delete process.env.AWS_PROFILE;
+
+      writeFileSync(join(agentcoreDir, 'aws-targets.json'), JSON.stringify([validTarget]));
+      changeWorkingDir(projectDir);
+      configIO = new ConfigIO({ baseDir: agentcoreDir });
+    });
+
+    afterEach(() => {
+      // Restore env vars
+      for (const [key, value] of Object.entries(savedEnv)) {
+        if (value === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = value;
+        }
+      }
+      vi.restoreAllMocks();
+    });
+
+    it('preserves saved region when AWS_REGION env var is set', async () => {
+      process.env.AWS_REGION = 'us-east-1';
+
+      const targets = await configIO.resolveAWSDeploymentTargets();
+
+      expect(targets).toHaveLength(1);
+      expect(targets[0]!.region).toBe('us-west-2');
+    });
+
+    it('preserves saved region when AWS_DEFAULT_REGION env var is set', async () => {
+      process.env.AWS_DEFAULT_REGION = 'eu-west-1';
+
+      const targets = await configIO.resolveAWSDeploymentTargets();
+
+      expect(targets).toHaveLength(1);
+      expect(targets[0]!.region).toBe('us-west-2');
+    });
+
+    it('returns saved region when no env vars are set', async () => {
+      const targets = await configIO.resolveAWSDeploymentTargets();
+
+      expect(targets).toHaveLength(1);
+      expect(targets[0]!.region).toBe('us-west-2');
     });
   });
 });

--- a/src/lib/schemas/io/config-io.ts
+++ b/src/lib/schemas/io/config-io.ts
@@ -134,31 +134,45 @@ export class ConfigIO {
   }
 
   /**
-   * Read AWS deployment targets with region overrides from environment/profile.
-   * Region precedence: AWS_REGION > AWS_DEFAULT_REGION > profile config > saved value.
+   * Read AWS deployment targets with region fallback from environment/profile.
+   * Region precedence: saved value > AWS_REGION > AWS_DEFAULT_REGION > profile config.
+   * Environment/profile region is only used as a fallback when no region is saved in aws-targets.json.
    */
   async resolveAWSDeploymentTargets(): Promise<AwsDeploymentTarget[]> {
     const targets = await this.readAWSDeploymentTargets();
 
-    // Override region from env vars
-    const envRegion = process.env.AWS_REGION ?? process.env.AWS_DEFAULT_REGION;
-    if (envRegion && AgentCoreRegionSchema.safeParse(envRegion).success) {
-      return targets.map(t => ({ ...t, region: envRegion as AwsDeploymentTarget['region'] }));
+    // Only resolve region for targets that don't already have one saved
+    const fallbackRegion = await this.resolveRegionFallback();
+    if (!fallbackRegion) {
+      return targets;
     }
 
-    // Check profile config for region
+    return targets.map(t => (t.region ? t : { ...t, region: fallbackRegion as AwsDeploymentTarget['region'] }));
+  }
+
+  /**
+   * Resolve a fallback region from environment variables or AWS profile config.
+   */
+  private async resolveRegionFallback(): Promise<string | undefined> {
+    // Check env vars first
+    const envRegion = process.env.AWS_REGION ?? process.env.AWS_DEFAULT_REGION;
+    if (envRegion && AgentCoreRegionSchema.safeParse(envRegion).success) {
+      return envRegion;
+    }
+
+    // Check profile config
     try {
       const profile = process.env.AWS_PROFILE ?? 'default';
       const config = await loadSharedConfigFiles();
       const profileRegion = config.configFile?.[profile]?.region;
       if (profileRegion && AgentCoreRegionSchema.safeParse(profileRegion).success) {
-        return targets.map(t => ({ ...t, region: profileRegion as AwsDeploymentTarget['region'] }));
+        return profileRegion;
       }
     } catch {
-      // Config file not available - use current targets
+      // Config file not available
     }
 
-    return targets;
+    return undefined;
   }
 
   /**


### PR DESCRIPTION
## Summary

- Changed `resolveAWSDeploymentTargets()` region precedence from env-overrides-saved to saved-overrides-env
- Environment/profile region (`AWS_REGION`, `AWS_DEFAULT_REGION`, profile config) is now only used as a **fallback** when no region is saved in `aws-targets.json`
- Extracted `resolveRegionFallback()` private method for clarity
- Added 3 unit tests covering the fix

## Related Issue

Closes #772

## Type of Change

- [x] Bug fix

## Root Cause

`resolveAWSDeploymentTargets()` unconditionally replaced the saved region with `AWS_REGION`/`AWS_DEFAULT_REGION`/profile region. This caused `agentcore deploy` to target the wrong region when the user explicitly configured a different one in `aws-targets.json`.

This was introduced by #595 (fix for #515), which correctly split read vs resolve paths but made the resolve path override unconditionally rather than as a fallback.

## Testing

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`

## Test plan

- [ ] Set `us-west-2` in `aws-targets.json`, set `AWS_REGION=us-east-1`, run `agentcore deploy` — should deploy to `us-west-2`
- [ ] Unset `AWS_REGION`, run `agentcore deploy` — should deploy to the region in `aws-targets.json`
- [ ] Post-deploy commands (`invoke`, `status`) still resolve region correctly