### PR TITLE
fix(invoke): pass session ID to local invoke log files

### DIFF
--- a/src/cli/commands/invoke/action.ts
+++ b/src/cli/commands/invoke/action.ts
@@ -118,12 +118,13 @@ export async function handleInvoke(context: InvokeContext, options: InvokeOption
       agentName: agentSpec.name,
       runtimeArn: agentState.runtimeArn,
       region: targetConfig.region,
+      sessionId: options.sessionId,
     });
     const command = options.prompt;
     if (!command) {
       return { success: false, error: '--exec requires a command (prompt)' };
     }
-    logger.logPrompt(command, undefined, options.userId);
+    logger.logPrompt(command, options.sessionId, options.userId);
 
     try {
       const result = await executeBashCommand({
@@ -324,9 +325,10 @@ export async function handleInvoke(context: InvokeContext, options: InvokeOption
     agentName: agentSpec.name,
     runtimeArn: agentState.runtimeArn,
     region: targetConfig.region,
+    sessionId: options.sessionId,
   });
 
-  logger.logPrompt(options.prompt, undefined, options.userId);
+  logger.logPrompt(options.prompt, options.sessionId, options.userId);
 
   if (options.stream) {
     // Streaming mode

--- a/src/cli/logging/__tests__/invoke-logger-session-id.test.ts
+++ b/src/cli/logging/__tests__/invoke-logger-session-id.test.ts
@@ -1,0 +1,96 @@
+import { InvokeLogger } from '../invoke-logger.js';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../lib', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../../lib')>();
+  return {
+    ...actual,
+    findConfigRoot: () => tempDir,
+  };
+});
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(path.join(tmpdir(), 'invoke-logger-test-'));
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+function readLog(logger: InvokeLogger): string {
+  return readFileSync(logger.logFilePath, 'utf-8');
+}
+
+describe('InvokeLogger session ID', () => {
+  it('writes session ID in header when provided via constructor', () => {
+    const logger = new InvokeLogger({
+      agentName: 'testAgent',
+      runtimeArn: 'arn:aws:bedrock-agentcore:us-east-1:123456:runtime/test',
+      region: 'us-east-1',
+      sessionId: 'my-session-123',
+    });
+
+    const content = readLog(logger);
+    expect(content).toContain('Session ID: my-session-123');
+    expect(content).not.toContain('Session ID: none');
+  });
+
+  it('writes "none" when session ID is not provided', () => {
+    const logger = new InvokeLogger({
+      agentName: 'testAgent',
+      runtimeArn: 'arn:aws:bedrock-agentcore:us-east-1:123456:runtime/test',
+      region: 'us-east-1',
+    });
+
+    const content = readLog(logger);
+    expect(content).toContain('Session ID: none');
+  });
+
+  it('includes session ID in logPrompt output when passed as argument', () => {
+    const logger = new InvokeLogger({
+      agentName: 'testAgent',
+      runtimeArn: 'arn:aws:bedrock-agentcore:us-east-1:123456:runtime/test',
+      region: 'us-east-1',
+      sessionId: 'my-session-456',
+    });
+
+    logger.logPrompt('hello world', 'my-session-456', 'user-1');
+
+    const content = readLog(logger);
+    expect(content).toContain('Session: my-session-456');
+    expect(content).toContain('"sessionId": "my-session-456"');
+  });
+
+  it('logPrompt falls back to constructor sessionId when argument is undefined', () => {
+    const logger = new InvokeLogger({
+      agentName: 'testAgent',
+      runtimeArn: 'arn:aws:bedrock-agentcore:us-east-1:123456:runtime/test',
+      region: 'us-east-1',
+      sessionId: 'constructor-session',
+    });
+
+    logger.logPrompt('hello world', undefined, 'user-1');
+
+    const content = readLog(logger);
+    expect(content).toContain('Session: constructor-session');
+    expect(content).toContain('"sessionId": "constructor-session"');
+  });
+
+  it('logPrompt shows "none" when no session ID anywhere', () => {
+    const logger = new InvokeLogger({
+      agentName: 'testAgent',
+      runtimeArn: 'arn:aws:bedrock-agentcore:us-east-1:123456:runtime/test',
+      region: 'us-east-1',
+    });
+
+    logger.logPrompt('hello world');
+
+    const content = readLog(logger);
+    expect(content).toContain('Session: none');
+  });
+});


### PR DESCRIPTION
## Summary
- Fix `agentcore invoke --session-id` local log files always showing `Session ID: none` instead of the actual session ID
- The session ID was correctly sent to Runtime but never passed to `InvokeLogger` in the CLI code path (both exec and standard invoke modes)
- Add unit tests to prevent regression

## Root Cause
In `src/cli/commands/invoke/action.ts`, `options.sessionId` was available but never wired through to:
1. The `InvokeLogger` constructor (missing `sessionId` property)
2. The `logPrompt()` calls (passed `undefined` instead of `options.sessionId`)

The TUI code path (`useInvokeFlow.ts`) already handled this correctly — only the CLI path was broken.

## Changes
- `src/cli/commands/invoke/action.ts`: Pass `options.sessionId` to `InvokeLogger` constructor and `logPrompt()` in both exec mode and standard invoke mode
- `src/cli/logging/__tests__/invoke-logger-session-id.test.ts`: 5 unit tests covering session ID in header, logPrompt output, fallback behavior, and absent session ID

## Test plan
- [x] 5 new unit tests pass (header, logPrompt, fallback, none cases)
- [x] Full test suite passes (230 files, 3301+ tests)
- [x] Build succeeds
- [x] E2E: deployed agent, ran `agentcore invoke --session-id <id> --stream`, verified log file shows correct session ID in header, request line, and JSON body

Closes #890