### PR TITLE
fix: update asset snapshots and fix useDevDeploy skip test

### DIFF
--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -110,6 +110,8 @@ async function main() {
     memoryName?: string;
     containerUri?: string;
     hasDockerfile?: boolean;
+    tools?: { type: string; name: string }[];
+    apiKeyArn?: string;
   }[] = [];
   for (const entry of specAny.harnesses ?? []) {
     const harnessPath = path.resolve(projectRoot, entry.path, 'harness.json');
@@ -121,6 +123,8 @@ async function main() {
         memoryName: harnessSpec.memory?.name,
         containerUri: harnessSpec.containerUri,
         hasDockerfile: !!harnessSpec.dockerfile,
+        tools: harnessSpec.tools,
+        apiKeyArn: harnessSpec.model?.apiKeyArn,
       });
     } catch (err) {
       throw new Error(
@@ -312,7 +316,15 @@ export interface AgentCoreStackProps extends StackProps {
   /**
    * Harness role configurations. Each entry creates an IAM execution role for a harness.
    */
-  harnesses?: { name: string; executionRoleArn?: string; memoryName?: string }[];
+  harnesses?: {
+    name: string;
+    executionRoleArn?: string;
+    memoryName?: string;
+    containerUri?: string;
+    hasDockerfile?: boolean;
+    tools?: { type: string; name: string }[];
+    apiKeyArn?: string;
+  }[];
 }
 
 /**
@@ -485,6 +497,7 @@ exports[`Assets Directory Snapshots > File listing > should match the expected f
   "evaluators/python-lambda/execution-role-policy.json",
   "evaluators/python-lambda/lambda_function.py",
   "evaluators/python-lambda/pyproject.toml",
+  "harness/invoke.py.template",
   "mcp/python-lambda/README.md",
   "mcp/python-lambda/handler.py",
   "mcp/python-lambda/pyproject.toml",

--- a/src/cli/tui/hooks/__tests__/useDevDeploy.test.tsx
+++ b/src/cli/tui/hooks/__tests__/useDevDeploy.test.tsx
@@ -47,7 +47,7 @@ describe('useDevDeploy', () => {
     const { lastFrame } = render(<Harness skip={true} />);
 
     await vi.waitFor(() => {
-      expect(lastFrame()).toContain('isComplete:false');
+      expect(lastFrame()).toContain('isComplete:true');
     });
 
     expect(mockHandleDeploy).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

- Update 3 asset snapshots that drifted from the harness-implementation branch content:
  - File listing (new harness files added)
  - `cdk/bin/cdk.ts`
  - `cdk/lib/cdk-stack.ts`
- Fix `useDevDeploy` test: when `skip=true`, `isComplete` is correctly `true` (skipped = done), not `false` as the test asserted

## Root cause

Asset snapshots were not regenerated after harness-related changes to CDK templates and file structure. The `useDevDeploy` test had a stale assertion — the hook returns `isComplete = skip || deployDone`, so skip=true means immediately complete.

## Test plan

- [x] All 95 tests pass (90 snapshot + 5 useDevDeploy)
- [x] Pre-commit hooks pass (eslint, prettier, secretlint, typecheck)