### PR TITLE
feat: instruct reviewer to include GitHub permalinks

### DIFF
--- a/.github/scripts/prompts/review.md
+++ b/.github/scripts/prompts/review.md
@@ -8,6 +8,6 @@ You have these repos cloned locally for context:
 
 Before reviewing, read all existing comments on the PR to understand what has already been discussed. Do not repeat or re-post issues that have already been raised in existing comments.
 
-Review the PR. If there are any serious issues that require code changes before merging, post a comment on the PR for each issue explaining the problem. If there are multiple ways to fix an issue, list the options so the author can choose. Skip style nits and minor suggestions — only flag things that actually need to change.
+Review the PR. If there are any serious issues that require code changes before merging, post a comment on the PR for each issue explaining the problem. When referencing specific lines of code, include a GitHub permalink. If there are multiple ways to fix an issue, list the options so the author can choose. Skip style nits and minor suggestions — only flag things that actually need to change.
 
 If all serious issues have already been raised in existing comments, or if you found no new issues, post a single comment on the PR saying it looks good to merge (or that all issues have already been flagged).


### PR DESCRIPTION
## Summary
- Adds instruction to the review prompt to include GitHub permalinks when referencing specific lines of code
- Makes review comments easier to navigate — click the link to jump straight to the relevant code

## Test plan
- [ ] Trigger `workflow_dispatch` and verify the reviewer includes links like `https://github.com/aws/agentcore-cli/blob/<sha>/path/file.ts#L42-L50` in comments