### PR TITLE
fix: unhide import command from TUI main menu

### DIFF
--- a/src/cli/tui/utils/commands.ts
+++ b/src/cli/tui/utils/commands.ts
@@ -12,7 +12,7 @@ export interface CommandMeta {
 /**
  * Commands hidden from TUI entirely (meta commands).
  */
-const HIDDEN_FROM_TUI = ['help', 'import', 'telemetry'] as const;
+const HIDDEN_FROM_TUI = ['help', 'telemetry'] as const;
 
 /**
  * Commands that are CLI-only (shown but marked as requiring CLI invocation).


### PR DESCRIPTION
## Description

Remove `import` from the `HIDDEN_FROM_TUI` list in `commands.ts` so the import command is discoverable in the TUI's main command list. It was previously hidden alongside `help` and `telemetry` in #797, but import is a user-facing command that should be accessible from the interactive menu.

## Related Issue

Closes #

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.