### PR TITLE
fix: add missing langchain instrumentor dependency to import flow

### DIFF
--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -1385,7 +1385,7 @@ dependencies = [
     {{/if}}{{#if (eq modelProvider "Gemini")}}"langchain-google-genai >= 2.0.0",
     {{/if}}{{#if (eq modelProvider "OpenAI")}}"langchain-openai >= 0.2.0",
     {{/if}}"aws-opentelemetry-distro",
-    "opentelemetry-instrumentation-langchain",
+    "opentelemetry-instrumentation-langchain >= 0.59.0",
     "bedrock-agentcore[a2a] >= 1.0.3",
     "botocore[crt] >= 1.35.0",
     "langgraph >= 0.2.0",
@@ -2832,7 +2832,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "aws-opentelemetry-distro",
-    "opentelemetry-instrumentation-langchain",
+    "opentelemetry-instrumentation-langchain >= 0.59.0",
     "langgraph >= 1.0.2",
     "mcp >= 1.19.0",
     "langchain-mcp-adapters >= 0.1.11",

--- a/src/assets/python/a2a/langchain_langgraph/base/pyproject.toml
+++ b/src/assets/python/a2a/langchain_langgraph/base/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     {{/if}}{{#if (eq modelProvider "Gemini")}}"langchain-google-genai >= 2.0.0",
     {{/if}}{{#if (eq modelProvider "OpenAI")}}"langchain-openai >= 0.2.0",
     {{/if}}"aws-opentelemetry-distro",
-    "opentelemetry-instrumentation-langchain",
+    "opentelemetry-instrumentation-langchain >= 0.59.0",
     "bedrock-agentcore[a2a] >= 1.0.3",
     "botocore[crt] >= 1.35.0",
     "langgraph >= 0.2.0",

--- a/src/assets/python/http/langchain_langgraph/base/pyproject.toml
+++ b/src/assets/python/http/langchain_langgraph/base/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "aws-opentelemetry-distro",
-    "opentelemetry-instrumentation-langchain",
+    "opentelemetry-instrumentation-langchain >= 0.59.0",
     "langgraph >= 1.0.2",
     "mcp >= 1.19.0",
     "langchain-mcp-adapters >= 0.1.11",

--- a/src/cli/operations/agent/import/__tests__/translator.test.ts
+++ b/src/cli/operations/agent/import/__tests__/translator.test.ts
@@ -254,6 +254,7 @@ describe('generatePyprojectToml', () => {
 
     expect(result).toContain('langgraph');
     expect(result).toContain('langchain_aws');
+    expect(result).toContain('opentelemetry-instrumentation-langchain');
     expect(result).not.toContain('strands-agents');
   });
 

--- a/src/cli/operations/agent/import/pyproject-generator.ts
+++ b/src/cli/operations/agent/import/pyproject-generator.ts
@@ -18,6 +18,7 @@ const LANGGRAPH_DEPS = [
   'langchain>=1.0.3',
   'langchain_aws>=1.0.0',
   'langchain-mcp-adapters>=0.1.11',
+  'opentelemetry-instrumentation-langchain>=0.59.0',
   'tiktoken==0.11.0',
 ];
 


### PR DESCRIPTION
## Summary

Two related fixes for `opentelemetry-instrumentation-langchain` dependency management:

1. **Import flow bug (ModuleNotFoundError):** `LangGraphTranslator` generates `LangchainInstrumentor().instrument()` in imported agents' `main.py`, but `pyproject-generator.ts` never declared the dependency in `LANGGRAPH_DEPS`. When `setupPythonProject()` runs `uv install`, the package is missing, and the imported agent crashes at runtime with `ModuleNotFoundError: No module named 'opentelemetry.instrumentation.langchain'`.

2. **Template version pin:** #835 added `opentelemetry-instrumentation-langchain` to both LangChain template `pyproject.toml` files without a version constraint. Every other third-party dep in these files uses `>= X.Y.Z`. This pins it to `>= 0.59.0` for consistency.

### Files changed

- `src/cli/operations/agent/import/pyproject-generator.ts` — add `opentelemetry-instrumentation-langchain>=0.59.0` to `LANGGRAPH_DEPS`
- `src/cli/operations/agent/import/__tests__/translator.test.ts` — add assertion that the dependency is present in generated LangGraph pyproject
- `src/assets/python/a2a/langchain_langgraph/base/pyproject.toml` — pin `>= 0.59.0`
- `src/assets/python/http/langchain_langgraph/base/pyproject.toml` — pin `>= 0.59.0`
- `src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap` — updated snapshots

## Related Issue

Pre-existing bug in the import flow, discovered during review of #835.

## Type of Change

- [x] Bug fix

## Test plan

- [x] `npx vitest run src/cli/operations/agent/import/__tests__/translator.test.ts` — all 10 tests pass (including new assertion)
- [x] `npx vitest run src/assets/__tests__/assets.snapshot.test.ts` — all 90 snapshot tests pass
- [x] `npm run build` — compiles cleanly
- [x] Pre-commit hooks pass (eslint, prettier, secretlint, typecheck)