### PR TITLE
fix: agentcore dev not working in windows

### DIFF
--- a/src/cli/operations/dev/__tests__/utils-open-browser.test.ts
+++ b/src/cli/operations/dev/__tests__/utils-open-browser.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockUnref = vi.fn();
+const mockSpawn = vi.fn().mockReturnValue({ unref: mockUnref });
+
+vi.mock('child_process', () => ({
+  spawn: (...args: unknown[]) => mockSpawn(...args),
+}));
+
+describe('openBrowser', () => {
+  const originalPlatform = process.platform;
+
+  beforeEach(() => {
+    mockSpawn.mockClear();
+    mockUnref.mockClear();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  it('uses "open" on macOS', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    const { openBrowser } = await import('../utils');
+    openBrowser('http://localhost:3000');
+
+    expect(mockSpawn).toHaveBeenCalledWith('open', ['http://localhost:3000'], {
+      stdio: 'ignore',
+      detached: true,
+    });
+    expect(mockUnref).toHaveBeenCalled();
+  });
+
+  it('uses "cmd /c start" on Windows to avoid ENOENT', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    const { openBrowser } = await import('../utils');
+    openBrowser('http://localhost:3000');
+
+    expect(mockSpawn).toHaveBeenCalledWith('cmd', ['/c', 'start', 'http://localhost:3000'], {
+      stdio: 'ignore',
+      detached: true,
+    });
+    expect(mockUnref).toHaveBeenCalled();
+  });
+
+  it('uses "xdg-open" on Linux', async () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    const { openBrowser } = await import('../utils');
+    openBrowser('http://localhost:3000');
+
+    expect(mockSpawn).toHaveBeenCalledWith('xdg-open', ['http://localhost:3000'], {
+      stdio: 'ignore',
+      detached: true,
+    });
+    expect(mockUnref).toHaveBeenCalled();
+  });
+});

--- a/src/cli/operations/dev/utils.ts
+++ b/src/cli/operations/dev/utils.ts
@@ -1,3 +1,4 @@
+import { spawn } from 'child_process';
 import { createConnection, createServer } from 'net';
 
 /** Check if a port is available on a specific host */
@@ -107,4 +108,11 @@ export function convertEntrypointToModule(entrypoint: string): string {
   if (entrypoint.includes(':')) return entrypoint;
   const path = entrypoint.replace(/\.py$/, '').replace(/\//g, '.');
   return `${path}:app`;
+}
+
+export function openBrowser(url: string): void {
+  const isWindows = process.platform === 'win32';
+  const cmd = isWindows ? 'cmd' : process.platform === 'darwin' ? 'open' : 'xdg-open';
+  const args = isWindows ? ['/c', 'start', url] : [url];
+  spawn(cmd, args, { stdio: 'ignore', detached: true }).unref();
 }

--- a/src/cli/operations/dev/web-ui/run-web-ui.ts
+++ b/src/cli/operations/dev/web-ui/run-web-ui.ts
@@ -1,8 +1,8 @@
 import { ExecLogger } from '../../../logging';
 import { findAvailablePort } from '../server';
+import { openBrowser } from '../utils';
 import { WEB_UI_DEFAULT_PORT } from './constants';
 import { type WebUIOptions, WebUIServer } from './web-server';
-import { spawn } from 'child_process';
 
 export interface RunWebUIOptions {
   /** Options to pass to WebUIServer (minus uiPort, which is resolved automatically) */
@@ -42,8 +42,7 @@ export async function runWebUI(opts: RunWebUIOptions): Promise<void> {
       const chatUrl = url;
       console.log(`\nChat UI: ${chatUrl}`);
       console.log(`Press Ctrl+C to stop\n`);
-      const openCmd = process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'start' : 'xdg-open';
-      spawn(openCmd, [chatUrl], { stdio: 'ignore', detached: true }).unref();
+      openBrowser(chatUrl);
     },
     onLog,
   });


### PR DESCRIPTION
## Description

On Windows, `agentcore dev` fails with `Error: spawn start ENOENT` when trying to open the browser. This is because `start` is a `cmd.exe` built-in, not a standalone executable, so `spawn('start', [url])` can't find it.

The fix spawns `cmd` directly with `/c start` as arguments (`spawn('cmd', ['/c', 'start', url])`). Also extracts the browser-opening logic into a reusable `openBrowser()` utility in `utils.ts` with tests for all three platforms (macOS, Windows, Linux).

## Related Issue

Closes #945

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots
- [x] Manually tested `agentcore dev` on a Windows machine and verified the browser opens without errors

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.