### PR TITLE
test: configure git in browser tests workflow

### DIFF
--- a/.github/workflows/e2e-tests-full.yml
+++ b/.github/workflows/e2e-tests-full.yml
@@ -91,6 +91,10 @@ jobs:
         with:
           node-version: '20.x'
           cache: 'npm'
+      - name: Configure git
+        run: |
+          git config --global user.email "ci@amazon.com"
+          git config --global user.name "CI"
       - uses: astral-sh/setup-uv@v7
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6


### PR DESCRIPTION
## Description

Fix workflow failure: https://github.com/aws/agentcore-cli/actions/runs/25002886488/job/73219242607

Add the missing `Configure git` step to the `browser-tests` CI job. `agentcore create` runs `git init` + `git commit` internally, which fails on GitHub Actions runners that don't have a git identity configured.

This was missed when splitting browser tests into their own job in #975 — the `e2e` job had this step but it wasn't carried over.

## Related Issue

Follow-up to #975

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

- [x] Verified the step is identical to the one in the `e2e` job

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.