### PR TITLE
fix(deploy): honor aws-targets.json region for all SDK and CDK calls

### DIFF
--- a/src/cli/aws/__tests__/target-region.test.ts
+++ b/src/cli/aws/__tests__/target-region.test.ts
@@ -1,0 +1,99 @@
+import { applyTargetRegionToEnv, withTargetRegion } from '../target-region.js';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+describe('target-region', () => {
+  let savedRegion: string | undefined;
+  let savedDefaultRegion: string | undefined;
+
+  beforeEach(() => {
+    savedRegion = process.env.AWS_REGION;
+    savedDefaultRegion = process.env.AWS_DEFAULT_REGION;
+    delete process.env.AWS_REGION;
+    delete process.env.AWS_DEFAULT_REGION;
+  });
+
+  afterEach(() => {
+    if (savedRegion !== undefined) process.env.AWS_REGION = savedRegion;
+    else delete process.env.AWS_REGION;
+    if (savedDefaultRegion !== undefined) process.env.AWS_DEFAULT_REGION = savedDefaultRegion;
+    else delete process.env.AWS_DEFAULT_REGION;
+  });
+
+  describe('applyTargetRegionToEnv', () => {
+    it('sets AWS_REGION and AWS_DEFAULT_REGION to the provided region', () => {
+      applyTargetRegionToEnv('ap-southeast-2');
+      expect(process.env.AWS_REGION).toBe('ap-southeast-2');
+      expect(process.env.AWS_DEFAULT_REGION).toBe('ap-southeast-2');
+    });
+
+    it('returns a restore function that clears env vars when they were previously unset', () => {
+      const restore = applyTargetRegionToEnv('eu-west-1');
+      restore();
+      expect(process.env.AWS_REGION).toBeUndefined();
+      expect(process.env.AWS_DEFAULT_REGION).toBeUndefined();
+    });
+
+    it('returns a restore function that restores previous env var values', () => {
+      process.env.AWS_REGION = 'us-east-1';
+      process.env.AWS_DEFAULT_REGION = 'us-east-1';
+
+      const restore = applyTargetRegionToEnv('ap-south-1');
+      expect(process.env.AWS_REGION).toBe('ap-south-1');
+      expect(process.env.AWS_DEFAULT_REGION).toBe('ap-south-1');
+
+      restore();
+      expect(process.env.AWS_REGION).toBe('us-east-1');
+      expect(process.env.AWS_DEFAULT_REGION).toBe('us-east-1');
+    });
+
+    it('restores each env var independently (only one was previously set)', () => {
+      process.env.AWS_REGION = 'us-west-2';
+      // AWS_DEFAULT_REGION intentionally left unset
+
+      const restore = applyTargetRegionToEnv('eu-central-1');
+      expect(process.env.AWS_REGION).toBe('eu-central-1');
+      expect(process.env.AWS_DEFAULT_REGION).toBe('eu-central-1');
+
+      restore();
+      expect(process.env.AWS_REGION).toBe('us-west-2');
+      expect(process.env.AWS_DEFAULT_REGION).toBeUndefined();
+    });
+  });
+
+  describe('withTargetRegion', () => {
+    it('applies region inside the callback and restores afterwards', async () => {
+      let seenRegion: string | undefined;
+      let seenDefaultRegion: string | undefined;
+
+      await withTargetRegion('ap-northeast-1', () => {
+        seenRegion = process.env.AWS_REGION;
+        seenDefaultRegion = process.env.AWS_DEFAULT_REGION;
+        return Promise.resolve();
+      });
+
+      expect(seenRegion).toBe('ap-northeast-1');
+      expect(seenDefaultRegion).toBe('ap-northeast-1');
+      expect(process.env.AWS_REGION).toBeUndefined();
+      expect(process.env.AWS_DEFAULT_REGION).toBeUndefined();
+    });
+
+    it('restores env vars even when the callback throws', async () => {
+      process.env.AWS_REGION = 'us-east-1';
+
+      await expect(
+        withTargetRegion('sa-east-1', () => {
+          expect(process.env.AWS_REGION).toBe('sa-east-1');
+          return Promise.reject(new Error('boom'));
+        })
+      ).rejects.toThrow('boom');
+
+      expect(process.env.AWS_REGION).toBe('us-east-1');
+      expect(process.env.AWS_DEFAULT_REGION).toBeUndefined();
+    });
+
+    it('returns the callback result', async () => {
+      const result = await withTargetRegion('eu-west-2', () => Promise.resolve(42));
+      expect(result).toBe(42);
+    });
+  });
+});

--- a/src/cli/aws/index.ts
+++ b/src/cli/aws/index.ts
@@ -1,7 +1,7 @@
 export { detectAwsContext, type AwsContext } from './aws-context';
 export { detectAccount, getCredentialProvider } from './account';
 export { detectRegion, type RegionDetectionResult } from './region';
-export { withTargetRegion } from './target-region';
+export { applyTargetRegionToEnv, withTargetRegion } from './target-region';
 export {
   invokeBedrockSync,
   invokeClaude,

--- a/src/cli/aws/index.ts
+++ b/src/cli/aws/index.ts
@@ -1,6 +1,7 @@
 export { detectAwsContext, type AwsContext } from './aws-context';
 export { detectAccount, getCredentialProvider } from './account';
 export { detectRegion, type RegionDetectionResult } from './region';
+export { withTargetRegion } from './target-region';
 export {
   invokeBedrockSync,
   invokeClaude,

--- a/src/cli/aws/target-region.ts
+++ b/src/cli/aws/target-region.ts
@@ -1,0 +1,55 @@
+/**
+ * Make a deployment target's region authoritative for downstream AWS SDK calls.
+ *
+ * The AWS SDK (and CDK toolkit-lib's internal clients) resolve region from
+ * AWS_REGION / AWS_DEFAULT_REGION when constructed without an explicit `region`
+ * option. aws-targets.json is the user's source of truth for where resources
+ * should be created, so we promote the target's region onto the environment for
+ * the operation and restore any prior values afterwards.
+ *
+ * Without this override, a user with a non-default region in aws-targets.json
+ * but no AWS_DEFAULT_REGION set would see resources created in the SDK's default
+ * region — see https://github.com/aws/agentcore-cli/issues/924.
+ */
+
+type RestoreEnv = () => void;
+
+/**
+ * Set AWS_REGION / AWS_DEFAULT_REGION to `region` and return a restore function.
+ * Callers that cannot wrap their work in a callback (e.g. CLI entrypoints that
+ * span many helpers) should use this, and invoke the returned function in a
+ * `finally` block.
+ */
+export function applyTargetRegionToEnv(region: string): RestoreEnv {
+  const prevRegion = process.env.AWS_REGION;
+  const prevDefaultRegion = process.env.AWS_DEFAULT_REGION;
+
+  process.env.AWS_REGION = region;
+  process.env.AWS_DEFAULT_REGION = region;
+
+  return () => {
+    if (prevRegion === undefined) {
+      delete process.env.AWS_REGION;
+    } else {
+      process.env.AWS_REGION = prevRegion;
+    }
+    if (prevDefaultRegion === undefined) {
+      delete process.env.AWS_DEFAULT_REGION;
+    } else {
+      process.env.AWS_DEFAULT_REGION = prevDefaultRegion;
+    }
+  };
+}
+
+/**
+ * Run `fn` with `region` applied to AWS_REGION / AWS_DEFAULT_REGION, restoring
+ * the prior values on return (including when `fn` throws).
+ */
+export async function withTargetRegion<T>(region: string, fn: () => Promise<T>): Promise<T> {
+  const restore = applyTargetRegionToEnv(region);
+  try {
+    return await fn();
+  } finally {
+    restore();
+  }
+}

--- a/src/cli/commands/deploy/actions.ts
+++ b/src/cli/commands/deploy/actions.ts
@@ -1,6 +1,7 @@
 import { ConfigIO, SecureCredentials } from '../../../lib';
 import type { AgentCoreMcpSpec, DeployedState } from '../../../schema';
 import { validateAwsCredentials } from '../../aws/account';
+import { applyTargetRegionToEnv } from '../../aws/target-region';
 import { createSwitchableIoHost } from '../../cdk/toolkit-lib';
 import {
   buildDeployedState,
@@ -48,6 +49,7 @@ const MEMORY_ONLY_NEXT_STEPS = ['agentcore add agent', 'agentcore status'];
 
 export async function handleDeploy(options: ValidatedDeployOptions): Promise<DeployResult> {
   let toolkitWrapper = null;
+  let restoreEnv: (() => void) | null = null;
   const logger = new ExecLogger({ command: 'deploy' });
   const { onProgress } = options;
   let currentStepName = '';
@@ -79,6 +81,10 @@ export async function handleDeploy(options: ValidatedDeployOptions): Promise<Dep
         logPath: logger.getRelativeLogPath(),
       };
     }
+    // Make the resolved target region authoritative for downstream SDK / CDK
+    // calls that don't receive an explicit region option.
+    // See https://github.com/aws/agentcore-cli/issues/924.
+    restoreEnv = applyTargetRegionToEnv(target.region);
     endStep('success');
 
     // Read project spec for gateway information (used later for deploy step name and outputs)
@@ -485,5 +491,6 @@ export async function handleDeploy(options: ValidatedDeployOptions): Promise<Dep
     if (toolkitWrapper) {
       await toolkitWrapper.dispose();
     }
+    restoreEnv?.();
   }
 }

--- a/src/cli/commands/deploy/actions.ts
+++ b/src/cli/commands/deploy/actions.ts
@@ -1,7 +1,7 @@
 import { ConfigIO, SecureCredentials } from '../../../lib';
 import type { AgentCoreMcpSpec, DeployedState } from '../../../schema';
+import { applyTargetRegionToEnv } from '../../aws';
 import { validateAwsCredentials } from '../../aws/account';
-import { applyTargetRegionToEnv } from '../../aws/target-region';
 import { createSwitchableIoHost } from '../../cdk/toolkit-lib';
 import {
   buildDeployedState,

--- a/src/cli/operations/deploy/teardown.ts
+++ b/src/cli/operations/deploy/teardown.ts
@@ -1,6 +1,6 @@
 import { CONFIG_DIR, ConfigIO } from '../../../lib';
 import type { AwsDeploymentTarget } from '../../../schema';
-import { withTargetRegion } from '../../aws/target-region';
+import { withTargetRegion } from '../../aws';
 import { CdkToolkitWrapper, silentIoHost } from '../../cdk/toolkit-lib';
 import { type DiscoveredStack, findStack } from '../../cloudformation/stack-discovery';
 import { StackSelectionStrategy } from '@aws-cdk/toolkit-lib';

--- a/src/cli/operations/deploy/teardown.ts
+++ b/src/cli/operations/deploy/teardown.ts
@@ -1,5 +1,6 @@
 import { CONFIG_DIR, ConfigIO } from '../../../lib';
 import type { AwsDeploymentTarget } from '../../../schema';
+import { withTargetRegion } from '../../aws/target-region';
 import { CdkToolkitWrapper, silentIoHost } from '../../cdk/toolkit-lib';
 import { type DiscoveredStack, findStack } from '../../cloudformation/stack-discovery';
 import { StackSelectionStrategy } from '@aws-cdk/toolkit-lib';
@@ -60,12 +61,18 @@ export async function destroyTarget(options: DestroyTargetOptions): Promise<void
     ioHost: silentIoHost,
   });
 
-  await toolkit.initialize();
-  await toolkit.destroy({
-    stacks: {
-      strategy: StackSelectionStrategy.PATTERN_MUST_MATCH,
-      patterns: [target.stack.stackName],
-    },
+  // aws-targets.json is authoritative for the destroy region; promote it onto
+  // the env so CDK toolkit-lib's internal SDK clients hit the right region even
+  // when AWS_REGION / AWS_DEFAULT_REGION are unset.
+  // See https://github.com/aws/agentcore-cli/issues/924.
+  await withTargetRegion(target.target.region, async () => {
+    await toolkit.initialize();
+    await toolkit.destroy({
+      stacks: {
+        strategy: StackSelectionStrategy.PATTERN_MUST_MATCH,
+        patterns: [target.stack.stackName],
+      },
+    });
   });
 
   // Clean up deployed-state.json after successful destroy

--- a/src/cli/tui/hooks/useCdkPreflight.ts
+++ b/src/cli/tui/hooks/useCdkPreflight.ts
@@ -1,7 +1,7 @@
 import { ConfigIO, SecureCredentials } from '../../../lib';
 import type { DeployedState } from '../../../schema';
+import { applyTargetRegionToEnv } from '../../aws';
 import { AwsCredentialsError, validateAwsCredentials } from '../../aws/account';
-import { applyTargetRegionToEnv } from '../../aws/target-region';
 import { type CdkToolkitWrapper, type SwitchableIoHost, createSwitchableIoHost } from '../../cdk/toolkit-lib';
 import { getErrorMessage, isExpiredTokenError, isNoCredentialsError } from '../../errors';
 import type { ExecLogger } from '../../logging';
@@ -211,6 +211,16 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
       restoreRegionEnv();
     };
   }, [disposeWrapper, restoreRegionEnv]);
+
+  // Restore region env override when any preflight stage lands in 'error'.
+  // Individual error branches inside the stage effects only call setPhase('error')
+  // without cleanup, so this hook is the single place that guarantees restore
+  // happens on every error path without threading the call into every branch.
+  useEffect(() => {
+    if (phase === 'error') {
+      restoreRegionEnv();
+    }
+  }, [phase, restoreRegionEnv]);
 
   const confirmTeardown = useCallback(() => {
     // Mark teardown as confirmed and restart the preflight flow

--- a/src/cli/tui/hooks/useCdkPreflight.ts
+++ b/src/cli/tui/hooks/useCdkPreflight.ts
@@ -1,6 +1,7 @@
 import { ConfigIO, SecureCredentials } from '../../../lib';
 import type { DeployedState } from '../../../schema';
 import { AwsCredentialsError, validateAwsCredentials } from '../../aws/account';
+import { applyTargetRegionToEnv } from '../../aws/target-region';
 import { type CdkToolkitWrapper, type SwitchableIoHost, createSwitchableIoHost } from '../../cdk/toolkit-lib';
 import { getErrorMessage, isExpiredTokenError, isNoCredentialsError } from '../../errors';
 import type { ExecLogger } from '../../logging';
@@ -137,6 +138,11 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
   const isRunningRef = useRef(false);
   // Keep a ref to the wrapper so we can dispose it when starting a new run
   const wrapperRef = useRef<CdkToolkitWrapper | null>(null);
+  // Restore function for AWS_REGION / AWS_DEFAULT_REGION overrides, applied
+  // after target resolution so downstream SDK / CDK toolkit-lib clients use the
+  // aws-targets.json region rather than whatever the SDK default chain resolves.
+  // See https://github.com/aws/agentcore-cli/issues/924.
+  const restoreRegionEnvRef = useRef<(() => void) | null>(null);
 
   const updateStep = (index: number, update: Partial<Step>) => {
     setSteps(prev => prev.map((s, i) => (i === index ? { ...s, ...update } : s)));
@@ -158,10 +164,18 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
     }
   }, []);
 
+  // Restore AWS_REGION / AWS_DEFAULT_REGION (no-op when nothing was applied)
+  const restoreRegionEnv = useCallback(() => {
+    restoreRegionEnvRef.current?.();
+    restoreRegionEnvRef.current = null;
+  }, []);
+
   const startPreflight = useCallback(async () => {
     if (isRunningRef.current) return;
     // Dispose any existing wrapper before starting a new run
     await disposeWrapper();
+    // Restore any previously-applied region env override before re-running
+    restoreRegionEnv();
     resetSteps();
     setCdkToolkitWrapper(null);
     setStackNames([]);
@@ -169,7 +183,7 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
     setHasTokenExpiredError(false); // Reset token expired state when retrying
     setHasCredentialsError(false); // Reset credentials error state when retrying
     setPhase('running');
-  }, [disposeWrapper]);
+  }, [disposeWrapper, restoreRegionEnv]);
 
   const clearTokenExpiredError = useCallback(() => {
     setHasTokenExpiredError(false);
@@ -183,6 +197,7 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
   useEffect(() => {
     const handleInterrupt = () => {
       void disposeWrapper();
+      restoreRegionEnv();
     };
 
     process.on('SIGINT', handleInterrupt);
@@ -193,8 +208,9 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
       process.off('SIGTERM', handleInterrupt);
       // Dispose on unmount (user navigated away)
       void disposeWrapper();
+      restoreRegionEnv();
     };
-  }, [disposeWrapper]);
+  }, [disposeWrapper, restoreRegionEnv]);
 
   const confirmTeardown = useCallback(() => {
     // Mark teardown as confirmed and restart the preflight flow
@@ -206,7 +222,8 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
   const cancelTeardown = useCallback(() => {
     setPhase('error');
     isRunningRef.current = false;
-  }, []);
+    restoreRegionEnv();
+  }, [restoreRegionEnv]);
 
   const confirmBootstrap = useCallback(() => {
     setPhase('bootstrapping');
@@ -274,6 +291,15 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
         try {
           preflightContext = await validateProject();
           setContext(preflightContext);
+          // Make aws-targets.json region authoritative for downstream SDK / CDK
+          // toolkit-lib clients that bypass explicit region options. Restored on
+          // unmount, teardown rejection, or subsequent preflight start.
+          // See https://github.com/aws/agentcore-cli/issues/924.
+          const firstTarget = preflightContext.awsTargets[0];
+          if (firstTarget) {
+            restoreRegionEnv();
+            restoreRegionEnvRef.current = applyTargetRegionToEnv(firstTarget.region);
+          }
           logger.endStep('success');
           updateStep(STEP_VALIDATE, { status: 'success' });
         } catch (err) {
@@ -493,7 +519,7 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
     return () => {
       process.off('unhandledRejection', handleUnhandledRejection);
     };
-  }, [phase, logger, switchableIoHost, isInteractive, skipIdentityCheck, teardownConfirmed]);
+  }, [phase, logger, switchableIoHost, isInteractive, skipIdentityCheck, teardownConfirmed, restoreRegionEnv]);
 
   // Handle identity-setup phase (after user provides credentials)
   useEffect(() => {


### PR DESCRIPTION
## Description

The agentcore CLI did not use the `region` field from `aws-targets.json` when making API calls for resources like runtimes, evaluators, and online eval configs. Changing `aws-targets.json` had no effect on where resources were created unless `AWS_DEFAULT_REGION` was also set.

### Root cause

The CLI passes `target.region` explicitly to its own SDK clients, but `@aws-cdk/toolkit-lib` constructs internal SDK clients (for CloudFormation, S3 asset upload, asset publishing, etc.) that do not receive an explicit region option and fall back to the SDK default region resolution chain: `AWS_REGION` → `AWS_DEFAULT_REGION` → shared config profile. When `aws-targets.json` specified a non-default region but those env vars were unset, CDK's internal clients resolved the wrong region and resources were created in the SDK default region.

### Fix

New helper `src/cli/aws/target-region.ts` exports:
- `applyTargetRegionToEnv(region)` — sets `AWS_REGION` and `AWS_DEFAULT_REGION` to the target region, returns a restore function.
- `withTargetRegion(region, fn)` — try/finally wrapper.

Applied at:
- `src/cli/commands/deploy/actions.ts` — `handleDeploy()` calls `applyTargetRegionToEnv(target.region)` after target resolution; restore runs in the existing `finally` block.
- `src/cli/operations/deploy/teardown.ts` — `destroyTarget()` wraps CDK `initialize()`/`destroy()` in `withTargetRegion(...)`.
- `src/cli/tui/hooks/useCdkPreflight.ts` — TUI path applies the override after `validateProject()`; restored on unmount, `cancelTeardown`, preflight retry, SIGINT/SIGTERM.

Invoke/status/eval/logs commands already pass `target.region` explicitly to every SDK client — no changes needed there.

## Related Issue

Closes #924

## Documentation PR

N/A — behavior-only fix.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran \`npm run test:unit\` and \`npm run test:integ\`
- [x] I ran \`npm run typecheck\`
- [x] I ran \`npm run lint\`
- [ ] If I modified \`src/assets/\`, I ran \`npm run test:update-snapshots\` and committed the updated snapshots

### Unit tests

7 new unit tests in \`src/cli/aws/__tests__/target-region.test.ts\` cover:
- sets both env vars to the provided region
- restore clears env vars when they were previously unset
- restore preserves previous values when they were set
- restore handles each env var independently
- applies inside callback and restores afterwards
- restores even when the callback throws
- returns the callback result

All 7 pass. Relevant targeted suites (aws, operations/deploy, config-io, tui/hooks): 354/354 pass. tsc: 0 errors. eslint: 0 errors on modified files.

### End-to-end testing against live AWS

Tested full lifecycle (create → add agent → deploy → invoke → teardown) against AWS account 603141041947 across 5 scenarios:

| # | Scenario | Region | Result |
|---|---|---|---|
| 1 | CLI non-interactive, no env vars | \`ap-southeast-2\` | ✅ Runtime in apse2, none in us-east-1 |
| 2 | Env isolation — success + error paths | \`ap-southeast-2\` | ✅ Env vars remain unset after both paths |
| 3 | CLI non-interactive, no env vars | \`eu-west-1\` | ✅ Runtime in euw1, invoke returned \"Hello!\" |
| 4 | Interactive TUI (tui-harness) | \`ap-southeast-2\` | ✅ Full interactive deploy + teardown |
| 5 | **Key test: target beats env var** | \`eu-west-2\` + \`AWS_DEFAULT_REGION=us-east-1\` | ✅ Runtime in euw2, none in us-east-1 |

All 5 verified via \`aws bedrock-agentcore-control list-agent-runtimes\` and teardown confirmed cleanup.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.