### PR TITLE
feat: upgrade @aws/agentinspector to 0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/agentcore",
-  "version": "0.9.1",
+  "version": "1.0.0-preview.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/agentcore",
-      "version": "0.9.1",
+      "version": "1.0.0-preview.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -24,7 +24,7 @@
         "@aws-sdk/client-sts": "^3.893.0",
         "@aws-sdk/client-xray": "^3.1003.0",
         "@aws-sdk/credential-providers": "^3.893.0",
-        "@aws/agent-inspector": "0.1.0",
+        "@aws/agent-inspector": "0.2.0",
         "@commander-js/extra-typings": "^14.0.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/otlp-transformer": "^0.213.0",
@@ -2856,9 +2856,9 @@
       }
     },
     "node_modules/@aws/agent-inspector": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@aws/agent-inspector/-/agent-inspector-0.1.0.tgz",
-      "integrity": "sha512-ooYUUTh80oLSMr7VkJt0zCbF3mEgdeyZI46kPZapx4sy0TsP2glpObKZ3baqPI0agh6NeuUTNmAidusnVxeFrg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@aws/agent-inspector/-/agent-inspector-0.2.0.tgz",
+      "integrity": "sha512-3ai4aFWr4gY0y4OY1bUk/BBWYYpkG1XJSmyr3Mv5D8ObHeWuLyb1V/NrDdI6IwWYdlxG0M1yqSNGyrwZOjVaTQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ag-ui/core": "^0.0.52",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@aws-sdk/client-sts": "^3.893.0",
     "@aws-sdk/client-xray": "^3.1003.0",
     "@aws-sdk/credential-providers": "^3.893.0",
-    "@aws/agent-inspector": "0.1.0",
+    "@aws/agent-inspector": "0.2.0",
     "@commander-js/extra-typings": "^14.0.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/otlp-transformer": "^0.213.0",


### PR DESCRIPTION
## Description

upgrade to @aws/agent-inspector 0.2.0 to support harness integration

Changelog:
https://github.com/aws/agent-inspector/pull/2

## Related Issue

<!-- Every PR must be associated with an issue. Link it below using #issue-number format. -->

Closes #

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:unit` and `npm run test:integ`
- [ ] I ran `npm run typecheck`
- [ ] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
