### PR TITLE
fix: agentcore add component opens component wizard directly

### DIFF
--- a/src/cli/primitives/AgentPrimitive.tsx
+++ b/src/cli/primitives/AgentPrimitive.tsx
@@ -340,6 +340,7 @@ export class AgentPrimitive extends BasePrimitive<AddAgentOptions, RemovableReso
           const { clear, unmount } = render(
             React.createElement(AddFlow, {
               isInteractive: false,
+              initialResource: 'agent',
               onExit: () => {
                 clear();
                 unmount();

--- a/src/cli/primitives/CredentialPrimitive.tsx
+++ b/src/cli/primitives/CredentialPrimitive.tsx
@@ -347,6 +347,7 @@ export class CredentialPrimitive extends BasePrimitive<AddCredentialOptions, Rem
               const { clear, unmount } = render(
                 React.createElement(AddFlow, {
                   isInteractive: false,
+                  initialResource: 'credential',
                   onExit: () => {
                     clear();
                     unmount();

--- a/src/cli/primitives/EvaluatorPrimitive.ts
+++ b/src/cli/primitives/EvaluatorPrimitive.ts
@@ -324,6 +324,7 @@ export class EvaluatorPrimitive extends BasePrimitive<AddEvaluatorOptions, Remov
               const { clear, unmount } = render(
                 React.createElement(AddFlow, {
                   isInteractive: false,
+                  initialResource: 'evaluator',
                   onExit: () => {
                     clear();
                     unmount();

--- a/src/cli/primitives/MemoryPrimitive.tsx
+++ b/src/cli/primitives/MemoryPrimitive.tsx
@@ -238,6 +238,7 @@ export class MemoryPrimitive extends BasePrimitive<AddMemoryOptions, RemovableMe
               const { clear, unmount } = render(
                 React.createElement(AddFlow, {
                   isInteractive: false,
+                  initialResource: 'memory',
                   onExit: () => {
                     clear();
                     unmount();

--- a/src/cli/primitives/OnlineEvalConfigPrimitive.ts
+++ b/src/cli/primitives/OnlineEvalConfigPrimitive.ts
@@ -179,6 +179,7 @@ export class OnlineEvalConfigPrimitive extends BasePrimitive<AddOnlineEvalConfig
               const { clear, unmount } = render(
                 React.createElement(AddFlow, {
                   isInteractive: false,
+                  initialResource: 'online-eval',
                   onExit: () => {
                     clear();
                     unmount();

--- a/src/cli/primitives/PolicyPrimitive.ts
+++ b/src/cli/primitives/PolicyPrimitive.ts
@@ -351,6 +351,7 @@ export class PolicyPrimitive extends BasePrimitive<AddPolicyOptions, RemovablePo
               const { clear, unmount } = render(
                 React.createElement(AddFlow, {
                   isInteractive: false,
+                  initialResource: 'policy',
                   onExit: () => {
                     clear();
                     unmount();

--- a/src/cli/tui/screens/add/AddFlow.tsx
+++ b/src/cli/tui/screens/add/AddFlow.tsx
@@ -157,12 +157,37 @@ interface AddFlowProps {
   onDev?: () => void;
   /** Called when user selects deploy from success screen */
   onDeploy?: () => void;
+  /** Skip the selection screen and go directly to a specific resource wizard */
+  initialResource?: AddResourceType;
+}
+
+function getInitialFlowState(resource?: AddResourceType): FlowState {
+  switch (resource) {
+    case 'agent':
+      return { name: 'agent-wizard' };
+    case 'gateway':
+      return { name: 'gateway-wizard' };
+    case 'gateway-target':
+      return { name: 'tool-wizard' };
+    case 'memory':
+      return { name: 'memory-wizard' };
+    case 'credential':
+      return { name: 'identity-wizard' };
+    case 'evaluator':
+      return { name: 'evaluator-wizard' };
+    case 'online-eval':
+      return { name: 'online-eval-wizard' };
+    case 'policy':
+      return { name: 'policy-wizard' };
+    default:
+      return { name: 'select' };
+  }
 }
 
 export function AddFlow(props: AddFlowProps) {
   const { addAgent, reset: resetAgent } = useAddAgent();
   const { agents, refresh: refreshAgents } = useAvailableAgents();
-  const [flow, setFlow] = useState<FlowState>({ name: 'select' });
+  const [flow, setFlow] = useState<FlowState>(() => getInitialFlowState(props.initialResource));
 
   // In non-interactive mode, exit after success (but not while loading)
   useEffect(() => {


### PR DESCRIPTION
## Summary

- `agentcore add memory` (and all other component subcommands) now opens the component-specific wizard directly instead of showing the generic resource selection screen
- Added `initialResource` prop to `AddFlow` that maps to the correct wizard state, skipping the selection screen
- Each primitive passes its resource type when rendering `AddFlow` in TUI fallback mode

## Root Cause

`AddFlow` always initialized with `{ name: 'select' }` state regardless of which subcommand invoked it. The primitives rendered `AddFlow` without telling it which component was requested.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] Pre-commit hooks pass (eslint, prettier, secretlint, typecheck)
- [ ] Manual: `agentcore add memory` → should open memory wizard directly
- [ ] Manual: `agentcore add agent` → should open agent wizard directly
- [ ] Manual: `agentcore add` (no subcommand) → should still show selection screen

Closes #857