### PR TITLE
fix(import): remove experimental warning from import command

### DIFF
--- a/src/cli/commands/import/command.ts
+++ b/src/cli/commands/import/command.ts
@@ -12,7 +12,7 @@ const { green, yellow, cyan, dim, reset } = ANSI;
 export const registerImport = (program: Command) => {
   const importCmd = program
     .command('import')
-    .description('Import a runtime, memory, or starter toolkit into this project. [experimental]');
+    .description('Import a runtime, memory, or starter toolkit into this project.');
 
   // Existing YAML flow: agentcore import --source <path>
   importCmd

--- a/src/cli/tui/screens/import/ImportSelectScreen.tsx
+++ b/src/cli/tui/screens/import/ImportSelectScreen.tsx
@@ -1,6 +1,5 @@
 import type { SelectableItem } from '../../components/SelectList';
 import { SelectScreen } from '../../components/SelectScreen';
-import { Text } from 'ink';
 
 export type ImportType = 'runtime' | 'memory' | 'evaluator' | 'online-eval' | 'starter-toolkit';
 
@@ -42,17 +41,5 @@ interface ImportSelectScreenProps {
 }
 
 export function ImportSelectScreen({ onSelect, onExit }: ImportSelectScreenProps) {
-  return (
-    <SelectScreen
-      title="Import"
-      headerContent={
-        <Text color="yellow">
-          Experimental: this feature imports resources that are already deployed, use with caution
-        </Text>
-      }
-      items={IMPORT_OPTIONS}
-      onSelect={item => onSelect(item.id)}
-      onExit={onExit}
-    />
-  );
+  return <SelectScreen title="Import" items={IMPORT_OPTIONS} onSelect={item => onSelect(item.id)} onExit={onExit} />;
 }


### PR DESCRIPTION
## Summary
- Removed `[experimental]` tag from the `import` command description
- Removed the yellow "Experimental" warning header from the import TUI select screen
- Removed unused `Text` import from `ImportSelectScreen.tsx`

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All 3476 unit tests pass
- [ ] Run `agentcore import` and verify no experimental warning appears
- [ ] Run `agentcore import --help` and verify no `[experimental]` tag in description