### PR TITLE
fix: add back support to eu west 2 to be able to agentcore depoly

### DIFF
--- a/src/schema/llm-compacted/aws-targets.ts
+++ b/src/schema/llm-compacted/aws-targets.ts
@@ -32,6 +32,7 @@ type AgentCoreRegion =
   | 'ap-southeast-2'
   | 'eu-central-1'
   | 'eu-west-1'
+  | 'eu-west-2'
   | 'us-east-1'
   | 'us-east-2'
   | 'us-west-2';

--- a/src/schema/schemas/aws-targets.ts
+++ b/src/schema/schemas/aws-targets.ts
@@ -12,6 +12,7 @@ export const AgentCoreRegionSchema = z.enum([
   'ap-southeast-2',
   'eu-central-1',
   'eu-west-1',
+  'eu-west-2',
   'us-east-1',
   'us-east-2',
   'us-west-2',


### PR DESCRIPTION
## Description

Failed to agentcore deploy to eu-west-2, because it is missing in the aws-target
```
/agentcore/aws-targets.json:
    - [0].region: expected "ap-northeast-1" | "ap-south-1" | "ap-southeast-1" | "ap-southeast-2" | "eu-central-1" | "eu-west-1" | "us-east-1" | "us-east-2" | "us-west-2"
```

[https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/agentcore-regions.html](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/agentcore-regions.html)

base on the doc, we may also need to add back
```
eu-west-3
eu-north-1
ap-northeast-2
ca-central-1
sa-east-1
```
in the aws-target.

## Related Issue

#822

## Type of Change

- [ x ] Bug fix
