### PR TITLE
fix: show 'Computing diff changes...' step during deploy diff phase

### DIFF
--- a/src/cli/tui/screens/deploy/useDeployFlow.ts
+++ b/src/cli/tui/screens/deploy/useDeployFlow.ts
@@ -122,6 +122,10 @@ export function useDeployFlow(options: DeployFlowOptions = {}): DeployFlowState 
   const identityKmsKeyArn = preSynthesized?.identityKmsKeyArn ?? preflight.identityKmsKeyArn;
   const allCredentials = preSynthesized?.allCredentials ?? preflight.allCredentials;
 
+  const [preDeployDiffStep, setPreDeployDiffStep] = useState<Step>({
+    label: 'Computing diff changes...',
+    status: 'pending',
+  });
   const [publishAssetsStep, setPublishAssetsStep] = useState<Step>({ label: 'Publish assets', status: 'pending' });
   const [deployStep, setDeployStep] = useState<Step>({ label: 'Deploy to AWS', status: 'pending' });
   const [diffStep, setDiffStep] = useState<Step>({ label: 'Run CDK diff', status: 'pending' });
@@ -144,6 +148,7 @@ export function useDeployFlow(options: DeployFlowOptions = {}): DeployFlowState 
   const streamOutputsRef = useRef<Record<string, string> | null>(null);
 
   const startDeploy = useCallback(() => {
+    setPreDeployDiffStep({ label: 'Computing diff changes...', status: 'pending' });
     setPublishAssetsStep({ label: 'Publish assets', status: 'pending' });
     setDeployStep({ label: 'Deploy to AWS', status: 'pending' });
     setDeployOutput(null);
@@ -327,6 +332,8 @@ export function useDeployFlow(options: DeployFlowOptions = {}): DeployFlowState 
       if (!isDiffRunningRef.current) {
         isDiffRunningRef.current = true;
         setIsDiffLoading(true);
+        setPreDeployDiffStep(prev => ({ ...prev, status: 'running' }));
+        logger.startStep('Computing diff changes...');
         switchableIoHost?.setOnRawMessage((code, _level, message, data) => {
           logger.logDiff(code, message);
           if (code === 'CDK_TOOLKIT_I4002') {
@@ -345,6 +352,8 @@ export function useDeployFlow(options: DeployFlowOptions = {}): DeployFlowState 
           switchableIoHost?.setOnRawMessage(null);
           isDiffRunningRef.current = false;
           setIsDiffLoading(false);
+          logger.endStep('success');
+          setPreDeployDiffStep(prev => ({ ...prev, status: 'success' }));
         }
       }
 
@@ -569,8 +578,10 @@ export function useDeployFlow(options: DeployFlowOptions = {}): DeployFlowState 
     if (diffMode) {
       return skipPreflight ? [diffStep] : [...preflight.steps, diffStep];
     }
-    return skipPreflight ? [publishAssetsStep, deployStep] : [...preflight.steps, publishAssetsStep, deployStep];
-  }, [preflight.steps, publishAssetsStep, deployStep, diffStep, skipPreflight, diffMode]);
+    return skipPreflight
+      ? [preDeployDiffStep, publishAssetsStep, deployStep]
+      : [...preflight.steps, preDeployDiffStep, publishAssetsStep, deployStep];
+  }, [preflight.steps, preDeployDiffStep, publishAssetsStep, deployStep, diffStep, skipPreflight, diffMode]);
 
   const phase: DeployPhase = useMemo(() => {
     const activeStep = diffMode ? diffStep : deployStep;


### PR DESCRIPTION
## Description

When running `agentcore deploy` in interactive TUI mode, the screen appeared frozen for 5-15 seconds between the last preflight step and 'Publish assets'. `cdkToolkitWrapper.diff()` was running silently during this window with no step marked as `running`, so `StepProgress` had nothing to highlight and users thought the CLI was hung.

This PR adds a dedicated `preDeployDiffStep` with label `"Computing diff changes..."` that transitions `running → success` around the diff call. The step is inserted into the deploy-mode step list between preflight and `publishAssetsStep`, reset alongside the other steps in `startDeploy()` for retry consistency, and its `endStep('success')` is placed in `finally` so diff failures (which remain non-fatal per existing behavior) still terminate the step cleanly instead of leaving it stuck in `running`.

Diff-mode path is unchanged — it already has its own explicit `diffStep`.

## Related Issue

Closes #781

## Documentation PR

N/A — user-visible UX fix, no docs change.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

Additionally, verified end-to-end via the TUI harness against a live AWS account:

1. Scaffolded a fresh project (`agentcore create` → Strands, Bedrock, no memory)
2. Ran `agentcore deploy` — confirmed the new step appears in the correct slot, transitions `running → done` during the diff phase, and the full 5/5-resource deploy succeeded
3. Stack torn down after verification

### Before / After

Text screenshots (bordered terminal captures) hosted on gist so they don't bloat the PR diff:

- Before (silent gap): https://gist.github.com/aidandaly24/289a88c3fc25a57a6f4d546143fa2e40#file-before-781-txt
- After (new step visible): https://gist.github.com/aidandaly24/289a88c3fc25a57a6f4d546143fa2e40#file-after-781-txt

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.