### PR TITLE
feat: add agentcore-cli User-Agent to all API calls

### DIFF
--- a/src/cli/aws/agentcore-control.ts
+++ b/src/cli/aws/agentcore-control.ts
@@ -1,4 +1,5 @@
 import type { EvaluationLevel } from '../../schema/schemas/primitives/evaluator';
+import { PACKAGE_VERSION } from '../constants';
 import { getCredentialProvider } from './account';
 import {
   BedrockAgentCoreControlClient,
@@ -23,6 +24,7 @@ export function createControlClient(region: string): BedrockAgentCoreControlClie
   return new BedrockAgentCoreControlClient({
     region,
     credentials: getCredentialProvider(),
+    customUserAgent: [['agentcore-cli', PACKAGE_VERSION]],
   });
 }
 

--- a/src/cli/aws/agentcore.ts
+++ b/src/cli/aws/agentcore.ts
@@ -1,4 +1,5 @@
 import { parseJsonRpcResponse } from '../../lib/utils/json-rpc';
+import { PACKAGE_VERSION } from '../constants';
 import { getCredentialProvider } from './account';
 import { parseAguiSSEStream } from './agui-parser';
 import { serviceEndpoint } from './partition';
@@ -23,11 +24,12 @@ function resolveDataPlaneEndpoint(region: string): string | undefined {
   return undefined;
 }
 
-function createAgentCoreClient(region: string, headers?: Record<string, string>): BedrockAgentCoreClient {
+export function createAgentCoreClient(region: string, headers?: Record<string, string>): BedrockAgentCoreClient {
   const endpoint = resolveDataPlaneEndpoint(region);
   const client = new BedrockAgentCoreClient({
     region,
     credentials: getCredentialProvider(),
+    customUserAgent: [['agentcore-cli', PACKAGE_VERSION]],
     ...(endpoint && { endpoint }),
   });
 
@@ -473,6 +475,7 @@ export async function evaluate(options: EvaluateOptions): Promise<EvaluateResult
   const client = new BedrockAgentCoreClient({
     region: options.region,
     credentials: getCredentialProvider(),
+    customUserAgent: [['agentcore-cli', PACKAGE_VERSION]],
   });
 
   const evaluationTarget = options.targetSpanIds
@@ -1066,6 +1069,7 @@ export async function stopRuntimeSession(options: StopRuntimeSessionOptions): Pr
   const client = new BedrockAgentCoreClient({
     region: options.region,
     credentials: getCredentialProvider(),
+    customUserAgent: [['agentcore-cli', PACKAGE_VERSION]],
   });
 
   const command = new StopRuntimeSessionCommand({

--- a/src/cli/aws/index.ts
+++ b/src/cli/aws/index.ts
@@ -56,6 +56,7 @@ export {
   type InvokeHarnessOptions,
 } from './agentcore-harness';
 export {
+  createAgentCoreClient,
   DEFAULT_RUNTIME_USER_ID,
   executeBashCommand,
   invokeA2ARuntime,

--- a/src/cli/aws/policy-generation.ts
+++ b/src/cli/aws/policy-generation.ts
@@ -1,6 +1,5 @@
-import { getCredentialProvider } from './account';
+import { createControlClient } from './agentcore-control';
 import {
-  BedrockAgentCoreControlClient,
   GetPolicyGenerationCommand,
   ListPolicyGenerationAssetsCommand,
   StartPolicyGenerationCommand,
@@ -33,10 +32,7 @@ export interface GetPolicyGenerationResult {
 export async function startPolicyGeneration(
   options: StartPolicyGenerationOptions
 ): Promise<StartPolicyGenerationResult> {
-  const client = new BedrockAgentCoreControlClient({
-    region: options.region,
-    credentials: getCredentialProvider(),
-  });
+  const client = createControlClient(options.region);
 
   const command = new StartPolicyGenerationCommand({
     policyEngineId: options.policyEngineId,
@@ -57,10 +53,7 @@ export async function startPolicyGeneration(
 }
 
 export async function getPolicyGeneration(options: GetPolicyGenerationOptions): Promise<GetPolicyGenerationResult> {
-  const client = new BedrockAgentCoreControlClient({
-    region: options.region,
-    credentials: getCredentialProvider(),
-  });
+  const client = createControlClient(options.region);
 
   // Use the SDK waiter to poll until generation completes
   const waiterResult = await waitUntilPolicyGenerationCompleted(

--- a/src/cli/operations/deploy/gateway-status.ts
+++ b/src/cli/operations/deploy/gateway-status.ts
@@ -1,7 +1,8 @@
 /**
  * Query gateway target sync statuses after deployment.
  */
-import { BedrockAgentCoreControlClient, ListGatewayTargetsCommand } from '@aws-sdk/client-bedrock-agentcore-control';
+import { createControlClient } from '../../aws/agentcore-control';
+import { ListGatewayTargetsCommand } from '@aws-sdk/client-bedrock-agentcore-control';
 
 export interface TargetSyncStatus {
   name: string;
@@ -29,7 +30,7 @@ export function formatTargetStatus(status: string): string {
  */
 export async function getGatewayTargetStatuses(gatewayId: string, region: string): Promise<TargetSyncStatus[]> {
   try {
-    const client = new BedrockAgentCoreControlClient({ region });
+    const client = createControlClient(region);
     const response = await client.send(
       new ListGatewayTargetsCommand({ gatewayIdentifier: gatewayId, maxResults: 100 })
     );

--- a/src/cli/operations/deploy/pre-deploy-identity.ts
+++ b/src/cli/operations/deploy/pre-deploy-identity.ts
@@ -1,6 +1,6 @@
 import { SecureCredentials, readEnvFile } from '../../../lib';
 import type { AgentCoreProjectSpec, Credential } from '../../../schema';
-import { getCredentialProvider } from '../../aws';
+import { createControlClient, getCredentialProvider } from '../../aws';
 import { isNoCredentialsError } from '../../errors';
 import { getAwsLoginGuidance } from '../../external-requirements/checks';
 import { computeDefaultCredentialEnvVarName } from '../../primitives/credential-utils';
@@ -13,7 +13,7 @@ import {
   updateApiKeyProvider,
   updateOAuth2Provider,
 } from '../identity';
-import { BedrockAgentCoreControlClient, GetTokenVaultCommand } from '@aws-sdk/client-bedrock-agentcore-control';
+import { type BedrockAgentCoreControlClient, GetTokenVaultCommand } from '@aws-sdk/client-bedrock-agentcore-control';
 import { CreateKeyCommand, KMSClient } from '@aws-sdk/client-kms';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -55,19 +55,17 @@ export interface SetupApiKeyProvidersOptions {
 export async function setupApiKeyProviders(options: SetupApiKeyProvidersOptions): Promise<PreDeployIdentityResult> {
   const { projectSpec, configBaseDir, region, runtimeCredentials, enableKmsEncryption } = options;
   const results: ApiKeyProviderSetupResult[] = [];
-  const credentials = getCredentialProvider();
-
   const envVars = await readEnvFile(configBaseDir);
   // Wrap env vars in SecureCredentials and merge with runtime credentials
   const envCredentials = SecureCredentials.fromEnvVars(envVars);
   const allCredentials = runtimeCredentials ? envCredentials.merge(runtimeCredentials) : envCredentials;
 
-  const client = new BedrockAgentCoreControlClient({ region, credentials });
+  const client = createControlClient(region);
 
   // Configure KMS encryption for token vault if enabled
   let kmsKeyArn: string | undefined;
   if (enableKmsEncryption) {
-    const kmsResult = await setupTokenVaultKms(region, credentials, projectSpec);
+    const kmsResult = await setupTokenVaultKms(region, projectSpec);
     if (!kmsResult.success) {
       return {
         results: [
@@ -100,11 +98,10 @@ export async function setupApiKeyProviders(options: SetupApiKeyProvidersOptions)
 
 async function setupTokenVaultKms(
   region: string,
-  credentials: ReturnType<typeof getCredentialProvider>,
   projectSpec: AgentCoreProjectSpec
 ): Promise<{ success: boolean; keyArn?: string; error?: string }> {
   try {
-    const controlClient = new BedrockAgentCoreControlClient({ region, credentials });
+    const controlClient = createControlClient(region);
 
     // Check if the token vault already has a customer-managed key
     try {
@@ -120,7 +117,7 @@ async function setupTokenVaultKms(
     }
 
     // No CMK configured — create a new KMS key and set it on the vault
-    const kmsClient = new KMSClient({ region, credentials });
+    const kmsClient = new KMSClient({ region, credentials: getCredentialProvider() });
     const response = await kmsClient.send(
       new CreateKeyCommand({
         Description: `AgentCore Identity encryption key for ${projectSpec.name}`,
@@ -289,13 +286,12 @@ export interface PreDeployOAuth2Result {
 export async function setupOAuth2Providers(options: SetupOAuth2ProvidersOptions): Promise<PreDeployOAuth2Result> {
   const { projectSpec, configBaseDir, region, runtimeCredentials } = options;
   const results: OAuth2ProviderSetupResult[] = [];
-  const credentials = getCredentialProvider();
 
   const envVars = await readEnvFile(configBaseDir);
   const envCredentials = SecureCredentials.fromEnvVars(envVars);
   const allCredentials = runtimeCredentials ? envCredentials.merge(runtimeCredentials) : envCredentials;
 
-  const client = new BedrockAgentCoreControlClient({ region, credentials });
+  const client = createControlClient(region);
 
   for (const credential of projectSpec.credentials) {
     if (credential.authorizerType === 'OAuthCredentialProvider') {

--- a/src/cli/operations/memory/list-memory-records.ts
+++ b/src/cli/operations/memory/list-memory-records.ts
@@ -1,5 +1,5 @@
-import { getCredentialProvider } from '../../aws';
-import { BedrockAgentCoreClient, ListMemoryRecordsCommand } from '@aws-sdk/client-bedrock-agentcore';
+import { createAgentCoreClient } from '../../aws';
+import { ListMemoryRecordsCommand } from '@aws-sdk/client-bedrock-agentcore';
 
 export interface MemoryRecordEntry {
   memoryRecordId: string;
@@ -33,10 +33,7 @@ export interface ListMemoryRecordsResult {
 export async function listMemoryRecords(options: ListMemoryRecordsOptions): Promise<ListMemoryRecordsResult> {
   const { region, memoryId, namespace, memoryStrategyId, maxResults = 50, nextToken } = options;
 
-  const client = new BedrockAgentCoreClient({
-    region,
-    credentials: getCredentialProvider(),
-  });
+  const client = createAgentCoreClient(region);
 
   try {
     const response = await client.send(

--- a/src/cli/operations/memory/retrieve-memory-records.ts
+++ b/src/cli/operations/memory/retrieve-memory-records.ts
@@ -1,6 +1,6 @@
-import { getCredentialProvider } from '../../aws';
+import { createAgentCoreClient } from '../../aws';
 import type { MemoryRecordEntry } from './list-memory-records';
-import { BedrockAgentCoreClient, RetrieveMemoryRecordsCommand } from '@aws-sdk/client-bedrock-agentcore';
+import { RetrieveMemoryRecordsCommand } from '@aws-sdk/client-bedrock-agentcore';
 
 export interface RetrieveMemoryRecordsOptions {
   region: string;
@@ -28,10 +28,7 @@ export async function retrieveMemoryRecords(
 ): Promise<RetrieveMemoryRecordsResult> {
   const { region, memoryId, namespace, searchQuery, memoryStrategyId, topK, maxResults, nextToken } = options;
 
-  const client = new BedrockAgentCoreClient({
-    region,
-    credentials: getCredentialProvider(),
-  });
+  const client = createAgentCoreClient(region);
 
   try {
     const response = await client.send(


### PR DESCRIPTION
## Summary

Sends `agentcore-cli/<version>` on all API requests so the service can differentiate CLI vs console vs curl traffic.

- agentcore-control.ts: customUserAgent on all BedrockAgentCoreControlClient instances (deploy, status, list)
- agentcore.ts: customUserAgent on all BedrockAgentCoreClient instances (invoke, evaluate, stop-session)

## Test plan

- [x] npm run typecheck passes
- [x] All hooks pass