### PR TITLE
feat: remove deployed/local from status legend

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,13 +13,19 @@ const partitionPlugin = {
     'no-hardcoded-arn-partition': {
       meta: {
         type: 'problem',
-        docs: { description: 'Disallow hardcoded arn:aws: partition in ARN construction. Use arnPrefix(region) instead.' },
+        docs: {
+          description: 'Disallow hardcoded arn:aws: partition in ARN construction. Use arnPrefix(region) instead.',
+        },
         schema: [],
       },
       create(context) {
         function checkForHardcodedArn(node, value) {
           if (/arn:aws:/.test(value)) {
-            context.report({ node, message: 'Hardcoded "arn:aws:" detected. Use arnPrefix(region) from src/cli/aws/partition.ts for multi-partition support.' });
+            context.report({
+              node,
+              message:
+                'Hardcoded "arn:aws:" detected. Use arnPrefix(region) from src/cli/aws/partition.ts for multi-partition support.',
+            });
           }
         }
         return {
@@ -34,7 +40,10 @@ const partitionPlugin = {
     'no-hardcoded-endpoint-tld': {
       meta: {
         type: 'problem',
-        docs: { description: 'Disallow hardcoded amazonaws.com in endpoint URL construction. Use serviceEndpoint() or dnsSuffix() instead.' },
+        docs: {
+          description:
+            'Disallow hardcoded amazonaws.com in endpoint URL construction. Use serviceEndpoint() or dnsSuffix() instead.',
+        },
         schema: [],
       },
       create(context) {
@@ -49,13 +58,21 @@ const partitionPlugin = {
           TemplateLiteral(node) {
             for (const quasi of node.quasis) {
               if (hasHardcodedEndpoint(quasi.value.raw)) {
-                context.report({ node, message: 'Hardcoded ".amazonaws.com" in template literal. Use serviceEndpoint() or dnsSuffix() from src/cli/aws/partition.ts for multi-partition support.' });
+                context.report({
+                  node,
+                  message:
+                    'Hardcoded ".amazonaws.com" in template literal. Use serviceEndpoint() or dnsSuffix() from src/cli/aws/partition.ts for multi-partition support.',
+                });
               }
             }
           },
           Literal(node) {
             if (typeof node.value === 'string' && hasHardcodedEndpointWithRegion(node.value)) {
-              context.report({ node, message: 'Hardcoded endpoint with region detected. Use serviceEndpoint() or dnsSuffix() from src/cli/aws/partition.ts for multi-partition support.' });
+              context.report({
+                node,
+                message:
+                  'Hardcoded endpoint with region detected. Use serviceEndpoint() or dnsSuffix() from src/cli/aws/partition.ts for multi-partition support.',
+              });
             }
           },
         };

--- a/src/cli/tui/components/ResourceGraph.tsx
+++ b/src/cli/tui/components/ResourceGraph.tsx
@@ -420,17 +420,6 @@ export function ResourceGraph({ project, mcp, agentName, resourceStatuses }: Res
           <Text color="magenta">{ICONS.gateway}</Text> gateway{'  '}
           <Text color="red">{ICONS['policy-engine']}</Text> policy engine
         </Text>
-        {resourceStatuses && resourceStatuses.length > 0 && (
-          <Box flexDirection="column" marginTop={1}>
-            <Text>
-              <Text color="green">[Deployed]</Text>
-              <Text color="gray"> live in AWS</Text>
-              {'  '}
-              <Text color="yellow">[Local only]</Text>
-              <Text color="gray"> not yet deployed</Text>
-            </Text>
-          </Box>
-        )}
       </Box>
     </Box>
   );

--- a/src/cli/tui/components/__tests__/ResourceGraph.test.tsx
+++ b/src/cli/tui/components/__tests__/ResourceGraph.test.tsx
@@ -262,37 +262,6 @@ describe('ResourceGraph', () => {
       expect(lastFrame()).toContain('deploy');
     });
 
-    it('renders deployment state legend when resourceStatuses provided', () => {
-      const project = {
-        ...baseProject,
-        runtimes: [{ name: 'my-agent' }],
-      } as unknown as AgentCoreProjectSpec;
-
-      const resourceStatuses: ResourceStatusEntry[] = [
-        { resourceType: 'agent', name: 'my-agent', deploymentState: 'deployed' },
-      ];
-
-      const { lastFrame } = render(<ResourceGraph project={project} resourceStatuses={resourceStatuses} />);
-
-      expect(lastFrame()).toContain('[Deployed]');
-      expect(lastFrame()).toContain('live in AWS');
-      expect(lastFrame()).toContain('[Local only]');
-      expect(lastFrame()).toContain('not yet deployed');
-    });
-
-    it('does not render deployment state legend when no resourceStatuses', () => {
-      const project = {
-        ...baseProject,
-        runtimes: [{ name: 'my-agent' }],
-      } as unknown as AgentCoreProjectSpec;
-
-      const { lastFrame } = render(<ResourceGraph project={project} />);
-
-      // Should have the base legend but not the deployment state legend
-      expect(lastFrame()).toContain('agent');
-      expect(lastFrame()).not.toContain('[Deployed]');
-    });
-
     it('renders removed credentials in Removed Locally section', () => {
       const resourceStatuses: ResourceStatusEntry[] = [
         {


### PR DESCRIPTION
## Description

Remove the `[Deployed]` / `[Local only]` legend from the status command's resource graph. This secondary legend was adding visual clutter without providing useful information — the deployment state of each resource is already shown inline next to each resource node, making the legend redundant.

<img width="684" height="268" alt="Screenshot 2026-04-23 at 2 02 37 PM" src="https://github.com/user-attachments/assets/2c4e548f-0e48-44c0-8669-829884c026b6" />


Prettier failed on the eslint config file so fixed that as well

## Related Issue

Closes https://github.com/aws/agentcore-cli/issues/935

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.