### PR TITLE
feat: add session filesystem storage support

### DIFF
--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -968,7 +968,8 @@ Thumbs.db
 `;
 
 exports[`Assets Directory Snapshots > Python framework assets > python/python/a2a/googleadk/base/main.py should match snapshot 1`] = `
-"from google.adk.agents import Agent
+"import os
+from google.adk.agents import Agent
 from google.adk.a2a.executor.a2a_agent_executor import A2aAgentExecutor
 from google.adk.runners import Runner
 from google.adk.sessions import InMemorySessionService
@@ -982,12 +983,71 @@ def add_numbers(a: int, b: int) -> int:
     return a + b
 
 
+tools = [add_numbers]
+
+{{#if sessionStorageMountPath}}
+SESSION_STORAGE_PATH = "{{sessionStorageMountPath}}"
+
+def _safe_resolve(path: str) -> str:
+    """Resolve path safely within the storage boundary."""
+    resolved = os.path.realpath(os.path.join(SESSION_STORAGE_PATH, path.lstrip("/")))
+    if not resolved.startswith(os.path.realpath(SESSION_STORAGE_PATH)):
+        raise ValueError(f"Path '{path}' is outside the storage boundary")
+    return resolved
+
+def file_read(path: str) -> str:
+    """Read a file from persistent storage. The path is relative to the storage root."""
+    try:
+        full_path = _safe_resolve(path)
+        with open(full_path) as f:
+            return f.read()
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error reading '{path}': {e.strerror}"
+
+def file_write(path: str, content: str) -> str:
+    """Write content to a file in persistent storage. The path is relative to the storage root."""
+    try:
+        full_path = _safe_resolve(path)
+        parent = os.path.dirname(full_path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with open(full_path, "w") as f:
+            f.write(content)
+        return f"Written to {path}"
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error writing '{path}': {e.strerror}"
+
+def list_files(directory: str = "") -> str:
+    """List files in persistent storage. The directory is relative to the storage root."""
+    try:
+        target = _safe_resolve(directory)
+        entries = os.listdir(target)
+        return "\\n".join(entries) if entries else "(empty directory)"
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error listing '{directory}': {e.strerror}"
+
+tools.extend([file_read, file_write, list_files])
+{{/if}}
+
+AGENT_INSTRUCTION = """
+You are a helpful assistant. Use tools when appropriate.
+{{#if sessionStorageMountPath}}
+You have persistent storage at {{sessionStorageMountPath}}. Use file tools to read and write files. Data persists across sessions.
+{{/if}}
+"""
+
 agent = Agent(
     model=load_model(),
     name="{{ name }}",
     description="A helpful assistant that can use tools.",
-    instruction="You are a helpful assistant. Use tools when appropriate.",
-    tools=[add_numbers],
+    instruction=AGENT_INSTRUCTION,
+    tools=tools,
 )
 
 runner = Runner(
@@ -1165,7 +1225,8 @@ Thumbs.db
 `;
 
 exports[`Assets Directory Snapshots > Python framework assets > python/python/a2a/langchain_langgraph/base/main.py should match snapshot 1`] = `
-"from langchain_core.tools import tool
+"import os
+from langchain_core.tools import tool
 from langgraph.prebuilt import create_react_agent
 from opentelemetry.instrumentation.langchain import LangchainInstrumentor
 from a2a.server.agent_execution import AgentExecutor, RequestContext
@@ -1185,8 +1246,70 @@ def add_numbers(a: int, b: int) -> int:
     return a + b
 
 
+tools = [add_numbers]
+
+{{#if sessionStorageMountPath}}
+SESSION_STORAGE_PATH = "{{sessionStorageMountPath}}"
+
+def _safe_resolve(path: str) -> str:
+    """Resolve path safely within the storage boundary."""
+    resolved = os.path.realpath(os.path.join(SESSION_STORAGE_PATH, path.lstrip("/")))
+    if not resolved.startswith(os.path.realpath(SESSION_STORAGE_PATH)):
+        raise ValueError(f"Path '{path}' is outside the storage boundary")
+    return resolved
+
+@tool
+def file_read(path: str) -> str:
+    """Read a file from persistent storage. The path is relative to the storage root."""
+    try:
+        full_path = _safe_resolve(path)
+        with open(full_path) as f:
+            return f.read()
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error reading '{path}': {e.strerror}"
+
+@tool
+def file_write(path: str, content: str) -> str:
+    """Write content to a file in persistent storage. The path is relative to the storage root."""
+    try:
+        full_path = _safe_resolve(path)
+        parent = os.path.dirname(full_path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with open(full_path, "w") as f:
+            f.write(content)
+        return f"Written to {path}"
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error writing '{path}': {e.strerror}"
+
+@tool
+def list_files(directory: str = "") -> str:
+    """List files in persistent storage. The directory is relative to the storage root."""
+    try:
+        target = _safe_resolve(directory)
+        entries = os.listdir(target)
+        return "\\n".join(entries) if entries else "(empty directory)"
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error listing '{directory}': {e.strerror}"
+
+tools.extend([file_read, file_write, list_files])
+{{/if}}
+
+SYSTEM_PROMPT = """
+You are a helpful assistant. Use tools when appropriate.
+{{#if sessionStorageMountPath}}
+You have persistent storage at {{sessionStorageMountPath}}. Use file tools to read and write files. Data persists across sessions.
+{{/if}}
+"""
+
 model = load_model()
-graph = create_react_agent(model, tools=[add_numbers])
+graph = create_react_agent(model, tools=tools, prompt=SYSTEM_PROMPT)
 
 
 class LangGraphA2AExecutor(AgentExecutor):
@@ -1475,6 +1598,9 @@ from model.load import load_model
 {{#if hasMemory}}
 from memory.session import get_memory_session_manager
 {{/if}}
+{{#if sessionStorageMountPath}}
+import os
+{{/if}}
 
 
 @tool
@@ -1485,6 +1611,66 @@ def add_numbers(a: int, b: int) -> int:
 
 tools = [add_numbers]
 
+{{#if sessionStorageMountPath}}
+SESSION_STORAGE_PATH = "{{sessionStorageMountPath}}"
+
+def _safe_resolve(path: str) -> str:
+    """Resolve path safely within the storage boundary."""
+    resolved = os.path.realpath(os.path.join(SESSION_STORAGE_PATH, path.lstrip("/")))
+    if not resolved.startswith(os.path.realpath(SESSION_STORAGE_PATH)):
+        raise ValueError(f"Path '{path}' is outside the storage boundary")
+    return resolved
+
+@tool
+def file_read(path: str) -> str:
+    """Read a file from persistent storage. The path is relative to the storage root."""
+    try:
+        full_path = _safe_resolve(path)
+        with open(full_path) as f:
+            return f.read()
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error reading '{path}': {e.strerror}"
+
+@tool
+def file_write(path: str, content: str) -> str:
+    """Write content to a file in persistent storage. The path is relative to the storage root."""
+    try:
+        full_path = _safe_resolve(path)
+        parent = os.path.dirname(full_path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with open(full_path, "w") as f:
+            f.write(content)
+        return f"Written to {path}"
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error writing '{path}': {e.strerror}"
+
+@tool
+def list_files(directory: str = "") -> str:
+    """List files in persistent storage. The directory is relative to the storage root."""
+    try:
+        target = _safe_resolve(directory)
+        entries = os.listdir(target)
+        return "\\n".join(entries) if entries else "(empty directory)"
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error listing '{directory}': {e.strerror}"
+
+tools.extend([file_read, file_write, list_files])
+{{/if}}
+
+SYSTEM_PROMPT = """
+You are a helpful assistant. Use tools when appropriate.
+{{#if sessionStorageMountPath}}
+You have persistent storage at {{sessionStorageMountPath}}. Use file tools to read and write files. Data persists across sessions.
+{{/if}}
+"""
+
 {{#if hasMemory}}
 def agent_factory():
     cache = {}
@@ -1494,7 +1680,7 @@ def agent_factory():
             cache[key] = Agent(
                 model=load_model(),
                 session_manager=get_memory_session_manager(session_id, user_id),
-                system_prompt="You are a helpful assistant. Use tools when appropriate.",
+                system_prompt=SYSTEM_PROMPT,
                 tools=tools,
             )
         return cache[key]
@@ -1505,7 +1691,7 @@ agent = get_or_create_agent("default-session", "default-user")
 {{else}}
 agent = Agent(
     model=load_model(),
-    system_prompt="You are a helpful assistant. Use tools when appropriate.",
+    system_prompt=SYSTEM_PROMPT,
     tools=tools,
 )
 {{/if}}
@@ -1834,6 +2020,66 @@ add_numbers_tool = FunctionTool(
 # Define a collection of tools used by the model
 tools = [add_numbers_tool]
 
+{{#if sessionStorageMountPath}}
+SESSION_STORAGE_PATH = "{{sessionStorageMountPath}}"
+
+def _safe_resolve(path: str) -> str:
+    """Resolve path safely within the storage boundary."""
+    resolved = os.path.realpath(os.path.join(SESSION_STORAGE_PATH, path.lstrip("/")))
+    if not resolved.startswith(os.path.realpath(SESSION_STORAGE_PATH)):
+        raise ValueError(f"Path '{path}' is outside the storage boundary")
+    return resolved
+
+def file_read(path: str) -> str:
+    """Read a file from persistent storage. The path is relative to the storage root."""
+    try:
+        full_path = _safe_resolve(path)
+        with open(full_path) as f:
+            return f.read()
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error reading '{path}': {e.strerror}"
+
+def file_write(path: str, content: str) -> str:
+    """Write content to a file in persistent storage. The path is relative to the storage root."""
+    try:
+        full_path = _safe_resolve(path)
+        parent = os.path.dirname(full_path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with open(full_path, "w") as f:
+            f.write(content)
+        return f"Written to {path}"
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error writing '{path}': {e.strerror}"
+
+def list_files(directory: str = "") -> str:
+    """List files in persistent storage. The directory is relative to the storage root."""
+    try:
+        target = _safe_resolve(directory)
+        entries = os.listdir(target)
+        return "\\n".join(entries) if entries else "(empty directory)"
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error listing '{directory}': {e.strerror}"
+
+tools.extend([
+    FunctionTool(file_read, description="Read a file from persistent storage. The path is relative to the storage root."),
+    FunctionTool(file_write, description="Write content to a file in persistent storage. The path is relative to the storage root."),
+    FunctionTool(list_files, description="List files in persistent storage. The directory is relative to the storage root."),
+])
+{{/if}}
+
+SYSTEM_MESSAGE = """
+You are a helpful assistant. Use tools when appropriate.
+{{#if sessionStorageMountPath}}
+You have persistent storage at {{sessionStorageMountPath}}. Use file tools to read and write files. Data persists across sessions.
+{{/if}}
+"""
 
 @app.entrypoint
 async def invoke(payload, context):
@@ -1847,7 +2093,7 @@ async def invoke(payload, context):
         name="{{ name }}",
         model_client=load_model(),
         tools=tools + mcp_tools,
-        system_message="You are a helpful assistant. Use tools when appropriate.",
+        system_message=SYSTEM_MESSAGE,
     )
 
     # Process the user prompt
@@ -2202,6 +2448,66 @@ def add_numbers(a: int, b: int) -> int:
     return a + b
 
 
+# Define a collection of tools used by the model
+tools = [add_numbers]
+
+{{#if sessionStorageMountPath}}
+SESSION_STORAGE_PATH = "{{sessionStorageMountPath}}"
+
+def _safe_resolve(path: str) -> str:
+    """Resolve path safely within the storage boundary."""
+    resolved = os.path.realpath(os.path.join(SESSION_STORAGE_PATH, path.lstrip("/")))
+    if not resolved.startswith(os.path.realpath(SESSION_STORAGE_PATH)):
+        raise ValueError(f"Path '{path}' is outside the storage boundary")
+    return resolved
+
+def file_read(path: str) -> str:
+    """Read a file from persistent storage. The path is relative to the storage root."""
+    try:
+        full_path = _safe_resolve(path)
+        with open(full_path) as f:
+            return f.read()
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error reading '{path}': {e.strerror}"
+
+def file_write(path: str, content: str) -> str:
+    """Write content to a file in persistent storage. The path is relative to the storage root."""
+    try:
+        full_path = _safe_resolve(path)
+        parent = os.path.dirname(full_path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with open(full_path, "w") as f:
+            f.write(content)
+        return f"Written to {path}"
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error writing '{path}': {e.strerror}"
+
+def list_files(directory: str = "") -> str:
+    """List files in persistent storage. The directory is relative to the storage root."""
+    try:
+        target = _safe_resolve(directory)
+        entries = os.listdir(target)
+        return "\\n".join(entries) if entries else "(empty directory)"
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error listing '{directory}': {e.strerror}"
+
+tools.extend([file_read, file_write, list_files])
+{{/if}}
+
+AGENT_INSTRUCTION = """
+I can answer your questions using the knowledge I have!
+{{#if sessionStorageMountPath}}
+You have persistent storage at {{sessionStorageMountPath}}. Use file tools to read and write files. Data persists across sessions.
+{{/if}}
+"""
+
 # Get MCP Toolset
 {{#if hasGateway}}
 mcp_toolset = get_all_gateway_mcp_toolsets()
@@ -2224,8 +2530,8 @@ agent = Agent(
     model=MODEL_ID,
     name="{{ name }}",
     description="Agent to answer questions",
-    instruction="I can answer your questions using the knowledge I have!",
-    tools=mcp_toolset + [add_numbers],
+    instruction=AGENT_INSTRUCTION,
+    tools=mcp_toolset + tools,
 )
 
 
@@ -2563,6 +2869,66 @@ def add_numbers(a: int, b: int) -> int:
 # Define a collection of tools used by the model
 tools = [add_numbers]
 
+{{#if sessionStorageMountPath}}
+SESSION_STORAGE_PATH = "{{sessionStorageMountPath}}"
+
+def _safe_resolve(path: str) -> str:
+    """Resolve path safely within the storage boundary."""
+    resolved = os.path.realpath(os.path.join(SESSION_STORAGE_PATH, path.lstrip("/")))
+    if not resolved.startswith(os.path.realpath(SESSION_STORAGE_PATH)):
+        raise ValueError(f"Path '{path}' is outside the storage boundary")
+    return resolved
+
+@tool
+def file_read(path: str) -> str:
+    """Read a file from persistent storage. The path is relative to the storage root."""
+    try:
+        full_path = _safe_resolve(path)
+        with open(full_path) as f:
+            return f.read()
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error reading '{path}': {e.strerror}"
+
+@tool
+def file_write(path: str, content: str) -> str:
+    """Write content to a file in persistent storage. The path is relative to the storage root."""
+    try:
+        full_path = _safe_resolve(path)
+        parent = os.path.dirname(full_path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with open(full_path, "w") as f:
+            f.write(content)
+        return f"Written to {path}"
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error writing '{path}': {e.strerror}"
+
+@tool
+def list_files(directory: str = "") -> str:
+    """List files in persistent storage. The directory is relative to the storage root."""
+    try:
+        target = _safe_resolve(directory)
+        entries = os.listdir(target)
+        return "\\n".join(entries) if entries else "(empty directory)"
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error listing '{directory}': {e.strerror}"
+
+tools.extend([file_read, file_write, list_files])
+{{/if}}
+
+SYSTEM_PROMPT = """
+You are a helpful assistant. Use tools when appropriate.
+{{#if sessionStorageMountPath}}
+You have persistent storage at {{sessionStorageMountPath}}. Use file tools to read and write files. Data persists across sessions.
+{{/if}}
+"""
+
 
 @app.entrypoint
 async def invoke(payload, context):
@@ -2581,7 +2947,7 @@ async def invoke(payload, context):
         mcp_tools = await mcp_client.get_tools()
 
     # Define the agent using create_react_agent
-    graph = create_react_agent(get_or_create_model(), tools=mcp_tools + tools)
+    graph = create_react_agent(get_or_create_model(), tools=mcp_tools + tools, prompt=SYSTEM_PROMPT)
 
     # Process the user prompt
     prompt = payload.get("prompt", "What can you help me with?")
@@ -2986,6 +3352,68 @@ def add_numbers(a: int, b: int) -> int:
     return a + b
 
 
+tools = [add_numbers]
+
+{{#if sessionStorageMountPath}}
+SESSION_STORAGE_PATH = "{{sessionStorageMountPath}}"
+
+def _safe_resolve(path: str) -> str:
+    """Resolve path safely within the storage boundary."""
+    resolved = os.path.realpath(os.path.join(SESSION_STORAGE_PATH, path.lstrip("/")))
+    if not resolved.startswith(os.path.realpath(SESSION_STORAGE_PATH)):
+        raise ValueError(f"Path '{path}' is outside the storage boundary")
+    return resolved
+
+@function_tool
+def file_read(path: str) -> str:
+    """Read a file from persistent storage. The path is relative to the storage root."""
+    try:
+        full_path = _safe_resolve(path)
+        with open(full_path) as f:
+            return f.read()
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error reading '{path}': {e.strerror}"
+
+@function_tool
+def file_write(path: str, content: str) -> str:
+    """Write content to a file in persistent storage. The path is relative to the storage root."""
+    try:
+        full_path = _safe_resolve(path)
+        parent = os.path.dirname(full_path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with open(full_path, "w") as f:
+            f.write(content)
+        return f"Written to {path}"
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error writing '{path}': {e.strerror}"
+
+@function_tool
+def list_files(directory: str = "") -> str:
+    """List files in persistent storage. The directory is relative to the storage root."""
+    try:
+        target = _safe_resolve(directory)
+        entries = os.listdir(target)
+        return "\\n".join(entries) if entries else "(empty directory)"
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error listing '{directory}': {e.strerror}"
+
+tools.extend([file_read, file_write, list_files])
+{{/if}}
+
+INSTRUCTIONS = """
+You are a helpful assistant. Use tools when appropriate.
+{{#if sessionStorageMountPath}}
+You have persistent storage at {{sessionStorageMountPath}}. Use file tools to read and write files. Data persists across sessions.
+{{/if}}
+"""
+
 # Define the agent execution
 async def main(query):
     ensure_credentials_loaded()
@@ -2995,8 +3423,9 @@ async def main(query):
             agent = Agent(
                 name="{{ name }}",
                 model="gpt-4.1",
+                instructions=INSTRUCTIONS,
                 mcp_servers=mcp_servers,
-                tools=[add_numbers]
+                tools=tools
             )
             result = await Runner.run(agent, query)
             return result
@@ -3004,8 +3433,9 @@ async def main(query):
             agent = Agent(
                 name="{{ name }}",
                 model="gpt-4.1",
+                instructions=INSTRUCTIONS,
                 mcp_servers=[],
-                tools=[add_numbers]
+                tools=tools
             )
             result = await Runner.run(agent, query)
             return result
@@ -3016,8 +3446,9 @@ async def main(query):
                 agent = Agent(
                     name="{{ name }}",
                     model="gpt-4.1",
+                    instructions=INSTRUCTIONS,
                     mcp_servers=active_servers,
-                    tools=[add_numbers]
+                    tools=tools
                 )
                 result = await Runner.run(agent, query)
                 return result
@@ -3025,8 +3456,9 @@ async def main(query):
             agent = Agent(
                 name="{{ name }}",
                 model="gpt-4.1",
+                instructions=INSTRUCTIONS,
                 mcp_servers=[],
-                tools=[add_numbers]
+                tools=tools
             )
             result = await Runner.run(agent, query)
             return result
@@ -3308,6 +3740,9 @@ from mcp_client.client import get_streamable_http_mcp_client
 {{#if hasMemory}}
 from memory.session import get_memory_session_manager
 {{/if}}
+{{#if sessionStorageMountPath}}
+import os
+{{/if}}
 
 app = BedrockAgentCoreApp()
 log = app.logger
@@ -3329,11 +3764,70 @@ def add_numbers(a: int, b: int) -> int:
     return a+b
 tools.append(add_numbers)
 
+{{#if sessionStorageMountPath}}
+SESSION_STORAGE_PATH = "{{sessionStorageMountPath}}"
+
+def _safe_resolve(path: str) -> str:
+    """Resolve path safely within the storage boundary."""
+    resolved = os.path.realpath(os.path.join(SESSION_STORAGE_PATH, path.lstrip("/")))
+    if not resolved.startswith(os.path.realpath(SESSION_STORAGE_PATH)):
+        raise ValueError(f"Path '{path}' is outside the storage boundary")
+    return resolved
+
+@tool
+def file_read(path: str) -> str:
+    """Read a file from persistent storage. The path is relative to the storage root."""
+    try:
+        full_path = _safe_resolve(path)
+        with open(full_path) as f:
+            return f.read()
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error reading '{path}': {e.strerror}"
+
+@tool
+def file_write(path: str, content: str) -> str:
+    """Write content to a file in persistent storage. The path is relative to the storage root."""
+    try:
+        full_path = _safe_resolve(path)
+        parent = os.path.dirname(full_path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with open(full_path, "w") as f:
+            f.write(content)
+        return f"Written to {path}"
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error writing '{path}': {e.strerror}"
+
+@tool
+def list_files(directory: str = "") -> str:
+    """List files in persistent storage. The directory is relative to the storage root."""
+    try:
+        target = _safe_resolve(directory)
+        entries = os.listdir(target)
+        return "\\n".join(entries) if entries else "(empty directory)"
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error listing '{directory}': {e.strerror}"
+
+tools.extend([file_read, file_write, list_files])
+{{/if}}
+
 # Add MCP client to tools if available
 for mcp_client in mcp_clients:
     if mcp_client:
         tools.append(mcp_client)
 
+SYSTEM_PROMPT = """
+You are a helpful assistant. Use tools when appropriate.
+{{#if sessionStorageMountPath}}
+You have persistent storage at {{sessionStorageMountPath}}. Use file tools to read and write files. Data persists across sessions.
+{{/if}}
+"""
 
 {{#if hasMemory}}
 def agent_factory():
@@ -3345,9 +3839,7 @@ def agent_factory():
             cache[key] = Agent(
                 model=load_model(),
                 session_manager=get_memory_session_manager(session_id, user_id),
-                system_prompt="""
-                    You are a helpful assistant. Use tools when appropriate.
-                """,
+                system_prompt=SYSTEM_PROMPT,
                 tools=tools
             )
         return cache[key]
@@ -3361,9 +3853,7 @@ def get_or_create_agent():
     if _agent is None:
         _agent = Agent(
             model=load_model(),
-            system_prompt="""
-                You are a helpful assistant. Use tools when appropriate.
-            """,
+            system_prompt=SYSTEM_PROMPT,
             tools=tools
         )
     return _agent

--- a/src/assets/python/a2a/googleadk/base/main.py
+++ b/src/assets/python/a2a/googleadk/base/main.py
@@ -1,3 +1,4 @@
+import os
 from google.adk.agents import Agent
 from google.adk.a2a.executor.a2a_agent_executor import A2aAgentExecutor
 from google.adk.runners import Runner
@@ -12,12 +13,71 @@ def add_numbers(a: int, b: int) -> int:
     return a + b
 
 
+tools = [add_numbers]
+
+{{#if sessionStorageMountPath}}
+SESSION_STORAGE_PATH = "{{sessionStorageMountPath}}"
+
+def _safe_resolve(path: str) -> str:
+    """Resolve path safely within the storage boundary."""
+    resolved = os.path.realpath(os.path.join(SESSION_STORAGE_PATH, path.lstrip("/")))
+    if not resolved.startswith(os.path.realpath(SESSION_STORAGE_PATH)):
+        raise ValueError(f"Path '{path}' is outside the storage boundary")
+    return resolved
+
+def file_read(path: str) -> str:
+    """Read a file from persistent storage. The path is relative to the storage root."""
+    try:
+        full_path = _safe_resolve(path)
+        with open(full_path) as f:
+            return f.read()
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error reading '{path}': {e.strerror}"
+
+def file_write(path: str, content: str) -> str:
+    """Write content to a file in persistent storage. The path is relative to the storage root."""
+    try:
+        full_path = _safe_resolve(path)
+        parent = os.path.dirname(full_path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with open(full_path, "w") as f:
+            f.write(content)
+        return f"Written to {path}"
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error writing '{path}': {e.strerror}"
+
+def list_files(directory: str = "") -> str:
+    """List files in persistent storage. The directory is relative to the storage root."""
+    try:
+        target = _safe_resolve(directory)
+        entries = os.listdir(target)
+        return "\n".join(entries) if entries else "(empty directory)"
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error listing '{directory}': {e.strerror}"
+
+tools.extend([file_read, file_write, list_files])
+{{/if}}
+
+AGENT_INSTRUCTION = """
+You are a helpful assistant. Use tools when appropriate.
+{{#if sessionStorageMountPath}}
+You have persistent storage at {{sessionStorageMountPath}}. Use file tools to read and write files. Data persists across sessions.
+{{/if}}
+"""
+
 agent = Agent(
     model=load_model(),
     name="{{ name }}",
     description="A helpful assistant that can use tools.",
-    instruction="You are a helpful assistant. Use tools when appropriate.",
-    tools=[add_numbers],
+    instruction=AGENT_INSTRUCTION,
+    tools=tools,
 )
 
 runner = Runner(

--- a/src/assets/python/a2a/langchain_langgraph/base/main.py
+++ b/src/assets/python/a2a/langchain_langgraph/base/main.py
@@ -1,3 +1,4 @@
+import os
 from langchain_core.tools import tool
 from langgraph.prebuilt import create_react_agent
 from opentelemetry.instrumentation.langchain import LangchainInstrumentor
@@ -18,8 +19,70 @@ def add_numbers(a: int, b: int) -> int:
     return a + b
 
 
+tools = [add_numbers]
+
+{{#if sessionStorageMountPath}}
+SESSION_STORAGE_PATH = "{{sessionStorageMountPath}}"
+
+def _safe_resolve(path: str) -> str:
+    """Resolve path safely within the storage boundary."""
+    resolved = os.path.realpath(os.path.join(SESSION_STORAGE_PATH, path.lstrip("/")))
+    if not resolved.startswith(os.path.realpath(SESSION_STORAGE_PATH)):
+        raise ValueError(f"Path '{path}' is outside the storage boundary")
+    return resolved
+
+@tool
+def file_read(path: str) -> str:
+    """Read a file from persistent storage. The path is relative to the storage root."""
+    try:
+        full_path = _safe_resolve(path)
+        with open(full_path) as f:
+            return f.read()
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error reading '{path}': {e.strerror}"
+
+@tool
+def file_write(path: str, content: str) -> str:
+    """Write content to a file in persistent storage. The path is relative to the storage root."""
+    try:
+        full_path = _safe_resolve(path)
+        parent = os.path.dirname(full_path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with open(full_path, "w") as f:
+            f.write(content)
+        return f"Written to {path}"
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error writing '{path}': {e.strerror}"
+
+@tool
+def list_files(directory: str = "") -> str:
+    """List files in persistent storage. The directory is relative to the storage root."""
+    try:
+        target = _safe_resolve(directory)
+        entries = os.listdir(target)
+        return "\n".join(entries) if entries else "(empty directory)"
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error listing '{directory}': {e.strerror}"
+
+tools.extend([file_read, file_write, list_files])
+{{/if}}
+
+SYSTEM_PROMPT = """
+You are a helpful assistant. Use tools when appropriate.
+{{#if sessionStorageMountPath}}
+You have persistent storage at {{sessionStorageMountPath}}. Use file tools to read and write files. Data persists across sessions.
+{{/if}}
+"""
+
 model = load_model()
-graph = create_react_agent(model, tools=[add_numbers])
+graph = create_react_agent(model, tools=tools, prompt=SYSTEM_PROMPT)
 
 
 class LangGraphA2AExecutor(AgentExecutor):

--- a/src/assets/python/a2a/strands/base/main.py
+++ b/src/assets/python/a2a/strands/base/main.py
@@ -5,6 +5,9 @@ from model.load import load_model
 {{#if hasMemory}}
 from memory.session import get_memory_session_manager
 {{/if}}
+{{#if sessionStorageMountPath}}
+import os
+{{/if}}
 
 
 @tool
@@ -15,6 +18,66 @@ def add_numbers(a: int, b: int) -> int:
 
 tools = [add_numbers]
 
+{{#if sessionStorageMountPath}}
+SESSION_STORAGE_PATH = "{{sessionStorageMountPath}}"
+
+def _safe_resolve(path: str) -> str:
+    """Resolve path safely within the storage boundary."""
+    resolved = os.path.realpath(os.path.join(SESSION_STORAGE_PATH, path.lstrip("/")))
+    if not resolved.startswith(os.path.realpath(SESSION_STORAGE_PATH)):
+        raise ValueError(f"Path '{path}' is outside the storage boundary")
+    return resolved
+
+@tool
+def file_read(path: str) -> str:
+    """Read a file from persistent storage. The path is relative to the storage root."""
+    try:
+        full_path = _safe_resolve(path)
+        with open(full_path) as f:
+            return f.read()
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error reading '{path}': {e.strerror}"
+
+@tool
+def file_write(path: str, content: str) -> str:
+    """Write content to a file in persistent storage. The path is relative to the storage root."""
+    try:
+        full_path = _safe_resolve(path)
+        parent = os.path.dirname(full_path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with open(full_path, "w") as f:
+            f.write(content)
+        return f"Written to {path}"
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error writing '{path}': {e.strerror}"
+
+@tool
+def list_files(directory: str = "") -> str:
+    """List files in persistent storage. The directory is relative to the storage root."""
+    try:
+        target = _safe_resolve(directory)
+        entries = os.listdir(target)
+        return "\n".join(entries) if entries else "(empty directory)"
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error listing '{directory}': {e.strerror}"
+
+tools.extend([file_read, file_write, list_files])
+{{/if}}
+
+SYSTEM_PROMPT = """
+You are a helpful assistant. Use tools when appropriate.
+{{#if sessionStorageMountPath}}
+You have persistent storage at {{sessionStorageMountPath}}. Use file tools to read and write files. Data persists across sessions.
+{{/if}}
+"""
+
 {{#if hasMemory}}
 def agent_factory():
     cache = {}
@@ -24,7 +87,7 @@ def agent_factory():
             cache[key] = Agent(
                 model=load_model(),
                 session_manager=get_memory_session_manager(session_id, user_id),
-                system_prompt="You are a helpful assistant. Use tools when appropriate.",
+                system_prompt=SYSTEM_PROMPT,
                 tools=tools,
             )
         return cache[key]
@@ -35,7 +98,7 @@ agent = get_or_create_agent("default-session", "default-user")
 {{else}}
 agent = Agent(
     model=load_model(),
-    system_prompt="You are a helpful assistant. Use tools when appropriate.",
+    system_prompt=SYSTEM_PROMPT,
     tools=tools,
 )
 {{/if}}

--- a/src/assets/python/http/autogen/base/main.py
+++ b/src/assets/python/http/autogen/base/main.py
@@ -22,6 +22,66 @@ add_numbers_tool = FunctionTool(
 # Define a collection of tools used by the model
 tools = [add_numbers_tool]
 
+{{#if sessionStorageMountPath}}
+SESSION_STORAGE_PATH = "{{sessionStorageMountPath}}"
+
+def _safe_resolve(path: str) -> str:
+    """Resolve path safely within the storage boundary."""
+    resolved = os.path.realpath(os.path.join(SESSION_STORAGE_PATH, path.lstrip("/")))
+    if not resolved.startswith(os.path.realpath(SESSION_STORAGE_PATH)):
+        raise ValueError(f"Path '{path}' is outside the storage boundary")
+    return resolved
+
+def file_read(path: str) -> str:
+    """Read a file from persistent storage. The path is relative to the storage root."""
+    try:
+        full_path = _safe_resolve(path)
+        with open(full_path) as f:
+            return f.read()
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error reading '{path}': {e.strerror}"
+
+def file_write(path: str, content: str) -> str:
+    """Write content to a file in persistent storage. The path is relative to the storage root."""
+    try:
+        full_path = _safe_resolve(path)
+        parent = os.path.dirname(full_path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with open(full_path, "w") as f:
+            f.write(content)
+        return f"Written to {path}"
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error writing '{path}': {e.strerror}"
+
+def list_files(directory: str = "") -> str:
+    """List files in persistent storage. The directory is relative to the storage root."""
+    try:
+        target = _safe_resolve(directory)
+        entries = os.listdir(target)
+        return "\n".join(entries) if entries else "(empty directory)"
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error listing '{directory}': {e.strerror}"
+
+tools.extend([
+    FunctionTool(file_read, description="Read a file from persistent storage. The path is relative to the storage root."),
+    FunctionTool(file_write, description="Write content to a file in persistent storage. The path is relative to the storage root."),
+    FunctionTool(list_files, description="List files in persistent storage. The directory is relative to the storage root."),
+])
+{{/if}}
+
+SYSTEM_MESSAGE = """
+You are a helpful assistant. Use tools when appropriate.
+{{#if sessionStorageMountPath}}
+You have persistent storage at {{sessionStorageMountPath}}. Use file tools to read and write files. Data persists across sessions.
+{{/if}}
+"""
 
 @app.entrypoint
 async def invoke(payload, context):
@@ -35,7 +95,7 @@ async def invoke(payload, context):
         name="{{ name }}",
         model_client=load_model(),
         tools=tools + mcp_tools,
-        system_message="You are a helpful assistant. Use tools when appropriate.",
+        system_message=SYSTEM_MESSAGE,
     )
 
     # Process the user prompt

--- a/src/assets/python/http/googleadk/base/main.py
+++ b/src/assets/python/http/googleadk/base/main.py
@@ -26,6 +26,66 @@ def add_numbers(a: int, b: int) -> int:
     return a + b
 
 
+# Define a collection of tools used by the model
+tools = [add_numbers]
+
+{{#if sessionStorageMountPath}}
+SESSION_STORAGE_PATH = "{{sessionStorageMountPath}}"
+
+def _safe_resolve(path: str) -> str:
+    """Resolve path safely within the storage boundary."""
+    resolved = os.path.realpath(os.path.join(SESSION_STORAGE_PATH, path.lstrip("/")))
+    if not resolved.startswith(os.path.realpath(SESSION_STORAGE_PATH)):
+        raise ValueError(f"Path '{path}' is outside the storage boundary")
+    return resolved
+
+def file_read(path: str) -> str:
+    """Read a file from persistent storage. The path is relative to the storage root."""
+    try:
+        full_path = _safe_resolve(path)
+        with open(full_path) as f:
+            return f.read()
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error reading '{path}': {e.strerror}"
+
+def file_write(path: str, content: str) -> str:
+    """Write content to a file in persistent storage. The path is relative to the storage root."""
+    try:
+        full_path = _safe_resolve(path)
+        parent = os.path.dirname(full_path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with open(full_path, "w") as f:
+            f.write(content)
+        return f"Written to {path}"
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error writing '{path}': {e.strerror}"
+
+def list_files(directory: str = "") -> str:
+    """List files in persistent storage. The directory is relative to the storage root."""
+    try:
+        target = _safe_resolve(directory)
+        entries = os.listdir(target)
+        return "\n".join(entries) if entries else "(empty directory)"
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error listing '{directory}': {e.strerror}"
+
+tools.extend([file_read, file_write, list_files])
+{{/if}}
+
+AGENT_INSTRUCTION = """
+I can answer your questions using the knowledge I have!
+{{#if sessionStorageMountPath}}
+You have persistent storage at {{sessionStorageMountPath}}. Use file tools to read and write files. Data persists across sessions.
+{{/if}}
+"""
+
 # Get MCP Toolset
 {{#if hasGateway}}
 mcp_toolset = get_all_gateway_mcp_toolsets()
@@ -48,8 +108,8 @@ agent = Agent(
     model=MODEL_ID,
     name="{{ name }}",
     description="Agent to answer questions",
-    instruction="I can answer your questions using the knowledge I have!",
-    tools=mcp_toolset + [add_numbers],
+    instruction=AGENT_INSTRUCTION,
+    tools=mcp_toolset + tools,
 )
 
 

--- a/src/assets/python/http/langchain_langgraph/base/main.py
+++ b/src/assets/python/http/langchain_langgraph/base/main.py
@@ -35,6 +35,66 @@ def add_numbers(a: int, b: int) -> int:
 # Define a collection of tools used by the model
 tools = [add_numbers]
 
+{{#if sessionStorageMountPath}}
+SESSION_STORAGE_PATH = "{{sessionStorageMountPath}}"
+
+def _safe_resolve(path: str) -> str:
+    """Resolve path safely within the storage boundary."""
+    resolved = os.path.realpath(os.path.join(SESSION_STORAGE_PATH, path.lstrip("/")))
+    if not resolved.startswith(os.path.realpath(SESSION_STORAGE_PATH)):
+        raise ValueError(f"Path '{path}' is outside the storage boundary")
+    return resolved
+
+@tool
+def file_read(path: str) -> str:
+    """Read a file from persistent storage. The path is relative to the storage root."""
+    try:
+        full_path = _safe_resolve(path)
+        with open(full_path) as f:
+            return f.read()
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error reading '{path}': {e.strerror}"
+
+@tool
+def file_write(path: str, content: str) -> str:
+    """Write content to a file in persistent storage. The path is relative to the storage root."""
+    try:
+        full_path = _safe_resolve(path)
+        parent = os.path.dirname(full_path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with open(full_path, "w") as f:
+            f.write(content)
+        return f"Written to {path}"
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error writing '{path}': {e.strerror}"
+
+@tool
+def list_files(directory: str = "") -> str:
+    """List files in persistent storage. The directory is relative to the storage root."""
+    try:
+        target = _safe_resolve(directory)
+        entries = os.listdir(target)
+        return "\n".join(entries) if entries else "(empty directory)"
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error listing '{directory}': {e.strerror}"
+
+tools.extend([file_read, file_write, list_files])
+{{/if}}
+
+SYSTEM_PROMPT = """
+You are a helpful assistant. Use tools when appropriate.
+{{#if sessionStorageMountPath}}
+You have persistent storage at {{sessionStorageMountPath}}. Use file tools to read and write files. Data persists across sessions.
+{{/if}}
+"""
+
 
 @app.entrypoint
 async def invoke(payload, context):
@@ -53,7 +113,7 @@ async def invoke(payload, context):
         mcp_tools = await mcp_client.get_tools()
 
     # Define the agent using create_react_agent
-    graph = create_react_agent(get_or_create_model(), tools=mcp_tools + tools)
+    graph = create_react_agent(get_or_create_model(), tools=mcp_tools + tools, prompt=SYSTEM_PROMPT)
 
     # Process the user prompt
     prompt = payload.get("prompt", "What can you help me with?")

--- a/src/assets/python/http/openaiagents/base/main.py
+++ b/src/assets/python/http/openaiagents/base/main.py
@@ -35,6 +35,68 @@ def add_numbers(a: int, b: int) -> int:
     return a + b
 
 
+tools = [add_numbers]
+
+{{#if sessionStorageMountPath}}
+SESSION_STORAGE_PATH = "{{sessionStorageMountPath}}"
+
+def _safe_resolve(path: str) -> str:
+    """Resolve path safely within the storage boundary."""
+    resolved = os.path.realpath(os.path.join(SESSION_STORAGE_PATH, path.lstrip("/")))
+    if not resolved.startswith(os.path.realpath(SESSION_STORAGE_PATH)):
+        raise ValueError(f"Path '{path}' is outside the storage boundary")
+    return resolved
+
+@function_tool
+def file_read(path: str) -> str:
+    """Read a file from persistent storage. The path is relative to the storage root."""
+    try:
+        full_path = _safe_resolve(path)
+        with open(full_path) as f:
+            return f.read()
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error reading '{path}': {e.strerror}"
+
+@function_tool
+def file_write(path: str, content: str) -> str:
+    """Write content to a file in persistent storage. The path is relative to the storage root."""
+    try:
+        full_path = _safe_resolve(path)
+        parent = os.path.dirname(full_path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with open(full_path, "w") as f:
+            f.write(content)
+        return f"Written to {path}"
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error writing '{path}': {e.strerror}"
+
+@function_tool
+def list_files(directory: str = "") -> str:
+    """List files in persistent storage. The directory is relative to the storage root."""
+    try:
+        target = _safe_resolve(directory)
+        entries = os.listdir(target)
+        return "\n".join(entries) if entries else "(empty directory)"
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error listing '{directory}': {e.strerror}"
+
+tools.extend([file_read, file_write, list_files])
+{{/if}}
+
+INSTRUCTIONS = """
+You are a helpful assistant. Use tools when appropriate.
+{{#if sessionStorageMountPath}}
+You have persistent storage at {{sessionStorageMountPath}}. Use file tools to read and write files. Data persists across sessions.
+{{/if}}
+"""
+
 # Define the agent execution
 async def main(query):
     ensure_credentials_loaded()
@@ -44,8 +106,9 @@ async def main(query):
             agent = Agent(
                 name="{{ name }}",
                 model="gpt-4.1",
+                instructions=INSTRUCTIONS,
                 mcp_servers=mcp_servers,
-                tools=[add_numbers]
+                tools=tools
             )
             result = await Runner.run(agent, query)
             return result
@@ -53,8 +116,9 @@ async def main(query):
             agent = Agent(
                 name="{{ name }}",
                 model="gpt-4.1",
+                instructions=INSTRUCTIONS,
                 mcp_servers=[],
-                tools=[add_numbers]
+                tools=tools
             )
             result = await Runner.run(agent, query)
             return result
@@ -65,8 +129,9 @@ async def main(query):
                 agent = Agent(
                     name="{{ name }}",
                     model="gpt-4.1",
+                    instructions=INSTRUCTIONS,
                     mcp_servers=active_servers,
-                    tools=[add_numbers]
+                    tools=tools
                 )
                 result = await Runner.run(agent, query)
                 return result
@@ -74,8 +139,9 @@ async def main(query):
             agent = Agent(
                 name="{{ name }}",
                 model="gpt-4.1",
+                instructions=INSTRUCTIONS,
                 mcp_servers=[],
-                tools=[add_numbers]
+                tools=tools
             )
             result = await Runner.run(agent, query)
             return result

--- a/src/assets/python/http/strands/base/main.py
+++ b/src/assets/python/http/strands/base/main.py
@@ -9,6 +9,9 @@ from mcp_client.client import get_streamable_http_mcp_client
 {{#if hasMemory}}
 from memory.session import get_memory_session_manager
 {{/if}}
+{{#if sessionStorageMountPath}}
+import os
+{{/if}}
 
 app = BedrockAgentCoreApp()
 log = app.logger
@@ -30,11 +33,70 @@ def add_numbers(a: int, b: int) -> int:
     return a+b
 tools.append(add_numbers)
 
+{{#if sessionStorageMountPath}}
+SESSION_STORAGE_PATH = "{{sessionStorageMountPath}}"
+
+def _safe_resolve(path: str) -> str:
+    """Resolve path safely within the storage boundary."""
+    resolved = os.path.realpath(os.path.join(SESSION_STORAGE_PATH, path.lstrip("/")))
+    if not resolved.startswith(os.path.realpath(SESSION_STORAGE_PATH)):
+        raise ValueError(f"Path '{path}' is outside the storage boundary")
+    return resolved
+
+@tool
+def file_read(path: str) -> str:
+    """Read a file from persistent storage. The path is relative to the storage root."""
+    try:
+        full_path = _safe_resolve(path)
+        with open(full_path) as f:
+            return f.read()
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error reading '{path}': {e.strerror}"
+
+@tool
+def file_write(path: str, content: str) -> str:
+    """Write content to a file in persistent storage. The path is relative to the storage root."""
+    try:
+        full_path = _safe_resolve(path)
+        parent = os.path.dirname(full_path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with open(full_path, "w") as f:
+            f.write(content)
+        return f"Written to {path}"
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error writing '{path}': {e.strerror}"
+
+@tool
+def list_files(directory: str = "") -> str:
+    """List files in persistent storage. The directory is relative to the storage root."""
+    try:
+        target = _safe_resolve(directory)
+        entries = os.listdir(target)
+        return "\n".join(entries) if entries else "(empty directory)"
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error listing '{directory}': {e.strerror}"
+
+tools.extend([file_read, file_write, list_files])
+{{/if}}
+
 # Add MCP client to tools if available
 for mcp_client in mcp_clients:
     if mcp_client:
         tools.append(mcp_client)
 
+SYSTEM_PROMPT = """
+You are a helpful assistant. Use tools when appropriate.
+{{#if sessionStorageMountPath}}
+You have persistent storage at {{sessionStorageMountPath}}. Use file tools to read and write files. Data persists across sessions.
+{{/if}}
+"""
 
 {{#if hasMemory}}
 def agent_factory():
@@ -46,9 +108,7 @@ def agent_factory():
             cache[key] = Agent(
                 model=load_model(),
                 session_manager=get_memory_session_manager(session_id, user_id),
-                system_prompt="""
-                    You are a helpful assistant. Use tools when appropriate.
-                """,
+                system_prompt=SYSTEM_PROMPT,
                 tools=tools
             )
         return cache[key]
@@ -62,9 +122,7 @@ def get_or_create_agent():
     if _agent is None:
         _agent = Agent(
             model=load_model(),
-            system_prompt="""
-                You are a helpful assistant. Use tools when appropriate.
-            """,
+            system_prompt=SYSTEM_PROMPT,
             tools=tools
         )
     return _agent

--- a/src/cli/aws/agentcore.ts
+++ b/src/cli/aws/agentcore.ts
@@ -858,6 +858,7 @@ export interface A2AInvokeOptions {
   region: string;
   runtimeArn: string;
   userId?: string;
+  sessionId?: string;
   logger?: SSELogger;
   /** Custom headers to forward to the agent runtime */
   headers?: Record<string, string>;
@@ -893,6 +894,7 @@ export async function invokeA2ARuntime(options: A2AInvokeOptions, message: strin
     contentType: 'application/json',
     accept: 'application/json, text/event-stream',
     runtimeUserId: options.userId ?? DEFAULT_RUNTIME_USER_ID,
+    ...(options.sessionId && { runtimeSessionId: options.sessionId }),
   });
 
   const response = await client.send(command);

--- a/src/cli/commands/add/__tests__/validate.test.ts
+++ b/src/cli/commands/add/__tests__/validate.test.ts
@@ -1526,3 +1526,48 @@ describe('validateAddAgentOptions - lifecycle configuration', () => {
     expect(result.error).toContain('--idle-timeout');
   });
 });
+
+describe('validateAddAgentOptions - session storage mount path', () => {
+  const baseOptions: AddAgentOptions = {
+    name: 'TestAgent',
+    type: 'byo',
+    language: 'Python',
+    framework: 'Strands',
+    modelProvider: 'Bedrock',
+    build: 'CodeZip',
+    codeLocation: './app/test/',
+  };
+
+  it('accepts valid mount path', () => {
+    const result = validateAddAgentOptions({ ...baseOptions, sessionStorageMountPath: '/mnt/data' });
+    expect(result.valid).toBe(true);
+  });
+
+  it('accepts mount path with hyphenated subdirectory', () => {
+    const result = validateAddAgentOptions({ ...baseOptions, sessionStorageMountPath: '/mnt/my-storage' });
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects path not under /mnt', () => {
+    const result = validateAddAgentOptions({ ...baseOptions, sessionStorageMountPath: '/data/storage' });
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('--session-storage-mount-path');
+  });
+
+  it('rejects path with more than one subdirectory level', () => {
+    const result = validateAddAgentOptions({ ...baseOptions, sessionStorageMountPath: '/mnt/data/subdir' });
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('--session-storage-mount-path');
+  });
+
+  it('rejects bare /mnt with no subdirectory', () => {
+    const result = validateAddAgentOptions({ ...baseOptions, sessionStorageMountPath: '/mnt/' });
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('--session-storage-mount-path');
+  });
+
+  it('accepts omitted mount path', () => {
+    const result = validateAddAgentOptions({ ...baseOptions });
+    expect(result.valid).toBe(true);
+  });
+});

--- a/src/cli/commands/add/types.ts
+++ b/src/cli/commands/add/types.ts
@@ -36,6 +36,7 @@ export interface AddAgentOptions extends VpcOptions {
   requestHeaderAllowlist?: string;
   idleTimeout?: number | string;
   maxLifetime?: number | string;
+  sessionStorageMountPath?: string;
   json?: boolean;
 }
 

--- a/src/cli/commands/add/validate.ts
+++ b/src/cli/commands/add/validate.ts
@@ -9,6 +9,7 @@ import {
   ProtocolModeSchema,
   RuntimeAuthorizerTypeSchema,
   SDKFrameworkSchema,
+  SessionStorageSchema,
   StreamDeliveryResourcesSchema,
   TARGET_TYPE_AUTH_CONFIG,
   TargetLanguageSchema,
@@ -267,6 +268,14 @@ export function validateAddAgentOptions(options: AddAgentOptions): ValidationRes
   if (!lifecycleResult.valid) return lifecycleResult;
   if (lifecycleResult.idleTimeout !== undefined) options.idleTimeout = lifecycleResult.idleTimeout;
   if (lifecycleResult.maxLifetime !== undefined) options.maxLifetime = lifecycleResult.maxLifetime;
+
+  // Validate session storage mount path
+  if (options.sessionStorageMountPath) {
+    const mountPathResult = SessionStorageSchema.shape.mountPath.safeParse(options.sessionStorageMountPath);
+    if (!mountPathResult.success) {
+      return { valid: false, error: `--session-storage-mount-path: ${mountPathResult.error.issues[0]?.message}` };
+    }
+  }
 
   // Validate VPC options
   const vpcResult = validateVpcOptions(options);

--- a/src/cli/commands/create/__tests__/validate.test.ts
+++ b/src/cli/commands/create/__tests__/validate.test.ts
@@ -342,3 +342,48 @@ describe('validateCreateOptions - lifecycle configuration', () => {
     expect(result.valid).toBe(true);
   });
 });
+
+describe('validateCreateOptions - session storage mount path', () => {
+  const cwd = join(tmpdir(), `create-session-storage-${randomUUID()}`);
+
+  const baseOptions = {
+    name: 'TestProject',
+    language: 'Python',
+    framework: 'Strands',
+    modelProvider: 'Bedrock',
+    memory: 'none',
+  };
+
+  it('accepts valid mount path', () => {
+    const result = validateCreateOptions({ ...baseOptions, sessionStorageMountPath: '/mnt/data' }, cwd);
+    expect(result.valid).toBe(true);
+  });
+
+  it('accepts mount path with hyphenated subdirectory', () => {
+    const result = validateCreateOptions({ ...baseOptions, sessionStorageMountPath: '/mnt/my-storage' }, cwd);
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects path not under /mnt', () => {
+    const result = validateCreateOptions({ ...baseOptions, sessionStorageMountPath: '/data/storage' }, cwd);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('--session-storage-mount-path');
+  });
+
+  it('rejects path with more than one subdirectory level', () => {
+    const result = validateCreateOptions({ ...baseOptions, sessionStorageMountPath: '/mnt/data/subdir' }, cwd);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('--session-storage-mount-path');
+  });
+
+  it('rejects bare /mnt with no subdirectory', () => {
+    const result = validateCreateOptions({ ...baseOptions, sessionStorageMountPath: '/mnt/' }, cwd);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('--session-storage-mount-path');
+  });
+
+  it('accepts omitted mount path', () => {
+    const result = validateCreateOptions({ ...baseOptions }, cwd);
+    expect(result.valid).toBe(true);
+  });
+});

--- a/src/cli/commands/create/action.ts
+++ b/src/cli/commands/create/action.ts
@@ -129,6 +129,7 @@ export interface CreateWithAgentOptions {
   region?: string;
   idleTimeout?: number;
   maxLifetime?: number;
+  sessionStorageMountPath?: string;
   skipGit?: boolean;
   skipInstall?: boolean;
   skipPythonSetup?: boolean;
@@ -152,6 +153,7 @@ export async function createProjectWithAgent(options: CreateWithAgentOptions): P
     requestHeaderAllowlist,
     idleTimeout,
     maxLifetime: maxLifetimeOpt,
+    sessionStorageMountPath,
     skipGit,
     skipInstall,
     skipPythonSetup,
@@ -232,6 +234,7 @@ export async function createProjectWithAgent(options: CreateWithAgentOptions): P
       requestHeaderAllowlist,
       ...(idleTimeout !== undefined && { idleRuntimeSessionTimeout: idleTimeout }),
       ...(maxLifetimeOpt !== undefined && { maxLifetime: maxLifetimeOpt }),
+      ...(sessionStorageMountPath && { sessionStorageMountPath }),
     };
 
     // Resolve credential strategy FIRST (new project has no existing credentials)

--- a/src/cli/commands/create/command.tsx
+++ b/src/cli/commands/create/command.tsx
@@ -145,6 +145,7 @@ async function handleCreateCLI(options: CreateOptions): Promise<void> {
         securityGroups: parseCommaSeparatedList(options.securityGroups),
         idleTimeout: options.idleTimeout ? Number(options.idleTimeout) : undefined,
         maxLifetime: options.maxLifetime ? Number(options.maxLifetime) : undefined,
+        sessionStorageMountPath: options.sessionStorageMountPath,
         skipGit: options.skipGit,
         skipInstall: options.skipInstall,
         skipPythonSetup: options.skipPythonSetup,
@@ -198,6 +199,10 @@ export const registerCreate = (program: Command) => {
     .option(
       '--max-lifetime <seconds>',
       `Max instance lifetime in seconds (${LIFECYCLE_TIMEOUT_MIN}-${LIFECYCLE_TIMEOUT_MAX}) [non-interactive]`
+    )
+    .option(
+      '--session-storage-mount-path <path>',
+      'Absolute mount path for session filesystem storage under /mnt (e.g. /mnt/data) [non-interactive]'
     )
     .option('--output-dir <dir>', 'Output directory (default: current directory) [non-interactive]')
     .option('--skip-git', 'Skip git repository initialization [non-interactive]')

--- a/src/cli/commands/create/types.ts
+++ b/src/cli/commands/create/types.ts
@@ -17,6 +17,7 @@ export interface CreateOptions extends VpcOptions {
   region?: string;
   idleTimeout?: number | string;
   maxLifetime?: number | string;
+  sessionStorageMountPath?: string;
   outputDir?: string;
   skipGit?: boolean;
   skipPythonSetup?: boolean;

--- a/src/cli/commands/create/validate.ts
+++ b/src/cli/commands/create/validate.ts
@@ -4,6 +4,7 @@ import {
   ProjectNameSchema,
   ProtocolModeSchema,
   SDKFrameworkSchema,
+  SessionStorageSchema,
   TargetLanguageSchema,
   getSupportedFrameworksForProtocol,
   getSupportedModelProviders,
@@ -206,6 +207,14 @@ export function validateCreateOptions(options: CreateOptions, cwd?: string): Val
   if (!lifecycleResult.valid) return lifecycleResult;
   if (lifecycleResult.idleTimeout !== undefined) options.idleTimeout = lifecycleResult.idleTimeout;
   if (lifecycleResult.maxLifetime !== undefined) options.maxLifetime = lifecycleResult.maxLifetime;
+
+  // Validate session storage mount path
+  if (options.sessionStorageMountPath) {
+    const mountPathResult = SessionStorageSchema.shape.mountPath.safeParse(options.sessionStorageMountPath);
+    if (!mountPathResult.success) {
+      return { valid: false, error: `--session-storage-mount-path: ${mountPathResult.error.issues[0]?.message}` };
+    }
+  }
 
   return { valid: true };
 }

--- a/src/cli/commands/invoke/action.ts
+++ b/src/cli/commands/invoke/action.ts
@@ -294,6 +294,7 @@ export async function handleInvoke(context: InvokeContext, options: InvokeOption
           region: targetConfig.region,
           runtimeArn: agentState.runtimeArn,
           userId: options.userId,
+          sessionId: options.sessionId,
           headers: options.headers,
         },
         options.prompt

--- a/src/cli/operations/agent/generate/schema-mapper.ts
+++ b/src/cli/operations/agent/generate/schema-mapper.ts
@@ -147,6 +147,9 @@ export function mapGenerateConfigToAgent(config: GenerateConfig): AgentEnvSpec {
           },
         }
       : {}),
+    ...(config.sessionStorageMountPath && {
+      filesystemConfigurations: [{ sessionStorage: { mountPath: config.sessionStorageMountPath } }],
+    }),
     // MCP uses mcp.run() which is incompatible with the opentelemetry-instrument wrapper
     ...(protocol === 'MCP' && { instrumentation: { enableOtel: false } }),
   };
@@ -278,5 +281,6 @@ export async function mapGenerateConfigToRenderConfig(
     gatewayAuthTypes: [...new Set(gatewayProviders.map(g => g.authType))],
     protocol: config.protocol,
     dockerfile: config.dockerfile,
+    sessionStorageMountPath: config.sessionStorageMountPath,
   };
 }

--- a/src/cli/operations/agent/import/index.ts
+++ b/src/cli/operations/agent/import/index.ts
@@ -31,6 +31,7 @@ export interface ExecuteImportAgentParams {
   jwtConfig?: JwtConfigOptions;
   idleTimeout?: number;
   maxLifetime?: number;
+  sessionStorageMountPath?: string;
 }
 
 export async function executeImportAgent(
@@ -48,6 +49,7 @@ export async function executeImportAgent(
     jwtConfig,
     idleTimeout,
     maxLifetime,
+    sessionStorageMountPath,
   } = params;
   const projectRoot = dirname(configBaseDir);
   const agentPath = join(projectRoot, APP_DIR, name);
@@ -98,6 +100,7 @@ export async function executeImportAgent(
       jwtConfig,
       idleRuntimeSessionTimeout: idleTimeout,
       maxLifetime,
+      sessionStorageMountPath,
     };
     await writeAgentToProject(generateConfig, { configBaseDir });
 

--- a/src/cli/primitives/AgentPrimitive.tsx
+++ b/src/cli/primitives/AgentPrimitive.tsx
@@ -74,6 +74,7 @@ export interface AddAgentOptions extends VpcOptions {
   clientSecret?: string;
   idleTimeout?: number;
   maxLifetime?: number;
+  sessionStorageMountPath?: string;
 }
 
 /**
@@ -247,6 +248,10 @@ export class AgentPrimitive extends BasePrimitive<AddAgentOptions, RemovableReso
         '--max-lifetime <seconds>',
         `Max instance lifetime in seconds (${LIFECYCLE_TIMEOUT_MIN}-${LIFECYCLE_TIMEOUT_MAX}) [non-interactive]`
       )
+      .option(
+        '--session-storage-mount-path <path>',
+        'Absolute mount path for session filesystem storage (e.g. /mnt/session-storage) [non-interactive]'
+      )
       .option('--json', 'Output as JSON [non-interactive]')
       .action(async options => {
         if (!findConfigRoot()) {
@@ -307,6 +312,7 @@ export class AgentPrimitive extends BasePrimitive<AddAgentOptions, RemovableReso
             clientSecret: cliOptions.clientSecret,
             idleTimeout: cliOptions.idleTimeout ? Number(cliOptions.idleTimeout) : undefined,
             maxLifetime: cliOptions.maxLifetime ? Number(cliOptions.maxLifetime) : undefined,
+            sessionStorageMountPath: cliOptions.sessionStorageMountPath,
           });
 
           if (cliOptions.json) {
@@ -402,6 +408,7 @@ export class AgentPrimitive extends BasePrimitive<AddAgentOptions, RemovableReso
       requestHeaderAllowlist: options.requestHeaderAllowlist,
       idleRuntimeSessionTimeout: options.idleTimeout,
       maxLifetime: options.maxLifetime,
+      sessionStorageMountPath: options.sessionStorageMountPath,
     };
 
     const agentPath = join(projectRoot, APP_DIR, options.name);
@@ -472,6 +479,7 @@ export class AgentPrimitive extends BasePrimitive<AddAgentOptions, RemovableReso
       configBaseDir,
       idleTimeout: options.idleTimeout,
       maxLifetime: options.maxLifetime,
+      sessionStorageMountPath: options.sessionStorageMountPath,
     });
   }
 
@@ -548,6 +556,9 @@ export class AgentPrimitive extends BasePrimitive<AddAgentOptions, RemovableReso
       ...(authorizerType && { authorizerType }),
       ...(authorizerConfiguration && { authorizerConfiguration }),
       ...(lifecycleConfiguration && { lifecycleConfiguration }),
+      ...(options.sessionStorageMountPath && {
+        filesystemConfigurations: [{ sessionStorage: { mountPath: options.sessionStorageMountPath } }],
+      }),
     };
 
     project.runtimes.push(agent);

--- a/src/cli/templates/types.ts
+++ b/src/cli/templates/types.ts
@@ -68,4 +68,6 @@ export interface AgentRenderConfig {
   protocol?: ProtocolMode;
   /** Custom Dockerfile name — when set, the template Dockerfile is not scaffolded */
   dockerfile?: string;
+  /** Session storage mount path — when set, file read/write tools are included */
+  sessionStorageMountPath?: string;
 }

--- a/src/cli/tui/screens/agent/AddAgentScreen.tsx
+++ b/src/cli/tui/screens/agent/AddAgentScreen.tsx
@@ -86,6 +86,7 @@ type ByoStep =
   | 'jwtConfig'
   | 'idleTimeout'
   | 'maxLifetime'
+  | 'sessionStorageMountPath'
   | 'confirm';
 
 const INITIAL_STEPS: InitialStep[] = ['name', 'agentType'];
@@ -126,6 +127,9 @@ export function computeByoSteps(input: ComputeByoStepsInput): ByoStep[] {
     }
     if (input.advancedSettings.has('lifecycle')) {
       subSteps.push('idleTimeout', 'maxLifetime');
+    }
+    if (input.advancedSettings.has('filesystem')) {
+      subSteps.push('sessionStorageMountPath');
     }
     steps = [...steps.slice(0, afterAdvanced), ...subSteps, ...steps.slice(afterAdvanced)];
   }
@@ -180,6 +184,7 @@ export function AddAgentScreen({ existingAgentNames, onComplete, onExit }: AddAg
     requestHeaderAllowlist: '' as string,
     idleTimeout: '' as string,
     maxLifetime: '' as string,
+    sessionStorageMountPath: '' as string,
   });
   const [byoAdvancedSettings, setByoAdvancedSettings] = useState<Set<AdvancedSettingId>>(new Set());
   const [byoAuthorizerType, setByoAuthorizerType] = useState<RuntimeAuthorizerType>('AWS_IAM');
@@ -305,6 +310,7 @@ export function AddAgentScreen({ existingAgentNames, onComplete, onExit }: AddAg
         }),
       idleRuntimeSessionTimeout: generateWizard.config.idleRuntimeSessionTimeout,
       maxLifetime: generateWizard.config.maxLifetime,
+      sessionStorageMountPath: generateWizard.config.sessionStorageMountPath,
       pythonVersion: DEFAULT_PYTHON_VERSION,
       memory: generateWizard.config.memory,
     };
@@ -426,6 +432,7 @@ export function AddAgentScreen({ existingAgentNames, onComplete, onExit }: AddAg
       ...(byoAuthorizerType === 'CUSTOM_JWT' && byoJwtConfig && { jwtConfig: byoJwtConfig }),
       ...(byoConfig.idleTimeout && { idleRuntimeSessionTimeout: Number(byoConfig.idleTimeout) }),
       ...(byoConfig.maxLifetime && { maxLifetime: Number(byoConfig.maxLifetime) }),
+      ...(byoConfig.sessionStorageMountPath && { sessionStorageMountPath: byoConfig.sessionStorageMountPath }),
       pythonVersion: DEFAULT_PYTHON_VERSION,
       memory: 'none',
     };
@@ -486,6 +493,7 @@ export function AddAgentScreen({ existingAgentNames, onComplete, onExit }: AddAg
           requestHeaderAllowlist: '',
           idleTimeout: '',
           maxLifetime: '',
+          sessionStorageMountPath: '',
         }));
         setByoAuthorizerType('AWS_IAM');
         setByoJwtConfig(undefined);
@@ -503,6 +511,8 @@ export function AddAgentScreen({ existingAgentNames, onComplete, onExit }: AddAg
             setByoStep('authorizerType');
           } else if (selected.has('lifecycle')) {
             setByoStep('idleTimeout');
+          } else if (selected.has('filesystem')) {
+            setByoStep('sessionStorageMountPath');
           } else {
             setByoStep('confirm');
           }
@@ -810,7 +820,8 @@ export function AddAgentScreen({ existingAgentNames, onComplete, onExit }: AddAg
       byoStep === 'securityGroups' ||
       byoStep === 'requestHeaderAllowlist' ||
       byoStep === 'idleTimeout' ||
-      byoStep === 'maxLifetime'
+      byoStep === 'maxLifetime' ||
+      byoStep === 'sessionStorageMountPath'
     ) {
       return HELP_TEXT.TEXT_INPUT;
     }
@@ -1242,7 +1253,25 @@ export function AddAgentScreen({ existingAgentNames, onComplete, onExit }: AddAg
             }}
             onSubmit={value => {
               setByoConfig(c => ({ ...c, maxLifetime: value }));
-              setByoStep('confirm');
+              goToNextByoStep('maxLifetime');
+            }}
+            onCancel={handleByoBack}
+          />
+        )}
+
+        {byoStep === 'sessionStorageMountPath' && (
+          <TextInput
+            prompt="Session storage mount path (e.g. /mnt/session-storage, or press Enter to skip)"
+            initialValue={byoConfig.sessionStorageMountPath}
+            allowEmpty
+            customValidation={value => {
+              if (!value) return true;
+              if (!value.startsWith('/')) return 'Must be an absolute path starting with /';
+              return true;
+            }}
+            onSubmit={value => {
+              setByoConfig(c => ({ ...c, sessionStorageMountPath: value }));
+              goToNextByoStep('sessionStorageMountPath');
             }}
             onCancel={handleByoBack}
           />
@@ -1316,6 +1345,9 @@ export function AddAgentScreen({ existingAgentNames, onComplete, onExit }: AddAg
                 : []),
               ...(byoConfig.idleTimeout ? [{ label: 'Idle Timeout', value: `${byoConfig.idleTimeout}s` }] : []),
               ...(byoConfig.maxLifetime ? [{ label: 'Max Lifetime', value: `${byoConfig.maxLifetime}s` }] : []),
+              ...(byoConfig.sessionStorageMountPath
+                ? [{ label: 'Session Storage', value: byoConfig.sessionStorageMountPath }]
+                : []),
             ]}
           />
         )}

--- a/src/cli/tui/screens/agent/types.ts
+++ b/src/cli/tui/screens/agent/types.ts
@@ -55,6 +55,7 @@ export type AddAgentStep =
   | 'jwtConfig'
   | 'idleTimeout'
   | 'maxLifetime'
+  | 'sessionStorageMountPath'
   | 'memory'
   | 'region'
   | 'bedrockAgent'
@@ -94,6 +95,8 @@ export interface AddAgentConfig {
   idleRuntimeSessionTimeout?: number;
   /** Max instance lifetime in seconds (LIFECYCLE_TIMEOUT_MIN-LIFECYCLE_TIMEOUT_MAX) */
   maxLifetime?: number;
+  /** Mount path for session filesystem storage (e.g. /mnt/session-storage) */
+  sessionStorageMountPath?: string;
   /** Python version (only for Python agents) */
   pythonVersion: PythonRuntime;
   /** Memory option (create path only) */
@@ -126,6 +129,7 @@ export const ADD_AGENT_STEP_LABELS: Record<AddAgentStep, string> = {
   jwtConfig: 'JWT Config',
   idleTimeout: 'Idle Timeout',
   maxLifetime: 'Max Lifetime',
+  sessionStorageMountPath: 'Session Storage',
   memory: 'Memory',
   region: 'Region',
   bedrockAgent: 'Agent',

--- a/src/cli/tui/screens/agent/useAddAgent.ts
+++ b/src/cli/tui/screens/agent/useAddAgent.ts
@@ -90,6 +90,9 @@ export function mapByoConfigToAgent(config: AddAgentConfig): AgentEnvSpec {
           },
         }
       : {}),
+    ...(config.sessionStorageMountPath && {
+      filesystemConfigurations: [{ sessionStorage: { mountPath: config.sessionStorageMountPath } }],
+    }),
   };
 }
 
@@ -114,6 +117,7 @@ function mapAddAgentConfigToGenerateConfig(config: AddAgentConfig): GenerateConf
     jwtConfig: config.jwtConfig,
     idleRuntimeSessionTimeout: config.idleRuntimeSessionTimeout,
     maxLifetime: config.maxLifetime,
+    sessionStorageMountPath: config.sessionStorageMountPath,
   };
 }
 
@@ -289,6 +293,7 @@ async function handleImportPath(
     jwtConfig: config.jwtConfig,
     idleTimeout: config.idleRuntimeSessionTimeout,
     maxLifetime: config.maxLifetime,
+    sessionStorageMountPath: config.sessionStorageMountPath,
   });
 
   if (!result.success) {

--- a/src/cli/tui/screens/create/useCreateFlow.ts
+++ b/src/cli/tui/screens/create/useCreateFlow.ts
@@ -275,6 +275,7 @@ export function useCreateFlow(cwd: string): CreateFlowState {
                   jwtConfig: addAgentConfig.jwtConfig,
                   idleRuntimeSessionTimeout: addAgentConfig.idleRuntimeSessionTimeout,
                   maxLifetime: addAgentConfig.maxLifetime,
+                  sessionStorageMountPath: addAgentConfig.sessionStorageMountPath,
                 };
 
                 logger.logSubStep(`Framework: ${generateConfig.sdk}`);
@@ -350,6 +351,9 @@ export function useCreateFlow(cwd: string): CreateFlowState {
                   configBaseDir,
                   authorizerType: addAgentConfig.authorizerType,
                   jwtConfig: addAgentConfig.jwtConfig,
+                  idleTimeout: addAgentConfig.idleRuntimeSessionTimeout,
+                  maxLifetime: addAgentConfig.maxLifetime,
+                  sessionStorageMountPath: addAgentConfig.sessionStorageMountPath,
                 });
                 if (!importResult.success) {
                   throw new Error(importResult.error ?? 'Import failed');

--- a/src/cli/tui/screens/generate/GenerateWizardUI.tsx
+++ b/src/cli/tui/screens/generate/GenerateWizardUI.tsx
@@ -1,5 +1,11 @@
 import type { ModelProvider, NetworkMode, RuntimeAuthorizerType } from '../../../../schema';
-import { DEFAULT_MODEL_IDS, LIFECYCLE_TIMEOUT_MAX, LIFECYCLE_TIMEOUT_MIN, ProjectNameSchema } from '../../../../schema';
+import {
+  DEFAULT_MODEL_IDS,
+  LIFECYCLE_TIMEOUT_MAX,
+  LIFECYCLE_TIMEOUT_MIN,
+  ProjectNameSchema,
+  SessionStorageSchema,
+} from '../../../../schema';
 import { parseAndNormalizeHeaders, validateHeaderAllowlist } from '../../../commands/shared/header-utils';
 import { validateSecurityGroupIds, validateSubnetIds } from '../../../commands/shared/vpc-utils';
 import { computeDefaultCredentialEnvVarName } from '../../../primitives/credential-utils';
@@ -113,6 +119,7 @@ export function GenerateWizardUI({
   const isJwtConfigStep = wizard.step === 'jwtConfig';
   const isIdleTimeoutStep = wizard.step === 'idleTimeout';
   const isMaxLifetimeStep = wizard.step === 'maxLifetime';
+  const isSessionStorageMountPathStep = wizard.step === 'sessionStorageMountPath';
   const isConfirmStep = wizard.step === 'confirm';
 
   // Advanced multi-select items — filter out dockerfile when not a Container build
@@ -380,6 +387,23 @@ export function GenerateWizardUI({
         />
       )}
 
+      {isSessionStorageMountPathStep && (
+        <TextInput
+          prompt="Session storage mount path (e.g. /mnt/data, or press Enter to skip)"
+          initialValue={wizard.config.sessionStorageMountPath ?? ''}
+          allowEmpty
+          schema={SessionStorageSchema.shape.mountPath}
+          onSubmit={value => {
+            if (value) {
+              wizard.setSessionStorageMountPath(value);
+            } else {
+              wizard.skipSessionStorageMountPath();
+            }
+          }}
+          onCancel={onBack}
+        />
+      )}
+
       {isConfirmStep && <ConfirmView config={wizard.config} credentialProjectName={credentialProjectName} />}
     </Panel>
   );
@@ -398,7 +422,8 @@ export function getWizardHelpText(step: GenerateStep): string {
     step === 'securityGroups' ||
     step === 'requestHeaderAllowlist' ||
     step === 'idleTimeout' ||
-    step === 'maxLifetime'
+    step === 'maxLifetime' ||
+    step === 'sessionStorageMountPath'
   )
     return 'Enter submit · Esc cancel';
   if (step === 'apiKey') return 'Enter submit · Tab show/hide · Esc back';
@@ -544,6 +569,12 @@ function ConfirmView({ config, credentialProjectName }: { config: GenerateConfig
           <Text>
             <Text dimColor>Max Lifetime: </Text>
             <Text>{config.maxLifetime}s</Text>
+          </Text>
+        )}
+        {config.sessionStorageMountPath && (
+          <Text>
+            <Text dimColor>Session Storage: </Text>
+            <Text>{config.sessionStorageMountPath}</Text>
           </Text>
         )}
       </Box>

--- a/src/cli/tui/screens/generate/__tests__/useGenerateWizard.test.tsx
+++ b/src/cli/tui/screens/generate/__tests__/useGenerateWizard.test.tsx
@@ -385,6 +385,133 @@ describe('useGenerateWizard — advanced config gate', () => {
     });
   });
 
+  describe('filesystem advanced setting', () => {
+    function walkToAdvanced(ref: React.RefObject<HarnessHandle | null>) {
+      act(() => {
+        ref.current!.wizard.setProjectName('Test');
+        ref.current!.wizard.setLanguage('Python');
+        ref.current!.wizard.setBuildType('CodeZip');
+        ref.current!.wizard.setProtocol('HTTP');
+        ref.current!.wizard.setSdk('Strands');
+        ref.current!.wizard.setModelProvider('Bedrock');
+        ref.current!.wizard.setMemory('none');
+      });
+    }
+
+    it('filesystem step is included in steps when filesystem is selected', () => {
+      const { ref } = setup();
+      walkToAdvanced(ref);
+
+      act(() => ref.current!.wizard.setAdvanced(['filesystem']));
+
+      expect(ref.current!.wizard.steps).toContain('sessionStorageMountPath');
+    });
+
+    it('setAdvanced with only filesystem navigates to sessionStorageMountPath step', () => {
+      vi.useFakeTimers();
+      const { ref, lastFrame } = setup();
+      walkToAdvanced(ref);
+
+      act(() => ref.current!.wizard.setAdvanced(['filesystem']));
+      act(() => {
+        vi.runAllTimers();
+      });
+
+      expect(lastFrame()).toContain('step:sessionStorageMountPath');
+      vi.useRealTimers();
+    });
+
+    it('setSessionStorageMountPath rejects invalid path and sets error without advancing', () => {
+      vi.useFakeTimers();
+      const { ref } = setup();
+      walkToAdvanced(ref);
+
+      act(() => ref.current!.wizard.setAdvanced(['filesystem']));
+      act(() => {
+        vi.runAllTimers();
+      });
+
+      let result: boolean | undefined;
+      act(() => {
+        result = ref.current!.wizard.setSessionStorageMountPath('/bad/path/too/deep');
+      });
+      act(() => {
+        vi.runAllTimers();
+      });
+
+      expect(result).toBe(false);
+      expect(ref.current!.wizard.error).toBeTruthy();
+      expect(ref.current!.wizard.step).toBe('sessionStorageMountPath');
+      vi.useRealTimers();
+    });
+
+    it('setSessionStorageMountPath accepts valid path, clears error, and advances to confirm', () => {
+      vi.useFakeTimers();
+      const { ref, lastFrame } = setup();
+      walkToAdvanced(ref);
+
+      act(() => ref.current!.wizard.setAdvanced(['filesystem']));
+      act(() => {
+        vi.runAllTimers();
+      });
+
+      let result: boolean | undefined;
+      act(() => {
+        result = ref.current!.wizard.setSessionStorageMountPath('/mnt/data');
+      });
+      act(() => {
+        vi.runAllTimers();
+      });
+
+      expect(result).toBe(true);
+      expect(ref.current!.wizard.error).toBeNull();
+      expect(lastFrame()).toContain('step:confirm');
+      expect(ref.current!.wizard.config.sessionStorageMountPath).toBe('/mnt/data');
+      vi.useRealTimers();
+    });
+
+    it('lifecycle + filesystem injects both sub-step groups', () => {
+      const { ref } = setup();
+      walkToAdvanced(ref);
+
+      act(() => ref.current!.wizard.setAdvanced(['lifecycle', 'filesystem']));
+
+      const steps = ref.current!.wizard.steps;
+      const advIdx = steps.indexOf('advanced');
+      expect(steps.slice(advIdx)).toEqual([
+        'advanced',
+        'idleTimeout',
+        'maxLifetime',
+        'sessionStorageMountPath',
+        'confirm',
+      ]);
+    });
+
+    it('deselecting all advanced clears sessionStorageMountPath config', () => {
+      vi.useFakeTimers();
+      const { ref } = setup();
+      walkToAdvanced(ref);
+
+      act(() => ref.current!.wizard.setAdvanced(['filesystem']));
+      act(() => {
+        vi.runAllTimers();
+      });
+      act(() => {
+        ref.current!.wizard.setSessionStorageMountPath('/mnt/data');
+      });
+      act(() => {
+        vi.runAllTimers();
+      });
+      expect(ref.current!.wizard.config.sessionStorageMountPath).toBe('/mnt/data');
+
+      act(() => ref.current!.wizard.setAdvanced([]));
+
+      expect(ref.current!.wizard.config.sessionStorageMountPath).toBeUndefined();
+      expect(ref.current!.wizard.step).toBe('confirm');
+      vi.useRealTimers();
+    });
+  });
+
   describe('reset clears advancedSelected', () => {
     it('reset returns advancedSelected to false', () => {
       const { ref, lastFrame } = setup();

--- a/src/cli/tui/screens/generate/types.ts
+++ b/src/cli/tui/screens/generate/types.ts
@@ -29,6 +29,7 @@ export type GenerateStep =
   | 'jwtConfig'
   | 'idleTimeout'
   | 'maxLifetime'
+  | 'sessionStorageMountPath'
   | 'confirm';
 
 export type MemoryOption = 'none' | 'shortTerm' | 'longAndShortTerm';
@@ -61,6 +62,8 @@ export interface GenerateConfig {
   idleRuntimeSessionTimeout?: number;
   /** Max instance lifetime in seconds (LIFECYCLE_TIMEOUT_MIN-LIFECYCLE_TIMEOUT_MAX) */
   maxLifetime?: number;
+  /** Mount path for session filesystem storage (e.g. /mnt/session-storage) */
+  sessionStorageMountPath?: string;
 }
 
 /** Base steps - apiKey, memory, subnets, securityGroups are conditionally added based on selections */
@@ -95,6 +98,7 @@ export const STEP_LABELS: Record<GenerateStep, string> = {
   jwtConfig: 'JWT Config',
   idleTimeout: 'Idle Timeout',
   maxLifetime: 'Max Lifetime',
+  sessionStorageMountPath: 'Session Storage',
   confirm: 'Confirm',
 };
 
@@ -153,7 +157,7 @@ export const NETWORK_MODE_OPTIONS = [
   { id: 'VPC', title: 'VPC', description: 'Attach to your VPC' },
 ] as const;
 
-export type AdvancedSettingId = 'dockerfile' | 'network' | 'headers' | 'auth' | 'lifecycle';
+export type AdvancedSettingId = 'dockerfile' | 'network' | 'headers' | 'auth' | 'lifecycle' | 'filesystem';
 
 export const ADVANCED_SETTING_OPTIONS = [
   { id: 'dockerfile', title: 'Custom Dockerfile', description: 'Specify a custom Dockerfile path' },
@@ -161,6 +165,7 @@ export const ADVANCED_SETTING_OPTIONS = [
   { id: 'headers', title: 'Request header allowlist', description: 'Allow custom headers through to your agent' },
   { id: 'auth', title: 'Custom auth (JWT)', description: 'OIDC-based token validation for inbound requests' },
   { id: 'lifecycle', title: 'Lifecycle timeouts', description: 'Idle timeout & max instance lifetime' },
+  { id: 'filesystem', title: 'Session filesystem storage', description: 'Persist files across session stop/resume' },
 ] as const;
 
 /** Dockerfile filename regex — must match the Zod schema in agent-env.ts */

--- a/src/cli/tui/screens/generate/useGenerateWizard.ts
+++ b/src/cli/tui/screens/generate/useGenerateWizard.ts
@@ -1,5 +1,5 @@
 import type { NetworkMode, RuntimeAuthorizerType } from '../../../../schema';
-import { ProjectNameSchema } from '../../../../schema';
+import { ProjectNameSchema, SessionStorageSchema } from '../../../../schema';
 import type { JwtConfigOptions } from '../../../primitives/auth-utils';
 import type { AdvancedSettingId, BuildType, GenerateConfig, GenerateStep, MemoryOption, ProtocolMode } from './types';
 import { BASE_GENERATE_STEPS, getModelProviderOptionsForSdk } from './types';
@@ -84,6 +84,10 @@ export function useGenerateWizard(options?: UseGenerateWizardOptions) {
       // Lifecycle
       if (advancedSettings.has('lifecycle')) {
         subSteps.push('idleTimeout', 'maxLifetime');
+      }
+      // Filesystem
+      if (advancedSettings.has('filesystem')) {
+        subSteps.push('sessionStorageMountPath');
       }
       filtered = [...filtered.slice(0, afterAdvanced), ...subSteps, ...filtered.slice(afterAdvanced)];
     }
@@ -229,6 +233,7 @@ export function useGenerateWizard(options?: UseGenerateWizardOptions) {
           jwtConfig: undefined,
           idleRuntimeSessionTimeout: undefined,
           maxLifetime: undefined,
+          sessionStorageMountPath: undefined,
         }));
         setStep('confirm');
       } else {
@@ -246,6 +251,8 @@ export function useGenerateWizard(options?: UseGenerateWizardOptions) {
             setStep('authorizerType');
           } else if (selected.has('lifecycle')) {
             setStep('idleTimeout');
+          } else if (selected.has('filesystem')) {
+            setStep('sessionStorageMountPath');
           } else {
             setStep('confirm');
           }
@@ -325,14 +332,38 @@ export function useGenerateWizard(options?: UseGenerateWizardOptions) {
     setStep('maxLifetime');
   }, []);
 
-  const setMaxLifetime = useCallback((value: number | undefined) => {
-    setConfig(c => ({ ...c, maxLifetime: value }));
-    setStep('confirm');
-  }, []);
+  const setMaxLifetime = useCallback(
+    (value: number | undefined) => {
+      setConfig(c => ({ ...c, maxLifetime: value }));
+      setTimeout(() => goToNextStep('maxLifetime'), 0);
+    },
+    [goToNextStep]
+  );
 
   const skipMaxLifetime = useCallback(() => {
-    setStep('confirm');
-  }, []);
+    setTimeout(() => goToNextStep('maxLifetime'), 0);
+  }, [goToNextStep]);
+
+  const setSessionStorageMountPath = useCallback(
+    (value: string | undefined) => {
+      if (value) {
+        const result = SessionStorageSchema.shape.mountPath.safeParse(value);
+        if (!result.success) {
+          setError(result.error.issues[0]?.message ?? 'Invalid mount path');
+          return false;
+        }
+      }
+      setError(null);
+      setConfig(c => ({ ...c, sessionStorageMountPath: value }));
+      setTimeout(() => goToNextStep('sessionStorageMountPath'), 0);
+      return true;
+    },
+    [goToNextStep]
+  );
+
+  const skipSessionStorageMountPath = useCallback(() => {
+    setTimeout(() => goToNextStep('sessionStorageMountPath'), 0);
+  }, [goToNextStep]);
 
   const goBack = useCallback(() => {
     setError(null);
@@ -390,6 +421,8 @@ export function useGenerateWizard(options?: UseGenerateWizardOptions) {
     skipIdleTimeout,
     setMaxLifetime,
     skipMaxLifetime,
+    setSessionStorageMountPath,
+    skipSessionStorageMountPath,
     goBack,
     reset,
     initWithName,

--- a/src/cli/tui/screens/invoke/useInvokeFlow.ts
+++ b/src/cli/tui/screens/invoke/useInvokeFlow.ts
@@ -324,7 +324,14 @@ export function useInvokeFlow(options: InvokeFlowOptions = {}): InvokeFlowState 
       try {
         const result = isA2A
           ? await invokeA2ARuntime(
-              { region: config.target.region, runtimeArn: agent.state.runtimeArn, userId, logger, headers },
+              {
+                region: config.target.region,
+                runtimeArn: agent.state.runtimeArn,
+                userId,
+                sessionId: sessionId ?? undefined,
+                logger,
+                headers,
+              },
               prompt
             )
           : await invokeAgentRuntimeStreaming({

--- a/src/schema/schemas/agent-env.ts
+++ b/src/schema/schemas/agent-env.ts
@@ -142,6 +142,23 @@ export const RequestHeaderAllowlistSchema = z
   )
   .max(MAX_HEADER_ALLOWLIST_SIZE, `Maximum ${MAX_HEADER_ALLOWLIST_SIZE} headers allowed`);
 
+/**
+ * Session storage configuration for filesystem persistence.
+ * Files written to mountPath persist across session stop/resume cycles.
+ */
+export const SessionStorageSchema = z.object({
+  /** Absolute mount path under /mnt with exactly one subdirectory level (e.g. /mnt/data). */
+  mountPath: z
+    .string()
+    .regex(/^\/mnt\/[^/]+$/, 'Must be a path under /mnt with exactly one subdirectory (e.g. /mnt/data)'),
+});
+export type SessionStorage = z.infer<typeof SessionStorageSchema>;
+
+export const FilesystemConfigurationSchema = z.object({
+  sessionStorage: SessionStorageSchema,
+});
+export type FilesystemConfiguration = z.infer<typeof FilesystemConfigurationSchema>;
+
 /** Minimum allowed value for lifecycle timeout fields (seconds). */
 export const LIFECYCLE_TIMEOUT_MIN = 60;
 /** Maximum allowed value for lifecycle timeout fields (seconds). */
@@ -212,6 +229,8 @@ export const AgentEnvSpecSchema = z
     tags: TagsSchema.optional(),
     /** Lifecycle configuration for runtime sessions. */
     lifecycleConfiguration: LifecycleConfigurationSchema.optional(),
+    /** Filesystem configurations for session-scoped persistent storage. */
+    filesystemConfigurations: z.array(FilesystemConfigurationSchema).optional(),
   })
   .superRefine((data, ctx) => {
     if (data.networkMode === 'VPC' && !data.networkConfig) {


### PR DESCRIPTION

## Description

Adds --session-storage-mount-path to agentcore create and agentcore add agent, wiring the mount path through schema, CLI flags, TUI wizard, template rendering, and CDK mapping. File tools (file_read, file_write, list_files) with path traversal protection are scaffolded into all 8 framework templates when storage is configured. Fixes A2A sessionId not being forwarded to InvokeAgentRuntimeCommand. Validation is centralised in SessionStorageSchema with no regex duplication across validators or TUI.


## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [x] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [ ] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
