### PR TITLE
feat: add auto-instrumentation to langchain agent template

### DIFF
--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -1167,6 +1167,7 @@ Thumbs.db
 exports[`Assets Directory Snapshots > Python framework assets > python/python/a2a/langchain_langgraph/base/main.py should match snapshot 1`] = `
 "from langchain_core.tools import tool
 from langgraph.prebuilt import create_react_agent
+from opentelemetry.instrumentation.langchain import LangchainInstrumentor
 from a2a.server.agent_execution import AgentExecutor, RequestContext
 from a2a.server.events import EventQueue
 from a2a.server.tasks import TaskUpdater
@@ -1174,6 +1175,8 @@ from a2a.types import AgentCapabilities, AgentCard, AgentSkill, Part, TextPart
 from a2a.utils import new_task
 from bedrock_agentcore.runtime import serve_a2a
 from model.load import load_model
+
+LangchainInstrumentor().instrument()
 
 
 @tool
@@ -1382,6 +1385,7 @@ dependencies = [
     {{/if}}{{#if (eq modelProvider "Gemini")}}"langchain-google-genai >= 2.0.0",
     {{/if}}{{#if (eq modelProvider "OpenAI")}}"langchain-openai >= 0.2.0",
     {{/if}}"aws-opentelemetry-distro",
+    "opentelemetry-instrumentation-langchain",
     "bedrock-agentcore[a2a] >= 1.0.3",
     "botocore[crt] >= 1.35.0",
     "langgraph >= 0.2.0",
@@ -2526,6 +2530,7 @@ exports[`Assets Directory Snapshots > Python framework assets > python/python/ht
 from langchain_core.messages import HumanMessage
 from langgraph.prebuilt import create_react_agent
 from langchain.tools import tool
+from opentelemetry.instrumentation.langchain import LangchainInstrumentor
 from bedrock_agentcore.runtime import BedrockAgentCoreApp
 from model.load import load_model
 {{#if hasGateway}}
@@ -2533,6 +2538,8 @@ from mcp_client.client import get_all_gateway_mcp_client
 {{else}}
 from mcp_client.client import get_streamable_http_mcp_client
 {{/if}}
+
+LangchainInstrumentor().instrument()
 
 app = BedrockAgentCoreApp()
 log = app.logger
@@ -2825,6 +2832,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "aws-opentelemetry-distro",
+    "opentelemetry-instrumentation-langchain",
     "langgraph >= 1.0.2",
     "mcp >= 1.19.0",
     "langchain-mcp-adapters >= 0.1.11",

--- a/src/assets/python/a2a/langchain_langgraph/base/main.py
+++ b/src/assets/python/a2a/langchain_langgraph/base/main.py
@@ -1,5 +1,6 @@
 from langchain_core.tools import tool
 from langgraph.prebuilt import create_react_agent
+from opentelemetry.instrumentation.langchain import LangchainInstrumentor
 from a2a.server.agent_execution import AgentExecutor, RequestContext
 from a2a.server.events import EventQueue
 from a2a.server.tasks import TaskUpdater
@@ -7,6 +8,8 @@ from a2a.types import AgentCapabilities, AgentCard, AgentSkill, Part, TextPart
 from a2a.utils import new_task
 from bedrock_agentcore.runtime import serve_a2a
 from model.load import load_model
+
+LangchainInstrumentor().instrument()
 
 
 @tool

--- a/src/assets/python/a2a/langchain_langgraph/base/pyproject.toml
+++ b/src/assets/python/a2a/langchain_langgraph/base/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     {{/if}}{{#if (eq modelProvider "Gemini")}}"langchain-google-genai >= 2.0.0",
     {{/if}}{{#if (eq modelProvider "OpenAI")}}"langchain-openai >= 0.2.0",
     {{/if}}"aws-opentelemetry-distro",
+    "opentelemetry-instrumentation-langchain",
     "bedrock-agentcore[a2a] >= 1.0.3",
     "botocore[crt] >= 1.35.0",
     "langgraph >= 0.2.0",

--- a/src/assets/python/http/langchain_langgraph/base/main.py
+++ b/src/assets/python/http/langchain_langgraph/base/main.py
@@ -2,6 +2,7 @@ import os
 from langchain_core.messages import HumanMessage
 from langgraph.prebuilt import create_react_agent
 from langchain.tools import tool
+from opentelemetry.instrumentation.langchain import LangchainInstrumentor
 from bedrock_agentcore.runtime import BedrockAgentCoreApp
 from model.load import load_model
 {{#if hasGateway}}
@@ -9,6 +10,8 @@ from mcp_client.client import get_all_gateway_mcp_client
 {{else}}
 from mcp_client.client import get_streamable_http_mcp_client
 {{/if}}
+
+LangchainInstrumentor().instrument()
 
 app = BedrockAgentCoreApp()
 log = app.logger

--- a/src/assets/python/http/langchain_langgraph/base/pyproject.toml
+++ b/src/assets/python/http/langchain_langgraph/base/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "aws-opentelemetry-distro",
+    "opentelemetry-instrumentation-langchain",
     "langgraph >= 1.0.2",
     "mcp >= 1.19.0",
     "langchain-mcp-adapters >= 0.1.11",


### PR DESCRIPTION
## Description

Adds auto-instrumentation to the LangChain/LangGraph agent templates so that traces emitted by LangChain agents are compatible with AgentCore's observability and evaluation features out of the box.

**Changes:**
- Import and call `LangchainInstrumentor().instrument()` at module level in both A2A and HTTP LangChain template `main.py` files
- Add `opentelemetry-instrumentation-langchain` to the template `pyproject.toml` dependencies for both A2A and HTTP variants
- Update asset snapshots

**Why:** Without the LangChain OpenTelemetry instrumentor, traces from LangChain agents are emitted under a generic scope that the Evaluate API does not recognize. Running `agentcore run eval` against a LangChain agent would fail with:

> Error: Provided input has no spans with supported scope. Currently supported scopes are ['strands.telemetry.tracer', 'opentelemetry.instrumentation.langchain', 'openinference.instrumentation.langchain']. Please verify that you are using the supported agentic-framework and instrumentation-library

With this change, LangChain agent traces are emitted under the `opentelemetry.instrumentation.langchain` scope, and `agentcore run eval` succeeds.

**Reference:** [Configuring custom observability in AgentCore](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/observability-configure.html#observability-configure-custom)

## Type of Change

- [x] New feature

## Testing

Verified by running `agentcore run eval` against a LangChain agent — evaluation completes successfully instead of returning the unsupported-scope error.

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [x] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.