### PR TITLE
docs: document executionRoleArn in runtime spec

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -191,6 +191,7 @@ on the next deployment.
 | `authorizerConfiguration` | No       | JWT authorizer settings (for `CUSTOM_JWT`)                      |
 | `requestHeaderAllowlist`  | No       | Headers to forward to the agent                                 |
 | `lifecycleConfiguration`  | No       | Runtime session lifecycle settings (idle timeout, max lifetime) |
+| `executionRoleArn`        | No       | ARN of an existing IAM execution role (skips CDK-managed role)  |
 | `tags`                    | No       | Agent-level tags                                                |
 
 ### Runtime Versions


### PR DESCRIPTION
## Summary

- Adds the existing optional `executionRoleArn` field to the Agent Specification table in `docs/configuration.md`.
- Fixes the documentation gap reported in #870, where users could not discover that the CLI supports bringing their own IAM execution role (the field is already wired through the schema at `src/schema/schemas/agent-env.ts:207`).

## Test plan

- [x] Field confirmed present and optional in the runtime schema
- [x] `prettier --check` and `tsc --noEmit` pass via pre-commit hooks