### PR TITLE
test: update asset snapshot for @aws/agentcore-cdk 0.1.0-alpha.19

### DIFF
--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -357,7 +357,7 @@ exports[`Assets Directory Snapshots > CDK assets > cdk/cdk/package.json should m
     "typescript": "~5.9.3"
   },
   "dependencies": {
-    "@aws/agentcore-cdk": "0.1.0-alpha.18",
+    "@aws/agentcore-cdk": "0.1.0-alpha.19",
     "aws-cdk-lib": "^2.248.0",
     "constructs": "^10.0.0"
   }


### PR DESCRIPTION
## Summary
- Regenerates the CDK `package.json` asset snapshot via `npm run test:update-snapshots`.
- Picks up the `@aws/agentcore-cdk` version pin (`0.1.0-alpha.18` → `0.1.0-alpha.19`) that landed in #852 but wasn't reflected in the snapshot.
- No changes to the vended template itself — this is a snapshot-only catch-up.

## Test plan
- [x] `npm run test:update-snapshots` — `1 updated`, diff scoped to the expected version bump
- [x] `git diff` reviewed: single-line change in `src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap`
- [x] Pre-commit typecheck passed