### PR TITLE
fix: pin @aws/agentcore-cdk to exact version in CDK template

### DIFF
--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -357,7 +357,7 @@ exports[`Assets Directory Snapshots > CDK assets > cdk/cdk/package.json should m
     "typescript": "~5.9.3"
   },
   "dependencies": {
-    "@aws/agentcore-cdk": "^0.1.0-alpha.18",
+    "@aws/agentcore-cdk": "0.1.0-alpha.18",
     "aws-cdk-lib": "^2.248.0",
     "constructs": "^10.0.0"
   }

--- a/src/assets/cdk/package.json
+++ b/src/assets/cdk/package.json
@@ -23,7 +23,7 @@
     "typescript": "~5.9.3"
   },
   "dependencies": {
-    "@aws/agentcore-cdk": "^0.1.0-alpha.18",
+    "@aws/agentcore-cdk": "0.1.0-alpha.18",
     "aws-cdk-lib": "^2.248.0",
     "constructs": "^10.0.0"
   }


### PR DESCRIPTION
## Summary
- Reverts caret range back to exact pinning (`0.1.0-alpha.18`) for `@aws/agentcore-cdk` in the CDK template
- The release workflow handles syncing to the latest version at release time

## Test plan
- [ ] Verify CI passes