### PR TITLE
fix: update E2E test regex to match new CUSTOM_JWT client-side error

### DIFF
--- a/e2e-tests/byo-custom-jwt.test.ts
+++ b/e2e-tests/byo-custom-jwt.test.ts
@@ -272,9 +272,11 @@ describe.sequential('e2e: BYO agent with CUSTOM_JWT auth', () => {
         projectPath
       );
 
-      // Expect failure due to auth method mismatch
+      // Expect failure due to auth method mismatch (client-side fast-fail or server-side rejection)
       const output = stripAnsi(result.stdout + result.stderr);
-      expect(output).toMatch(/[Aa]uthoriz(ation|er).*mismatch|different.*authorization/i);
+      expect(output).toMatch(
+        /configured for CUSTOM_JWT but no bearer token|[Aa]uthoriz(ation|er).*mismatch|different.*authorization/i
+      );
     },
     180000
   );
@@ -294,7 +296,9 @@ describe.sequential('e2e: BYO agent with CUSTOM_JWT auth', () => {
 
       const output = stripAnsi(result.stdout + result.stderr);
       // The invoke may fail for other reasons (agent logic), but it should NOT fail with auth mismatch
-      expect(output).not.toMatch(/[Aa]uthoriz(ation|er).*mismatch|different.*authorization/i);
+      expect(output).not.toMatch(
+        /configured for CUSTOM_JWT but no bearer token|[Aa]uthoriz(ation|er).*mismatch|different.*authorization/i
+      );
     },
     180000
   );
@@ -307,7 +311,9 @@ describe.sequential('e2e: BYO agent with CUSTOM_JWT auth', () => {
       const result = await runLocalCLI(['invoke', '--runtime', mcpAgentName, 'list-tools', '--json'], projectPath);
 
       const output = stripAnsi(result.stdout + result.stderr);
-      expect(output).toMatch(/[Aa]uthoriz(ation|er).*mismatch|different.*authorization/i);
+      expect(output).toMatch(
+        /configured for CUSTOM_JWT but no bearer token|[Aa]uthoriz(ation|er).*mismatch|different.*authorization/i
+      );
     },
     180000
   );
@@ -325,7 +331,9 @@ describe.sequential('e2e: BYO agent with CUSTOM_JWT auth', () => {
       );
 
       const output = stripAnsi(result.stdout + result.stderr);
-      expect(output).not.toMatch(/[Aa]uthoriz(ation|er).*mismatch|different.*authorization/i);
+      expect(output).not.toMatch(
+        /configured for CUSTOM_JWT but no bearer token|[Aa]uthoriz(ation|er).*mismatch|different.*authorization/i
+      );
     },
     180000
   );
@@ -355,7 +363,9 @@ describe.sequential('e2e: BYO agent with CUSTOM_JWT auth', () => {
       );
 
       const output = stripAnsi(result.stdout + result.stderr);
-      expect(output).not.toMatch(/[Aa]uthoriz(ation|er).*mismatch|different.*authorization/i);
+      expect(output).not.toMatch(
+        /configured for CUSTOM_JWT but no bearer token|[Aa]uthoriz(ation|er).*mismatch|different.*authorization/i
+      );
     },
     180000
   );


### PR DESCRIPTION
## Description

PR #817 changed `src/cli/commands/invoke/action.ts` to fail fast client-side when a CUSTOM_JWT agent is invoked without a bearer token (and without stored client credentials for auto-fetch). The new error message:

> Agent '...' is configured for CUSTOM_JWT but no bearer token is available.

The E2E tests in `byo-custom-jwt.test.ts` still expected the old server-side error pattern (`/[Aa]uthoriz(ation|er).*mismatch|different.*authorization/i`), causing 2 test failures on main.

This updates all 5 regex assertions (2 positive, 3 negative) to also match the new client-side message.

## Related Issue

Closes #

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [ ] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.