### PR TITLE
fix(ci): bump @aws/agentcore-cdk to 0.1.0-alpha.18 and remove snapshot step from release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,11 +141,6 @@ jobs:
           npx prettier --write schemas/
           echo "✓ JSON schema regenerated and formatted"
 
-      - name: Update snapshots after CDK sync
-        run: |
-          npm run test:update-snapshots
-          echo "✓ Snapshots updated"
-
       - name: Create release branch and PR
         env:
           NEW_VERSION: ${{ steps.bump.outputs.version }}

--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -357,7 +357,7 @@ exports[`Assets Directory Snapshots > CDK assets > cdk/cdk/package.json should m
     "typescript": "~5.9.3"
   },
   "dependencies": {
-    "@aws/agentcore-cdk": "0.1.0-alpha.17",
+    "@aws/agentcore-cdk": "0.1.0-alpha.18",
     "aws-cdk-lib": "^2.248.0",
     "constructs": "^10.0.0"
   }

--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -357,7 +357,7 @@ exports[`Assets Directory Snapshots > CDK assets > cdk/cdk/package.json should m
     "typescript": "~5.9.3"
   },
   "dependencies": {
-    "@aws/agentcore-cdk": "0.1.0-alpha.18",
+    "@aws/agentcore-cdk": "^0.1.0-alpha.18",
     "aws-cdk-lib": "^2.248.0",
     "constructs": "^10.0.0"
   }

--- a/src/assets/cdk/package.json
+++ b/src/assets/cdk/package.json
@@ -23,7 +23,7 @@
     "typescript": "~5.9.3"
   },
   "dependencies": {
-    "@aws/agentcore-cdk": "0.1.0-alpha.17",
+    "@aws/agentcore-cdk": "0.1.0-alpha.18",
     "aws-cdk-lib": "^2.248.0",
     "constructs": "^10.0.0"
   }

--- a/src/assets/cdk/package.json
+++ b/src/assets/cdk/package.json
@@ -23,7 +23,7 @@
     "typescript": "~5.9.3"
   },
   "dependencies": {
-    "@aws/agentcore-cdk": "0.1.0-alpha.18",
+    "@aws/agentcore-cdk": "^0.1.0-alpha.18",
     "aws-cdk-lib": "^2.248.0",
     "constructs": "^10.0.0"
   }


### PR DESCRIPTION
## Summary
- Bumps `@aws/agentcore-cdk` from `0.1.0-alpha.17` to `0.1.0-alpha.18` in the CDK template and updates the asset snapshot to match
- Removes the snapshot update step from the release workflow — `npm run test:update-snapshots` runs the full test suite which requires `uv`, and `uv` is not installed in the `prepare-release` job

## Test plan
- [ ] Verify CI passes on this PR
- [ ] Trigger the release workflow and verify it completes successfully