### PR TITLE
ci: auto-update asset snapshots during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,9 @@ jobs:
             fi
           fi
 
+      - name: Update asset snapshots
+        run: npx vitest run --project unit --update -t "Assets Directory Snapshots"
+
       - name: Get current version
         id: current
         run: |

--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -357,7 +357,7 @@ exports[`Assets Directory Snapshots > CDK assets > cdk/cdk/package.json should m
     "typescript": "~5.9.3"
   },
   "dependencies": {
-    "@aws/agentcore-cdk": "0.1.0-alpha.18",
+    "@aws/agentcore-cdk": "0.1.0-alpha.19",
     "aws-cdk-lib": "^2.248.0",
     "constructs": "^10.0.0"
   }


### PR DESCRIPTION
## Summary
- Adds a step to `.github/workflows/release.yml` that regenerates the CDK asset snapshot right after the existing `@aws/agentcore-cdk` version sync.
- Any version drift in `src/assets/cdk/package.json` is now captured in the same release commit — the existing `git add -A` on line 162 picks it up automatically.
- Scoped to the `Assets Directory Snapshots` describe block via `-t` so only the one snapshot file that can drift from a CDK version bump runs. ~35s instead of a full ~65s unit-test run, and not blocked by unrelated tests that require `dist/cli/index.mjs`.

## Context
Follow-up to #852 (CDK version pin bump) and #875 (manual snapshot regen). The release workflow bumps `@aws/agentcore-cdk` in the vended template on every release but never refreshed the snapshot, so contributors had to catch the drift after the fact.

## Test plan
- [x] Ran `npx vitest run --project unit --update -t "Assets Directory Snapshots"` locally — exit 0, `Test Files: 1 passed | 229 skipped`, 90 tests passed
- [x] Verified the step is placed before `git add -A` so regenerated snapshot files are included in the release commit
- [x] Pre-commit typecheck + prettier + secretlint passed