### PR TITLE
fix(ci): unpin boto3 in e2e workflow

### DIFF
--- a/.github/workflows/e2e-tests-full.yml
+++ b/.github/workflows/e2e-tests-full.yml
@@ -41,7 +41,7 @@ jobs:
           git config --global user.name "CI"
       - uses: astral-sh/setup-uv@v7
       - name: Install Python dependencies for import tests
-        run: pip install boto3==1.38.0
+        run: pip install boto3
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:


### PR DESCRIPTION
## Summary
- Removes the `boto3==1.38.0` version pin in the full e2e test workflow, replacing it with `pip install boto3` (latest)
- The pinned version did not include the `bedrock-agentcore-control` service model, causing `import-resources.test.ts` to fail with `botocore.exceptions.UnknownServiceError`
- See failed run: https://github.com/aws/agentcore-cli/actions/runs/24415968386

## Test plan
- [ ] Verify the full e2e suite passes with latest boto3 (trigger via workflow_dispatch or push to main)