### PR TITLE
fix: improve duplicate agent error message and stream delivery docs

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -238,16 +238,41 @@ agentcore add memory \
   --expiry 30
 ```
 
-| Flag                                 | Description                                                                 |
-| ------------------------------------ | --------------------------------------------------------------------------- |
-| `--name <name>`                      | Memory name                                                                 |
-| `--strategies <types>`               | Comma-separated: `SEMANTIC`, `SUMMARIZATION`, `USER_PREFERENCE`, `EPISODIC` |
-| `--expiry <days>`                    | Event expiry duration in days (default: 30, min: 7, max: 365)               |
-| `--delivery-type <type>`             | Delivery target type (default: `kinesis`)                                   |
-| `--data-stream-arn <arn>`            | Kinesis data stream ARN for memory record streaming                         |
-| `--stream-content-level <level>`     | `FULL_CONTENT` (default) or `METADATA_ONLY`                                 |
-| `--stream-delivery-resources <json>` | Stream delivery config as JSON (advanced, overrides flat flags)             |
-| `--json`                             | JSON output                                                                 |
+| Flag                                 | Description                                                                         |
+| ------------------------------------ | ----------------------------------------------------------------------------------- |
+| `--name <name>`                      | Memory name                                                                         |
+| `--strategies <types>`               | Comma-separated: `SEMANTIC`, `SUMMARIZATION`, `USER_PREFERENCE`, `EPISODIC`         |
+| `--expiry <days>`                    | Event expiry duration in days (default: 30, min: 7, max: 365)                       |
+| `--delivery-type <type>`             | Delivery target type (default: `kinesis`)                                           |
+| `--data-stream-arn <arn>`            | Kinesis data stream ARN for memory record streaming                                 |
+| `--stream-content-level <level>`     | `FULL_CONTENT` (default) or `METADATA_ONLY`                                         |
+| `--stream-delivery-resources <json>` | Stream delivery config as JSON (advanced, overrides flat flags). See example below. |
+| `--json`                             | JSON output                                                                         |
+
+<details>
+<summary><code>--stream-delivery-resources</code> JSON example</summary>
+
+```json
+{
+  "resources": [
+    {
+      "kinesis": {
+        "dataStreamArn": "arn:aws:kinesis:us-west-2:123456789012:stream/my-stream",
+        "contentConfigurations": [
+          {
+            "type": "MEMORY_RECORDS",
+            "level": "FULL_CONTENT"
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+`level` can be `FULL_CONTENT` (default) or `METADATA_ONLY`. Currently only Kinesis is supported as a delivery type.
+
+</details>
 
 ### add gateway
 

--- a/src/cli/__tests__/errors.test.ts
+++ b/src/cli/__tests__/errors.test.ts
@@ -12,7 +12,9 @@ describe('errors', () => {
   describe('AgentAlreadyExistsError', () => {
     it('has correct message with agent name', () => {
       const err = new AgentAlreadyExistsError('my-agent');
-      expect(err.message).toBe('An agent named "my-agent" already exists in the schema.');
+      expect(err.message).toBe(
+        'An agent named "my-agent" already exists. To update its configuration, edit agentcore/agentcore.json directly.'
+      );
     });
 
     it('has correct name', () => {

--- a/src/cli/errors.ts
+++ b/src/cli/errors.ts
@@ -3,7 +3,9 @@
  */
 export class AgentAlreadyExistsError extends Error {
   constructor(agentName: string) {
-    super(`An agent named "${agentName}" already exists in the schema.`);
+    super(
+      `An agent named "${agentName}" already exists. To update its configuration, edit agentcore/agentcore.json directly.`
+    );
     this.name = 'AgentAlreadyExistsError';
   }
 }

--- a/src/cli/primitives/MemoryPrimitive.tsx
+++ b/src/cli/primitives/MemoryPrimitive.tsx
@@ -168,7 +168,7 @@ export class MemoryPrimitive extends BasePrimitive<AddMemoryOptions, RemovableMe
       )
       .option(
         '--stream-delivery-resources <json>',
-        'Stream delivery config as JSON string (advanced, overrides flat flags) [non-interactive]'
+        'Stream delivery config as JSON string (advanced, overrides flat flags). Example: \'{"resources":[{"kinesis":{"dataStreamArn":"arn:aws:kinesis:REGION:ACCOUNT:stream/NAME","contentConfigurations":[{"type":"MEMORY_RECORDS","level":"FULL_CONTENT"}]}}]}\' See docs/memory.md for details. [non-interactive]'
       )
       .option('--json', 'Output as JSON [non-interactive]')
       .action(


### PR DESCRIPTION
## Description

Two small UX improvements based on user feedback:

### 1. Better error message for duplicate agent names (#826)

When a user tries to add an agent with a name that already exists, the error now guides them to edit `agentcore/agentcore.json` directly. There is currently no `agentcore update agent` command, so users need to know where to make config changes (e.g. adding `requestHeaderAllowlist` after initial creation).

**Before:** `An agent named "foo" already exists in the schema.`
**After:** `An agent named "foo" already exists. To update its configuration, edit agentcore/agentcore.json directly.`

### 2. Add JSON example for `--stream-delivery-resources` (#827)

The `--stream-delivery-resources <json>` flag accepts a complex JSON structure, but the expected format was hard to discover. Added:
- Compact JSON example in `agentcore add memory --help` text with pointer to `docs/memory.md`
- Expandable JSON example with explanation in `docs/commands.md`

## Related Issue

Closes #826
Closes #827

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

**Manual testing:**
- Ran `agentcore add agent --name ExistingAgent ...` twice — confirmed new error message appears
- Ran `agentcore add memory --help` — confirmed JSON example renders cleanly in terminal

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.