### PR TITLE
fix: lower eventExpiryDuration minimum from 7 to 3 days

### DIFF
--- a/src/cli/commands/import/__tests__/import-memory.test.ts
+++ b/src/cli/commands/import/__tests__/import-memory.test.ts
@@ -38,7 +38,7 @@ function toMemorySpec(mem: ParsedStarterToolkitMemory): Memory {
 
   return {
     name: mem.name,
-    eventExpiryDuration: Math.max(7, Math.min(365, mem.eventExpiryDays)),
+    eventExpiryDuration: Math.max(3, Math.min(365, mem.eventExpiryDays)),
     strategies,
   };
 }
@@ -408,7 +408,7 @@ describe('toMemorySpec', () => {
       };
 
       const result = toMemorySpec(mem);
-      expect(result.eventExpiryDuration).toBe(7);
+      expect(result.eventExpiryDuration).toBe(3);
     });
 
     it('clamps zero to minimum of 7', () => {
@@ -419,7 +419,7 @@ describe('toMemorySpec', () => {
       };
 
       const result = toMemorySpec(mem);
-      expect(result.eventExpiryDuration).toBe(7);
+      expect(result.eventExpiryDuration).toBe(3);
     });
 
     it('clamps negative values to minimum of 7', () => {
@@ -430,7 +430,7 @@ describe('toMemorySpec', () => {
       };
 
       const result = toMemorySpec(mem);
-      expect(result.eventExpiryDuration).toBe(7);
+      expect(result.eventExpiryDuration).toBe(3);
     });
 
     it('clamps high values to maximum of 365', () => {
@@ -473,7 +473,7 @@ describe('YAML Parsing: eventExpiryDays values', () => {
 
       // But toMemorySpec should clamp it
       const spec = toMemorySpec(parsed.memories[0]!);
-      expect(spec.eventExpiryDuration).toBe(7);
+      expect(spec.eventExpiryDuration).toBe(3);
     } finally {
       fs.unlinkSync(tmpFile);
     }

--- a/src/cli/commands/import/__tests__/merge-logic.test.ts
+++ b/src/cli/commands/import/__tests__/merge-logic.test.ts
@@ -39,7 +39,7 @@ function toMemorySpec(mem: ParsedStarterToolkitConfig['memories'][0]): Memory {
   }
   return {
     name: mem.name,
-    eventExpiryDuration: Math.max(7, Math.min(365, mem.eventExpiryDays)),
+    eventExpiryDuration: Math.max(3, Math.min(365, mem.eventExpiryDays)),
     strategies,
   };
 }
@@ -194,7 +194,7 @@ describe('source copy skip logic', () => {
 describe('toMemorySpec', () => {
   it('clamps below 7', () => {
     const mem: ParsedStarterToolkitConfig['memories'][0] = { name: 't', mode: 'STM_ONLY', eventExpiryDays: 1 };
-    expect(toMemorySpec(mem).eventExpiryDuration).toBe(7);
+    expect(toMemorySpec(mem).eventExpiryDuration).toBe(3);
   });
   it('clamps above 365', () => {
     const mem: ParsedStarterToolkitConfig['memories'][0] = { name: 't', mode: 'STM_ONLY', eventExpiryDays: 999 };

--- a/src/cli/commands/import/actions.ts
+++ b/src/cli/commands/import/actions.ts
@@ -78,7 +78,7 @@ function toMemorySpec(mem: ParsedStarterToolkitConfig['memories'][0]): Memory {
 
   return {
     name: mem.name,
-    eventExpiryDuration: Math.max(7, Math.min(365, mem.eventExpiryDays)),
+    eventExpiryDuration: Math.max(3, Math.min(365, mem.eventExpiryDays)),
     strategies,
   };
 }

--- a/src/cli/commands/import/import-memory.ts
+++ b/src/cli/commands/import/import-memory.ts
@@ -55,7 +55,7 @@ function toMemorySpec(memory: MemoryDetail, localName: string): Memory {
 
   return {
     name: localName,
-    eventExpiryDuration: Math.max(7, Math.min(365, memory.eventExpiryDuration)),
+    eventExpiryDuration: Math.max(3, Math.min(365, memory.eventExpiryDuration)),
     strategies,
     ...(memory.tags && Object.keys(memory.tags).length > 0 && { tags: memory.tags }),
     ...(memory.encryptionKeyArn && { encryptionKeyArn: memory.encryptionKeyArn }),

--- a/src/schema/llm-compacted/agentcore.ts
+++ b/src/schema/llm-compacted/agentcore.ts
@@ -73,7 +73,7 @@ interface EnvVar {
 
 interface Memory {
   name: string; // @regex ^[a-zA-Z][a-zA-Z0-9_]{0,47}$ @max 48
-  eventExpiryDuration: number; // @min 7 @max 365 (days)
+  eventExpiryDuration: number; // @min 3 @max 365 (days)
   strategies: MemoryStrategy[]; // @min 1, unique by type
   tags?: Record<string, string>;
 }

--- a/src/schema/schemas/__tests__/agentcore-project.test.ts
+++ b/src/schema/schemas/__tests__/agentcore-project.test.ts
@@ -137,10 +137,10 @@ describe('MemorySchema', () => {
     }
   });
 
-  it('rejects eventExpiryDuration below 7', () => {
+  it('rejects eventExpiryDuration below 3', () => {
     const result = MemorySchema.safeParse({
       name: 'Test',
-      eventExpiryDuration: 6,
+      eventExpiryDuration: 2,
       strategies: [],
     });
     expect(result.success).toBe(false);
@@ -155,11 +155,11 @@ describe('MemorySchema', () => {
     expect(result.success).toBe(false);
   });
 
-  it('accepts eventExpiryDuration boundary values (7 and 365)', () => {
+  it('accepts eventExpiryDuration boundary values (3 and 365)', () => {
     expect(
       MemorySchema.safeParse({
         name: 'Min',
-        eventExpiryDuration: 7,
+        eventExpiryDuration: 3,
         strategies: [],
       }).success
     ).toBe(true);

--- a/src/schema/schemas/agentcore-project.ts
+++ b/src/schema/schemas/agentcore-project.ts
@@ -126,7 +126,7 @@ export type StreamDeliveryResources = z.infer<typeof StreamDeliveryResourcesSche
 
 export const MemorySchema = z.object({
   name: MemoryNameSchema,
-  eventExpiryDuration: z.number().int().min(7).max(365),
+  eventExpiryDuration: z.number().int().min(3).max(365),
   // Strategies array can be empty for short-term memory (just base memory with expiration)
   // Long-term memory includes strategies like SEMANTIC, SUMMARIZATION, USER_PREFERENCE
   strategies: z


### PR DESCRIPTION
## Summary
- Aligns CLI schema with the AWS CreateMemory API which allows a minimum of 3 days for `eventExpiryDuration`
- Users can now configure memories with 3-6 day expiry through the CLI

Closes #744

## Changes
- `src/schema/schemas/agentcore-project.ts` — `.min(7)` → `.min(3)`
- `src/schema/llm-compacted/agentcore.ts` — comment `@min 7` → `@min 3`
- `src/cli/commands/import/import-memory.ts` — clamping floor 7 → 3
- `src/cli/commands/import/actions.ts` — clamping floor 7 → 3
- Updated all related tests (schema validation, import clamping, merge logic)

## Test plan
- [ ] All 123 tests pass across 3 test files
- [ ] `agentcore validate` accepts `eventExpiryDuration: 3`
- [ ] `agentcore validate` rejects `eventExpiryDuration: 2`