### PR TITLE
chore: remove single-commit-must-match-PR-title validation

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -38,10 +38,7 @@ jobs:
             The subject "{subject}" found in the pull request title "{title}"
             must start with a lowercase letter.
             Example: "feat: add deploy command"
-          # Validate the commit message when a PR has a single commit, since
-          # GitHub suggests using it as the merge commit message on squash-merge
-          validateSingleCommit: true
-          validateSingleCommitMatchesPrTitle: true
+          validateSingleCommit: false
           # Skip validation for bot/dependency PRs
           ignoreLabels: |
             bot


### PR DESCRIPTION
## Summary

- Removes `validateSingleCommit` and `validateSingleCommitMatchesPrTitle` from the PR title workflow

## Why

The current config requires that when a PR has a single commit, the commit message must exactly match the PR title. This creates unnecessary friction — if you edit the PR title after pushing, or use backticks/special characters in the title, CI fails and you have to amend + force-push.

Since we squash-merge, GitHub already uses the PR title as the final commit message regardless of individual commit messages. Validating the PR title itself (which we keep) is sufficient.

## Test plan

- [x] Workflow YAML is valid
- [x] PR title validation (`subjectPattern`, `types`) still enforced