### PR TITLE
fix: use pull_request_target for fork PR support

### DIFF
--- a/.github/workflows/pr-ai-review.yml
+++ b/.github/workflows/pr-ai-review.yml
@@ -87,6 +87,7 @@ jobs:
           echo "number=$PR_NUM" >> "$GITHUB_OUTPUT"
 
       - name: Add agentcore-harness-reviewing label
+        continue-on-error: true
         uses: actions/github-script@v8
         with:
           script: |

--- a/.github/workflows/pr-ai-review.yml
+++ b/.github/workflows/pr-ai-review.yml
@@ -1,7 +1,7 @@
 name: AgentCore Harness Reviewing
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened]
   workflow_dispatch:
     inputs:
@@ -18,13 +18,13 @@ permissions:
 jobs:
   authorize:
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request'
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request_target'
     outputs:
       authorized: ${{ steps.auth.outputs.authorized }}
     steps:
       - name: Check authorization
         id: auth
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request_target'
         uses: actions/github-script@v8
         with:
           script: |
@@ -87,7 +87,6 @@ jobs:
           echo "number=$PR_NUM" >> "$GITHUB_OUTPUT"
 
       - name: Add agentcore-harness-reviewing label
-        continue-on-error: true
         uses: actions/github-script@v8
         with:
           script: |


### PR DESCRIPTION
## Summary
- Switches the AI review workflow trigger from `pull_request` to `pull_request_target`
- `pull_request` gives fork PRs a read-only `GITHUB_TOKEN`, which blocks labels, secrets, and the review entirely
- `pull_request_target` runs in the base repo context with full write permissions and secret access
- This is safe because we never check out or execute fork code — the Checkout step gets the base branch (where the review scripts live), and the harness fetches the PR diff via the GitHub API

## Test plan
- [ ] Open/reopen a fork PR from an `agentcore-cli-devs` member and verify the label is added, the review runs, and the label is removed
- [ ] Verify `workflow_dispatch` still works