### PR TITLE
fix: use nullish coalescing in CreateScreen

### DIFF
--- a/src/cli/tui/screens/create/CreateScreen.tsx
+++ b/src/cli/tui/screens/create/CreateScreen.tsx
@@ -173,7 +173,7 @@ function CreatedSummary({
   const isByo = agentConfig?.agentType === 'byo';
   const agentPath = isCreate ? `app/${agentConfig.name}/` : isByo ? agentConfig.codeLocation : null;
   const harnessPath = harnessConfig ? `harness/${harnessConfig.name}/` : null;
-  const resourcePath = agentPath || harnessPath;
+  const resourcePath = agentPath ?? harnessPath;
   const agentcorePath = 'agentcore/';
   const maxPathLen = resourcePath ? Math.max(resourcePath.length, agentcorePath.length) : agentcorePath.length;
 


### PR DESCRIPTION
## Summary
- Fixes ESLint error (`@typescript-eslint/prefer-nullish-coalescing`) in `CreateScreen.tsx:176` by replacing `||` with `??`.

## Test plan
- [x] `npm run lint` passes with no errors after this change