### PR TITLE
fix: use caret range for @aws/agentcore-cdk in CDK template

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,32 +62,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Sync @aws/agentcore-cdk to latest npm version
-        run: |
-          echo "Fetching latest @aws/agentcore-cdk version from npm..."
-          LATEST_CDK=$(npm view @aws/agentcore-cdk version 2>/dev/null || echo "")
-
-          if [ -z "$LATEST_CDK" ]; then
-            echo "⚠️  Could not fetch @aws/agentcore-cdk version from npm. Skipping sync."
-          else
-            TEMPLATE_PKG="src/assets/cdk/package.json"
-            CURRENT_CDK=$(node -p "require('./$TEMPLATE_PKG').dependencies['@aws/agentcore-cdk']")
-            echo "Current pinned version: $CURRENT_CDK"
-            echo "Latest npm version:     $LATEST_CDK"
-
-            if [ "$CURRENT_CDK" != "$LATEST_CDK" ]; then
-              node -e "
-                const fs = require('fs');
-                const pkg = JSON.parse(fs.readFileSync('$TEMPLATE_PKG', 'utf8'));
-                pkg.dependencies['@aws/agentcore-cdk'] = '$LATEST_CDK';
-                fs.writeFileSync('$TEMPLATE_PKG', JSON.stringify(pkg, null, 2) + '\n');
-              "
-              echo "✅ Updated @aws/agentcore-cdk: $CURRENT_CDK -> $LATEST_CDK"
-            else
-              echo "✅ @aws/agentcore-cdk already at latest ($LATEST_CDK)"
-            fi
-          fi
-
       - name: Get current version
         id: current
         run: |

--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -357,7 +357,7 @@ exports[`Assets Directory Snapshots > CDK assets > cdk/cdk/package.json should m
     "typescript": "~5.9.3"
   },
   "dependencies": {
-    "@aws/agentcore-cdk": "0.1.0-alpha.19",
+    "@aws/agentcore-cdk": "^0.1.0-alpha.19",
     "aws-cdk-lib": "^2.248.0",
     "constructs": "^10.0.0"
   }

--- a/src/assets/cdk/package.json
+++ b/src/assets/cdk/package.json
@@ -23,7 +23,7 @@
     "typescript": "~5.9.3"
   },
   "dependencies": {
-    "@aws/agentcore-cdk": "0.1.0-alpha.19",
+    "@aws/agentcore-cdk": "^0.1.0-alpha.19",
     "aws-cdk-lib": "^2.248.0",
     "constructs": "^10.0.0"
   }


### PR DESCRIPTION
## Summary
- Use `^` (caret) range for `@aws/agentcore-cdk` in the vended CDK template so users always get the latest compatible constructs on `npm install`
- Remove the now-redundant "Sync @aws/agentcore-cdk to latest npm version" step from the release workflow
- Update snapshot to match

## Test plan
- [x] Snapshot tests pass (90/90)
- [x] Pre-commit hooks pass (prettier, secretlint, typecheck)