### PR TITLE
chore: disable automatic PR review trigger

### DIFF
--- a/.github/workflows/pr-ai-review.yml
+++ b/.github/workflows/pr-ai-review.yml
@@ -1,8 +1,8 @@
 name: AgentCore Harness Reviewing
 
 on:
-  pull_request:
-    types: [opened, reopened]
+  # pull_request:
+  #   types: [opened, reopened]
   workflow_dispatch:
     inputs:
       pr_url:


### PR DESCRIPTION
## Summary
- Comments out the `pull_request` trigger on the AI review workflow so it no longer runs automatically on PR open/reopen
- The workflow can still be triggered manually via `workflow_dispatch`

## Test plan
- [ ] Verify the workflow no longer triggers on PR open/reopen
- [ ] Verify manual workflow_dispatch still works