### PR TITLE
fix: fail fast when harness dockerfile field is silently ignored on deploy

### DIFF
--- a/src/cli/operations/deploy/imperative/deployers/__tests__/harness-mapper.test.ts
+++ b/src/cli/operations/deploy/imperative/deployers/__tests__/harness-mapper.test.ts
@@ -302,6 +302,18 @@ describe('mapHarnessSpecToCreateOptions', () => {
     });
   });
 
+  // ── Dockerfile fail-fast ──────────────────────────────────────────────
+
+  describe('dockerfile fail-fast', () => {
+    it('throws when dockerfile is set without containerUri', async () => {
+      const spec = minimalSpec({ dockerfile: 'Dockerfile' });
+
+      await expect(mapHarnessSpecToCreateOptions({ ...BASE_OPTIONS, harnessSpec: spec })).rejects.toThrow(
+        'does not yet build and push Dockerfiles for harnesses'
+      );
+    });
+  });
+
   // ── Network/Lifecycle mapping ──────────────────────────────────────────
 
   describe('environment provider mapping', () => {

--- a/src/cli/operations/deploy/imperative/deployers/harness-mapper.ts
+++ b/src/cli/operations/deploy/imperative/deployers/harness-mapper.ts
@@ -43,6 +43,14 @@ export interface MapHarnessOptions {
 export async function mapHarnessSpecToCreateOptions(options: MapHarnessOptions): Promise<CreateHarnessOptions> {
   const { harnessSpec, harnessDir, executionRoleArn, region, projectName, deployedResources, cdkOutputs } = options;
 
+  if (harnessSpec.dockerfile && !harnessSpec.containerUri) {
+    throw new Error(
+      `Harness "${harnessSpec.name}" specifies "dockerfile" but the CLI does not yet build and push ` +
+        `Dockerfiles for harnesses. Either replace "dockerfile" with a pre-built "containerUri" ` +
+        `(e.g. an ECR image URI), or remove the "dockerfile" field.`
+    );
+  }
+
   const result: CreateHarnessOptions = {
     region,
     harnessName: `${projectName}_${harnessSpec.name}`,


### PR DESCRIPTION
## Summary

Fixes #927.

- `harness.json` accepts a `dockerfile` field, but `agentcore deploy` silently ignores it because the CLI does not yet build/push Docker images for harnesses (unlike the agent Container path from #783).
- This adds a fail-fast check in `mapHarnessSpecToCreateOptions`: when `dockerfile` is set without `containerUri`, the deploy throws a clear error telling the user to either provide a pre-built `containerUri` or remove the `dockerfile` field.
- Adds a unit test for the new validation.

## Test plan

- [x] New unit test: `throws when dockerfile is set without containerUri`
- [x] All existing harness-mapper tests pass (27/27)
- [x] All existing harness-deployer tests pass (14/14)