### PR TITLE
test: speed up CI and fix mock cleanup gaps

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -93,8 +93,10 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: blob-${{ matrix.node-version }}-${{ strategy.job-index }}
-          path: .vitest-reports/
+          path: .vitest-reports
           retention-days: 1
+          if-no-files-found: error
+          include-hidden-files: true
 
   merge-reports:
     needs: unit-test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x, 24.x]
+        node-version: ${{ github.event_name == 'pull_request' && fromJSON('["20.x"]') || fromJSON('["20.x", "22.x", "24.x"]') }}
 
     steps:
       - uses: actions/checkout@v6
@@ -39,14 +39,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
       - run: npm ci
       - run: npm run build --if-present
-      - run: npm run test:unit
       - run: npm run test:integ
-      - name: Upload coverage artifact
-        if: matrix.node-version == '20.x'
-        uses: actions/upload-artifact@v7
-        with:
-          name: coverage-report
-          path: coverage/
       - name: Pack tarball
         if: matrix.node-version == '20.x'
         run: npm pack
@@ -66,8 +59,69 @@ jobs:
           name: tarball
           path: '*.tgz'
 
+  unit-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ${{ github.event_name == 'pull_request' && fromJSON('["20.x"]') || fromJSON('["20.x", "22.x", "24.x"]') }}
+        shard: [1/3, 2/3, 3/3]
+
+    steps:
+      - uses: actions/checkout@v6
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+      - name: Configure git for tests
+        run: |
+          git config --global user.email "bedrock-agentcore-npm+ci@amazon.com"
+          git config --global user.name "CI"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      - run: npm ci
+      - run: npm run build --if-present
+      - name: Run unit tests (shard ${{ matrix.shard }})
+        run: npx vitest run --project unit --shard=${{ matrix.shard }} --reporter=blob --reporter=verbose
+      - name: Upload blob report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: blob-${{ matrix.node-version }}-${{ strategy.job-index }}
+          path: .vitest-reports/
+          retention-days: 1
+
+  merge-reports:
+    needs: unit-test
+    runs-on: ubuntu-latest
+    if: always()
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20.x
+          cache: 'npm'
+      - run: npm ci
+      - name: Download blob reports (Node 20)
+        uses: actions/download-artifact@v8
+        with:
+          pattern: blob-20.x-*
+          merge-multiple: true
+          path: .vitest-reports/
+      - name: Merge reports
+        run: npx vitest --mergeReports=.vitest-reports/ --project unit --coverage
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-report
+          path: coverage/
+
   coverage:
-    needs: build
+    needs: merge-reports
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     permissions:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,7 +22,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ${{ github.event_name == 'pull_request' && fromJSON('["20.x"]') || fromJSON('["20.x", "22.x", "24.x"]') }}
+        node-version:
+          ${{ github.event_name == 'pull_request' && fromJSON('["20.x"]') || fromJSON('["20.x", "22.x", "24.x"]') }}
 
     steps:
       - uses: actions/checkout@v6
@@ -66,7 +67,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ${{ github.event_name == 'pull_request' && fromJSON('["20.x"]') || fromJSON('["20.x", "22.x", "24.x"]') }}
+        node-version:
+          ${{ github.event_name == 'pull_request' && fromJSON('["20.x"]') || fromJSON('["20.x", "22.x", "24.x"]') }}
         shard: [1/3, 2/3, 3/3]
 
     steps:

--- a/src/cli/commands/remove/__tests__/subcommand-priority.test.ts
+++ b/src/cli/commands/remove/__tests__/subcommand-priority.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Mock registry to break circular dependency
 vi.mock('../../../primitives/registry', () => ({
@@ -21,6 +21,8 @@ vi.mock('../../../../lib/index.js', () => ({
  * but this test ensures that contract holds if the registration pattern changes.
  */
 describe('remove subcommand priority', () => {
+  afterEach(() => vi.restoreAllMocks());
+
   it('named subcommands are matched before the catch-all', async () => {
     const { Command } = await import('@commander-js/extra-typings');
     const { registerRemove } = await import('../command.js');

--- a/src/cli/operations/dev/__tests__/codezip-dev-server.test.ts
+++ b/src/cli/operations/dev/__tests__/codezip-dev-server.test.ts
@@ -2,7 +2,7 @@ import { CodeZipDevServer } from '../codezip-dev-server';
 import type { DevConfig } from '../config';
 import type { DevServerCallbacks, DevServerOptions } from '../dev-server';
 import { EventEmitter } from 'events';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockSpawn = vi.fn();
 vi.mock('child_process', () => ({
@@ -34,6 +34,8 @@ describe('CodeZipDevServer spawn config', () => {
   beforeEach(() => {
     mockSpawn.mockReturnValue(createMockChildProcess());
   });
+
+  afterEach(() => vi.restoreAllMocks());
 
   it('HTTP: uses uvicorn with --reload', async () => {
     const config: DevConfig = {

--- a/src/cli/operations/eval/__tests__/logs-eval.test.ts
+++ b/src/cli/operations/eval/__tests__/logs-eval.test.ts
@@ -89,7 +89,10 @@ describe('handleLogsEval', () => {
     );
   });
 
-  afterEach(() => vi.clearAllMocks());
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
 
   it('returns error when agent resolution fails', async () => {
     mockLoadDeployedProjectConfig.mockResolvedValue({});
@@ -156,7 +159,7 @@ describe('handleLogsEval', () => {
     mockStreamLogs.mockReturnValue(emptyGenerator());
 
     // eslint-disable-next-line @typescript-eslint/no-empty-function
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const result = await handleLogsEval({});
 
@@ -168,8 +171,6 @@ describe('handleLogsEval', () => {
       })
     );
     expect(mockSearchLogs).not.toHaveBeenCalled();
-
-    consoleSpy.mockRestore();
   });
 
   it('skips ResourceNotFoundException during search', async () => {
@@ -282,6 +283,5 @@ describe('handleLogsEval', () => {
     await handleLogsEval({ since: '1h' });
 
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('IAM role does not exist'));
-    consoleSpy.mockRestore();
   });
 });

--- a/src/cli/operations/remove/__tests__/get-agent-scoped-credentials.test.ts
+++ b/src/cli/operations/remove/__tests__/get-agent-scoped-credentials.test.ts
@@ -1,6 +1,6 @@
 import type { Credential } from '../../../../schema/index.js';
 import { AgentPrimitive } from '../../../primitives/AgentPrimitive.js';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Mock registry to break circular dependency: AgentPrimitive → AddFlow → hooks → registry → AgentPrimitive
 vi.mock('../../../primitives/registry', () => ({
@@ -12,6 +12,8 @@ const getAgentScopedCredentials = (...args: Parameters<typeof AgentPrimitive.get
   AgentPrimitive.getAgentScopedCredentials(...args);
 
 describe('getAgentScopedCredentials', () => {
+  afterEach(() => vi.restoreAllMocks());
+
   const projectName = 'MyProject';
 
   const makeCredential = (name: string): Credential => ({ name, authorizerType: 'ApiKeyCredentialProvider' });

--- a/src/tui-harness/__tests__/proof-of-concept.test.ts
+++ b/src/tui-harness/__tests__/proof-of-concept.test.ts
@@ -52,6 +52,14 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 const { Terminal } = xtermHeadless;
 
+let ptyAvailable = true;
+try {
+  const p = pty.spawn('/bin/echo', ['test'], { cols: 80, rows: 24 });
+  p.kill();
+} catch {
+  ptyAvailable = false;
+}
+
 // ---------------------------------------------------------------------------
 // Test A: xterm standalone
 // ---------------------------------------------------------------------------
@@ -77,7 +85,7 @@ describe('xterm standalone', () => {
 // ---------------------------------------------------------------------------
 // Test B: PTY + xterm wiring
 // ---------------------------------------------------------------------------
-describe('PTY + xterm wiring', () => {
+describe.skipIf(!ptyAvailable)('PTY + xterm wiring', () => {
   let terminal: InstanceType<typeof Terminal>;
   let ptyProcess: ReturnType<typeof pty.spawn> | undefined;
 
@@ -119,7 +127,7 @@ describe('PTY + xterm wiring', () => {
 // ---------------------------------------------------------------------------
 // Test C: DSR/CPR handler
 // ---------------------------------------------------------------------------
-describe('DSR/CPR handler', () => {
+describe.skipIf(!ptyAvailable)('DSR/CPR handler', () => {
   let terminal: InstanceType<typeof Terminal>;
   let ptyProcess: ReturnType<typeof pty.spawn> | undefined;
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -33,13 +33,20 @@ export default defineConfig({
   },
   plugins: [textLoaderPlugin],
   test: {
+    deps: {
+      optimizer: {
+        ssr: {
+          include: ['@aws-sdk/*', '@smithy/*', 'zod', 'commander'],
+        },
+      },
+    },
     projects: [
       {
         extends: true,
         test: {
           name: 'unit',
           include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
-          exclude: ['src/assets/cdk/test/*.test.ts'],
+          exclude: ['src/assets/cdk/test/*.test.ts', 'src/tui-harness/**'],
         },
       },
       {


### PR DESCRIPTION
## Summary

Day 1 of the test suite improvement plan (see `docs/test-improvement-plan.md` in workspace root).

- **Node 20 only on PRs**: Full matrix (20/22/24) still runs on push to main, but PRs only run Node 20. Cuts CI jobs from 3x to 1x for PRs.
- **3-way vitest sharding**: Unit tests split across 3 parallel shard jobs using blob reporter. A merge-reports job recombines results and generates coverage. Wall-clock for unit tests should drop from ~3 min to ~1-1.5 min.
- **deps.optimizer**: Pre-bundles `@aws-sdk/*`, `@smithy/*`, `zod`, and `commander` via vitest's SSR optimizer to reduce per-worker import overhead.
- **Exclude tui-harness from unit tests**: These are proof-of-concept tests for the TUI harness, not production code. Excluded from the unit test project.
- **Mock cleanup fixes**: Added `afterEach(vi.restoreAllMocks)` to 3 test files that had `vi.mock` without cleanup. Moved inline `consoleSpy.mockRestore()` calls to `afterEach` in logs-eval tests.
- **PTY test skip**: Added `describe.skipIf(!ptyAvailable)` around PTY-dependent tests that fail when `node-pty` spawn is unavailable.

Note: The CDK repo (`agentcore-l3-cdk-constructs`) Node 20 matrix change will be a separate PR.

## Test plan

- [ ] CI runs 3 shard jobs (Node 20 only) on this PR instead of 3 Node version jobs
- [ ] merge-reports job successfully combines blob reports and produces coverage
- [ ] Coverage report comment appears on this PR
- [ ] No new test failures compared to main
- [ ] PTY tests show as skipped, not failed