### PR TITLE
feat: add e2e tests for import command

### DIFF
--- a/.github/workflows/e2e-tests-full.yml
+++ b/.github/workflows/e2e-tests-full.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: main
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref || 'main' }}
       - uses: actions/setup-node@v6
         with:
           node-version: '20.x'

--- a/.github/workflows/e2e-tests-full.yml
+++ b/.github/workflows/e2e-tests-full.yml
@@ -41,7 +41,7 @@ jobs:
           git config --global user.name "CI"
       - uses: astral-sh/setup-uv@v7
       - name: Install Python dependencies for import tests
-        run: pip install boto3
+        run: pip install --upgrade boto3
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:

--- a/.github/workflows/e2e-tests-full.yml
+++ b/.github/workflows/e2e-tests-full.yml
@@ -40,6 +40,8 @@ jobs:
           git config --global user.email "ci@amazon.com"
           git config --global user.name "CI"
       - uses: astral-sh/setup-uv@v7
+      - name: Install Python dependencies for import tests
+        run: pip install boto3
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:

--- a/.github/workflows/e2e-tests-full.yml
+++ b/.github/workflows/e2e-tests-full.yml
@@ -41,7 +41,7 @@ jobs:
           git config --global user.name "CI"
       - uses: astral-sh/setup-uv@v7
       - name: Install Python dependencies for import tests
-        run: pip install --upgrade boto3
+        run: pip install boto3==1.38.0
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:

--- a/e2e-tests/fixtures/import/app/main.py
+++ b/e2e-tests/fixtures/import/app/main.py
@@ -1,0 +1,44 @@
+from strands import Agent, tool
+from bedrock_agentcore.runtime import BedrockAgentCoreApp
+from model.load import load_model
+
+app = BedrockAgentCoreApp()
+log = app.logger
+
+tools = []
+
+
+@tool
+def add_numbers(a: int, b: int) -> int:
+    """Return the sum of two numbers"""
+    return a + b
+
+
+tools.append(add_numbers)
+
+_agent = None
+
+
+def get_or_create_agent():
+    global _agent
+    if _agent is None:
+        _agent = Agent(
+            model=load_model(),
+            system_prompt="You are a helpful assistant. Use tools when appropriate.",
+            tools=tools,
+        )
+    return _agent
+
+
+@app.entrypoint
+async def invoke(payload, context):
+    log.info("Invoking Agent.....")
+    agent = get_or_create_agent()
+    stream = agent.stream_async(payload.get("prompt"))
+    async for event in stream:
+        if "data" in event and isinstance(event["data"], str):
+            yield event["data"]
+
+
+if __name__ == "__main__":
+    app.run()

--- a/e2e-tests/fixtures/import/app/model/load.py
+++ b/e2e-tests/fixtures/import/app/model/load.py
@@ -1,0 +1,6 @@
+from strands.models.bedrock import BedrockModel
+
+
+def load_model() -> BedrockModel:
+    """Get Bedrock model client using IAM credentials."""
+    return BedrockModel(model_id="anthropic.claude-3-haiku-20240307-v1:0")

--- a/e2e-tests/fixtures/import/app/model/load.py
+++ b/e2e-tests/fixtures/import/app/model/load.py
@@ -3,4 +3,4 @@ from strands.models.bedrock import BedrockModel
 
 def load_model() -> BedrockModel:
     """Get Bedrock model client using IAM credentials."""
-    return BedrockModel(model_id="anthropic.claude-3-haiku-20240307-v1:0")
+    return BedrockModel(model_id="us.anthropic.claude-sonnet-4-5-20250514-v1:0")

--- a/e2e-tests/fixtures/import/app/pyproject.toml
+++ b/e2e-tests/fixtures/import/app/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "bugbash-agent"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "aws-opentelemetry-distro",
+    "bedrock-agentcore >= 1.0.3",
+    "botocore[crt] >= 1.35.0",
+    "strands-agents >= 1.13.0",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]

--- a/e2e-tests/fixtures/import/cleanup_resources.py
+++ b/e2e-tests/fixtures/import/cleanup_resources.py
@@ -3,13 +3,37 @@
 
 Called from afterAll in import e2e tests as a fallback cleanup
 for resources that were not successfully imported into CloudFormation.
+
+Note: The IAM role (bugbash-agentcore-role) is intentionally left in place —
+it is shared across test runs via ensure_role() in common.py.
 """
 import json
 import os
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from common import RESOURCES_FILE, get_control_client
+from common import REGION, RESOURCES_FILE, get_control_client, get_account_id
+
+import boto3
+
+
+def cleanup_s3_code_objects():
+    """Delete uploaded code.zip objects from the bugbash S3 bucket."""
+    account_id = get_account_id()
+    bucket_name = f"bugbash-agentcore-code-{account_id}-{REGION}"
+    s3 = boto3.client("s3", region_name=REGION)
+    try:
+        resp = s3.list_objects_v2(Bucket=bucket_name)
+        objects = resp.get("Contents", [])
+        if not objects:
+            return
+        s3.delete_objects(
+            Bucket=bucket_name,
+            Delete={"Objects": [{"Key": o["Key"]} for o in objects]},
+        )
+        print(f"Deleted {len(objects)} object(s) from s3://{bucket_name}")
+    except Exception as e:
+        print(f"Could not clean up S3 objects: {e}")
 
 
 def main():
@@ -47,6 +71,8 @@ def main():
     else:
         os.remove(RESOURCES_FILE)
         print("Cleaned up bugbash-resources.json")
+
+    cleanup_s3_code_objects()
 
 
 if __name__ == "__main__":

--- a/e2e-tests/fixtures/import/cleanup_resources.py
+++ b/e2e-tests/fixtures/import/cleanup_resources.py
@@ -9,7 +9,7 @@ import os
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from common import REGION, RESOURCES_FILE, get_control_client
+from common import RESOURCES_FILE, get_control_client
 
 
 def main():

--- a/e2e-tests/fixtures/import/cleanup_resources.py
+++ b/e2e-tests/fixtures/import/cleanup_resources.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Delete all resources tracked in bugbash-resources.json.
+
+Called from afterAll in import e2e tests as a fallback cleanup
+for resources that were not successfully imported into CloudFormation.
+"""
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from common import REGION, RESOURCES_FILE, get_control_client
+
+
+def main():
+    if not os.path.exists(RESOURCES_FILE):
+        print("No bugbash-resources.json found, nothing to clean up")
+        return
+
+    with open(RESOURCES_FILE) as f:
+        resources = json.load(f)
+
+    client = get_control_client()
+
+    for key, val in resources.items():
+        rid = val.get("id")
+        if not rid:
+            continue
+        try:
+            if "runtime" in key:
+                client.delete_agent_runtime(agentRuntimeId=rid)
+            elif "memory" in key:
+                client.delete_memory(memoryId=rid)
+            elif "evaluator" in key:
+                client.delete_evaluator(evaluatorId=rid)
+            print(f"Deleted {key}: {rid}")
+        except Exception as e:
+            print(f"Could not delete {key} ({rid}): {e}")
+
+    os.remove(RESOURCES_FILE)
+    print("Cleaned up bugbash-resources.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/e2e-tests/fixtures/import/cleanup_resources.py
+++ b/e2e-tests/fixtures/import/cleanup_resources.py
@@ -22,6 +22,7 @@ def main():
 
     client = get_control_client()
 
+    failed = []
     for key, val in resources.items():
         rid = val.get("id")
         if not rid:
@@ -36,9 +37,16 @@ def main():
             print(f"Deleted {key}: {rid}")
         except Exception as e:
             print(f"Could not delete {key} ({rid}): {e}")
+            failed.append(key)
 
-    os.remove(RESOURCES_FILE)
-    print("Cleaned up bugbash-resources.json")
+    if failed:
+        remaining = {k: v for k, v in resources.items() if k in failed}
+        with open(RESOURCES_FILE, "w") as f:
+            json.dump(remaining, f, indent=2)
+        print(f"WARNING: {len(failed)} resources could not be deleted, kept in {RESOURCES_FILE}")
+    else:
+        os.remove(RESOURCES_FILE)
+        print("Cleaned up bugbash-resources.json")
 
 
 if __name__ == "__main__":

--- a/e2e-tests/fixtures/import/common.py
+++ b/e2e-tests/fixtures/import/common.py
@@ -7,7 +7,7 @@ import tempfile
 
 import boto3
 
-REGION = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION") or boto3.session.Session().region_name or "us-west-2"
+REGION = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION") or "us-west-2"
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 APP_DIR = os.path.join(SCRIPT_DIR, "app")
 RESOURCES_FILE = os.path.join(SCRIPT_DIR, "bugbash-resources.json")

--- a/e2e-tests/fixtures/import/common.py
+++ b/e2e-tests/fixtures/import/common.py
@@ -1,0 +1,254 @@
+"""Shared helpers for bugbash setup scripts."""
+import json
+import os
+import sys
+import time
+import zipfile
+import tempfile
+
+import boto3
+
+REGION = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION") or boto3.session.Session().region_name or "us-west-2"
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+APP_DIR = os.path.join(SCRIPT_DIR, "app")
+RESOURCES_FILE = os.path.join(SCRIPT_DIR, "bugbash-resources.json")
+INLINE_POLICY_NAME = "bugbash-agentcore-permissions"
+
+
+def get_code_bucket():
+    """Return the code bucket name, creating it if needed."""
+    account_id = get_account_id()
+    bucket_name = f"bugbash-agentcore-code-{account_id}-{REGION}"
+    s3 = boto3.client("s3", region_name=REGION)
+    try:
+        s3.head_bucket(Bucket=bucket_name)
+        print(f"S3 bucket already exists: {bucket_name}")
+    except s3.exceptions.ClientError:
+        print(f"Creating S3 bucket: {bucket_name}")
+        create_args = {"Bucket": bucket_name}
+        if REGION != "us-east-1":
+            create_args["CreateBucketConfiguration"] = {"LocationConstraint": REGION}
+        s3.create_bucket(**create_args)
+    return bucket_name
+
+
+def upload_code(prefix="bugbash"):
+    """Zip APP_DIR and upload to S3. Returns (bucket, s3_key)."""
+    bucket_name = get_code_bucket()
+    s3 = boto3.client("s3", region_name=REGION)
+
+    # Create zip of app directory
+    with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
+        tmp_path = tmp.name
+    try:
+        with zipfile.ZipFile(tmp_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            for root, _dirs, files in os.walk(APP_DIR):
+                for f in files:
+                    if f == "Dockerfile":
+                        continue
+                    full = os.path.join(root, f)
+                    arcname = os.path.relpath(full, APP_DIR)
+                    zf.write(full, arcname)
+
+        s3_key = f"{prefix}/code.zip"
+        print(f"Uploading code to s3://{bucket_name}/{s3_key}")
+        s3.upload_file(tmp_path, bucket_name, s3_key)
+        print("Upload complete")
+        return bucket_name, s3_key
+    finally:
+        os.unlink(tmp_path)
+
+
+def get_account_id():
+    sts = boto3.client("sts", region_name=REGION)
+    return sts.get_caller_identity()["Account"]
+
+
+def get_control_client():
+    return boto3.client("bedrock-agentcore-control", region_name=REGION)
+
+
+def ensure_role():
+    """Create the bugbash IAM role if it doesn't exist, with all needed permissions."""
+    account_id = get_account_id()
+    role_name = "bugbash-agentcore-role"
+    role_arn = f"arn:aws:iam::{account_id}:role/{role_name}"
+    bucket_name = f"bugbash-agentcore-code-{account_id}-{REGION}"
+
+    iam = boto3.client("iam")
+    created = False
+    try:
+        iam.get_role(RoleName=role_name)
+        print(f"IAM role already exists: {role_arn}")
+    except iam.exceptions.NoSuchEntityException:
+        print(f"Creating IAM role: {role_name}")
+        try:
+            iam.create_role(
+                RoleName=role_name,
+                AssumeRolePolicyDocument=json.dumps({
+                    "Version": "2012-10-17",
+                    "Statement": [{
+                        "Effect": "Allow",
+                        "Principal": {"Service": "bedrock-agentcore.amazonaws.com"},
+                        "Action": "sts:AssumeRole",
+                    }],
+                }),
+            )
+            created = True
+        except iam.exceptions.EntityAlreadyExistsException:
+            print("Role was created by another process, waiting for propagation...")
+            created = True
+
+    # Attach managed policies
+    managed_policies = [
+        "arn:aws:iam::aws:policy/AmazonBedrockFullAccess",
+        "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess",
+        "arn:aws:iam::aws:policy/CloudWatchLogsFullAccess",
+        "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+    ]
+    for policy_arn in managed_policies:
+        try:
+            iam.attach_role_policy(RoleName=role_name, PolicyArn=policy_arn)
+        except Exception:
+            pass  # Already attached
+
+    # Add inline policy for S3 code bucket and ECR auth
+    inline_policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": ["s3:GetObject", "s3:GetBucketLocation", "s3:ListBucket"],
+                "Resource": [
+                    f"arn:aws:s3:::{bucket_name}",
+                    f"arn:aws:s3:::{bucket_name}/*",
+                ],
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "ecr:GetDownloadUrlForLayer",
+                    "ecr:BatchGetImage",
+                    "ecr:GetAuthorizationToken",
+                ],
+                "Resource": "*",
+            },
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "bedrock:InvokeModel",
+                    "bedrock:InvokeModelWithResponseStream",
+                ],
+                "Resource": "*",
+            },
+        ],
+    }
+    try:
+        iam.put_role_policy(
+            RoleName=role_name,
+            PolicyName=INLINE_POLICY_NAME,
+            PolicyDocument=json.dumps(inline_policy),
+        )
+        print("Inline permissions policy attached")
+    except Exception as e:
+        print(f"Warning: could not attach inline policy: {e}")
+
+    if created:
+        print("Waiting 10s for role propagation...")
+        time.sleep(10)
+
+    return role_arn
+
+
+def wait_for_runtime(client, runtime_id, timeout=300):
+    """Wait for a runtime to reach READY status."""
+    print(f"Waiting for runtime {runtime_id} to become READY...")
+    start = time.time()
+    while time.time() - start < timeout:
+        resp = client.get_agent_runtime(agentRuntimeId=runtime_id)
+        status = resp.get("status", "UNKNOWN")
+        if status == "READY":
+            print(f"Runtime {runtime_id} is READY")
+            return True
+        if status in ("CREATE_FAILED", "UPDATE_FAILED", "FAILED"):
+            print(f"ERROR: Runtime {runtime_id} status: {status}")
+            return False
+        elapsed = int(time.time() - start)
+        print(f"  Status: {status} ({elapsed}s elapsed)")
+        time.sleep(5)
+    print(f"WARNING: Runtime did not reach READY after {timeout}s")
+    return False
+
+
+def wait_for_memory(client, memory_id, timeout=300):
+    """Wait for a memory to reach ACTIVE status."""
+    print(f"Waiting for memory {memory_id} to become ACTIVE...")
+    start = time.time()
+    while time.time() - start < timeout:
+        resp = client.get_memory(memoryId=memory_id)
+        status = resp.get("memory", {}).get("status", "UNKNOWN")
+        if status == "ACTIVE":
+            print(f"Memory {memory_id} is ACTIVE")
+            return True
+        elapsed = int(time.time() - start)
+        print(f"  Status: {status} ({elapsed}s elapsed)")
+        time.sleep(5)
+    print(f"WARNING: Memory did not reach ACTIVE after {timeout}s")
+    return False
+
+
+def wait_for_evaluator(client, evaluator_id, timeout=120):
+    """Wait for an evaluator to reach ACTIVE status."""
+    print(f"Waiting for evaluator {evaluator_id} to become ACTIVE...")
+    start = time.time()
+    while time.time() - start < timeout:
+        resp = client.get_evaluator(evaluatorId=evaluator_id)
+        status = resp.get("status", "UNKNOWN")
+        if status == "ACTIVE":
+            print(f"Evaluator {evaluator_id} is ACTIVE")
+            return True
+        if status in ("CREATE_FAILED", "FAILED"):
+            print(f"ERROR: Evaluator {evaluator_id} status: {status}")
+            return False
+        elapsed = int(time.time() - start)
+        print(f"  Status: {status} ({elapsed}s elapsed)")
+        time.sleep(5)
+    print(f"WARNING: Evaluator did not reach ACTIVE after {timeout}s")
+    return False
+
+
+def save_resource(key, arn, resource_id):
+    """Save a resource entry to bugbash-resources.json."""
+    resources = {}
+    if os.path.exists(RESOURCES_FILE):
+        with open(RESOURCES_FILE) as f:
+            resources = json.load(f)
+    resources[key] = {"arn": arn, "id": resource_id}
+    with open(RESOURCES_FILE, "w") as f:
+        json.dump(resources, f, indent=2)
+    print(f"Saved {key} to {RESOURCES_FILE}")
+
+
+def print_import_command(resource_type, arn, extra_flags=""):
+    """Print the agentcore import command for the tester."""
+    print()
+    print("=" * 50)
+    print("To test import, run (from an agentcore project directory):")
+    print()
+    print(f"  export AWS_REGION={REGION}")
+    if resource_type == "runtime":
+        print(f"  agentcore import runtime --arn {arn} --code {APP_DIR} {extra_flags}")
+    elif resource_type == "evaluator":
+        print(f"  agentcore import evaluator --arn {arn} {extra_flags}")
+    else:
+        print(f"  agentcore import memory --arn {arn} {extra_flags}")
+    print()
+    print("NOTE: The project must have aws-targets.json with a target for the same region.")
+    print("=" * 50)
+    print()
+
+
+def tag_resource(client, arn, tags):
+    """Tag a resource via the control plane API."""
+    print(f"Tagging resource with {tags}...")
+    client.tag_resource(resourceArn=arn, tags=tags)

--- a/e2e-tests/fixtures/import/common.py
+++ b/e2e-tests/fixtures/import/common.py
@@ -7,7 +7,7 @@ import tempfile
 
 import boto3
 
-REGION = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION") or "us-west-2"
+REGION = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION") or "us-east-1"
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 APP_DIR = os.path.join(SCRIPT_DIR, "app")
 RESOURCES_FILE = os.path.join(SCRIPT_DIR, "bugbash-resources.json")
@@ -68,7 +68,12 @@ def get_control_client():
 
 
 def ensure_role():
-    """Create the bugbash IAM role if it doesn't exist, with all needed permissions."""
+    """Create the bugbash IAM role if it doesn't exist, with all needed permissions.
+
+    This role is intentionally persistent across test runs — ensure_role() is
+    idempotent (create-if-not-exists) so multiple CI jobs and local debugging
+    sessions share the same role without conflicts.
+    """
     account_id = get_account_id()
     role_name = "bugbash-agentcore-role"
     role_arn = f"arn:aws:iam::{account_id}:role/{role_name}"

--- a/e2e-tests/fixtures/import/common.py
+++ b/e2e-tests/fixtures/import/common.py
@@ -1,7 +1,6 @@
 """Shared helpers for bugbash setup scripts."""
 import json
 import os
-import sys
 import time
 import zipfile
 import tempfile

--- a/e2e-tests/fixtures/import/setup_evaluator.py
+++ b/e2e-tests/fixtures/import/setup_evaluator.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Setup: LLM-as-a-Judge evaluator with rating scale and tags.
+
+Tests: evaluator import, level detection, llmAsAJudge config, rating scale,
+       model config, tags.
+"""
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import time
+from common import (
+    REGION, get_control_client, save_resource, tag_resource,
+    wait_for_evaluator, print_import_command,
+)
+
+
+def main():
+    client = get_control_client()
+    ts = int(time.time())
+    evaluator_name = f"bugbash_eval_{ts}"
+
+    print(f"Creating evaluator: {evaluator_name}")
+    resp = client.create_evaluator(
+        evaluatorName=evaluator_name,
+        description="Bugbash evaluator for import testing",
+        level="SESSION",
+        evaluatorConfig={
+            "llmAsAJudge": {
+                "instructions": (
+                    "Evaluate the quality of the agent's response in this session.\n"
+                    "Consider the following criteria:\n"
+                    "1. Did the agent answer the user's question? ({context})\n"
+                    "2. Was the response accurate and helpful?\n"
+                    "3. Was the response well-structured?"
+                ),
+                "ratingScale": {
+                    "numerical": [
+                        {"value": 1, "label": "Poor", "definition": "Response is irrelevant or incorrect"},
+                        {"value": 2, "label": "Fair", "definition": "Response is partially correct but missing key information"},
+                        {"value": 3, "label": "Good", "definition": "Response is correct and addresses the question"},
+                        {"value": 4, "label": "Very Good", "definition": "Response is thorough and well-structured"},
+                        {"value": 5, "label": "Excellent", "definition": "Response is comprehensive, accurate, and exceptionally helpful"},
+                    ],
+                },
+                "modelConfig": {
+                    "bedrockEvaluatorModelConfig": {
+                        "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+                    }
+                },
+            }
+        },
+    )
+
+    evaluator_id = resp["evaluatorId"]
+    evaluator_arn = resp["evaluatorArn"]
+    print(f"Evaluator ID: {evaluator_id}")
+    print(f"Evaluator ARN: {evaluator_arn}")
+
+    tag_resource(client, evaluator_arn, {
+        "env": "bugbash",
+        "team": "agentcore-cli",
+    })
+
+    save_resource("evaluator-llm", evaluator_arn, evaluator_id)
+    wait_for_evaluator(client, evaluator_id)
+
+    print()
+    print("Expected fields after import:")
+    print(f"  name: {evaluator_name}")
+    print("  level: SESSION")
+    print("  description: Bugbash evaluator for import testing")
+    print("  config.llmAsAJudge.model: anthropic.claude-3-haiku-20240307-v1:0")
+    print("  config.llmAsAJudge.instructions: (multi-line with {context} placeholder)")
+    print("  config.llmAsAJudge.ratingScale: numerical 1-5 (Poor to Excellent)")
+    print("  tags: {env: bugbash, team: agentcore-cli}")
+
+    print_import_command("evaluator", evaluator_arn)
+
+
+if __name__ == "__main__":
+    main()

--- a/e2e-tests/fixtures/import/setup_evaluator.py
+++ b/e2e-tests/fixtures/import/setup_evaluator.py
@@ -65,7 +65,8 @@ def main():
     })
 
     save_resource("evaluator-llm", evaluator_arn, evaluator_id)
-    wait_for_evaluator(client, evaluator_id)
+    if not wait_for_evaluator(client, evaluator_id):
+        sys.exit(1)
 
     print()
     print("Expected fields after import:")

--- a/e2e-tests/fixtures/import/setup_evaluator.py
+++ b/e2e-tests/fixtures/import/setup_evaluator.py
@@ -10,7 +10,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 import time
 from common import (
-    REGION, get_control_client, save_resource, tag_resource,
+    get_control_client, save_resource, tag_resource,
     wait_for_evaluator, print_import_command,
 )
 

--- a/e2e-tests/fixtures/import/setup_evaluator.py
+++ b/e2e-tests/fixtures/import/setup_evaluator.py
@@ -14,6 +14,9 @@ from common import (
     wait_for_evaluator, print_import_command,
 )
 
+# Keep in sync with DEFAULT_MODEL in src/cli/tui/screens/evaluator/types.ts
+DEFAULT_EVALUATOR_MODEL = "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+
 
 def main():
     client = get_control_client()
@@ -45,7 +48,7 @@ def main():
                 },
                 "modelConfig": {
                     "bedrockEvaluatorModelConfig": {
-                        "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+                        "modelId": DEFAULT_EVALUATOR_MODEL,
                     }
                 },
             }
@@ -70,7 +73,7 @@ def main():
     print(f"  name: {evaluator_name}")
     print("  level: SESSION")
     print("  description: Bugbash evaluator for import testing")
-    print("  config.llmAsAJudge.model: anthropic.claude-3-haiku-20240307-v1:0")
+    print(f"  config.llmAsAJudge.model: {DEFAULT_EVALUATOR_MODEL}")
     print("  config.llmAsAJudge.instructions: (multi-line with {context} placeholder)")
     print("  config.llmAsAJudge.ratingScale: numerical 1-5 (Poor to Excellent)")
     print("  tags: {env: bugbash, team: agentcore-cli}")

--- a/e2e-tests/fixtures/import/setup_evaluator.py
+++ b/e2e-tests/fixtures/import/setup_evaluator.py
@@ -14,8 +14,7 @@ from common import (
     wait_for_evaluator, print_import_command,
 )
 
-# Keep in sync with DEFAULT_MODEL in src/cli/tui/screens/evaluator/types.ts
-DEFAULT_EVALUATOR_MODEL = "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+DEFAULT_EVALUATOR_MODEL = os.environ.get("DEFAULT_EVALUATOR_MODEL", "us.anthropic.claude-sonnet-4-5-20250929-v1:0")
 
 
 def main():

--- a/e2e-tests/fixtures/import/setup_memory_full.py
+++ b/e2e-tests/fixtures/import/setup_memory_full.py
@@ -60,7 +60,8 @@ def main():
     })
 
     save_resource("memory-full", memory_arn, memory_id)
-    wait_for_memory(client, memory_id)
+    if not wait_for_memory(client, memory_id):
+        sys.exit(1)
 
     print()
     print("Expected fields after import:")

--- a/e2e-tests/fixtures/import/setup_memory_full.py
+++ b/e2e-tests/fixtures/import/setup_memory_full.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Setup: Memory with multiple strategies and tags.
+
+Tests: memory import with SEMANTIC, SUMMARIZATION, USER_PREFERENCE strategies,
+       tags, eventExpiryDuration, executionRoleArn.
+"""
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import time
+from common import (
+    ensure_role, get_control_client, wait_for_memory,
+    save_resource, print_import_command, tag_resource,
+)
+
+
+def main():
+    role_arn = ensure_role()
+    client = get_control_client()
+    memory_name = f"bugbash_memory_{int(time.time())}"
+
+    print(f"Creating memory: {memory_name}")
+    resp = client.create_memory(
+        name=memory_name,
+        clientToken=f"bugbash-{int(time.time())}",
+        eventExpiryDuration=30,
+        memoryExecutionRoleArn=role_arn,
+        memoryStrategies=[
+            {
+                "semanticMemoryStrategy": {
+                    "name": "bugbash_semantic",
+                    "description": "Semantic strategy for bugbash testing",
+                    "namespaces": ["default"],
+                }
+            },
+            {
+                "summaryMemoryStrategy": {
+                    "name": "bugbash_summary",
+                    "description": "Summary strategy for bugbash testing",
+                }
+            },
+            {
+                "userPreferenceMemoryStrategy": {
+                    "name": "bugbash_userpref",
+                    "description": "User preference strategy for bugbash testing",
+                }
+            },
+        ],
+    )
+
+    memory_id = resp["memory"]["id"]
+    memory_arn = resp["memory"]["arn"]
+    print(f"Memory ID: {memory_id}")
+    print(f"Memory ARN: {memory_arn}")
+
+    tag_resource(client, memory_arn, {
+        "env": "bugbash",
+        "team": "agentcore-cli",
+    })
+
+    save_resource("memory-full", memory_arn, memory_id)
+    wait_for_memory(client, memory_id)
+
+    print()
+    print("Expected fields after import:")
+    print(f"  eventExpiryDuration: 30")
+    print(f"  executionRoleArn: {role_arn}")
+    print("  strategies:")
+    print("    - type: SEMANTIC, name: bugbash_semantic, namespaces: [default]")
+    print("    - type: SUMMARIZATION, name: bugbash_summary")
+    print("    - type: USER_PREFERENCE, name: bugbash_userpref")
+    print("  tags: {env: bugbash, team: agentcore-cli}")
+
+    print_import_command("memory", memory_arn)
+
+
+if __name__ == "__main__":
+    main()

--- a/e2e-tests/fixtures/import/setup_runtime_basic.py
+++ b/e2e-tests/fixtures/import/setup_runtime_basic.py
@@ -9,7 +9,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 import time
 from common import (
-    REGION, ensure_role, get_control_client, wait_for_runtime,
+    ensure_role, get_control_client, wait_for_runtime,
     save_resource, print_import_command, upload_code,
 )
 

--- a/e2e-tests/fixtures/import/setup_runtime_basic.py
+++ b/e2e-tests/fixtures/import/setup_runtime_basic.py
@@ -13,6 +13,7 @@ from common import (
     save_resource, print_import_command, upload_code,
 )
 
+
 def main():
     role_arn = ensure_role()
     client = get_control_client()

--- a/e2e-tests/fixtures/import/setup_runtime_basic.py
+++ b/e2e-tests/fixtures/import/setup_runtime_basic.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Setup: Bare minimum CodeZip runtime (PUBLIC, HTTP, basic entrypoint).
+
+Tests: baseline import, entrypoint detection, CodeZip build type, executionRoleArn.
+"""
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import time
+from common import (
+    REGION, ensure_role, get_control_client, wait_for_runtime,
+    save_resource, print_import_command, upload_code,
+)
+
+def main():
+    role_arn = ensure_role()
+    client = get_control_client()
+    ts = int(time.time())
+    runtime_name = f"bugbash_basic_{ts}"
+
+    bucket, s3_key = upload_code(f"bugbash-basic-{ts}")
+
+    print(f"Creating basic runtime: {runtime_name}")
+    resp = client.create_agent_runtime(
+        agentRuntimeName=runtime_name,
+        roleArn=role_arn,
+        networkConfiguration={"networkMode": "PUBLIC"},
+        agentRuntimeArtifact={
+            "codeConfiguration": {
+                "code": {
+                    "s3": {
+                        "bucket": bucket,
+                        "prefix": s3_key,
+                    }
+                },
+                "runtime": "PYTHON_3_12",
+                "entryPoint": ["main.py"],
+            }
+        },
+        protocolConfiguration={"serverProtocol": "HTTP"},
+    )
+
+    runtime_id = resp["agentRuntimeId"]
+    runtime_arn = resp["agentRuntimeArn"]
+    print(f"Runtime ID: {runtime_id}")
+    print(f"Runtime ARN: {runtime_arn}")
+
+    save_resource("runtime-basic", runtime_arn, runtime_id)
+    wait_for_runtime(client, runtime_id)
+
+    print()
+    print("Expected fields after import:")
+    print("  build: CodeZip")
+    print("  entrypoint: main.py")
+    print("  runtimeVersion: PYTHON_3_12")
+    print("  protocol: HTTP")
+    print("  networkMode: PUBLIC")
+    print(f"  executionRoleArn: {role_arn}")
+    print("  lifecycleConfiguration: defaults (idleRuntimeSessionTimeout=900, maxLifetime=28800)")
+    print("  (no envVars, tags, or requestHeaderAllowlist)")
+
+    print_import_command("runtime", runtime_arn)
+
+
+if __name__ == "__main__":
+    main()

--- a/e2e-tests/fixtures/import/setup_runtime_basic.py
+++ b/e2e-tests/fixtures/import/setup_runtime_basic.py
@@ -48,7 +48,8 @@ def main():
     print(f"Runtime ARN: {runtime_arn}")
 
     save_resource("runtime-basic", runtime_arn, runtime_id)
-    wait_for_runtime(client, runtime_id)
+    if not wait_for_runtime(client, runtime_id):
+        sys.exit(1)
 
     print()
     print("Expected fields after import:")

--- a/e2e-tests/import-resources.test.ts
+++ b/e2e-tests/import-resources.test.ts
@@ -8,6 +8,7 @@ import {
   spawnAndCollect,
   stripAnsi,
 } from '../src/test-utils/index.js';
+import { DEFAULT_MODEL as DEFAULT_EVALUATOR_MODEL } from '../src/cli/tui/screens/evaluator/types.js';
 import { installCdkTarball, runAgentCoreCLI, writeAwsTargets } from './e2e-helper.js';
 import { execSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
@@ -50,7 +51,10 @@ describe.sequential('e2e: import runtime/memory/evaluator', () => {
     //    Scripts run sequentially because save_resource() does a read-modify-write
     //    on a shared bugbash-resources.json file — parallel runs would race.
     for (const script of ['setup_runtime_basic.py', 'setup_memory_full.py', 'setup_evaluator.py']) {
-      const result = await spawnAndCollect('python3', [script], fixtureDir, { AWS_REGION: region });
+      const result = await spawnAndCollect('python3', [script], fixtureDir, {
+        AWS_REGION: region,
+        DEFAULT_EVALUATOR_MODEL,
+      });
       if (result.exitCode !== 0) {
         throw new Error(
           `${script} failed (exit ${result.exitCode}):\nstdout: ${result.stdout}\nstderr: ${result.stderr}`

--- a/e2e-tests/import-resources.test.ts
+++ b/e2e-tests/import-resources.test.ts
@@ -85,6 +85,9 @@ describe.sequential('e2e: import runtime/memory/evaluator', () => {
     installCdkTarball(projectPath);
   }, 600_000);
 
+  // Note: we don't use teardownE2EProject() here because import tests need
+  // extra cleanup — the Python fallback script deletes resources that weren't
+  // successfully imported into CloudFormation, and cleans up S3 code objects.
   afterAll(async () => {
     // 1. Tear down CFN stack created by import (this deletes all imported resources)
     if (projectPath && hasAws) {

--- a/e2e-tests/import-resources.test.ts
+++ b/e2e-tests/import-resources.test.ts
@@ -1,0 +1,203 @@
+import {
+  type RunResult,
+  hasAwsCredentials,
+  hasCommand,
+  parseJsonOutput,
+  prereqs,
+  retry,
+  spawnAndCollect,
+  stripAnsi,
+} from '../src/test-utils/index.js';
+import { installCdkTarball, runAgentCoreCLI, writeAwsTargets } from './e2e-helper.js';
+import { execSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { mkdir, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const hasAws = hasAwsCredentials();
+const hasPython =
+  hasCommand('python3') &&
+  (() => {
+    try {
+      execSync('python3 -c "import boto3"', { stdio: 'ignore' });
+      return true;
+    } catch {
+      return false;
+    }
+  })();
+const canRun = prereqs.npm && prereqs.git && prereqs.uv && hasAws && hasPython;
+
+describe.sequential('e2e: import runtime/memory/evaluator', () => {
+  const region = process.env.AWS_REGION ?? 'us-east-1';
+  const fixtureDir = join(__dirname, 'fixtures', 'import');
+  const appDir = join(fixtureDir, 'app');
+  const suffix = Date.now().toString().slice(-8);
+  const agentName = `E2eImp${suffix}`;
+
+  let runtimeArn: string;
+  let memoryArn: string;
+  let evaluatorArn: string;
+  let projectPath: string;
+  let testDir: string;
+
+  beforeAll(async () => {
+    if (!canRun) return;
+
+    // 1. Run Python setup scripts to create AWS resources via API.
+    //    Each script creates a resource and saves its ARN/ID to bugbash-resources.json.
+    for (const script of ['setup_runtime_basic.py', 'setup_memory_full.py', 'setup_evaluator.py']) {
+      const result = await spawnAndCollect('python3', [script], fixtureDir, { AWS_REGION: region });
+      if (result.exitCode !== 0) {
+        throw new Error(
+          `${script} failed (exit ${result.exitCode}):\nstdout: ${result.stdout}\nstderr: ${result.stderr}`
+        );
+      }
+    }
+
+    // 2. Read resource ARNs from bugbash-resources.json
+    const resourcesPath = join(fixtureDir, 'bugbash-resources.json');
+    const resources = JSON.parse(await readFile(resourcesPath, 'utf-8')) as Record<string, { arn: string; id: string }>;
+    runtimeArn = resources['runtime-basic']!.arn;
+    memoryArn = resources['memory-full']!.arn;
+    evaluatorArn = resources['evaluator-llm']!.arn;
+
+    // 3. Create a destination CLI project (no agent — we'll import one)
+    testDir = join(tmpdir(), `agentcore-e2e-import-${randomUUID()}`);
+    await mkdir(testDir, { recursive: true });
+
+    const result = await runAgentCoreCLI(
+      ['create', '--name', agentName, '--no-agent', '--defaults', '--skip-git', '--skip-python-setup', '--json'],
+      testDir
+    );
+    expect(result.exitCode, `Create failed: ${result.stderr}`).toBe(0);
+    projectPath = (parseJsonOutput(result.stdout) as { projectPath: string }).projectPath;
+
+    // 4. Configure deployment target + CDK
+    await writeAwsTargets(projectPath);
+    installCdkTarball(projectPath);
+  }, 600_000);
+
+  afterAll(async () => {
+    // 1. Tear down CFN stack created by import (this deletes all imported resources)
+    if (projectPath && hasAws) {
+      await runAgentCoreCLI(['remove', 'all', '--json'], projectPath);
+      await runAgentCoreCLI(['deploy', '--yes', '--json'], projectPath);
+    }
+
+    // 2. Fallback: delete any resources that weren't imported into CFN
+    try {
+      await spawnAndCollect('python3', ['cleanup_resources.py'], fixtureDir, { AWS_REGION: region });
+    } catch {
+      /* ignore — resources may already be deleted by CFN teardown */
+    }
+
+    // 3. Clean up temp directory
+    if (testDir) await rm(testDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 1000 });
+  }, 600_000);
+
+  const run = (args: string[]): Promise<RunResult> => runAgentCoreCLI(args, projectPath);
+
+  // ── Import tests ──────────────────────────────────────────────────
+
+  it.skipIf(!canRun)(
+    'imports a runtime by ARN',
+    async () => {
+      const result = await run(['import', 'runtime', '--arn', runtimeArn, '--code', appDir, '--name', agentName, '-y']);
+
+      if (result.exitCode !== 0) {
+        console.log('Import runtime stdout:', result.stdout);
+        console.log('Import runtime stderr:', result.stderr);
+      }
+
+      expect(result.exitCode, `Import runtime failed: ${result.stderr}`).toBe(0);
+      expect(stripAnsi(result.stdout).toLowerCase()).toContain('imported successfully');
+    },
+    600_000
+  );
+
+  it.skipIf(!canRun)(
+    'imports a memory by ARN',
+    async () => {
+      const result = await run(['import', 'memory', '--arn', memoryArn, '-y']);
+
+      if (result.exitCode !== 0) {
+        console.log('Import memory stdout:', result.stdout);
+        console.log('Import memory stderr:', result.stderr);
+      }
+
+      expect(result.exitCode, `Import memory failed: ${result.stderr}`).toBe(0);
+      expect(stripAnsi(result.stdout).toLowerCase()).toContain('imported successfully');
+    },
+    600_000
+  );
+
+  it.skipIf(!canRun)(
+    'imports an evaluator by ARN',
+    async () => {
+      const result = await run(['import', 'evaluator', '--arn', evaluatorArn]);
+
+      if (result.exitCode !== 0) {
+        console.log('Import evaluator stdout:', result.stdout);
+        console.log('Import evaluator stderr:', result.stderr);
+      }
+
+      expect(result.exitCode, `Import evaluator failed: ${result.stderr}`).toBe(0);
+      expect(stripAnsi(result.stdout).toLowerCase()).toContain('imported successfully');
+    },
+    600_000
+  );
+
+  // ── Verification tests ────────────────────────────────────────────
+
+  it.skipIf(!canRun)(
+    'status shows all imported resources as deployed',
+    async () => {
+      const result = await run(['status', '--json']);
+
+      expect(result.exitCode, `Status failed: ${result.stderr}`).toBe(0);
+
+      const json = parseJsonOutput(result.stdout) as {
+        success: boolean;
+        resources: { resourceType: string; name: string; deploymentState: string }[];
+      };
+      expect(json.success).toBe(true);
+
+      const agent = json.resources.find(r => r.resourceType === 'agent');
+      expect(agent, 'Imported runtime should appear in status').toBeDefined();
+      expect(agent!.deploymentState).toBe('deployed');
+
+      const memory = json.resources.find(r => r.resourceType === 'memory');
+      expect(memory, 'Imported memory should appear in status').toBeDefined();
+
+      const evaluator = json.resources.find(r => r.resourceType === 'evaluator');
+      expect(evaluator, 'Imported evaluator should appear in status').toBeDefined();
+    },
+    120_000
+  );
+
+  it.skipIf(!canRun)(
+    'invokes the imported runtime',
+    async () => {
+      await retry(
+        async () => {
+          const result = await run(['invoke', '--prompt', 'Say hello', '--runtime', agentName, '--json']);
+
+          if (result.exitCode !== 0) {
+            console.log('Invoke stdout:', result.stdout);
+            console.log('Invoke stderr:', result.stderr);
+          }
+
+          expect(result.exitCode, `Invoke failed: ${result.stderr}`).toBe(0);
+
+          const json = parseJsonOutput(result.stdout) as { success: boolean };
+          expect(json.success, 'Invoke should report success').toBe(true);
+        },
+        3,
+        15_000
+      );
+    },
+    180_000
+  );
+});

--- a/e2e-tests/import-resources.test.ts
+++ b/e2e-tests/import-resources.test.ts
@@ -47,6 +47,8 @@ describe.sequential('e2e: import runtime/memory/evaluator', () => {
 
     // 1. Run Python setup scripts to create AWS resources via API.
     //    Each script creates a resource and saves its ARN/ID to bugbash-resources.json.
+    //    Scripts run sequentially because save_resource() does a read-modify-write
+    //    on a shared bugbash-resources.json file — parallel runs would race.
     for (const script of ['setup_runtime_basic.py', 'setup_memory_full.py', 'setup_evaluator.py']) {
       const result = await spawnAndCollect('python3', [script], fixtureDir, { AWS_REGION: region });
       if (result.exitCode !== 0) {
@@ -83,7 +85,10 @@ describe.sequential('e2e: import runtime/memory/evaluator', () => {
     // 1. Tear down CFN stack created by import (this deletes all imported resources)
     if (projectPath && hasAws) {
       await runAgentCoreCLI(['remove', 'all', '--json'], projectPath);
-      await runAgentCoreCLI(['deploy', '--yes', '--json'], projectPath);
+      const deployResult = await runAgentCoreCLI(['deploy', '--yes', '--json'], projectPath);
+      if (deployResult.exitCode !== 0) {
+        console.warn('Teardown deploy failed:', deployResult.stderr);
+      }
     }
 
     // 2. Fallback: delete any resources that weren't imported into CFN

--- a/e2e-tests/import-resources.test.ts
+++ b/e2e-tests/import-resources.test.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_MODEL as DEFAULT_EVALUATOR_MODEL } from '../src/cli/tui/screens/evaluator/types.js';
 import {
   type RunResult,
   hasAwsCredentials,
@@ -8,7 +9,6 @@ import {
   spawnAndCollect,
   stripAnsi,
 } from '../src/test-utils/index.js';
-import { DEFAULT_MODEL as DEFAULT_EVALUATOR_MODEL } from '../src/cli/tui/screens/evaluator/types.js';
 import { installCdkTarball, runAgentCoreCLI, writeAwsTargets } from './e2e-helper.js';
 import { execSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';


### PR DESCRIPTION
## Description

Add end-to-end tests for `import runtime`, `import memory`, and `import evaluator` commands against real AWS resources.

Python fixture scripts create resources via the Bedrock AgentCore control plane API in `beforeAll`, then the tests import them into a CLI project and verify status + invocation. A cleanup script in `afterAll` tears down the CFN stack and deletes any leftover resources.

Key design decisions:
- Setup scripts run sequentially because `save_resource()` does a read-modify-write on a shared `bugbash-resources.json` file
- The default evaluator model ID is passed from the CLI TypeScript source to the Python setup script via env var to stay in sync automatically
- `cleanup_resources.py` preserves the resource file on partial failure so leaked resources can be retried

## Related Issue

Closes #

## Documentation PR

N/A — no user-facing changes.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

Additional testing:
- All 5 e2e import tests pass locally against real AWS (us-east-1)
- Full e2e suite passes in CI via `e2e-tests-full.yml` workflow dispatch

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.