### PR TITLE
revert: roll back version bump to 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.8.2] - 2026-04-16
-
-### Added
-- feat: upgrade default Python runtime to PYTHON_3_14 (#837) (b139c05)
-
 ## [0.8.1] - 2026-04-14
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/agentcore",
-  "version": "0.8.2",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/agentcore",
-      "version": "0.8.2",
+      "version": "0.8.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws/agentcore",
-  "version": "0.8.2",
+  "version": "0.8.1",
   "description": "CLI for Amazon Bedrock AgentCore",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary
Reverts the version and changelog portions of #874 so the release workflow can be re-run cleanly.

## Files changed
- `package.json` — 0.8.2 → 0.8.1
- `package-lock.json` — 0.8.2 → 0.8.1
- `CHANGELOG.md` — remove 0.8.2 section

## Intentionally not reverted
- `schemas/agentcore.schema.v1.json` — next release run regenerates this
- `src/assets/cdk/package.json` — next release run bumps the CDK pin

## Test plan
- [x] Pre-commit typecheck + prettier + secretlint passed on `0.8.1`
- [ ] Merge, then re-run the Release workflow