### PR TITLE
fix: preserve harness deployed state on early deploy errors

### DIFF
--- a/src/cli/operations/deploy/imperative/deployers/__tests__/harness-deployer.test.ts
+++ b/src/cli/operations/deploy/imperative/deployers/__tests__/harness-deployer.test.ts
@@ -348,6 +348,85 @@ describe('HarnessDeployer', () => {
       expect(result.error).toContain('Failed to read harness.json');
     });
 
+    it('preserves existing harness state when validation fails', async () => {
+      mockedReadFile.mockResolvedValueOnce('{ "invalid": true }');
+
+      const existingState = {
+        harnessId: 'h-existing',
+        harnessArn: 'arn:aws:bedrock-agentcore:us-east-1:123456789012:harness/h-existing',
+        roleArn: 'arn:aws:iam::123456789012:role/HarnessRole',
+        status: 'READY' as const,
+        configHash: 'abc123',
+      };
+
+      const ctx = createContext({
+        harnesses: [{ name: 'my_harness', path: 'harnesses/my_harness' }],
+        deployedHarnesses: {
+          harnesses: { my_harness: existingState },
+        },
+        cdkOutputs: {
+          ApplicationHarnessMyHarnessRoleArnOutput123: 'arn:aws:iam::123456789012:role/HarnessRole',
+        },
+      });
+
+      const result = await deployer.deploy(ctx);
+
+      expect(result.success).toBe(false);
+      expect(result.state).toEqual({ my_harness: existingState });
+    });
+
+    it('preserves existing harness state when harness.json read fails', async () => {
+      mockedReadFile.mockRejectedValueOnce(new Error('ENOENT'));
+
+      const existingState = {
+        harnessId: 'h-existing',
+        harnessArn: 'arn:aws:bedrock-agentcore:us-east-1:123456789012:harness/h-existing',
+        roleArn: 'arn:aws:iam::123456789012:role/HarnessRole',
+        status: 'READY' as const,
+        configHash: 'abc123',
+      };
+
+      const ctx = createContext({
+        harnesses: [{ name: 'my_harness', path: 'harnesses/my_harness' }],
+        deployedHarnesses: {
+          harnesses: { my_harness: existingState },
+        },
+        cdkOutputs: {
+          ApplicationHarnessMyHarnessRoleArnOutput123: 'arn:aws:iam::123456789012:role/HarnessRole',
+        },
+      });
+
+      const result = await deployer.deploy(ctx);
+
+      expect(result.success).toBe(false);
+      expect(result.state).toEqual({ my_harness: existingState });
+    });
+
+    it('preserves existing harness state when role ARN not found', async () => {
+      mockedReadFile.mockResolvedValueOnce(HARNESS_SPEC_JSON);
+
+      const existingState = {
+        harnessId: 'h-existing',
+        harnessArn: 'arn:aws:bedrock-agentcore:us-east-1:123456789012:harness/h-existing',
+        roleArn: 'arn:aws:iam::123456789012:role/HarnessRole',
+        status: 'READY' as const,
+        configHash: 'abc123',
+      };
+
+      const ctx = createContext({
+        harnesses: [{ name: 'my_harness', path: 'harnesses/my_harness' }],
+        deployedHarnesses: {
+          harnesses: { my_harness: existingState },
+        },
+        cdkOutputs: { SomeOtherOutput: 'value' },
+      });
+
+      const result = await deployer.deploy(ctx);
+
+      expect(result.success).toBe(false);
+      expect(result.state).toEqual({ my_harness: existingState });
+    });
+
     it('returns error when API call fails', async () => {
       mockedReadFile.mockResolvedValueOnce(HARNESS_SPEC_JSON);
       mockedMapHarness.mockResolvedValueOnce({

--- a/src/cli/operations/deploy/imperative/deployers/harness-deployer.ts
+++ b/src/cli/operations/deploy/imperative/deployers/harness-deployer.ts
@@ -96,12 +96,13 @@ export class HarnessDeployer implements ImperativeDeployer<HarnessDeployedStateM
           return {
             success: false,
             error: `Invalid harness.json for "${entry.name}": ${validated.error.message}`,
+            state: resultState,
           };
         }
         harnessSpec = validated.data;
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        return { success: false, error: `Failed to read harness.json for "${entry.name}": ${message}` };
+        return { success: false, error: `Failed to read harness.json for "${entry.name}": ${message}`, state: resultState };
       }
 
       // Resolve role ARN from CDK outputs
@@ -110,6 +111,7 @@ export class HarnessDeployer implements ImperativeDeployer<HarnessDeployedStateM
         return {
           success: false,
           error: `Could not find role ARN in CDK outputs for harness "${entry.name}". Expected output key starting with "ApplicationHarness${toPascalId(entry.name)}RoleArn".`,
+          state: resultState,
         };
       }
 
@@ -226,7 +228,7 @@ export class HarnessDeployer implements ImperativeDeployer<HarnessDeployedStateM
           notes.push(`Deleted harness "${name}"`);
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
-          return { success: false, error: `Failed to delete harness "${name}": ${message}` };
+          return { success: false, error: `Failed to delete harness "${name}": ${message}`, state: resultState };
         }
       }
     }


### PR DESCRIPTION
## Summary
- Early error returns in `HarnessDeployer.deploy()` (validation failure, read error, missing role ARN, delete failure) were not including `state: resultState` in the return value
- This caused the caller in `actions.ts` to see `harnessResult.state` as `undefined`, wiping the harness entries from `deployed-state.json`
- On the next deploy the missing state caused the deployer to take the "create" path instead of "update", producing a 409 "agent already exists" error

## Test plan
- [x] Three new unit tests verify that existing harness state is preserved on validation failure, read failure, and missing role ARN
- [x] All 17 harness-deployer tests pass