### PR TITLE
fix(invoke): auto-generate session ID for bearer-token invocations

### DIFF
--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -1889,6 +1889,7 @@ exports[`Assets Directory Snapshots > Python framework assets > python/python/a2
 
 exports[`Assets Directory Snapshots > Python framework assets > python/python/a2a/strands/capabilities/memory/session.py should match snapshot 1`] = `
 "import os
+import uuid
 from typing import Optional
 
 from bedrock_agentcore.memory.integrations.strands.config import AgentCoreMemoryConfig{{#if memoryProviders.[0].strategies.length}}, RetrievalConfig{{/if}}
@@ -1897,9 +1898,13 @@ from bedrock_agentcore.memory.integrations.strands.session_manager import AgentC
 MEMORY_ID = os.getenv("{{memoryProviders.[0].envVarName}}")
 REGION = os.getenv("AWS_REGION")
 
-def get_memory_session_manager(session_id: str, actor_id: str) -> Optional[AgentCoreMemorySessionManager]:
+def get_memory_session_manager(session_id: Optional[str], actor_id: str) -> Optional[AgentCoreMemorySessionManager]:
     if not MEMORY_ID:
         return None
+
+    # AgentCoreMemoryConfig rejects None; OAuth/CUSTOM_JWT callers can reach us
+    # without a runtime session header, so synthesize one when absent.
+    session_id = session_id or uuid.uuid4().hex
 
 {{#if memoryProviders.[0].strategies.length}}
     retrieval_config = {
@@ -2724,6 +2729,7 @@ exports[`Assets Directory Snapshots > Python framework assets > python/python/ag
 
 exports[`Assets Directory Snapshots > Python framework assets > python/python/agui/strands/capabilities/memory/session.py should match snapshot 1`] = `
 "import os
+import uuid
 from typing import Optional
 
 from bedrock_agentcore.memory.integrations.strands.config import AgentCoreMemoryConfig{{#if memoryProviders.[0].strategies.length}}, RetrievalConfig{{/if}}
@@ -2732,9 +2738,13 @@ from bedrock_agentcore.memory.integrations.strands.session_manager import AgentC
 MEMORY_ID = os.getenv("{{memoryProviders.[0].envVarName}}")
 REGION = os.getenv("AWS_REGION")
 
-def get_memory_session_manager(session_id: str, actor_id: str) -> Optional[AgentCoreMemorySessionManager]:
+def get_memory_session_manager(session_id: Optional[str], actor_id: str) -> Optional[AgentCoreMemorySessionManager]:
     if not MEMORY_ID:
         return None
+
+    # AgentCoreMemoryConfig rejects None; OAuth/CUSTOM_JWT callers can reach us
+    # without a runtime session header, so synthesize one when absent.
+    session_id = session_id or uuid.uuid4().hex
 
 {{#if memoryProviders.[0].strategies.length}}
     retrieval_config = {
@@ -4993,6 +5003,7 @@ exports[`Assets Directory Snapshots > Python framework assets > python/python/ht
 
 exports[`Assets Directory Snapshots > Python framework assets > python/python/http/strands/capabilities/memory/session.py should match snapshot 1`] = `
 "import os
+import uuid
 from typing import Optional
 
 from bedrock_agentcore.memory.integrations.strands.config import AgentCoreMemoryConfig{{#if memoryProviders.[0].strategies.length}}, RetrievalConfig{{/if}}
@@ -5001,9 +5012,13 @@ from bedrock_agentcore.memory.integrations.strands.session_manager import AgentC
 MEMORY_ID = os.getenv("{{memoryProviders.[0].envVarName}}")
 REGION = os.getenv("AWS_REGION")
 
-def get_memory_session_manager(session_id: str, actor_id: str) -> Optional[AgentCoreMemorySessionManager]:
+def get_memory_session_manager(session_id: Optional[str], actor_id: str) -> Optional[AgentCoreMemorySessionManager]:
     if not MEMORY_ID:
         return None
+
+    # AgentCoreMemoryConfig rejects None; OAuth/CUSTOM_JWT callers can reach us
+    # without a runtime session header, so synthesize one when absent.
+    session_id = session_id or uuid.uuid4().hex
 
 {{#if memoryProviders.[0].strategies.length}}
     retrieval_config = {

--- a/src/assets/python/a2a/strands/capabilities/memory/session.py
+++ b/src/assets/python/a2a/strands/capabilities/memory/session.py
@@ -1,4 +1,5 @@
 import os
+import uuid
 from typing import Optional
 
 from bedrock_agentcore.memory.integrations.strands.config import AgentCoreMemoryConfig{{#if memoryProviders.[0].strategies.length}}, RetrievalConfig{{/if}}
@@ -7,9 +8,13 @@ from bedrock_agentcore.memory.integrations.strands.session_manager import AgentC
 MEMORY_ID = os.getenv("{{memoryProviders.[0].envVarName}}")
 REGION = os.getenv("AWS_REGION")
 
-def get_memory_session_manager(session_id: str, actor_id: str) -> Optional[AgentCoreMemorySessionManager]:
+def get_memory_session_manager(session_id: Optional[str], actor_id: str) -> Optional[AgentCoreMemorySessionManager]:
     if not MEMORY_ID:
         return None
+
+    # AgentCoreMemoryConfig rejects None; OAuth/CUSTOM_JWT callers can reach us
+    # without a runtime session header, so synthesize one when absent.
+    session_id = session_id or uuid.uuid4().hex
 
 {{#if memoryProviders.[0].strategies.length}}
     retrieval_config = {

--- a/src/assets/python/agui/strands/capabilities/memory/session.py
+++ b/src/assets/python/agui/strands/capabilities/memory/session.py
@@ -1,4 +1,5 @@
 import os
+import uuid
 from typing import Optional
 
 from bedrock_agentcore.memory.integrations.strands.config import AgentCoreMemoryConfig{{#if memoryProviders.[0].strategies.length}}, RetrievalConfig{{/if}}
@@ -7,9 +8,13 @@ from bedrock_agentcore.memory.integrations.strands.session_manager import AgentC
 MEMORY_ID = os.getenv("{{memoryProviders.[0].envVarName}}")
 REGION = os.getenv("AWS_REGION")
 
-def get_memory_session_manager(session_id: str, actor_id: str) -> Optional[AgentCoreMemorySessionManager]:
+def get_memory_session_manager(session_id: Optional[str], actor_id: str) -> Optional[AgentCoreMemorySessionManager]:
     if not MEMORY_ID:
         return None
+
+    # AgentCoreMemoryConfig rejects None; OAuth/CUSTOM_JWT callers can reach us
+    # without a runtime session header, so synthesize one when absent.
+    session_id = session_id or uuid.uuid4().hex
 
 {{#if memoryProviders.[0].strategies.length}}
     retrieval_config = {

--- a/src/assets/python/http/strands/capabilities/memory/session.py
+++ b/src/assets/python/http/strands/capabilities/memory/session.py
@@ -1,4 +1,5 @@
 import os
+import uuid
 from typing import Optional
 
 from bedrock_agentcore.memory.integrations.strands.config import AgentCoreMemoryConfig{{#if memoryProviders.[0].strategies.length}}, RetrievalConfig{{/if}}
@@ -7,9 +8,13 @@ from bedrock_agentcore.memory.integrations.strands.session_manager import AgentC
 MEMORY_ID = os.getenv("{{memoryProviders.[0].envVarName}}")
 REGION = os.getenv("AWS_REGION")
 
-def get_memory_session_manager(session_id: str, actor_id: str) -> Optional[AgentCoreMemorySessionManager]:
+def get_memory_session_manager(session_id: Optional[str], actor_id: str) -> Optional[AgentCoreMemorySessionManager]:
     if not MEMORY_ID:
         return None
+
+    # AgentCoreMemoryConfig rejects None; OAuth/CUSTOM_JWT callers can reach us
+    # without a runtime session header, so synthesize one when absent.
+    session_id = session_id or uuid.uuid4().hex
 
 {{#if memoryProviders.[0].strategies.length}}
     retrieval_config = {

--- a/src/cli/commands/invoke/action.ts
+++ b/src/cli/commands/invoke/action.ts
@@ -14,6 +14,7 @@ import {
 import { InvokeLogger } from '../../logging';
 import { formatMcpToolList } from '../../operations/dev/utils';
 import { canFetchRuntimeToken, fetchRuntimeToken } from '../../operations/fetch-access';
+import { generateSessionId } from '../../operations/session';
 import type { InvokeOptions, InvokeResult } from './types';
 
 export interface InvokeContext {
@@ -112,6 +113,14 @@ export async function handleInvoke(context: InvokeContext, options: InvokeOption
         error: `Agent '${agentSpec.name}' is configured for CUSTOM_JWT but no bearer token is available.\nEither provide --bearer-token or re-add the agent with --client-id and --client-secret to enable auto-fetch.`,
       };
     }
+  }
+
+  // When invoking with a bearer token (OAuth/CUSTOM_JWT), AgentCore does not
+  // auto-generate a runtime session ID the way it does for SigV4 callers. Templates
+  // that wire up AgentCoreMemorySessionManager require a non-null session_id, so
+  // generate one here if the caller didn't pass --session-id.
+  if (options.bearerToken && !options.sessionId) {
+    options = { ...options, sessionId: generateSessionId() };
   }
 
   // Exec mode: run shell command in runtime container


### PR DESCRIPTION
## Description

When invoking an agent with a bearer token (OAuth/CUSTOM_JWT) and no session ID, `AgentCoreMemoryConfig` raised a Pydantic validation error because `session_id=None` is rejected:

```
Error: 1 validation error for AgentCoreMemoryConfig
session_id
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
```

Unlike SigV4 callers, bearer-token callers do not get a server-side auto-generated runtime session ID from AgentCore, so the `None` value reached the memory-enabled Strands templates and broke them.

### Two-layer fix

1. **CLI auto-generation** (`src/cli/commands/invoke/action.ts`) — when `options.bearerToken` is set and `options.sessionId` is missing, synthesize a UUID via the existing `generateSessionId` helper before dispatching to any invocation branch (streaming, non-streaming, MCP, A2A, AGUI, exec). Covers both explicit `--bearer-token` and the CUSTOM_JWT auto-fetch path.

2. **Template hardening** (`src/assets/python/{http,agui,a2a}/strands/capabilities/memory/session.py`) — each template now imports `uuid`, widens the parameter type to `Optional[str]`, and synthesizes `session_id = session_id or uuid.uuid4().hex` before constructing `AgentCoreMemoryConfig`. This protects non-CLI callers (curl, Postman, custom apps) who reach the deployed runtime without a session header.

## Related Issue

Closes #840

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

Unit + snapshot tests:
- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [x] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

### End-to-end verification against a deployed agent

Deployed a Strands agent with CUSTOM_JWT (Cognito M2M) inbound auth + short-term memory to `us-west-2`, built the CLI from this PR's HEAD, and exercised both call paths:

- **Test 1 (CLI fix):** `agentcore invoke --bearer-token $TOKEN "What is 2+2?"` with no `--session-id` → `"2 + 2 = **4**"`; invoke log confirms a UUID session ID was synthesized client-side.
- **Test 2 (template hardening):** raw `curl` to the runtime `/invocations` endpoint without an `X-Amzn-Bedrock-AgentCore-Runtime-Session-Id` header → agent responded normally; the Python template self-defended via `uuid.uuid4().hex`.

Full command output and session ID evidence: https://gist.github.com/aidandaly24/d8fb51e4048acd0dd2e6f670c701b857

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.