### PR TITLE
fix: accept AWS_IAM as valid gateway authorizer type in CLI flags

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -276,7 +276,7 @@ agentcore add gateway \
 | `--name <name>`               | Gateway name                                                 |
 | `--description <desc>`        | Gateway description                                          |
 | `--runtimes <names>`          | Comma-separated runtime names to expose through this gateway |
-| `--authorizer-type <type>`    | `NONE` (default) or `CUSTOM_JWT`                             |
+| `--authorizer-type <type>`    | `NONE` (default), `AWS_IAM`, or `CUSTOM_JWT`                 |
 | `--discovery-url <url>`       | OIDC discovery URL (required for CUSTOM_JWT)                 |
 | `--allowed-audience <values>` | Comma-separated allowed audiences (required for CUSTOM_JWT)  |
 | `--allowed-clients <values>`  | Comma-separated allowed client IDs (required for CUSTOM_JWT) |

--- a/src/cli/commands/add/__tests__/validate.test.ts
+++ b/src/cli/commands/add/__tests__/validate.test.ts
@@ -55,6 +55,11 @@ const validGatewayOptionsNone: AddGatewayOptions = {
   authorizerType: 'NONE',
 };
 
+const validGatewayOptionsAwsIam: AddGatewayOptions = {
+  name: 'test-gateway',
+  authorizerType: 'AWS_IAM',
+};
+
 const validGatewayOptionsJwt: AddGatewayOptions = {
   name: 'test-gateway',
   authorizerType: 'CUSTOM_JWT',
@@ -218,6 +223,12 @@ describe('validate', () => {
       expect(result.error?.includes('Invalid authorizer type')).toBeTruthy();
     });
 
+    // AC10b: AWS_IAM is a valid authorizerType
+    it('accepts AWS_IAM as a valid authorizerType', () => {
+      const result = validateAddGatewayOptions(validGatewayOptionsAwsIam);
+      expect(result.valid).toBe(true);
+    });
+
     // AC11: CUSTOM_JWT requires discoveryUrl; at least one of allowedAudience/allowedClients/allowedScopes
     it('returns error for CUSTOM_JWT missing required fields', () => {
       // discoveryUrl is always required
@@ -343,6 +354,7 @@ describe('validate', () => {
     // AC14: Valid options pass
     it('passes for valid options', () => {
       expect(validateAddGatewayOptions(validGatewayOptionsNone)).toEqual({ valid: true });
+      expect(validateAddGatewayOptions(validGatewayOptionsAwsIam)).toEqual({ valid: true });
       expect(validateAddGatewayOptions(validGatewayOptionsJwt)).toEqual({ valid: true });
     });
 

--- a/src/cli/commands/add/validate.ts
+++ b/src/cli/commands/add/validate.ts
@@ -2,6 +2,7 @@ import { ConfigIO, findConfigRoot } from '../../../lib';
 import {
   AgentNameSchema,
   BuildTypeSchema,
+  GatewayAuthorizerTypeSchema,
   GatewayExceptionLevelSchema,
   GatewayNameSchema,
   ModelProviderSchema,
@@ -305,8 +306,11 @@ export function validateAddGatewayOptions(options: AddGatewayOptions): Validatio
     return { valid: false, error: nameResult.error.issues[0]?.message ?? 'Invalid gateway name' };
   }
 
-  if (options.authorizerType && !['NONE', 'CUSTOM_JWT'].includes(options.authorizerType)) {
-    return { valid: false, error: 'Invalid authorizer type. Use NONE or CUSTOM_JWT' };
+  if (options.authorizerType) {
+    const authResult = GatewayAuthorizerTypeSchema.safeParse(options.authorizerType);
+    if (!authResult.success) {
+      return { valid: false, error: 'Invalid authorizer type. Use NONE, AWS_IAM, or CUSTOM_JWT' };
+    }
   }
 
   if (options.authorizerType === 'CUSTOM_JWT') {


### PR DESCRIPTION
## Description

`agentcore add gateway --authorizer-type AWS_IAM` was rejected with "Invalid authorizer type. Use NONE or CUSTOM_JWT", even though the interactive TUI correctly offered AWS_IAM as a selectable option.

**Root cause:** `validateAddGatewayOptions` in `validate.ts` used a hardcoded `['NONE', 'CUSTOM_JWT']` array instead of the Zod schema `GatewayAuthorizerTypeSchema` (which includes `AWS_IAM`). The agent validation already used the schema-based approach — only the gateway validation was out of sync.

**Fix:** Replace the hardcoded array with `GatewayAuthorizerTypeSchema.safeParse()`, matching how agent authorizer validation already works. Also updated `docs/commands.md` to list all three valid values.

## Related Issue

Closes #819

## Documentation PR

N/A — docs updated inline (`docs/commands.md`)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.