### PR TITLE
fix: remove docker info check from container runtime detection

### DIFF
--- a/src/cli/external-requirements/__tests__/detect.test.ts
+++ b/src/cli/external-requirements/__tests__/detect.test.ts
@@ -1,4 +1,4 @@
-import { detectContainerRuntime, getStartHint, requireContainerRuntime } from '../detect.js';
+import { detectContainerRuntime, requireContainerRuntime } from '../detect.js';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const { mockCheckSubprocess, mockRunSubprocessCapture } = vi.hoisted(() => ({
@@ -8,11 +8,6 @@ const { mockCheckSubprocess, mockRunSubprocessCapture } = vi.hoisted(() => ({
 
 vi.mock('../../../lib', () => ({
   CONTAINER_RUNTIMES: ['docker', 'podman', 'finch'],
-  START_HINTS: {
-    docker: 'Start Docker Desktop or run: sudo systemctl start docker',
-    podman: 'Run: podman machine start',
-    finch: 'Run: finch vm init && finch vm start',
-  },
   checkSubprocess: mockCheckSubprocess,
   runSubprocessCapture: mockRunSubprocessCapture,
   isWindows: false,
@@ -20,38 +15,16 @@ vi.mock('../../../lib', () => ({
 
 afterEach(() => vi.clearAllMocks());
 
-describe('getStartHint', () => {
-  it('formats a single runtime hint', () => {
-    const result = getStartHint(['docker']);
-    expect(result).toBe('  docker: Start Docker Desktop or run: sudo systemctl start docker');
-  });
-
-  it('joins multiple runtime hints with newlines', () => {
-    const result = getStartHint(['docker', 'finch']);
-    expect(result).toBe(
-      '  docker: Start Docker Desktop or run: sudo systemctl start docker\n' +
-        '  finch: Run: finch vm init && finch vm start'
-    );
-  });
-
-  it('returns empty string for empty array', () => {
-    const result = getStartHint([]);
-    expect(result).toBe('');
-  });
-});
-
 describe('detectContainerRuntime', () => {
-  it('returns docker when docker is installed and ready', async () => {
+  it('returns docker when docker is installed', async () => {
     mockCheckSubprocess.mockResolvedValue(true);
     mockRunSubprocessCapture.mockImplementation((_bin: string, args: string[]) => {
       if (args[0] === '--version') return Promise.resolve({ code: 0, stdout: 'Docker version 24.0.0\n', stderr: '' });
-      if (args[0] === 'info') return Promise.resolve({ code: 0, stdout: '', stderr: '' });
       return Promise.resolve({ code: 1, stdout: '', stderr: '' });
     });
 
     const result = await detectContainerRuntime();
     expect(result.runtime).toEqual({ runtime: 'docker', binary: 'docker', version: 'Docker version 24.0.0' });
-    expect(result.notReadyRuntimes).toEqual([]);
   });
 
   it('falls back to podman when docker not installed', async () => {
@@ -63,7 +36,6 @@ describe('detectContainerRuntime', () => {
     mockRunSubprocessCapture.mockImplementation((bin: string, args: string[]) => {
       if (bin === 'podman' && args[0] === '--version')
         return Promise.resolve({ code: 0, stdout: 'podman version 4.5.0\n', stderr: '' });
-      if (bin === 'podman' && args[0] === 'info') return Promise.resolve({ code: 0, stdout: '', stderr: '' });
       return Promise.resolve({ code: 1, stdout: '', stderr: '' });
     });
 
@@ -71,44 +43,11 @@ describe('detectContainerRuntime', () => {
     expect(result.runtime).toEqual({ runtime: 'podman', binary: 'podman', version: 'podman version 4.5.0' });
   });
 
-  it('reports docker as notReady when installed but daemon not running', async () => {
-    // docker exists and --version works, but info fails
-    mockCheckSubprocess.mockImplementation((_cmd: string, args: string[]) => {
-      if (args[0] === 'docker') return Promise.resolve(true);
-      return Promise.resolve(false);
-    });
-    mockRunSubprocessCapture.mockImplementation((bin: string, args: string[]) => {
-      if (bin === 'docker' && args[0] === '--version')
-        return Promise.resolve({ code: 0, stdout: 'Docker version 24.0.0\n', stderr: '' });
-      if (bin === 'docker' && args[0] === 'info')
-        return Promise.resolve({ code: 1, stdout: '', stderr: 'Cannot connect to the Docker daemon' });
-      return Promise.resolve({ code: 1, stdout: '', stderr: '' });
-    });
-
-    const result = await detectContainerRuntime();
-    expect(result.runtime).toBeNull();
-    expect(result.notReadyRuntimes).toContain('docker');
-  });
-
   it('returns null runtime when nothing is installed', async () => {
     mockCheckSubprocess.mockResolvedValue(false);
 
     const result = await detectContainerRuntime();
     expect(result.runtime).toBeNull();
-    expect(result.notReadyRuntimes).toEqual([]);
-  });
-
-  it('returns null with notReadyRuntimes when installed but not ready', async () => {
-    mockCheckSubprocess.mockResolvedValue(true);
-    mockRunSubprocessCapture.mockImplementation((_bin: string, args: string[]) => {
-      if (args[0] === '--version') return Promise.resolve({ code: 0, stdout: 'v1.0.0\n', stderr: '' });
-      if (args[0] === 'info') return Promise.resolve({ code: 1, stdout: '', stderr: 'not running' });
-      return Promise.resolve({ code: 1, stdout: '', stderr: '' });
-    });
-
-    const result = await detectContainerRuntime();
-    expect(result.runtime).toBeNull();
-    expect(result.notReadyRuntimes).toEqual(['docker', 'podman', 'finch']);
   });
 
   it('skips runtime when --version check fails', async () => {
@@ -118,7 +57,6 @@ describe('detectContainerRuntime', () => {
       if (bin === 'docker' && args[0] === '--version') return Promise.resolve({ code: 1, stdout: '', stderr: 'error' });
       if (bin === 'podman' && args[0] === '--version')
         return Promise.resolve({ code: 0, stdout: 'podman version 4.5.0\n', stderr: '' });
-      if (bin === 'podman' && args[0] === 'info') return Promise.resolve({ code: 0, stdout: '', stderr: '' });
       // finch --version also fails
       if (bin === 'finch' && args[0] === '--version') return Promise.resolve({ code: 1, stdout: '', stderr: 'error' });
       return Promise.resolve({ code: 1, stdout: '', stderr: '' });
@@ -126,7 +64,6 @@ describe('detectContainerRuntime', () => {
 
     const result = await detectContainerRuntime();
     expect(result.runtime).toEqual({ runtime: 'podman', binary: 'podman', version: 'podman version 4.5.0' });
-    expect(result.notReadyRuntimes).toEqual([]);
   });
 
   it('extracts first line of --version output as version string', async () => {
@@ -134,7 +71,6 @@ describe('detectContainerRuntime', () => {
     mockRunSubprocessCapture.mockImplementation((_bin: string, args: string[]) => {
       if (args[0] === '--version')
         return Promise.resolve({ code: 0, stdout: 'Docker version 24.0.0\nExtra info line\n', stderr: '' });
-      if (args[0] === 'info') return Promise.resolve({ code: 0, stdout: '', stderr: '' });
       return Promise.resolve({ code: 1, stdout: '', stderr: '' });
     });
 
@@ -146,13 +82,28 @@ describe('detectContainerRuntime', () => {
     mockCheckSubprocess.mockResolvedValue(true);
     mockRunSubprocessCapture.mockImplementation((_bin: string, args: string[]) => {
       if (args[0] === '--version') return Promise.resolve({ code: 0, stdout: '', stderr: '' });
-      if (args[0] === 'info') return Promise.resolve({ code: 0, stdout: '', stderr: '' });
       return Promise.resolve({ code: 1, stdout: '', stderr: '' });
     });
 
     const result = await detectContainerRuntime();
     // ''.trim().split('\n')[0] returns '' (not undefined), so ?? 'unknown' doesn't trigger
     expect(result.runtime?.version).toBe('');
+  });
+
+  it('does not call docker info to check daemon status', async () => {
+    mockCheckSubprocess.mockResolvedValue(true);
+    mockRunSubprocessCapture.mockImplementation((_bin: string, args: string[]) => {
+      if (args[0] === '--version') return Promise.resolve({ code: 0, stdout: 'Docker version 24.0.0\n', stderr: '' });
+      return Promise.resolve({ code: 1, stdout: '', stderr: '' });
+    });
+
+    await detectContainerRuntime();
+
+    // Verify 'info' was never called — this is the key behavioral change
+    const infoCalls = mockRunSubprocessCapture.mock.calls.filter(
+      (call: unknown[]) => (call[1] as string[])[0] === 'info'
+    );
+    expect(infoCalls).toHaveLength(0);
   });
 });
 
@@ -161,7 +112,6 @@ describe('requireContainerRuntime', () => {
     mockCheckSubprocess.mockResolvedValue(true);
     mockRunSubprocessCapture.mockImplementation((_bin: string, args: string[]) => {
       if (args[0] === '--version') return Promise.resolve({ code: 0, stdout: 'Docker version 24.0.0\n', stderr: '' });
-      if (args[0] === 'info') return Promise.resolve({ code: 0, stdout: '', stderr: '' });
       return Promise.resolve({ code: 1, stdout: '', stderr: '' });
     });
 
@@ -169,22 +119,10 @@ describe('requireContainerRuntime', () => {
     expect(result).toEqual({ runtime: 'docker', binary: 'docker', version: 'Docker version 24.0.0' });
   });
 
-  it('throws with install links when no runtime found and none notReady', async () => {
+  it('throws with install links when no runtime found', async () => {
     mockCheckSubprocess.mockResolvedValue(false);
 
     await expect(requireContainerRuntime()).rejects.toThrow('No container runtime found');
     await expect(requireContainerRuntime()).rejects.toThrow('https://docker.com');
-  });
-
-  it('throws with start hints when runtimes installed but not ready', async () => {
-    mockCheckSubprocess.mockResolvedValue(true);
-    mockRunSubprocessCapture.mockImplementation((_bin: string, args: string[]) => {
-      if (args[0] === '--version') return Promise.resolve({ code: 0, stdout: 'v1.0.0\n', stderr: '' });
-      if (args[0] === 'info') return Promise.resolve({ code: 1, stdout: '', stderr: 'not running' });
-      return Promise.resolve({ code: 1, stdout: '', stderr: '' });
-    });
-
-    await expect(requireContainerRuntime()).rejects.toThrow('not ready');
-    await expect(requireContainerRuntime()).rejects.toThrow('Start a runtime');
   });
 });

--- a/src/cli/external-requirements/detect.ts
+++ b/src/cli/external-requirements/detect.ts
@@ -2,7 +2,7 @@
  * Container runtime detection.
  * Detects Docker, Podman, or Finch for container operations.
  */
-import { CONTAINER_RUNTIMES, type ContainerRuntime, START_HINTS } from '../../lib';
+import { CONTAINER_RUNTIMES, type ContainerRuntime } from '../../lib';
 import { checkSubprocess, isWindows, runSubprocessCapture } from '../../lib';
 
 export type { ContainerRuntime } from '../../lib';
@@ -14,26 +14,19 @@ export interface ContainerRuntimeInfo {
 }
 
 export interface DetectionResult {
-  /** The first ready runtime, or null if none are ready. */
+  /** The first available runtime, or null if none are installed. */
   runtime: ContainerRuntimeInfo | null;
-  /** Runtimes that are installed but not ready (e.g., VM not started). */
-  notReadyRuntimes: ContainerRuntime[];
-}
-
-/**
- * Build a user-friendly hint for runtimes that are installed but not ready.
- */
-export function getStartHint(runtimes: ContainerRuntime[]): string {
-  return runtimes.map(r => `  ${r}: ${START_HINTS[r]}`).join('\n');
 }
 
 /**
  * Detect available container runtime.
- * Checks docker, podman, finch in order; returns the first that is installed and usable,
- * plus a list of runtimes that are installed but not ready.
+ * Checks docker, podman, finch in order; returns the first that is installed.
+ * Does not probe the daemon (e.g., `docker info`) — that would require socket
+ * access and can trigger OS password prompts on systems where the user is not
+ * in the docker group. Actual daemon availability is validated when the runtime
+ * is used (build, run, etc.).
  */
 export async function detectContainerRuntime(): Promise<DetectionResult> {
-  const notReadyRuntimes: ContainerRuntime[] = [];
   for (const runtime of CONTAINER_RUNTIMES) {
     // Check if binary exists
     const exists = isWindows ? await checkSubprocess('where', [runtime]) : await checkSubprocess('which', [runtime]);
@@ -43,17 +36,10 @@ export async function detectContainerRuntime(): Promise<DetectionResult> {
     const result = await runSubprocessCapture(runtime, ['--version']);
     if (result.code !== 0) continue;
 
-    // Verify the runtime is actually usable (e.g., finch VM initialized, docker daemon running)
-    const infoResult = await runSubprocessCapture(runtime, ['info']);
-    if (infoResult.code !== 0) {
-      notReadyRuntimes.push(runtime);
-      continue;
-    }
-
     const version = result.stdout.trim().split('\n')[0] ?? 'unknown';
-    return { runtime: { runtime, binary: runtime, version }, notReadyRuntimes };
+    return { runtime: { runtime, binary: runtime, version } };
   }
-  return { runtime: null, notReadyRuntimes };
+  return { runtime: null };
 }
 
 /**
@@ -61,13 +47,8 @@ export async function detectContainerRuntime(): Promise<DetectionResult> {
  * Used by commands that require a container runtime (e.g., dev).
  */
 export async function requireContainerRuntime(): Promise<ContainerRuntimeInfo> {
-  const { runtime, notReadyRuntimes } = await detectContainerRuntime();
+  const { runtime } = await detectContainerRuntime();
   if (!runtime) {
-    if (notReadyRuntimes.length > 0) {
-      throw new Error(
-        `Found ${notReadyRuntimes.join(', ')} but not ready. Start a runtime:\n${getStartHint(notReadyRuntimes)}`
-      );
-    }
     throw new Error(
       'No container runtime found. Install Docker (https://docker.com), ' +
         'Podman (https://podman.io), or Finch (https://runfinch.com).'

--- a/src/cli/external-requirements/index.ts
+++ b/src/cli/external-requirements/index.ts
@@ -32,7 +32,6 @@ export {
 export {
   detectContainerRuntime,
   requireContainerRuntime,
-  getStartHint,
   type ContainerRuntime,
   type ContainerRuntimeInfo,
   type DetectionResult,

--- a/src/cli/operations/dev/__tests__/container-dev-server.test.ts
+++ b/src/cli/operations/dev/__tests__/container-dev-server.test.ts
@@ -9,7 +9,6 @@ const mockSpawnSync = vi.fn();
 const mockSpawn = vi.fn();
 const mockExistsSync = vi.fn();
 const mockDetectContainerRuntime = vi.fn();
-const mockGetStartHint = vi.fn();
 const mockWaitForServerReady = vi.fn();
 
 vi.mock('child_process', () => ({
@@ -29,7 +28,6 @@ vi.mock('os', () => ({
 // Path is relative to this test file in __tests__/, so 3 levels up to reach cli/
 vi.mock('../../../external-requirements/detect', () => ({
   detectContainerRuntime: (...args: unknown[]) => mockDetectContainerRuntime(...args),
-  getStartHint: (...args: unknown[]) => mockGetStartHint(...args),
 }));
 
 vi.mock('../utils', async importOriginal => {
@@ -71,7 +69,6 @@ function mockSuccessfulPrepare() {
   // Runtime detected
   mockDetectContainerRuntime.mockResolvedValue({
     runtime: { runtime: 'docker', binary: 'docker', version: 'Docker 24.0' },
-    notReadyRuntimes: [],
   });
   // Dockerfile exists (first call), ~/.aws exists (second call in getSpawnConfig)
   mockExistsSync.mockReturnValue(true);
@@ -115,7 +112,6 @@ describe('ContainerDevServer', () => {
     it('returns null when no container runtime detected', async () => {
       mockDetectContainerRuntime.mockResolvedValue({
         runtime: null,
-        notReadyRuntimes: [],
       });
 
       const server = new ContainerDevServer(defaultConfig, defaultOptions);
@@ -128,25 +124,9 @@ describe('ContainerDevServer', () => {
       );
     });
 
-    it('logs start hints when runtimes installed but not ready', async () => {
-      mockDetectContainerRuntime.mockResolvedValue({
-        runtime: null,
-        notReadyRuntimes: ['docker', 'podman'],
-      });
-      mockGetStartHint.mockReturnValue('Start Docker Desktop');
-
-      const server = new ContainerDevServer(defaultConfig, defaultOptions);
-      const result = await server.start();
-
-      expect(result).toBeNull();
-      expect(mockCallbacks.onLog).toHaveBeenCalledWith('error', expect.stringContaining('docker, podman'));
-      expect(mockGetStartHint).toHaveBeenCalledWith(['docker', 'podman']);
-    });
-
     it('returns null when Dockerfile is missing', async () => {
       mockDetectContainerRuntime.mockResolvedValue({
         runtime: { runtime: 'docker', binary: 'docker', version: 'Docker 24.0' },
-        notReadyRuntimes: [],
       });
       mockExistsSync.mockReturnValue(false);
 
@@ -175,7 +155,6 @@ describe('ContainerDevServer', () => {
     it('returns null when image build fails', async () => {
       mockDetectContainerRuntime.mockResolvedValue({
         runtime: { runtime: 'docker', binary: 'docker', version: 'Docker 24.0' },
-        notReadyRuntimes: [],
       });
       mockExistsSync.mockReturnValue(true);
       // rm succeeds (spawnSync)
@@ -250,7 +229,6 @@ describe('ContainerDevServer', () => {
     it('streams build output lines at system level in real-time', async () => {
       mockDetectContainerRuntime.mockResolvedValue({
         runtime: { runtime: 'docker', binary: 'docker', version: 'Docker 24.0' },
-        notReadyRuntimes: [],
       });
       mockExistsSync.mockReturnValue(true);
       mockSpawnSync.mockReturnValue({ status: 0, stdout: Buffer.from(''), stderr: Buffer.from('') }); // rm
@@ -437,7 +415,6 @@ describe('ContainerDevServer', () => {
     it('skips ~/.aws mount when directory does not exist', async () => {
       mockDetectContainerRuntime.mockResolvedValue({
         runtime: { runtime: 'docker', binary: 'docker', version: 'Docker 24.0' },
-        notReadyRuntimes: [],
       });
       // existsSync is called for: (1) Dockerfile in prepare(), (2) ~/.aws in getSpawnConfig()
       mockExistsSync.mockImplementation((path: string) => {

--- a/src/cli/operations/dev/container-dev-server.ts
+++ b/src/cli/operations/dev/container-dev-server.ts
@@ -1,6 +1,6 @@
 import { CONTAINER_INTERNAL_PORT, DOCKERFILE_NAME, getDockerfilePath } from '../../../lib';
 import { getUvBuildArgs } from '../../../lib/packaging/build-args';
-import { detectContainerRuntime, getStartHint } from '../../external-requirements/detect';
+import { detectContainerRuntime } from '../../external-requirements/detect';
 import { DevServer, type LogLevel, type SpawnConfig } from './dev-server';
 import { waitForServerReady } from './utils';
 import { type ChildProcess, spawn, spawnSync } from 'child_process';
@@ -58,16 +58,9 @@ export class ContainerDevServer extends DevServer {
     const { onLog } = this.options.callbacks;
 
     // 1. Detect container runtime
-    const { runtime, notReadyRuntimes } = await detectContainerRuntime();
+    const { runtime } = await detectContainerRuntime();
     if (!runtime) {
-      if (notReadyRuntimes.length > 0) {
-        onLog(
-          'error',
-          `Found ${notReadyRuntimes.join(', ')} but not ready. Start a runtime:\n${getStartHint(notReadyRuntimes)}`
-        );
-      } else {
-        onLog('error', 'No container runtime found. Install Docker, Podman, or Finch.');
-      }
+      onLog('error', 'No container runtime found. Install Docker, Podman, or Finch.');
       return false;
     }
     this.runtimeBinary = runtime.binary;

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -47,16 +47,6 @@ export const CONTAINER_INTERNAL_PORT = 8080;
 export type ContainerRuntime = 'docker' | 'podman' | 'finch';
 export const CONTAINER_RUNTIMES: ContainerRuntime[] = ['docker', 'podman', 'finch'];
 
-/** Platform-aware start hints for container runtimes. */
-export const START_HINTS: Record<ContainerRuntime, string> = {
-  docker:
-    process.platform === 'win32'
-      ? 'Start Docker Desktop or run: Start-Service docker'
-      : 'Start Docker Desktop or run: sudo systemctl start docker',
-  podman: 'Run: podman machine start',
-  finch: 'Run: finch vm init && finch vm start',
-};
-
 /**
  * Get the Dockerfile path for a given code location.
  * @param codeLocation - Directory containing the Dockerfile

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -16,7 +16,6 @@ export {
   DOCKERFILE_NAME,
   CONTAINER_INTERNAL_PORT,
   CONTAINER_RUNTIMES,
-  START_HINTS,
   getDockerfilePath,
   type ContainerRuntime,
 } from './constants';


### PR DESCRIPTION
## Problem

During `agentcore deploy`, the "Check dependencies" preflight calls `detectContainerRuntime()` which runs `docker info`. This command communicates with the Docker daemon through the Unix socket (`/var/run/docker.sock`). If the user isn't in the `docker` group, the OS prompts for a password — a confusing experience since the container runtime check is non-blocking (deploy falls back to CodeBuild for container builds anyway).

The same issue affects `agentcore dev` with Container agents and users of Colima (which uses the standard `docker` CLI binary).

## Options considered

1. **Remove `docker info` entirely** — detect runtimes with `which` + `--version` only. If the daemon isn't running, the user finds out when they actually use it (`docker build` fails with a clear "Cannot connect to the Docker daemon" error).

2. **Keep `docker info` but suppress the password prompt** — not possible. The OS-level polkit/sudo prompt fires before our code can react to the result.

3. **Keep `docker info` but catch the failure silently** — same problem: the prompt appears *before* the command returns a result. We can't prevent it.

## Solution

Option 1. Remove the `docker info` call from `detectContainerRuntime()` and rely on `which` + `--version` for binary detection. This matches the approach already used by `detectContainerRuntimeSync()` in `src/lib/packaging/container.ts`.

The tradeoff is losing the proactive "start Docker" hint when the daemon is down. But the `docker build` error message is clear enough, and avoiding a surprise password prompt is worth that tradeoff.

## Changes

- Remove `docker info` probe from `detectContainerRuntime()`
- Remove `notReadyRuntimes` tracking (only populated by the `docker info` failure path)
- Remove `getStartHint()` helper and `START_HINTS` constant (only used to format `notReadyRuntimes` messages)
- Simplify `requireContainerRuntime()` to just throw "not found" if no runtime passes `which` + `--version`
- Simplify `container-dev-server.ts` prepare() to just check if `runtime` is null

## Test plan

- [x] Unit tests: 35/35 pass across detect.test.ts and container-dev-server.test.ts
- [x] Full test suite: 3295/3295 pass
- [x] TypeScript compilation: 0 errors
- [x] Pre-commit hooks: eslint, prettier, secretlint, typecheck all pass
- [x] Manual: `detectContainerRuntime()` returns Docker info via `which` + `--version` only (no password prompt)
- [x] Manual: `agentcore dev -l` with Container agent — full flow completes (build, start, run) with no password prompt
- [ ] Manual: `agentcore deploy` with Container agent on a machine without docker group membership — verify no password prompt