### PR TITLE
fix: duplicate header flash and help menu truncation

### DIFF
--- a/src/cli/tui/copy.ts
+++ b/src/cli/tui/copy.ts
@@ -45,7 +45,7 @@ export const COMMAND_DESCRIPTIONS = {
   fetch: 'Fetch access info for deployed resources.',
   pause: 'Pause an online eval config. Supports --arn for configs outside the project.',
   resume: 'Resume a paused online eval config. Supports --arn for configs outside the project.',
-  run: 'Run on-demand evaluation. Supports --agent-arn for agents outside the project.',
+  run: 'Run on-demand evaluation.',
   import: 'Import a runtime, memory, or starter toolkit into this project. [experimental]',
   telemetry: 'Manage anonymous usage analytics preferences.',
   update: 'Check for and install CLI updates',

--- a/src/cli/tui/screens/create/CreateScreen.tsx
+++ b/src/cli/tui/screens/create/CreateScreen.tsx
@@ -237,75 +237,12 @@ export function CreateScreen({ cwd, isInteractive, onExit, onNavigate }: CreateS
     isActive: flow.phase === 'create-prompt',
   });
 
-  // Checking phase: brief loading state
+  // Checking phase: instant async check — render nothing to avoid a flash before the real UI
   if (flow.phase === 'checking') {
-    return (
-      <Screen title="AgentCore Create" onExit={handleExit}>
-        <Text dimColor>Checking for existing project...</Text>
-      </Screen>
-    );
+    return null;
   }
 
-  // Existing project error phase
-  if (flow.phase === 'existing-project-error') {
-    return (
-      <Screen title="AgentCore Create" onExit={handleExit} helpText="Press Esc to exit">
-        <Box marginBottom={1} flexDirection="column">
-          <Text color="red">A project already exists at this location.</Text>
-          {flow.existingProjectPath && <Text dimColor>Found: {flow.existingProjectPath}</Text>}
-          <Box marginTop={1}>
-            <Text>
-              Use <Text color="cyan">add agent</Text> to create a new agent in the existing project.
-            </Text>
-          </Box>
-        </Box>
-      </Screen>
-    );
-  }
-
-  // Input phase: ask for project name
-  if (flow.phase === 'input') {
-    return (
-      <Screen title="AgentCore Create" onExit={handleExit} helpText={HELP_TEXT.TEXT_INPUT}>
-        <Box marginBottom={1} flexDirection="column">
-          <Text>Create a new AgentCore project</Text>
-          <Text dimColor>This will create a directory with your project name.</Text>
-        </Box>
-        <TextInput
-          prompt="Project name"
-          initialValue=""
-          schema={ProjectNameSchema}
-          customValidation={name => validateFolderNotExists(name, cwd)}
-          onSubmit={name => {
-            flow.setProjectName(name);
-            flow.confirmProjectName();
-          }}
-          onCancel={handleExit}
-        />
-      </Screen>
-    );
-  }
-
-  // Create prompt phase
-  if (flow.phase === 'create-prompt') {
-    return (
-      <Screen title="AgentCore Create" onExit={handleExit} helpText={HELP_TEXT.NAVIGATE_SELECT}>
-        <Box marginBottom={1}>
-          <Text>
-            Project: <Text color={STATUS_COLORS.success}>{flow.projectName}</Text>
-          </Text>
-        </Box>
-        <Box flexDirection="column">
-          <Text>Would you like to add an agent now?</Text>
-          <Box marginTop={1}>
-            <SelectList items={CREATE_PROMPT_ITEMS} selectedIndex={createPromptIndex} />
-          </Box>
-        </Box>
-      </Screen>
-    );
-  }
-
-  // Create wizard phase - use AddAgentScreen for consistent experience
+  // Create wizard phase - use AddAgentScreen (separate component, no header conflict)
   if (flow.phase === 'create-wizard') {
     return (
       <AddAgentScreen
@@ -316,22 +253,84 @@ export function CreateScreen({ cwd, isInteractive, onExit, onNavigate }: CreateS
     );
   }
 
-  // Running/complete phase: show progress
-  const headerContent = (
+  // All other phases share a single <Screen> to prevent duplicate header flashes
+  // when Ink transitions between different <Screen> mounts.
+  const phase = flow.phase;
+  const showProjectHeader = phase !== 'input' && phase !== 'existing-project-error';
+  const headerContent = showProjectHeader ? (
     <Box marginTop={1}>
       <Text>
         Project: <Text color={STATUS_COLORS.success}>{flow.projectName}</Text>
       </Text>
     </Box>
-  );
+  ) : undefined;
 
-  const helpText = flow.hasError || allSuccess ? HELP_TEXT.EXIT : undefined;
+  const helpText =
+    phase === 'existing-project-error'
+      ? 'Press Esc to exit'
+      : phase === 'input'
+        ? HELP_TEXT.TEXT_INPUT
+        : phase === 'create-prompt'
+          ? HELP_TEXT.NAVIGATE_SELECT
+          : flow.hasError || allSuccess
+            ? HELP_TEXT.EXIT
+            : undefined;
 
   return (
     <Screen title="AgentCore Create" onExit={handleExit} headerContent={headerContent} helpText={helpText}>
-      <StepProgress steps={flow.steps} />
+      {phase === 'existing-project-error' && (
+        <Box marginBottom={1} flexDirection="column">
+          <Text color="red">A project already exists at this location.</Text>
+          {flow.existingProjectPath && <Text dimColor>Found: {flow.existingProjectPath}</Text>}
+          <Box marginTop={1}>
+            <Text>
+              Use <Text color="cyan">add agent</Text> to create a new agent in the existing project.
+            </Text>
+          </Box>
+        </Box>
+      )}
+
+      {phase === 'input' && (
+        <>
+          <Box marginBottom={1} flexDirection="column">
+            <Text>Create a new AgentCore project</Text>
+            <Text dimColor>This will create a directory with your project name.</Text>
+          </Box>
+          <TextInput
+            prompt="Project name"
+            initialValue=""
+            schema={ProjectNameSchema}
+            customValidation={name => validateFolderNotExists(name, cwd)}
+            onSubmit={name => {
+              flow.setProjectName(name);
+              flow.confirmProjectName();
+            }}
+            onCancel={handleExit}
+          />
+        </>
+      )}
+
+      {phase === 'create-prompt' && (
+        <>
+          <Box marginBottom={1}>
+            <Text>
+              Project: <Text color={STATUS_COLORS.success}>{flow.projectName}</Text>
+            </Text>
+          </Box>
+          <Box flexDirection="column">
+            <Text>Would you like to add an agent now?</Text>
+            <Box marginTop={1}>
+              <SelectList items={CREATE_PROMPT_ITEMS} selectedIndex={createPromptIndex} />
+            </Box>
+          </Box>
+        </>
+      )}
+
+      {phase === 'running' && <StepProgress steps={flow.steps} />}
+
       {allSuccess && flow.outputDir && (
         <Box marginTop={1} flexDirection="column">
+          <StepProgress steps={flow.steps} />
           <CreatedSummary projectName={flow.projectName} agentConfig={flow.addAgentConfig} />
           {isInteractive ? (
             <Box marginTop={1}>
@@ -352,8 +351,10 @@ export function CreateScreen({ cwd, isInteractive, onExit, onNavigate }: CreateS
           )}
         </Box>
       )}
+
       {flow.hasError && (
         <Box marginTop={1} flexDirection="column">
+          <StepProgress steps={flow.steps} />
           <Text color={STATUS_COLORS.error}>Project creation failed.</Text>
           {flow.logFilePath && (
             <Box marginTop={1}>

--- a/src/cli/tui/screens/deploy/DeployScreen.tsx
+++ b/src/cli/tui/screens/deploy/DeployScreen.tsx
@@ -228,13 +228,13 @@ export function DeployScreen({
     );
   }
 
-  // AWS target configuration phase (skip when preSynthesized - we already have context)
-  if (!skipPreflight && !awsConfig.isConfigured) {
-    return (
-      <Screen title="AgentCore Deploy" onExit={onExit} helpText={getAwsConfigHelpText(awsConfig.phase)}>
-        <AwsTargetConfigUI config={awsConfig} onExit={onExit} isActive={true} />
-      </Screen>
-    );
+  const showAwsConfig = !skipPreflight && !awsConfig.isConfigured;
+
+  // Brief transitional phases — render nothing to avoid a header flash before the real UI
+  const awsTransitional =
+    awsConfig.phase === 'checking' || awsConfig.phase === 'detecting' || awsConfig.phase === 'saving';
+  if (showAwsConfig && awsTransitional) {
+    return null;
   }
 
   // Credentials prompt phase
@@ -304,7 +304,11 @@ export function DeployScreen({
   ]
     .filter(Boolean)
     .join(' · ');
-  const helpText = context && isInteractive ? `${toggleHints} · ${baseHelpText}` : baseHelpText;
+  const helpText = showAwsConfig
+    ? (getAwsConfigHelpText(awsConfig.phase) ?? HELP_TEXT.EXIT)
+    : context && isInteractive
+      ? `${toggleHints} · ${baseHelpText}`
+      : baseHelpText;
 
   const screenTitle = diffMode ? 'AgentCore Diff' : 'AgentCore Deploy';
 
@@ -316,94 +320,105 @@ export function DeployScreen({
   const diffMaxHeight = Math.max(6, terminalRows - chromeLines);
 
   return (
-    <Screen title={screenTitle} onExit={onExit} helpText={helpText} headerContent={headerContent}>
-      <StepProgress steps={displaySteps} />
+    <Screen
+      title={screenTitle}
+      onExit={onExit}
+      helpText={helpText}
+      headerContent={showAwsConfig ? undefined : headerContent}
+    >
+      {showAwsConfig ? (
+        <AwsTargetConfigUI config={awsConfig} onExit={onExit} isActive={true} />
+      ) : (
+        <>
+          <StepProgress steps={displaySteps} />
 
-      {/* Toggleable ResourceGraph view */}
-      {showResourceGraph && context && (
-        <Box marginTop={1}>
-          <ResourceGraph project={context.projectSpec} mcp={mcpSpec} />
-        </Box>
-      )}
+          {/* Toggleable ResourceGraph view */}
+          {showResourceGraph && context && (
+            <Box marginTop={1}>
+              <ResourceGraph project={context.projectSpec} mcp={mcpSpec} />
+            </Box>
+          )}
 
-      {/* Show deploy status when deploying or complete */}
-      {showDeployStatus && (
-        <Box marginTop={1}>
-          <DeployStatus messages={deployMessages} isComplete={isComplete} hasError={hasError} />
-        </Box>
-      )}
+          {/* Show deploy status when deploying or complete */}
+          {showDeployStatus && (
+            <Box marginTop={1}>
+              <DeployStatus messages={deployMessages} isComplete={isComplete} hasError={hasError} />
+            </Box>
+          )}
 
-      {/* Show diff output (diff mode: always; normal mode: Ctrl+D toggle) */}
-      {(diffMode === true || showDiff) && isDiffLoading && (
-        <Box marginTop={1}>
-          <Text dimColor>Loading diff...</Text>
-        </Box>
-      )}
-      {(diffMode === true || showDiff) && diffSummaries.length > 0 && (
-        <Box marginTop={1}>
-          <DiffSummaryView
-            summaries={diffSummaries}
-            numStacksWithChanges={numStacksWithChanges}
-            isActive={showDiff || diffMode === true}
-            maxHeight={diffMaxHeight}
-          />
-        </Box>
-      )}
+          {/* Show diff output (diff mode: always; normal mode: Ctrl+D toggle) */}
+          {(diffMode === true || showDiff) && isDiffLoading && (
+            <Box marginTop={1}>
+              <Text dimColor>Loading diff...</Text>
+            </Box>
+          )}
+          {(diffMode === true || showDiff) && diffSummaries.length > 0 && (
+            <Box marginTop={1}>
+              <DiffSummaryView
+                summaries={diffSummaries}
+                numStacksWithChanges={numStacksWithChanges}
+                isActive={showDiff || diffMode === true}
+                maxHeight={diffMaxHeight}
+              />
+            </Box>
+          )}
 
-      {allSuccess && deployOutput && !diffMode && (
-        <Box flexDirection="column" marginTop={1}>
-          <Text color="green">{deployOutput}</Text>
-        </Box>
-      )}
+          {allSuccess && deployOutput && !diffMode && (
+            <Box flexDirection="column" marginTop={1}>
+              <Text color="green">{deployOutput}</Text>
+            </Box>
+          )}
 
-      {allSuccess && diffMode && (
-        <Box flexDirection="column" marginTop={1}>
-          <Text color="green">Diff complete</Text>
-        </Box>
-      )}
+          {allSuccess && diffMode && (
+            <Box flexDirection="column" marginTop={1}>
+              <Text color="green">Diff complete</Text>
+            </Box>
+          )}
 
-      {allSuccess && deployNotes.length > 0 && (
-        <Box flexDirection="column" marginTop={1}>
-          {deployNotes.map((note, i) => (
-            <Text key={i} dimColor>
-              Note: {note}
-            </Text>
-          ))}
-        </Box>
-      )}
+          {allSuccess && deployNotes.length > 0 && (
+            <Box flexDirection="column" marginTop={1}>
+              {deployNotes.map((note, i) => (
+                <Text key={i} dimColor>
+                  Note: {note}
+                </Text>
+              ))}
+            </Box>
+          )}
 
-      {allSuccess && targetStatuses.length > 0 && (
-        <Box flexDirection="column" marginTop={1}>
-          <Text bold>Gateway Targets:</Text>
-          {targetStatuses.map(t => (
-            <Text key={t.name}>
-              {' '}
-              {t.name}: {formatTargetStatus(t.status)}
-            </Text>
-          ))}
-        </Box>
-      )}
+          {allSuccess && targetStatuses.length > 0 && (
+            <Box flexDirection="column" marginTop={1}>
+              <Text bold>Gateway Targets:</Text>
+              {targetStatuses.map(t => (
+                <Text key={t.name}>
+                  {' '}
+                  {t.name}: {formatTargetStatus(t.status)}
+                </Text>
+              ))}
+            </Box>
+          )}
 
-      {logFilePath && (
-        <Box marginTop={1}>
-          <LogLink filePath={logFilePath} />
-        </Box>
-      )}
+          {logFilePath && (
+            <Box marginTop={1}>
+              <LogLink filePath={logFilePath} />
+            </Box>
+          )}
 
-      {allSuccess && !diffMode && (
-        <NextSteps
-          steps={getDeployNextSteps((context?.projectSpec.runtimes.length ?? 0) > 0)}
-          isInteractive={isInteractive}
-          onSelect={step => {
-            if (step.command === 'invoke') {
-              setShowInvoke(true);
-            } else if (onNavigate) {
-              onNavigate(step.command);
-            }
-          }}
-          onBack={onExit}
-          isActive={allSuccess && !showInvoke}
-        />
+          {allSuccess && !diffMode && (
+            <NextSteps
+              steps={getDeployNextSteps((context?.projectSpec.runtimes.length ?? 0) > 0)}
+              isInteractive={isInteractive}
+              onSelect={step => {
+                if (step.command === 'invoke') {
+                  setShowInvoke(true);
+                } else if (onNavigate) {
+                  onNavigate(step.command);
+                }
+              }}
+              onBack={onExit}
+              isActive={allSuccess && !showInvoke}
+            />
+          )}
+        </>
       )}
     </Screen>
   );

--- a/src/cli/tui/screens/home/CommandListScreen.tsx
+++ b/src/cli/tui/screens/home/CommandListScreen.tsx
@@ -1,9 +1,7 @@
 import { buildLogo, useLayout } from '../../context';
 import type { CommandMeta } from '../../utils/commands';
-import { Box, Text, useApp } from 'ink';
+import { Box, Text, useApp, useStdout } from 'ink';
 import React, { useEffect } from 'react';
-
-const MAX_DESC_WIDTH = 50;
 
 function truncateDescription(desc: string, maxLen: number): string {
   if (desc.length <= maxLen) return desc;
@@ -21,6 +19,9 @@ interface CommandListScreenProps {
 export function CommandListScreen({ commands }: CommandListScreenProps) {
   const { exit } = useApp();
   const { contentWidth } = useLayout();
+  const { stdout } = useStdout();
+  const terminalWidth = stdout?.columns ?? 80;
+  const maxDescWidth = Math.max(20, terminalWidth - 18);
   const logo = buildLogo(contentWidth);
 
   // Exit after render
@@ -44,7 +45,7 @@ export function CommandListScreen({ commands }: CommandListScreenProps) {
         Commands:
       </Text>
       {visibleCommands.map(cmd => {
-        const desc = truncateDescription(cmd.description, MAX_DESC_WIDTH);
+        const desc = truncateDescription(cmd.description, maxDescWidth);
         const padding = ' '.repeat(Math.max(1, 14 - cmd.title.length));
         return (
           <Box key={cmd.id}>

--- a/src/cli/tui/screens/home/HelpScreen.tsx
+++ b/src/cli/tui/screens/home/HelpScreen.tsx
@@ -3,10 +3,8 @@ import { useLayout } from '../../context';
 import { HINTS } from '../../copy';
 import { useTextInput } from '../../hooks';
 import type { CommandMeta } from '../../utils/commands';
-import { Box, Text, useInput } from 'ink';
+import { Box, Text, useInput, useStdout } from 'ink';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-
-const MAX_DESC_WIDTH = 50;
 
 function truncateDescription(desc: string, maxLen: number): string {
   if (desc.length <= maxLen) return desc;
@@ -29,8 +27,18 @@ interface HelpDisplayProps {
   notice?: React.ReactNode;
 }
 
-function CommandRow({ item, selected, maxLabelLen }: { item: DisplayItem; selected: boolean; maxLabelLen: number }) {
-  const desc = truncateDescription(item.command.description, MAX_DESC_WIDTH);
+function CommandRow({
+  item,
+  selected,
+  maxLabelLen,
+  maxDescWidth,
+}: {
+  item: DisplayItem;
+  selected: boolean;
+  maxLabelLen: number;
+  maxDescWidth: number;
+}) {
+  const desc = truncateDescription(item.command.description, maxDescWidth);
   const labelLen = item.matchedSubcommand
     ? item.command.title.length + 3 + item.matchedSubcommand.length
     : item.command.title.length;
@@ -77,10 +85,13 @@ function HelpDisplay({
   notice,
 }: HelpDisplayProps) {
   const { contentWidth } = useLayout();
+  const { stdout } = useStdout();
+  const terminalWidth = stdout?.columns ?? 80;
   const bottomDivider = '─'.repeat(contentWidth);
 
   const allItems = [...interactiveItems, ...cliOnlyItems];
   const maxLabelLen = getMaxLabelLen(allItems);
+  const maxDescWidth = Math.max(20, terminalWidth - maxLabelLen - 8);
 
   const hasCliOnly = cliOnlyItems.length > 0;
   const showCliSection = hasCliOnly && (showCliOnly || !!query);
@@ -114,6 +125,7 @@ function HelpDisplay({
                 item={item}
                 selected={idx === clampedIndex}
                 maxLabelLen={maxLabelLen}
+                maxDescWidth={maxDescWidth}
               />
             ))}
 
@@ -128,6 +140,7 @@ function HelpDisplay({
                     item={item}
                     selected={interactiveCount + idx === clampedIndex}
                     maxLabelLen={maxLabelLen}
+                    maxDescWidth={maxDescWidth}
                   />
                 ))}
               </>


### PR DESCRIPTION
## Summary
- Fixes the duplicate header that appeared on command screens (deploy, create, etc.) when run directly from the CLI
- Makes help menu description width responsive to terminal size instead of truncating at 50 chars

Closes #895
Closes #637

## Changes
- **DeployScreen**: Return `null` during brief AWS config transitional phases (`checking`/`detecting`/`saving`) instead of rendering a `<Screen>` that gets immediately replaced
- **CreateScreen**: Return `null` during `checking` phase; consolidate all other phases into a single `<Screen>` mount so Ink doesn't output multiple frames with the same header
- **HelpScreen/CommandListScreen**: Replace hardcoded `MAX_DESC_WIDTH = 50` with dynamic width computed from terminal columns
- **copy.ts**: Trim verbose `run` command description

## Root Cause
Ink (React for terminal) doesn't use an alternate screen buffer in non-interactive mode. When a component renders briefly during a transitional phase then re-renders with different content, both frames get written to stdout — causing the title to appear twice.

## Test plan
- [ ] Run `agentcore create` from CLI — verify single "AgentCore Create" header
- [ ] Run `agentcore deploy` from CLI — verify single "AgentCore Deploy" header  
- [ ] Run `agentcore` TUI, navigate to deploy — verify single header
- [ ] Check help menu descriptions on wide terminal — should not truncate prematurely
- [ ] Check help menu on narrow terminal — should still truncate gracefully