### PR TITLE
fix: display session ID after CLI invoke completes

### DIFF
--- a/src/cli/commands/invoke/action.ts
+++ b/src/cli/commands/invoke/action.ts
@@ -369,6 +369,7 @@ export async function handleInvoke(context: InvokeContext, options: InvokeOption
         agentName: agentSpec.name,
         targetName: selectedTargetName,
         response,
+        sessionId: aguiResult.sessionId,
         logFilePath: logger.logFilePath,
       };
     } catch (err) {

--- a/src/cli/commands/invoke/action.ts
+++ b/src/cli/commands/invoke/action.ts
@@ -415,6 +415,7 @@ export async function handleInvoke(context: InvokeContext, options: InvokeOption
         agentName: agentSpec.name,
         targetName: selectedTargetName,
         response: fullResponse,
+        sessionId: result.sessionId,
         logFilePath: logger.logFilePath,
       };
     } catch (err) {
@@ -441,6 +442,7 @@ export async function handleInvoke(context: InvokeContext, options: InvokeOption
     agentName: agentSpec.name,
     targetName: selectedTargetName,
     response: response.content,
+    sessionId: response.sessionId,
     logFilePath: logger.logFilePath,
   };
 }

--- a/src/cli/commands/invoke/command.tsx
+++ b/src/cli/commands/invoke/command.tsx
@@ -56,9 +56,13 @@ async function handleInvokeCLI(options: InvokeOptions): Promise<void> {
     if (options.json) {
       console.log(JSON.stringify(result));
     } else if (options.stream) {
-      // Streaming already wrote to stdout, just show log path
+      // Streaming already wrote to stdout, just show session and log path
+      if (result.sessionId) {
+        console.error(`\nSession: ${result.sessionId}`);
+        console.error(`To resume: agentcore invoke --session-id ${result.sessionId}`);
+      }
       if (result.logFilePath) {
-        console.error(`\nLog: ${result.logFilePath}`);
+        console.error(`Log: ${result.logFilePath}`);
       }
     } else {
       // Non-streaming, non-json: print provider info and response or error
@@ -67,8 +71,12 @@ async function handleInvokeCLI(options: InvokeOptions): Promise<void> {
       } else if (!result.success && result.error) {
         console.error(result.error);
       }
+      if (result.sessionId) {
+        console.error(`\nSession: ${result.sessionId}`);
+        console.error(`To resume: agentcore invoke --session-id ${result.sessionId}`);
+      }
       if (result.logFilePath) {
-        console.error(`\nLog: ${result.logFilePath}`);
+        console.error(`Log: ${result.logFilePath}`);
       }
     }
 

--- a/src/cli/commands/invoke/types.ts
+++ b/src/cli/commands/invoke/types.ts
@@ -25,6 +25,7 @@ export interface InvokeResult {
   agentName?: string;
   targetName?: string;
   response?: string;
+  sessionId?: string;
   error?: string;
   logFilePath?: string;
 }


### PR DESCRIPTION
## Summary
- Shows the session ID and a resume command hint after `agentcore invoke` completes in non-interactive CLI mode (both `--stream` and default)
- The TUI path was already fixed by #904, but the CLI paths discarded the session ID

Closes #664

## Changes
- **types.ts** — Added `sessionId` to `InvokeResult` interface
- **action.ts** — Capture `sessionId` from `invokeAgentRuntimeStreaming()` and `invokeAgentRuntime()` responses and include it in the returned result
- **command.tsx** — Print session ID and resume command to stderr after streaming or non-streaming output completes

## Example output
```
<agent response>

Session: abc123-def456-...
To resume: agentcore invoke --session-id abc123-def456-...
Log: agentcore/.cli/logs/invoke/...
```

## Test plan
- [ ] Run `agentcore invoke "hello" --stream` — session ID printed after stream
- [ ] Run `agentcore invoke "hello"` — session ID printed after response
- [ ] Run `agentcore invoke "hello" --json` — session ID included in JSON output
- [ ] Verify session ID is not printed when invoke fails