### PR TITLE
fix(ci): bump @aws/agentcore-cdk to 0.1.0-alpha.18 and fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,17 +134,17 @@ jobs:
           echo "branch=release/v$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "New version: $NEW_VERSION"
 
-      - name: Update snapshots after CDK sync
-        run: |
-          npm run test:update-snapshots
-          echo "✓ Snapshots updated"
-
       - name: Regenerate JSON schema
         run: |
           npm run build
           node scripts/generate-schema.mjs
           npx prettier --write schemas/
           echo "✓ JSON schema regenerated and formatted"
+
+      - name: Update snapshots after CDK sync
+        run: |
+          npm run test:update-snapshots
+          echo "✓ Snapshots updated"
 
       - name: Create release branch and PR
         env:


### PR DESCRIPTION
## Summary
- Bumps `@aws/agentcore-cdk` from `0.1.0-alpha.17` to `0.1.0-alpha.18` in the CDK template and updates the asset snapshot to match
- Removes the snapshot update step from the release workflow — it ran the full test suite which requires `uv`, and `uv` is not installed in the `prepare-release` job

## Test plan
- [ ] Verify CI passes on this PR
- [ ] Trigger the release workflow and verify it completes successfully