### PR TITLE
fix(e2e): use uv run for import test Python scripts

### DIFF
--- a/.github/workflows/e2e-tests-full.yml
+++ b/.github/workflows/e2e-tests-full.yml
@@ -40,8 +40,6 @@ jobs:
           git config --global user.email "ci@amazon.com"
           git config --global user.name "CI"
       - uses: astral-sh/setup-uv@v7
-      - name: Install Python dependencies for import tests
-        run: pip install boto3
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:

--- a/.github/workflows/e2e-tests-full.yml
+++ b/.github/workflows/e2e-tests-full.yml
@@ -41,7 +41,7 @@ jobs:
           git config --global user.name "CI"
       - uses: astral-sh/setup-uv@v7
       - name: Install Python dependencies for import tests
-        run: pip install boto3==1.38.0
+        run: pip install boto3
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:

--- a/e2e-tests/import-resources.test.ts
+++ b/e2e-tests/import-resources.test.ts
@@ -22,7 +22,7 @@ const hasPython =
   hasCommand('python3') &&
   (() => {
     try {
-      execSync('python3 -c "import boto3"', { stdio: 'ignore' });
+      execSync('uv run --with boto3 python3 -c "import boto3"', { stdio: 'ignore' });
       return true;
     } catch {
       return false;
@@ -51,7 +51,7 @@ describe.sequential('e2e: import runtime/memory/evaluator', () => {
     //    Scripts run sequentially because save_resource() does a read-modify-write
     //    on a shared bugbash-resources.json file — parallel runs would race.
     for (const script of ['setup_runtime_basic.py', 'setup_memory_full.py', 'setup_evaluator.py']) {
-      const result = await spawnAndCollect('python3', [script], fixtureDir, {
+      const result = await spawnAndCollect('uv', ['run', '--with', 'boto3', 'python3', script], fixtureDir, {
         AWS_REGION: region,
         DEFAULT_EVALUATOR_MODEL,
       });
@@ -100,7 +100,9 @@ describe.sequential('e2e: import runtime/memory/evaluator', () => {
 
     // 2. Fallback: delete any resources that weren't imported into CFN
     try {
-      await spawnAndCollect('python3', ['cleanup_resources.py'], fixtureDir, { AWS_REGION: region });
+      await spawnAndCollect('uv', ['run', '--with', 'boto3', 'python3', 'cleanup_resources.py'], fixtureDir, {
+        AWS_REGION: region,
+      });
     } catch {
       /* ignore — resources may already be deleted by CFN teardown */
     }


### PR DESCRIPTION
## Summary
- Replaces bare `python3` calls with `uv run --with boto3 python3` in the import e2e tests
- Removes the `pip install boto3` step from the full e2e workflow (no longer needed)
- Root cause: CI runners have an ancient system boto3 at `/usr/lib/python3/dist-packages/` that doesn't include `bedrock-agentcore-control`. `pip install boto3` installs to user site-packages which the spawned `python3` child process ignores. `uv run --with boto3` creates an isolated env with the correct version.
- Supersedes #841 which only unpinned the version but didn't fix the real issue

## Test plan
- [x] Reproduced failure locally: `uv run --with 'boto3==1.38.0' python3 -c "import boto3; boto3.client('bedrock-agentcore-control')"` → `UnknownServiceError`
- [x] Verified fix locally: `uv run --with boto3 python3 -c "import boto3; boto3.client('bedrock-agentcore-control')"` → success
- [x] Full import e2e test suite passes locally (5/5 tests, 366s)
- [ ] Verify full e2e suite passes in CI