### PR TITLE
fix(invoke): show full session ID and print resume command on exit

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -224,4 +224,10 @@ export const main = async (argv: string[]) => {
 
   // Telemetry notice already printed above; only run update check here.
   await printPostCommandNotices(false, updateCheck);
+
+  const exitMessage = getExitMessage();
+  if (exitMessage) {
+    console.log(`\n${exitMessage}`);
+    clearExitMessage();
+  }
 };

--- a/src/cli/commands/invoke/command.tsx
+++ b/src/cli/commands/invoke/command.tsx
@@ -168,10 +168,10 @@ export const registerInvoke = (program: Command) => {
             });
           } else {
             // No CLI options - interactive TUI mode (headers still passed if provided)
-            const { waitUntilExit } = render(
+            const { waitUntilExit, unmount } = render(
               <InvokeScreen
                 isInteractive={true}
-                onExit={() => process.exit(0)}
+                onExit={() => unmount()}
                 initialSessionId={cliOptions.sessionId}
                 initialUserId={cliOptions.userId}
                 initialHeaders={headers}

--- a/src/cli/tui/screens/invoke/InvokeScreen.tsx
+++ b/src/cli/tui/screens/invoke/InvokeScreen.tsx
@@ -147,12 +147,12 @@ export function InvokeScreen({
   const mcpFetchTriggeredRef = useRef(false);
 
   useEffect(() => {
-    if (sessionId) {
+    if (sessionId && messages.length > 0) {
       const cyan = '\x1b[36m';
       const reset = '\x1b[0m';
       setExitMessage(`To resume this session, run: ${cyan}agentcore invoke --session-id ${sessionId}${reset}`);
     }
-  }, [sessionId]);
+  }, [sessionId, messages.length]);
 
   // Compute auth type early so hooks can reference it
   const currentAgent = config?.runtimes[selectedAgent];

--- a/src/cli/tui/screens/invoke/InvokeScreen.tsx
+++ b/src/cli/tui/screens/invoke/InvokeScreen.tsx
@@ -1,5 +1,6 @@
 import { buildTraceConsoleUrl } from '../../../operations/traces';
 import { GradientText, LogLink, Panel, Screen, SelectList, TextInput } from '../../components';
+import { setExitMessage } from '../../exit-message';
 import { useInvokeFlow } from './useInvokeFlow';
 import { Box, Text, useInput, useStdout } from 'ink';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -144,6 +145,14 @@ export function InvokeScreen({
   const { stdout } = useStdout();
   const justCancelledRef = useRef(false);
   const mcpFetchTriggeredRef = useRef(false);
+
+  useEffect(() => {
+    if (sessionId) {
+      const cyan = '\x1b[36m';
+      const reset = '\x1b[0m';
+      setExitMessage(`To resume this session, run: ${cyan}agentcore invoke --session-id ${sessionId}${reset}`);
+    }
+  }, [sessionId]);
 
   // Compute auth type early so hooks can reference it
   const currentAgent = config?.runtimes[selectedAgent];
@@ -398,7 +407,7 @@ export function InvokeScreen({
       {mode !== 'select-agent' && (
         <Box>
           <Text>Session: </Text>
-          <Text color="magenta">{sessionId?.slice(0, 8) ?? 'none'}</Text>
+          <Text color="magenta">{sessionId ?? 'none'}</Text>
         </Box>
       )}
       {mode !== 'select-agent' && (


### PR DESCRIPTION
## Description

The invoke TUI truncated the session ID to 8 characters (`550e8400`), making it impossible to copy the full UUID needed for `agentcore invoke --session-id <id>` to resume a session. Additionally, there was no guidance on how to resume a session after exiting.

This PR:
- Displays the full session ID in the TUI header instead of truncating to 8 chars
- Prints a colored resume command (`agentcore invoke --session-id <full-uuid>`) after TUI exit
- Uses Ink's `unmount()` instead of `process.exit(0)` for clean shutdown, which also fixes the update notifier not appearing on Esc exit

<img width="2542" height="1058" alt="Screenshot 2026-04-21 at 3 34 25 PM" src="https://github.com/user-attachments/assets/66fcce2a-00d0-48ed-ae54-3cf76689154b" />


## Related Issue

Closes #

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

Manually tested all exit paths:
- **Ctrl+C**: Resume message and update notifier both display ✅
- **Double Esc**: Resume message and update notifier both display ✅
- **`agentcore invoke` (direct)**: Works correctly ✅
- **`agentcore` → invoke (TUI)**: Works correctly ✅
- **Session resumption**: Copied session ID from output, used `--session-id` flag to resume successfully ✅

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.