### PR TITLE
fix(ci): update snapshots after CDK version sync in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,11 @@ jobs:
           echo "branch=release/v$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "New version: $NEW_VERSION"
 
+      - name: Update snapshots after CDK sync
+        run: |
+          npm run test:update-snapshots
+          echo "✓ Snapshots updated"
+
       - name: Regenerate JSON schema
         run: |
           npm run build


### PR DESCRIPTION
## Summary
- The release workflow syncs `@aws/agentcore-cdk` to the latest npm version in `src/assets/cdk/package.json`, but never updates the corresponding snapshot tests
- This caused the `test-and-build` job to fail with a snapshot mismatch (`0.1.0-alpha.17` in snapshot vs `0.1.0-alpha.18` in the synced file)
- Adds a `npm run test:update-snapshots` step after the CDK sync and version bump, before the release branch commit

## Test plan
- [ ] Trigger the release workflow and verify the `test-and-build` job passes
- [ ] Verify the snapshot update step appears in the workflow logs