### PR TITLE
test: split browser tests into its own job, fix logs path

### DIFF
--- a/.github/workflows/e2e-tests-full.yml
+++ b/.github/workflows/e2e-tests-full.yml
@@ -79,6 +79,31 @@ jobs:
           GEMINI_API_KEY: ${{ env.E2E_GEMINI_API_KEY }}
           CDK_TARBALL: ${{ env.CDK_TARBALL }}
         run: npm run test:e2e
+  browser-tests:
+    runs-on: ubuntu-latest
+    environment: e2e-testing
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref || 'main' }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+      - uses: astral-sh/setup-uv@v7
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.E2E_AWS_ROLE_ARN }}
+          aws-region: ${{ inputs.aws_region || 'us-east-1' }}
+      - name: Get AWS Account ID
+        id: aws
+        run: echo "account_id=$(aws sts get-caller-identity --query Account --output text)" >> "$GITHUB_OUTPUT"
+      - run: npm ci
+      - run: npm run build
+      - name: Install CLI globally
+        run: npm install -g "$(npm pack | tail -1)"
       - name: Install Playwright browsers
         run: npx playwright install chromium --with-deps
       - name: Run browser tests
@@ -91,7 +116,7 @@ jobs:
         if: failure()
         run: |
           echo "=== Dev server PTY output ==="
-          cat test-results/agentcore-dev-pty.log 2>/dev/null || echo "(no pty log)"
+          cat browser-tests/test-results/agentcore-dev-pty.log 2>/dev/null || echo "(no pty log)"
           echo ""
           echo "=== Error contexts ==="
-          find test-results -name 'error-context.md' -exec echo "--- {} ---" \; -exec cat {} \; 2>/dev/null || echo "(no error contexts)"
+          find browser-tests/test-results -name 'error-context.md' -exec echo "--- {} ---" \; -exec cat {} \; 2>/dev/null || echo "(no error contexts)"


### PR DESCRIPTION
## Description

Split browser tests (Playwright) out of the `e2e` matrix job into a standalone `browser-tests` job so they run in parallel with the E2E suite.

Also fixes the failure debug step paths — `test-results/` → `browser-tests/test-results/` — so the PTY log and error contexts are actually captured on failure. Previously these pointed to the wrong directory, so failure diagnostics always showed `(no pty log)`.

## Related Issue

Closes #

## Documentation PR

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe): CI workflow improvement

## Testing

- [x] Verified the workflow YAML is valid
- [x] `browser-tests` job has no `needs:` dependency, so it runs in parallel with the `e2e` matrix
- [x] Browser tests don't use the CDK tarball or API keys from Secrets Manager, so those steps are correctly omitted
- [x] Debug step paths now match Playwright's `outputDir` (`browser-tests/test-results/`)

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.