### PR TITLE
fix: revert vended CDK dep to ^0.1.0-alpha.19

### DIFF
--- a/src/assets/cdk/package.json
+++ b/src/assets/cdk/package.json
@@ -23,7 +23,7 @@
     "typescript": "~5.9.3"
   },
   "dependencies": {
-    "@aws/agentcore-cdk": "^0.1.0-alpha.20",
+    "@aws/agentcore-cdk": "^0.1.0-alpha.19",
     "aws-cdk-lib": "^2.248.0",
     "constructs": "^10.0.0"
   }


### PR DESCRIPTION
## Summary
- PR #128 bumped the vended CDK project's dependency to `@aws/agentcore-cdk@^0.1.0-alpha.20`, but that version has never been published to npm (highest published is `alpha.19`).
- As a result, `agentcore create` fails during the vended project's `npm install` with `npm ERR! code ETARGET / No matching version found for @aws/agentcore-cdk@^0.1.0-alpha.20`, which broke E2E tests (run 24792727254 — all 4 Bedrock suites failed in `beforeAll` at `e2e-helper.ts:90`).
- Revert just the caret range back to `^0.1.0-alpha.19`. When alpha.20 is actually published, bump again.

## Test plan
- [ ] `agentcore create` scaffolds a project without ETARGET locally
- [ ] E2E workflow passes on both matrix rows (`npm` and `main`)