### PR TITLE
fix: add AWS_IAM as a valid authorizer type for gateway commands

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -276,7 +276,7 @@ agentcore add gateway \
 | `--name <name>`               | Gateway name                                                 |
 | `--description <desc>`        | Gateway description                                          |
 | `--runtimes <names>`          | Comma-separated runtime names to expose through this gateway |
-| `--authorizer-type <type>`    | `NONE` (default) or `CUSTOM_JWT`                             |
+| `--authorizer-type <type>`    | `NONE` (default), `AWS_IAM`, or `CUSTOM_JWT`                 |
 | `--discovery-url <url>`       | OIDC discovery URL (required for CUSTOM_JWT)                 |
 | `--allowed-audience <values>` | Comma-separated allowed audiences (required for CUSTOM_JWT)  |
 | `--allowed-clients <values>`  | Comma-separated allowed client IDs (required for CUSTOM_JWT) |

--- a/src/cli/commands/add/__tests__/validate.test.ts
+++ b/src/cli/commands/add/__tests__/validate.test.ts
@@ -55,6 +55,11 @@ const validGatewayOptionsNone: AddGatewayOptions = {
   authorizerType: 'NONE',
 };
 
+const validGatewayOptionsIam: AddGatewayOptions = {
+  name: 'test-gateway',
+  authorizerType: 'AWS_IAM',
+};
+
 const validGatewayOptionsJwt: AddGatewayOptions = {
   name: 'test-gateway',
   authorizerType: 'CUSTOM_JWT',
@@ -343,6 +348,7 @@ describe('validate', () => {
     // AC14: Valid options pass
     it('passes for valid options', () => {
       expect(validateAddGatewayOptions(validGatewayOptionsNone)).toEqual({ valid: true });
+      expect(validateAddGatewayOptions(validGatewayOptionsIam)).toEqual({ valid: true });
       expect(validateAddGatewayOptions(validGatewayOptionsJwt)).toEqual({ valid: true });
     });
 

--- a/src/cli/commands/add/validate.ts
+++ b/src/cli/commands/add/validate.ts
@@ -2,6 +2,7 @@ import { ConfigIO, findConfigRoot } from '../../../lib';
 import {
   AgentNameSchema,
   BuildTypeSchema,
+  GatewayAuthorizerTypeSchema,
   GatewayExceptionLevelSchema,
   GatewayNameSchema,
   ModelProviderSchema,
@@ -296,8 +297,12 @@ export function validateAddGatewayOptions(options: AddGatewayOptions): Validatio
     return { valid: false, error: nameResult.error.issues[0]?.message ?? 'Invalid gateway name' };
   }
 
-  if (options.authorizerType && !['NONE', 'CUSTOM_JWT'].includes(options.authorizerType)) {
-    return { valid: false, error: 'Invalid authorizer type. Use NONE or CUSTOM_JWT' };
+  if (options.authorizerType) {
+    const result = GatewayAuthorizerTypeSchema.safeParse(options.authorizerType);
+    if (!result.success) {
+      const valid = GatewayAuthorizerTypeSchema.options.join(', ');
+      return { valid: false, error: `Invalid authorizer type. Use ${valid}` };
+    }
   }
 
   if (options.authorizerType === 'CUSTOM_JWT') {

--- a/src/cli/primitives/GatewayPrimitive.ts
+++ b/src/cli/primitives/GatewayPrimitive.ts
@@ -162,7 +162,7 @@ export class GatewayPrimitive extends BasePrimitive<AddGatewayOptions, Removable
       .option('--name <name>', 'Gateway name [non-interactive]')
       .option('--description <desc>', 'Gateway description [non-interactive]')
       .option('--runtimes <runtimes>', 'Comma-separated runtime names to expose through this gateway [non-interactive]')
-      .option('--authorizer-type <type>', 'Authorizer type: NONE or CUSTOM_JWT [non-interactive]')
+      .option('--authorizer-type <type>', 'Authorizer type: NONE, AWS_IAM, or CUSTOM_JWT [non-interactive]')
       .option('--discovery-url <url>', 'OIDC discovery URL (for CUSTOM_JWT) [non-interactive]')
       .option('--allowed-audience <audience>', 'Comma-separated allowed audiences (for CUSTOM_JWT) [non-interactive]')
       .option('--allowed-clients <clients>', 'Comma-separated allowed client IDs (for CUSTOM_JWT) [non-interactive]')


### PR DESCRIPTION
## Description

<!-- Provide a detailed description of the changes in this PR -->

- agentcore add gateway --authorizer-type AWS_IAM was rejected with Invalid authorizer type. Use NONE or CUSTOM_JWT, while the interactive TUI accepted AWS_IAM successfully, an inconsistency introduced by a hardcoded allowlist in the CLI validator that had drifted from the Zod schema.
- Replaced the hardcoded list with GatewayAuthorizerTypeSchema.safeParse() so validation is driven by the schema and can never drift again.
- Updated help text, docs, and tests to reflect all three valid values (NONE, AWS_IAM, CUSTOM_JWT).

## Related Issue

<!-- Every PR must be associated with an issue. Link it below using #issue-number format. -->

Closes #819

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Check all that apply -->

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [X] I ran `npm run test:unit` and `npm run test:integ`
- [X] I ran `npm run typecheck`
- [X] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [X] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
