### PR TITLE
fix: add missing AgentCore regions to match AWS documentation

### DIFF
--- a/src/schema/llm-compacted/aws-targets.ts
+++ b/src/schema/llm-compacted/aws-targets.ts
@@ -23,15 +23,22 @@ interface AwsDeploymentTarget {
 
 // ─────────────────────────────────────────────────────────────────────────────
 // SUPPORTED REGIONS
+// https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/agentcore-regions.html
 // ─────────────────────────────────────────────────────────────────────────────
 
 type AgentCoreRegion =
   | 'ap-northeast-1'
+  | 'ap-northeast-2'
   | 'ap-south-1'
   | 'ap-southeast-1'
   | 'ap-southeast-2'
+  | 'ca-central-1'
   | 'eu-central-1'
+  | 'eu-north-1'
   | 'eu-west-1'
+  | 'eu-west-2'
+  | 'eu-west-3'
+  | 'sa-east-1'
   | 'us-east-1'
   | 'us-east-2'
   | 'us-west-2';

--- a/src/schema/schemas/__tests__/aws-targets.test.ts
+++ b/src/schema/schemas/__tests__/aws-targets.test.ts
@@ -10,11 +10,17 @@ import { describe, expect, it } from 'vitest';
 describe('AgentCoreRegionSchema', () => {
   const validRegions = [
     'ap-northeast-1',
+    'ap-northeast-2',
     'ap-south-1',
     'ap-southeast-1',
     'ap-southeast-2',
+    'ca-central-1',
     'eu-central-1',
+    'eu-north-1',
     'eu-west-1',
+    'eu-west-2',
+    'eu-west-3',
+    'sa-east-1',
     'us-east-1',
     'us-east-2',
     'us-west-2',
@@ -26,8 +32,8 @@ describe('AgentCoreRegionSchema', () => {
 
   it('rejects unsupported regions', () => {
     expect(AgentCoreRegionSchema.safeParse('us-west-1').success).toBe(false);
-    expect(AgentCoreRegionSchema.safeParse('eu-west-2').success).toBe(false);
-    expect(AgentCoreRegionSchema.safeParse('sa-east-1').success).toBe(false);
+    expect(AgentCoreRegionSchema.safeParse('af-south-1').success).toBe(false);
+    expect(AgentCoreRegionSchema.safeParse('me-south-1').success).toBe(false);
   });
 
   it('rejects empty string', () => {

--- a/src/schema/schemas/aws-targets.ts
+++ b/src/schema/schemas/aws-targets.ts
@@ -3,15 +3,22 @@ import { z } from 'zod';
 
 // ============================================================================
 // AgentCore Regions
+// Keep in sync with: https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/agentcore-regions.html
 // ============================================================================
 
 export const AgentCoreRegionSchema = z.enum([
   'ap-northeast-1',
+  'ap-northeast-2',
   'ap-south-1',
   'ap-southeast-1',
   'ap-southeast-2',
+  'ca-central-1',
   'eu-central-1',
+  'eu-north-1',
   'eu-west-1',
+  'eu-west-2',
+  'eu-west-3',
+  'sa-east-1',
   'us-east-1',
   'us-east-2',
   'us-west-2',


### PR DESCRIPTION
## Summary

- Add 6 missing regions to `AgentCoreRegionSchema` to match the [official AWS Bedrock Agentcore documentation](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/agentcore-regions.html): `ap-northeast-2`, `ca-central-1`, `eu-north-1`, `eu-west-2`, `eu-west-3`, `sa-east-1`
- Update the LLM-compacted schema mirror (`llm-compacted/aws-targets.ts`) to stay in sync
- Add a doc link comment above the enum for future maintainers
- Update tests: new regions added to `validRegions`, rejected-region examples updated to use actually-unsupported regions

## Related Issue

Closes #822 (supersedes #823 which only adds `eu-west-2`)

## Type of Change

- [x] Bug fix

## Test plan

- [x] `npx vitest run src/schema/schemas/__tests__/aws-targets.test.ts` — all 38 tests pass
- [x] `npm run build` — compiles cleanly (tsc, esbuild, assets)
- [x] Pre-commit hooks pass (eslint, prettier, secretlint, typecheck)
- [x] Smoke-tested built artifact: all 6 new regions validate via `AgentCoreRegionSchema.safeParse()`
- [ ] Verify `agentcore deploy` with `eu-west-2` in config (needs AWS credentials)