### PR TITLE
fix: build and push Dockerfile for harnesses on deploy

### DIFF
--- a/src/assets/cdk/bin/cdk.ts
+++ b/src/assets/cdk/bin/cdk.ts
@@ -65,11 +65,14 @@ async function main() {
     memoryName?: string;
     containerUri?: string;
     hasDockerfile?: boolean;
+    dockerfileName?: string;
+    harnessDir?: string;
     tools?: { type: string; name: string }[];
     apiKeyArn?: string;
   }[] = [];
   for (const entry of specAny.harnesses ?? []) {
-    const harnessPath = path.resolve(projectRoot, entry.path, 'harness.json');
+    const harnessDir = path.resolve(projectRoot, entry.path);
+    const harnessPath = path.resolve(harnessDir, 'harness.json');
     try {
       const harnessSpec = JSON.parse(fs.readFileSync(harnessPath, 'utf-8'));
       harnessConfigs.push({
@@ -78,6 +81,8 @@ async function main() {
         memoryName: harnessSpec.memory?.name,
         containerUri: harnessSpec.containerUri,
         hasDockerfile: !!harnessSpec.dockerfile,
+        dockerfileName: harnessSpec.dockerfile,
+        harnessDir,
         tools: harnessSpec.tools,
         apiKeyArn: harnessSpec.model?.apiKeyArn,
       });

--- a/src/assets/cdk/lib/cdk-stack.ts
+++ b/src/assets/cdk/lib/cdk-stack.ts
@@ -3,9 +3,25 @@ import {
   AgentCoreMcp,
   type AgentCoreProjectSpec,
   type AgentCoreMcpSpec,
+  ContainerSourceAssetFromPath,
+  AgentEcrRepository,
+  ContainerBuildProject,
+  ContainerImageBuilder,
 } from '@aws/agentcore-cdk';
 import { CfnOutput, Stack, type StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
+
+export interface HarnessConfig {
+  name: string;
+  executionRoleArn?: string;
+  memoryName?: string;
+  containerUri?: string;
+  hasDockerfile?: boolean;
+  dockerfileName?: string;
+  harnessDir?: string;
+  tools?: { type: string; name: string }[];
+  apiKeyArn?: string;
+}
 
 export interface AgentCoreStackProps extends StackProps {
   /**
@@ -23,15 +39,7 @@ export interface AgentCoreStackProps extends StackProps {
   /**
    * Harness role configurations. Each entry creates an IAM execution role for a harness.
    */
-  harnesses?: {
-    name: string;
-    executionRoleArn?: string;
-    memoryName?: string;
-    containerUri?: string;
-    hasDockerfile?: boolean;
-    tools?: { type: string; name: string }[];
-    apiKeyArn?: string;
-  }[];
+  harnesses?: HarnessConfig[];
 }
 
 /**
@@ -49,10 +57,46 @@ export class AgentCoreStack extends Stack {
 
     const { spec, mcpSpec, credentials, harnesses } = props;
 
+    // Build container images for harnesses that specify a dockerfile (no containerUri).
+    // Produces CDK outputs consumed by the imperative harness deployer.
+    const harnessesForCdk = harnesses ? [...harnesses] : [];
+    if (harnesses) {
+      for (let i = 0; i < harnesses.length; i++) {
+        const h = harnesses[i]!;
+        if (h.hasDockerfile && !h.containerUri && h.harnessDir) {
+          const pascalName = h.name.replace(/(^|_)([a-z])/g, (_: string, __: string, c: string) => c.toUpperCase());
+          const sourceAsset = new ContainerSourceAssetFromPath(this, `Harness${pascalName}SourceAsset`, {
+            sourcePath: h.harnessDir,
+          });
+          const ecrRepo = new AgentEcrRepository(this, `Harness${pascalName}EcrRepo`, {
+            projectName: spec.name,
+            agentName: `harness-${h.name}`,
+          });
+          const buildProject = ContainerBuildProject.getOrCreate(this);
+          buildProject.grantPushTo(ecrRepo.repository);
+          sourceAsset.asset.grantRead(buildProject.role);
+
+          const builder = new ContainerImageBuilder(this, `Harness${pascalName}ContainerBuild`, {
+            buildProject,
+            sourceAsset,
+            repository: ecrRepo,
+            dockerfile: h.dockerfileName ?? 'Dockerfile',
+          });
+
+          new CfnOutput(this, `Harness${pascalName}ContainerUriOutput`, {
+            value: builder.containerUri,
+          });
+
+          // Pass the built containerUri to the harness role construct so it gets ECR pull permissions
+          harnessesForCdk[i] = { ...h, containerUri: builder.containerUri };
+        }
+      }
+    }
+
     // Create AgentCoreApplication with all agents and harness roles
     this.application = new AgentCoreApplication(this, 'Application', {
       spec,
-      harnesses,
+      harnesses: harnessesForCdk.length > 0 ? harnessesForCdk : undefined,
     });
 
     // Create AgentCoreMcp if there are gateways configured

--- a/src/cli/operations/deploy/__tests__/preflight-harness-dockerfile.test.ts
+++ b/src/cli/operations/deploy/__tests__/preflight-harness-dockerfile.test.ts
@@ -1,0 +1,100 @@
+import type { AgentCoreProjectSpec } from '../../../../schema';
+import { validateHarnessDockerfiles } from '../preflight.js';
+import { existsSync, readFileSync } from 'node:fs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+}));
+
+vi.mock('../../../../lib', () => ({
+  DOCKERFILE_NAME: 'Dockerfile',
+  getDockerfilePath: (codeLocation: string, dockerfile?: string) => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const p = require('node:path') as typeof import('node:path');
+    return p.join(codeLocation, dockerfile ?? 'Dockerfile');
+  },
+  ConfigIO: vi.fn(),
+  requireConfigRoot: vi.fn(),
+  resolveCodeLocation: vi.fn(),
+}));
+
+const mockedExistsSync = vi.mocked(existsSync);
+const mockedReadFileSync = vi.mocked(readFileSync);
+
+const CONFIG_ROOT = '/project/agentcore';
+
+function makeSpec(harnesses: { name: string; path: string }[]): AgentCoreProjectSpec {
+  return {
+    name: 'test-project',
+    runtimes: [],
+    harnesses,
+  } as unknown as AgentCoreProjectSpec;
+}
+
+describe('validateHarnessDockerfiles', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does nothing when no harnesses are defined', () => {
+    const spec = makeSpec([]);
+    expect(() => validateHarnessDockerfiles(spec, CONFIG_ROOT)).not.toThrow();
+    expect(mockedReadFileSync).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when harness has no dockerfile field', () => {
+    mockedReadFileSync.mockReturnValue(JSON.stringify({ name: 'my_harness', model: {} }));
+
+    const spec = makeSpec([{ name: 'my_harness', path: 'harnesses/my_harness' }]);
+    expect(() => validateHarnessDockerfiles(spec, CONFIG_ROOT)).not.toThrow();
+    expect(mockedExistsSync).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when harness has containerUri (dockerfile is ignored)', () => {
+    mockedReadFileSync.mockReturnValue(
+      JSON.stringify({ name: 'my_harness', dockerfile: 'Dockerfile', containerUri: 'ecr-uri' })
+    );
+
+    const spec = makeSpec([{ name: 'my_harness', path: 'harnesses/my_harness' }]);
+    expect(() => validateHarnessDockerfiles(spec, CONFIG_ROOT)).not.toThrow();
+    expect(mockedExistsSync).not.toHaveBeenCalled();
+  });
+
+  it('passes when harness has dockerfile and file exists', () => {
+    mockedReadFileSync.mockReturnValue(JSON.stringify({ name: 'my_harness', dockerfile: 'Dockerfile' }));
+    mockedExistsSync.mockReturnValue(true);
+
+    const spec = makeSpec([{ name: 'my_harness', path: 'harnesses/my_harness' }]);
+    expect(() => validateHarnessDockerfiles(spec, CONFIG_ROOT)).not.toThrow();
+  });
+
+  it('throws when harness has dockerfile but file does not exist', () => {
+    mockedReadFileSync.mockReturnValue(JSON.stringify({ name: 'my_harness', dockerfile: 'Dockerfile' }));
+    mockedExistsSync.mockReturnValue(false);
+
+    const spec = makeSpec([{ name: 'my_harness', path: 'harnesses/my_harness' }]);
+    expect(() => validateHarnessDockerfiles(spec, CONFIG_ROOT)).toThrow(/my_harness.*Dockerfile not found/);
+  });
+
+  it('checks for custom dockerfile name', () => {
+    mockedReadFileSync.mockReturnValue(JSON.stringify({ name: 'gpu', dockerfile: 'Dockerfile.gpu' }));
+    mockedExistsSync.mockReturnValue(true);
+
+    const spec = makeSpec([{ name: 'gpu', path: 'harnesses/gpu' }]);
+    expect(() => validateHarnessDockerfiles(spec, CONFIG_ROOT)).not.toThrow();
+
+    const calledPath = mockedExistsSync.mock.calls[0]?.[0] as string;
+    expect(calledPath).toContain('Dockerfile.gpu');
+  });
+
+  it('continues if harness.json cannot be read', () => {
+    mockedReadFileSync.mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+
+    const spec = makeSpec([{ name: 'broken', path: 'harnesses/broken' }]);
+    expect(() => validateHarnessDockerfiles(spec, CONFIG_ROOT)).not.toThrow();
+  });
+});

--- a/src/cli/operations/deploy/imperative/deployers/__tests__/harness-mapper.test.ts
+++ b/src/cli/operations/deploy/imperative/deployers/__tests__/harness-mapper.test.ts
@@ -300,6 +300,44 @@ describe('mapHarnessSpecToCreateOptions', () => {
         },
       });
     });
+
+    it('resolves containerUri from CDK outputs when dockerfile is set', async () => {
+      const spec = minimalSpec({ dockerfile: 'Dockerfile' });
+      const cdkOutputs = {
+        HarnessTestHarnessContainerUriOutputABC123: '123456789012.dkr.ecr.us-east-1.amazonaws.com/harness-test:abc',
+      };
+
+      const result = await mapHarnessSpecToCreateOptions({ ...BASE_OPTIONS, harnessSpec: spec, cdkOutputs });
+
+      expect(result.environmentArtifact).toEqual({
+        containerConfiguration: {
+          containerUri: '123456789012.dkr.ecr.us-east-1.amazonaws.com/harness-test:abc',
+        },
+      });
+    });
+
+    it('throws when dockerfile is set but no container URI found in CDK outputs', async () => {
+      const spec = minimalSpec({ dockerfile: 'Dockerfile' });
+
+      await expect(
+        mapHarnessSpecToCreateOptions({ ...BASE_OPTIONS, harnessSpec: spec, cdkOutputs: {} })
+      ).rejects.toThrow('no container URI was found in CDK outputs');
+    });
+
+    it('prefers explicit containerUri over dockerfile', async () => {
+      const spec = minimalSpec({
+        containerUri: '123456789012.dkr.ecr.us-east-1.amazonaws.com/explicit:latest',
+        dockerfile: undefined,
+      });
+
+      const result = await mapHarnessSpecToCreateOptions({ ...BASE_OPTIONS, harnessSpec: spec });
+
+      expect(result.environmentArtifact).toEqual({
+        containerConfiguration: {
+          containerUri: '123456789012.dkr.ecr.us-east-1.amazonaws.com/explicit:latest',
+        },
+      });
+    });
   });
 
   // ── Network/Lifecycle mapping ──────────────────────────────────────────

--- a/src/cli/operations/deploy/imperative/deployers/harness-mapper.ts
+++ b/src/cli/operations/deploy/imperative/deployers/harness-mapper.ts
@@ -99,6 +99,15 @@ export async function mapHarnessSpecToCreateOptions(options: MapHarnessOptions):
   // Container artifact
   if (harnessSpec.containerUri) {
     result.environmentArtifact = mapEnvironmentArtifact(harnessSpec.containerUri);
+  } else if (harnessSpec.dockerfile) {
+    const builtUri = resolveContainerUriFromOutputs(harnessSpec.name, cdkOutputs);
+    if (!builtUri) {
+      throw new Error(
+        `Harness "${harnessSpec.name}" specifies "dockerfile" but no container URI was found in CDK outputs. ` +
+          `Expected a CDK output key starting with "Harness${toPascalId(harnessSpec.name)}ContainerUri".`
+      );
+    }
+    result.environmentArtifact = mapEnvironmentArtifact(builtUri);
   }
 
   // Environment provider (network + lifecycle)
@@ -317,6 +326,25 @@ function mapTruncation(truncation: NonNullable<HarnessSpec['truncation']>): Harn
     strategy: truncation.strategy,
     config: truncation.config as HarnessTruncationConfiguration['config'],
   };
+}
+
+// ============================================================================
+// Container URI Resolution (from CDK outputs for dockerfile-based harnesses)
+// ============================================================================
+
+function resolveContainerUriFromOutputs(harnessName: string, cdkOutputs?: Record<string, string>): string | undefined {
+  if (!cdkOutputs) return undefined;
+
+  const pascalName = toPascalId(harnessName);
+  const prefix = `Harness${pascalName}ContainerUri`;
+
+  for (const [key, value] of Object.entries(cdkOutputs)) {
+    if (key.startsWith(prefix)) {
+      return value;
+    }
+  }
+
+  return undefined;
 }
 
 // ============================================================================

--- a/src/cli/operations/deploy/preflight.ts
+++ b/src/cli/operations/deploy/preflight.ts
@@ -6,7 +6,7 @@ import { CdkToolkitWrapper, createCdkToolkitWrapper, silentIoHost } from '../../
 import { checkBootstrapStatus, checkStacksStatus, formatCdkEnvironment } from '../../cloudformation';
 import { cleanupStaleLockFiles } from '../../tui/utils';
 import type { IIoHost } from '@aws-cdk/toolkit-lib';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import * as path from 'node:path';
 
 export interface PreflightContext {
@@ -114,6 +114,9 @@ export async function validateProject(): Promise<PreflightContext> {
   // Validate Container agents have Dockerfiles
   validateContainerAgents(projectSpec, configRoot);
 
+  // Validate harnesses with dockerfile field have actual Dockerfiles
+  validateHarnessDockerfiles(projectSpec, configRoot);
+
   // Validate AWS credentials before proceeding with build/synth.
   // Skip for teardown deploys — callers validate after teardown confirmation.
   if (!isTeardownDeploy) {
@@ -180,6 +183,41 @@ export function validateContainerAgents(projectSpec: AgentCoreProjectSpec, confi
       }
     }
   }
+  if (errors.length > 0) {
+    throw new Error(errors.join('\n'));
+  }
+}
+
+/**
+ * Validates that harnesses specifying a dockerfile have the Dockerfile on disk.
+ */
+export function validateHarnessDockerfiles(projectSpec: AgentCoreProjectSpec, configRoot: string): void {
+  const projectRoot = path.dirname(configRoot);
+  const errors: string[] = [];
+
+  for (const entry of projectSpec.harnesses || []) {
+    const harnessDir = path.join(projectRoot, entry.path);
+    const harnessJsonPath = path.join(harnessDir, 'harness.json');
+
+    let harnessSpec: { dockerfile?: string; containerUri?: string };
+    try {
+      const raw = readFileSync(harnessJsonPath, 'utf-8');
+      harnessSpec = JSON.parse(raw) as { dockerfile?: string; containerUri?: string };
+    } catch {
+      continue; // harness-deployer will report this error with full context
+    }
+
+    if (harnessSpec.dockerfile && !harnessSpec.containerUri) {
+      const dockerfilePath = getDockerfilePath(harnessDir, harnessSpec.dockerfile);
+      if (!existsSync(dockerfilePath)) {
+        errors.push(
+          `Harness "${entry.name}": ${harnessSpec.dockerfile} not found at ${dockerfilePath}. ` +
+            `Harnesses with a "dockerfile" field require the Dockerfile to exist.`
+        );
+      }
+    }
+  }
+
   if (errors.length > 0) {
     throw new Error(errors.join('\n'));
   }


### PR DESCRIPTION
## Summary

Fixes #927.

The `dockerfile` field in `harness.json` was silently ignored during `agentcore deploy` because no code path built and pushed the image. This PR adds the full container build pipeline for harnesses, mirroring the existing agent Container path from #783.

**CDK stack** (`cdk-stack.ts`, `cdk.ts`): When a harness specifies `dockerfile` (and no `containerUri`), the stack creates a `ContainerSourceAssetFromPath` from the harness directory, an ECR repository, and a `ContainerImageBuilder` that builds and pushes the image via CodeBuild. The resulting container URI is emitted as a `CfnOutput` and also passed to the harness role construct for ECR pull permissions.

**Imperative deployer** (`harness-mapper.ts`): When `harnessSpec.dockerfile` is set, resolves the CDK-produced container URI from stack outputs and wires it into `environmentArtifact.containerConfiguration.containerUri` on the create/update API call.

**Preflight validation** (`preflight.ts`): Validates the Dockerfile exists on disk before CDK synth, matching the existing `validateContainerAgents` pattern.

Requires a companion change in `agentcore-l3-cdk-constructs` to export `ContainerSourceAssetFromPath`, `AgentEcrRepository`, `ContainerBuildProject`, and `ContainerImageBuilder` from `@aws/agentcore-cdk`.

## Test plan

- [x] New unit tests for dockerfile → containerUri resolution from CDK outputs (3 tests)
- [x] New unit tests for preflight harness Dockerfile validation (7 tests)
- [x] All existing harness-mapper tests pass (29/29)
- [x] All existing harness-deployer tests pass (14/14)
- [x] All existing preflight-container tests pass (8/8)
- [x] `tsc --noEmit` clean