### PR TITLE
ci: add coordinated main + preview release workflow

### DIFF
--- a/.github/workflows/release-main-and-preview.yml
+++ b/.github/workflows/release-main-and-preview.yml
@@ -1,0 +1,521 @@
+name: Release Both (Main + Preview)
+
+on:
+  workflow_dispatch:
+    inputs:
+      main_bump_type:
+        description: 'Main branch version bump'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      preview_bump_type:
+        description: 'Preview branch version bump'
+        required: true
+        type: choice
+        options:
+          - preview
+          - preview-major
+      main_changelog:
+        description: 'Main changelog entry (optional)'
+        required: false
+        type: string
+      preview_changelog:
+        description: 'Preview changelog entry (optional)'
+        required: false
+        type: string
+      dry_run:
+        description: 'Dry run — create PRs but skip npm publish'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  # ═══════════════════════════════════════════════════════════════════
+  # Preflight — verify both branches are rebased on main
+  # ═══════════════════════════════════════════════════════════════════
+  preflight:
+    name: Preflight Checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Verify running from main
+        run: |
+          if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
+            echo "❌ This workflow must be run from the main branch."
+            exit 1
+          fi
+
+      - name: Verify preview branch is rebased on main
+        run: |
+          git fetch origin preview
+          MAIN_SHA=$(git rev-parse HEAD)
+          MERGE_BASE=$(git merge-base HEAD origin/preview)
+
+          if [[ "$MAIN_SHA" != "$MERGE_BASE" ]]; then
+            echo "❌ preview branch is NOT rebased on main."
+            echo ""
+            echo "Main HEAD:  $MAIN_SHA"
+            echo "Merge base: $MERGE_BASE"
+            echo ""
+            echo "Please rebase preview onto main first:"
+            echo "  git checkout preview && git rebase main && git push --force-with-lease"
+            exit 1
+          fi
+
+          echo "✅ preview branch is rebased on main"
+
+  # ═══════════════════════════════════════════════════════════════════
+  # Step 1 — Prepare main release (bump, PR)
+  # ═══════════════════════════════════════════════════════════════════
+  prepare-main:
+    name: Prepare Main Release
+    needs: preflight
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.bump.outputs.version }}
+      branch: ${{ steps.bump.outputs.branch }}
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20.x
+
+      - name: Configure git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - run: npm ci
+
+      - name: Sync @aws/agentcore-cdk to latest npm version
+        run: |
+          LATEST_CDK=$(npm view @aws/agentcore-cdk version 2>/dev/null || echo "")
+          if [ -n "$LATEST_CDK" ]; then
+            TEMPLATE_PKG="src/assets/cdk/package.json"
+            CURRENT_CDK=$(node -p "require('./$TEMPLATE_PKG').dependencies['@aws/agentcore-cdk']")
+            if [ "$CURRENT_CDK" != "$LATEST_CDK" ]; then
+              node -e "
+                const fs = require('fs');
+                const pkg = JSON.parse(fs.readFileSync('$TEMPLATE_PKG', 'utf8'));
+                pkg.dependencies['@aws/agentcore-cdk'] = '$LATEST_CDK';
+                fs.writeFileSync('$TEMPLATE_PKG', JSON.stringify(pkg, null, 2) + '\n');
+              "
+              echo "✅ Updated @aws/agentcore-cdk: $CURRENT_CDK -> $LATEST_CDK"
+            fi
+          fi
+
+      - name: Bump version
+        id: bump
+        env:
+          BUMP_TYPE: ${{ github.event.inputs.main_bump_type }}
+          CHANGELOG_INPUT: ${{ github.event.inputs.main_changelog }}
+        run: |
+          BUMP_CMD="npx tsx scripts/bump-version.ts $BUMP_TYPE"
+          if [ -n "$CHANGELOG_INPUT" ]; then
+            BUMP_CMD="$BUMP_CMD --changelog \"$CHANGELOG_INPUT\""
+          fi
+          eval $BUMP_CMD
+
+          NEW_VERSION=$(node -p "require('./package.json').version")
+          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "branch=release/v$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "📦 Main version: $NEW_VERSION"
+
+      - name: Regenerate JSON schema
+        run: |
+          npm run build
+          node scripts/generate-schema.mjs
+          npx prettier --write schemas/
+
+      - name: Create release branch and PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEW_VERSION: ${{ steps.bump.outputs.version }}
+        run: |
+          BRANCH_NAME="release/v$NEW_VERSION"
+          git ls-remote --exit-code --heads origin $BRANCH_NAME && git push origin --delete $BRANCH_NAME || true
+          git show-ref --verify --quiet refs/heads/$BRANCH_NAME && git branch -D $BRANCH_NAME || true
+
+          git checkout -b $BRANCH_NAME
+          git add -A
+          git commit -m "chore: bump version to $NEW_VERSION"
+          git push origin $BRANCH_NAME
+
+          gh pr create \
+            --base main \
+            --head "$BRANCH_NAME" \
+            --title "Release v$NEW_VERSION" \
+            --body "## Release v$NEW_VERSION (main)
+
+          Part of a coordinated main + preview release.
+
+          ### Checklist
+          - [ ] Review CHANGELOG.md
+          - [ ] All CI checks passing
+          - [ ] Merge this PR before approving the publish step"
+
+  # ═══════════════════════════════════════════════════════════════════
+  # Step 2 — Prepare preview release (bump, PR)
+  # ═══════════════════════════════════════════════════════════════════
+  prepare-preview:
+    name: Prepare Preview Release
+    needs: preflight
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.bump.outputs.version }}
+      branch: ${{ steps.bump.outputs.branch }}
+
+    steps:
+      - name: Checkout preview
+        uses: actions/checkout@v6
+        with:
+          ref: preview
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20.x
+
+      - name: Configure git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - run: npm ci
+
+      - name: Sync @aws/agentcore-cdk to latest npm version
+        run: |
+          LATEST_CDK=$(npm view @aws/agentcore-cdk version 2>/dev/null || echo "")
+          if [ -n "$LATEST_CDK" ]; then
+            TEMPLATE_PKG="src/assets/cdk/package.json"
+            CURRENT_CDK=$(node -p "require('./$TEMPLATE_PKG').dependencies['@aws/agentcore-cdk']")
+            if [ "$CURRENT_CDK" != "$LATEST_CDK" ]; then
+              node -e "
+                const fs = require('fs');
+                const pkg = JSON.parse(fs.readFileSync('$TEMPLATE_PKG', 'utf8'));
+                pkg.dependencies['@aws/agentcore-cdk'] = '$LATEST_CDK';
+                fs.writeFileSync('$TEMPLATE_PKG', JSON.stringify(pkg, null, 2) + '\n');
+              "
+              echo "✅ Updated @aws/agentcore-cdk: $CURRENT_CDK -> $LATEST_CDK"
+            fi
+          fi
+
+      - name: Bump version
+        id: bump
+        env:
+          BUMP_TYPE: ${{ github.event.inputs.preview_bump_type }}
+          CHANGELOG_INPUT: ${{ github.event.inputs.preview_changelog }}
+        run: |
+          BUMP_CMD="npx tsx scripts/bump-version.ts $BUMP_TYPE"
+          if [ -n "$CHANGELOG_INPUT" ]; then
+            BUMP_CMD="$BUMP_CMD --changelog \"$CHANGELOG_INPUT\""
+          fi
+          eval $BUMP_CMD
+
+          NEW_VERSION=$(node -p "require('./package.json').version")
+          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "branch=release/v$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "📦 Preview version: $NEW_VERSION"
+
+      - name: Regenerate JSON schema
+        run: |
+          npm run build
+          node scripts/generate-schema.mjs
+          npx prettier --write schemas/
+
+      - name: Create release branch and PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEW_VERSION: ${{ steps.bump.outputs.version }}
+        run: |
+          BRANCH_NAME="release/v$NEW_VERSION"
+          git ls-remote --exit-code --heads origin $BRANCH_NAME && git push origin --delete $BRANCH_NAME || true
+          git show-ref --verify --quiet refs/heads/$BRANCH_NAME && git branch -D $BRANCH_NAME || true
+
+          git checkout -b $BRANCH_NAME
+          git add -A
+          git commit -m "chore: bump version to $NEW_VERSION"
+          git push origin $BRANCH_NAME
+
+          gh pr create \
+            --base preview \
+            --head "$BRANCH_NAME" \
+            --title "Release v$NEW_VERSION (preview)" \
+            --body "## Release v$NEW_VERSION (preview)
+
+          Part of a coordinated main + preview release.
+
+          ### Checklist
+          - [ ] Review CHANGELOG.md
+          - [ ] All CI checks passing
+          - [ ] Merge this PR before approving the publish step"
+
+  # ═══════════════════════════════════════════════════════════════════
+  # Step 3 — Build and test both
+  # ═══════════════════════════════════════════════════════════════════
+  test-main:
+    name: Test Main
+    needs: prepare-main
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: release/v${{ needs.prepare-main.outputs.version }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20.x
+      - name: Configure git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+      - run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run typecheck
+      - run: npm run build
+      - run: npm run test:unit
+      - run: npm pack
+      - uses: actions/upload-artifact@v7
+        with:
+          name: dist-main
+          path: |
+            dist/
+            *.tgz
+
+  test-preview:
+    name: Test Preview
+    needs: prepare-preview
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: release/v${{ needs.prepare-preview.outputs.version }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20.x
+      - name: Configure git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+      - run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run typecheck
+      - run: npm run build
+      - run: npm run test:unit
+      - run: npm pack
+      - uses: actions/upload-artifact@v7
+        with:
+          name: dist-preview
+          path: |
+            dist/
+            *.tgz
+
+  # ═══════════════════════════════════════════════════════════════════
+  # Step 4 — Manual approval gate
+  # ═══════════════════════════════════════════════════════════════════
+  release-approval:
+    name: Release Approval (Both)
+    needs: [test-main, test-preview, prepare-main, prepare-preview]
+    runs-on: ubuntu-latest
+    environment:
+      name: npm-publish-approval
+    steps:
+      - name: Approval checkpoint
+        env:
+          MAIN_VERSION: ${{ needs.prepare-main.outputs.version }}
+          PREVIEW_VERSION: ${{ needs.prepare-preview.outputs.version }}
+        run: |
+          echo "✅ Both builds and tests passed"
+          echo ""
+          echo "📦 Main version:    $MAIN_VERSION (npm tag: latest)"
+          echo "📦 Preview version: $PREVIEW_VERSION (npm tag: preview)"
+          echo ""
+          echo "⚠️  MANUAL APPROVAL REQUIRED"
+          echo ""
+          echo "Before approving:"
+          echo "1. Merge the main release PR (release/v$MAIN_VERSION → main)"
+          echo "2. Merge the preview release PR (release/v$PREVIEW_VERSION → preview)"
+          echo "3. Verify both PRs are merged"
+          echo ""
+          echo "🚨 Main is published FIRST, then preview."
+
+  # ═══════════════════════════════════════════════════════════════════
+  # Step 5a — Publish main to npm (tag: latest)
+  # ═══════════════════════════════════════════════════════════════════
+  publish-main:
+    name: Publish Main (@latest)
+    needs: [prepare-main, release-approval]
+    if: ${{ !inputs.dry_run }}
+    runs-on: ubuntu-latest
+    environment:
+      name: npm-publish
+      url: https://www.npmjs.com/package/@aws/agentcore
+    permissions:
+      id-token: write
+      contents: write
+
+    steps:
+      - name: Checkout main (after PR merge)
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Verify version
+        env:
+          EXPECTED_VERSION: ${{ needs.prepare-main.outputs.version }}
+        run: |
+          ACTUAL=$(node -p "require('./package.json').version")
+          if [ "$ACTUAL" != "$EXPECTED_VERSION" ]; then
+            echo "❌ Main release PR not merged yet!"
+            echo "Expected: $EXPECTED_VERSION, Got: $ACTUAL"
+            echo "👉 Merge the PR first, then re-approve."
+            exit 1
+          fi
+          echo "✅ Main version verified: $ACTUAL"
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm install -g npm@11.5.1
+      - run: npm ci
+      - run: npm run build
+
+      - name: Publish to npm
+        run: npm publish --access public --provenance --tag latest
+
+      - name: Tag and release
+        env:
+          VERSION: ${{ needs.prepare-main.outputs.version }}
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "v$VERSION" -m "Release v$VERSION"
+          git push origin "v$VERSION"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ needs.prepare-main.outputs.version }}
+          name: AgentCore CLI v${{ needs.prepare-main.outputs.version }}
+          generate_release_notes: true
+          prerelease: false
+          body: |
+            ## Installation
+
+            ```bash
+            npm install -g @aws/agentcore@${{ needs.prepare-main.outputs.version }}
+            ```
+
+  # ═══════════════════════════════════════════════════════════════════
+  # Step 5b — Publish preview to npm (tag: preview)
+  # ═══════════════════════════════════════════════════════════════════
+  publish-preview:
+    name: Publish Preview (@preview)
+    needs: [prepare-preview, publish-main]
+    if: ${{ !inputs.dry_run }}
+    runs-on: ubuntu-latest
+    environment:
+      name: npm-publish
+      url: https://www.npmjs.com/package/@aws/agentcore
+    permissions:
+      id-token: write
+      contents: write
+
+    steps:
+      - name: Checkout preview (after PR merge)
+        uses: actions/checkout@v6
+        with:
+          ref: preview
+          fetch-depth: 0
+
+      - name: Verify version
+        env:
+          EXPECTED_VERSION: ${{ needs.prepare-preview.outputs.version }}
+        run: |
+          ACTUAL=$(node -p "require('./package.json').version")
+          if [ "$ACTUAL" != "$EXPECTED_VERSION" ]; then
+            echo "❌ Preview release PR not merged yet!"
+            echo "Expected: $EXPECTED_VERSION, Got: $ACTUAL"
+            echo "👉 Merge the PR first, then re-approve."
+            exit 1
+          fi
+          echo "✅ Preview version verified: $ACTUAL"
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm install -g npm@11.5.1
+      - run: npm ci
+      - run: npm run build
+
+      - name: Publish to npm
+        run: npm publish --access public --provenance --tag preview
+
+      - name: Tag and release
+        env:
+          VERSION: ${{ needs.prepare-preview.outputs.version }}
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "v$VERSION" -m "Release v$VERSION (preview)"
+          git push origin "v$VERSION"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ needs.prepare-preview.outputs.version }}
+          name: AgentCore CLI v${{ needs.prepare-preview.outputs.version }} (Preview)
+          generate_release_notes: true
+          prerelease: true
+          body: |
+            ## Installation (Preview)
+
+            ```bash
+            npm install -g @aws/agentcore@preview
+            ```
+
+  # ═══════════════════════════════════════════════════════════════════
+  # Summary
+  # ═══════════════════════════════════════════════════════════════════
+  summary:
+    name: Release Summary
+    needs: [prepare-main, prepare-preview, publish-main, publish-preview]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Summary
+        env:
+          MAIN_VERSION: ${{ needs.prepare-main.outputs.version }}
+          PREVIEW_VERSION: ${{ needs.prepare-preview.outputs.version }}
+          MAIN_STATUS: ${{ needs.publish-main.result }}
+          PREVIEW_STATUS: ${{ needs.publish-preview.result }}
+        run: |
+          echo "## Release Summary"
+          echo ""
+          echo "| Package | Version | npm Tag | Status |"
+          echo "|---------|---------|---------|--------|"
+          echo "| @aws/agentcore | $MAIN_VERSION | latest | $MAIN_STATUS |"
+          echo "| @aws/agentcore | $PREVIEW_VERSION | preview | $PREVIEW_STATUS |"

--- a/.github/workflows/release-main-and-preview.yml
+++ b/.github/workflows/release-main-and-preview.yml
@@ -55,45 +55,27 @@ jobs:
             exit 1
           fi
 
-      - name: Configure git
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Rebase preview onto main
+      - name: Verify preview branch is rebased on main
         run: |
           git fetch origin preview
           MAIN_SHA=$(git rev-parse HEAD)
           MERGE_BASE=$(git merge-base HEAD origin/preview)
 
-          if [[ "$MAIN_SHA" == "$MERGE_BASE" ]]; then
-            echo "✅ preview is already rebased on main — nothing to do"
-            exit 0
-          fi
-
-          echo "ℹ️  preview is not rebased on main. Rebasing automatically..."
-          echo "Main HEAD:  $MAIN_SHA"
-          echo "Merge base: $MERGE_BASE"
-
-          git checkout origin/preview -B preview
-
-          if git rebase origin/main; then
-            git push --force-with-lease origin preview
-            echo "✅ preview rebased and pushed successfully"
-          else
-            git rebase --abort
+          if [[ "$MAIN_SHA" != "$MERGE_BASE" ]]; then
+            echo "❌ preview branch is NOT rebased on main."
             echo ""
-            echo "❌ Rebase failed due to conflicts."
+            echo "Main HEAD:  $MAIN_SHA"
+            echo "Merge base: $MERGE_BASE"
             echo ""
-            echo "Please resolve manually:"
-            echo "  git checkout preview"
-            echo "  git rebase main"
-            echo "  # resolve conflicts"
-            echo "  git push --force-with-lease"
+            echo "The sync-preview workflow should have rebased automatically."
+            echo "If it failed due to conflicts, resolve manually:"
+            echo "  git checkout preview && git rebase main && git push --force-with-lease"
             echo ""
             echo "Then re-run this workflow."
             exit 1
           fi
+
+          echo "✅ preview branch is rebased on main"
 
   # ═══════════════════════════════════════════════════════════════════
   # Step 1 — Prepare main release (bump, PR)

--- a/.github/workflows/release-main-and-preview.yml
+++ b/.github/workflows/release-main-and-preview.yml
@@ -202,6 +202,8 @@ jobs:
 
       - run: npm ci
 
+      # TODO: When @aws/agentcore-cdk publishes a @preview dist-tag, change this
+      # to: npm view @aws/agentcore-cdk@preview version
       - name: Sync @aws/agentcore-cdk to latest npm version
         run: |
           LATEST_CDK=$(npm view @aws/agentcore-cdk version 2>/dev/null || echo "")

--- a/.github/workflows/release-main-and-preview.yml
+++ b/.github/workflows/release-main-and-preview.yml
@@ -37,7 +37,7 @@ permissions:
 
 jobs:
   # ═══════════════════════════════════════════════════════════════════
-  # Preflight — verify both branches are rebased on main
+  # Preflight — verify preview contains all of main
   # ═══════════════════════════════════════════════════════════════════
   preflight:
     name: Preflight Checks
@@ -55,27 +55,27 @@ jobs:
             exit 1
           fi
 
-      - name: Verify preview branch is rebased on main
+      - name: Verify preview contains all of main
         run: |
           git fetch origin preview
           MAIN_SHA=$(git rev-parse HEAD)
           MERGE_BASE=$(git merge-base HEAD origin/preview)
 
           if [[ "$MAIN_SHA" != "$MERGE_BASE" ]]; then
-            echo "❌ preview branch is NOT rebased on main."
+            echo "❌ preview branch does not contain all of main."
             echo ""
             echo "Main HEAD:  $MAIN_SHA"
             echo "Merge base: $MERGE_BASE"
             echo ""
-            echo "The sync-preview workflow should have rebased automatically."
+            echo "The sync-preview workflow should have merged automatically."
             echo "If it failed due to conflicts, resolve manually:"
-            echo "  git checkout preview && git rebase main && git push --force-with-lease"
+            echo "  git checkout preview && git merge main && git push origin preview"
             echo ""
             echo "Then re-run this workflow."
             exit 1
           fi
 
-          echo "✅ preview branch is rebased on main"
+          echo "✅ preview contains all of main"
 
   # ═══════════════════════════════════════════════════════════════════
   # Step 1 — Prepare main release (bump, PR)

--- a/.github/workflows/release-main-and-preview.yml
+++ b/.github/workflows/release-main-and-preview.yml
@@ -55,24 +55,45 @@ jobs:
             exit 1
           fi
 
-      - name: Verify preview branch is rebased on main
+      - name: Configure git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Rebase preview onto main
         run: |
           git fetch origin preview
           MAIN_SHA=$(git rev-parse HEAD)
           MERGE_BASE=$(git merge-base HEAD origin/preview)
 
-          if [[ "$MAIN_SHA" != "$MERGE_BASE" ]]; then
-            echo "❌ preview branch is NOT rebased on main."
-            echo ""
-            echo "Main HEAD:  $MAIN_SHA"
-            echo "Merge base: $MERGE_BASE"
-            echo ""
-            echo "Please rebase preview onto main first:"
-            echo "  git checkout preview && git rebase main && git push --force-with-lease"
-            exit 1
+          if [[ "$MAIN_SHA" == "$MERGE_BASE" ]]; then
+            echo "✅ preview is already rebased on main — nothing to do"
+            exit 0
           fi
 
-          echo "✅ preview branch is rebased on main"
+          echo "ℹ️  preview is not rebased on main. Rebasing automatically..."
+          echo "Main HEAD:  $MAIN_SHA"
+          echo "Merge base: $MERGE_BASE"
+
+          git checkout origin/preview -B preview
+
+          if git rebase origin/main; then
+            git push --force-with-lease origin preview
+            echo "✅ preview rebased and pushed successfully"
+          else
+            git rebase --abort
+            echo ""
+            echo "❌ Rebase failed due to conflicts."
+            echo ""
+            echo "Please resolve manually:"
+            echo "  git checkout preview"
+            echo "  git rebase main"
+            echo "  # resolve conflicts"
+            echo "  git push --force-with-lease"
+            echo ""
+            echo "Then re-run this workflow."
+            exit 1
+          fi
 
   # ═══════════════════════════════════════════════════════════════════
   # Step 1 — Prepare main release (bump, PR)

--- a/.github/workflows/release-main-and-preview.yml
+++ b/.github/workflows/release-main-and-preview.yml
@@ -12,12 +12,11 @@ on:
           - minor
           - major
       preview_bump_type:
-        description: 'Preview branch version bump'
+        description: 'Preview branch version bump (prerelease with preview tag)'
         required: true
         type: choice
         options:
-          - preview
-          - preview-major
+          - prerelease
       main_changelog:
         description: 'Main changelog entry (optional)'
         required: false
@@ -220,10 +219,9 @@ jobs:
       - name: Bump version
         id: bump
         env:
-          BUMP_TYPE: ${{ github.event.inputs.preview_bump_type }}
           CHANGELOG_INPUT: ${{ github.event.inputs.preview_changelog }}
         run: |
-          BUMP_CMD="npx tsx scripts/bump-version.ts $BUMP_TYPE"
+          BUMP_CMD="npx tsx scripts/bump-version.ts prerelease --prerelease-tag preview"
           if [ -n "$CHANGELOG_INPUT" ]; then
             BUMP_CMD="$BUMP_CMD --changelog \"$CHANGELOG_INPUT\""
           fi
@@ -291,13 +289,6 @@ jobs:
       - run: npm run typecheck
       - run: npm run build
       - run: npm run test:unit
-      - run: npm pack
-      - uses: actions/upload-artifact@v7
-        with:
-          name: dist-main
-          path: |
-            dist/
-            *.tgz
 
   test-preview:
     name: Test Preview
@@ -320,13 +311,6 @@ jobs:
       - run: npm run typecheck
       - run: npm run build
       - run: npm run test:unit
-      - run: npm pack
-      - uses: actions/upload-artifact@v7
-        with:
-          name: dist-preview
-          path: |
-            dist/
-            *.tgz
 
   # ═══════════════════════════════════════════════════════════════════
   # Step 4 — Manual approval gate
@@ -354,16 +338,53 @@ jobs:
           echo "1. Merge the main release PR (release/v$MAIN_VERSION → main)"
           echo "2. Merge the preview release PR (release/v$PREVIEW_VERSION → preview)"
           echo "3. Verify both PRs are merged"
-          echo ""
-          echo "🚨 Main is published FIRST, then preview."
 
   # ═══════════════════════════════════════════════════════════════════
-  # Step 5a — Publish main to npm (tag: latest)
+  # Step 5 — Verify both PRs merged before any publish
+  # ═══════════════════════════════════════════════════════════════════
+  verify-merges:
+    name: Verify Both PRs Merged
+    needs: [prepare-main, prepare-preview, release-approval]
+    if: ${{ !inputs.dry_run }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Verify main version
+        env:
+          EXPECTED: ${{ needs.prepare-main.outputs.version }}
+        run: |
+          git fetch origin main
+          ACTUAL=$(git show origin/main:package.json | node -p "JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).version")
+          if [ "$ACTUAL" != "$EXPECTED" ]; then
+            echo "❌ Main release PR not merged yet!"
+            echo "Expected: $EXPECTED, Got: $ACTUAL"
+            exit 1
+          fi
+          echo "✅ Main version verified: $ACTUAL"
+
+      - name: Verify preview version
+        env:
+          EXPECTED: ${{ needs.prepare-preview.outputs.version }}
+        run: |
+          git fetch origin preview
+          ACTUAL=$(git show origin/preview:package.json | node -p "JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).version")
+          if [ "$ACTUAL" != "$EXPECTED" ]; then
+            echo "❌ Preview release PR not merged yet!"
+            echo "Expected: $EXPECTED, Got: $ACTUAL"
+            exit 1
+          fi
+          echo "✅ Preview version verified: $ACTUAL"
+
+  # ═══════════════════════════════════════════════════════════════════
+  # Step 6a — Publish main to npm (tag: latest)
   # ═══════════════════════════════════════════════════════════════════
   publish-main:
     name: Publish Main (@latest)
-    needs: [prepare-main, release-approval]
-    if: ${{ !inputs.dry_run }}
+    needs: [prepare-main, verify-merges]
     runs-on: ubuntu-latest
     environment:
       name: npm-publish
@@ -373,24 +394,11 @@ jobs:
       contents: write
 
     steps:
-      - name: Checkout main (after PR merge)
+      - name: Checkout main
         uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0
-
-      - name: Verify version
-        env:
-          EXPECTED_VERSION: ${{ needs.prepare-main.outputs.version }}
-        run: |
-          ACTUAL=$(node -p "require('./package.json').version")
-          if [ "$ACTUAL" != "$EXPECTED_VERSION" ]; then
-            echo "❌ Main release PR not merged yet!"
-            echo "Expected: $EXPECTED_VERSION, Got: $ACTUAL"
-            echo "👉 Merge the PR first, then re-approve."
-            exit 1
-          fi
-          echo "✅ Main version verified: $ACTUAL"
 
       - uses: actions/setup-node@v6
         with:
@@ -428,12 +436,11 @@ jobs:
             ```
 
   # ═══════════════════════════════════════════════════════════════════
-  # Step 5b — Publish preview to npm (tag: preview)
+  # Step 6b — Publish preview to npm (tag: preview)
   # ═══════════════════════════════════════════════════════════════════
   publish-preview:
     name: Publish Preview (@preview)
-    needs: [prepare-preview, publish-main]
-    if: ${{ !inputs.dry_run }}
+    needs: [prepare-preview, verify-merges]
     runs-on: ubuntu-latest
     environment:
       name: npm-publish
@@ -443,24 +450,11 @@ jobs:
       contents: write
 
     steps:
-      - name: Checkout preview (after PR merge)
+      - name: Checkout preview
         uses: actions/checkout@v6
         with:
           ref: preview
           fetch-depth: 0
-
-      - name: Verify version
-        env:
-          EXPECTED_VERSION: ${{ needs.prepare-preview.outputs.version }}
-        run: |
-          ACTUAL=$(node -p "require('./package.json').version")
-          if [ "$ACTUAL" != "$EXPECTED_VERSION" ]; then
-            echo "❌ Preview release PR not merged yet!"
-            echo "Expected: $EXPECTED_VERSION, Got: $ACTUAL"
-            echo "👉 Merge the PR first, then re-approve."
-            exit 1
-          fi
-          echo "✅ Preview version verified: $ACTUAL"
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/sync-preview.yml
+++ b/.github/workflows/sync-preview.yml
@@ -4,8 +4,13 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: sync-preview
+  cancel-in-progress: false
+
 permissions:
   contents: write
+  issues: write
 
 jobs:
   sync:
@@ -24,6 +29,7 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Merge main into preview
+        id: merge
         run: |
           git fetch origin main
           MAIN_SHA=$(git rev-parse origin/main)
@@ -31,6 +37,7 @@ jobs:
 
           if [[ "$MAIN_SHA" == "$MERGE_BASE" ]]; then
             echo "✅ preview already contains all of main"
+            echo "status=up-to-date" >> $GITHUB_OUTPUT
             exit 0
           fi
 
@@ -39,14 +46,36 @@ jobs:
           if git merge origin/main --no-edit -m "chore: merge main into preview"; then
             git push origin preview
             echo "✅ main merged into preview and pushed"
+            echo "status=merged" >> $GITHUB_OUTPUT
           else
             git merge --abort
-            echo ""
-            echo "⚠️  Merge had conflicts — skipping auto-sync."
-            echo "Manual merge needed before next release:"
-            echo "  git checkout preview && git merge main"
-            echo "  # resolve conflicts"
-            echo "  git push origin preview"
-            echo ""
-            echo "This is not a failure — preview just needs manual attention."
+            echo "status=conflict" >> $GITHUB_OUTPUT
           fi
+
+      - name: Create issue on conflict
+        if: steps.merge.outputs.status == 'conflict'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Only create if no open issue with this title exists
+          EXISTING=$(gh issue list --state open --search "preview branch needs manual merge from main" --json number --jq 'length')
+          if [[ "$EXISTING" != "0" ]]; then
+            echo "ℹ️  Issue already open — skipping duplicate."
+            exit 0
+          fi
+
+          gh issue create \
+            --title "preview branch needs manual merge from main" \
+            --body "The automated sync-preview workflow failed to merge \`main\` into \`preview\` due to conflicts.
+
+          **To resolve:**
+          \`\`\`bash
+          git checkout preview
+          git merge main
+          # resolve conflicts
+          git push origin preview
+          \`\`\`
+
+          This must be resolved before the next coordinated release.
+
+          _Opened automatically by the sync-preview workflow._"

--- a/.github/workflows/sync-preview.yml
+++ b/.github/workflows/sync-preview.yml
@@ -9,12 +9,13 @@ permissions:
 
 jobs:
   sync:
-    name: Rebase preview onto main
+    name: Merge main into preview
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout preview
         uses: actions/checkout@v6
         with:
+          ref: preview
           fetch-depth: 0
 
       - name: Configure git
@@ -22,29 +23,30 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Rebase preview onto main
+      - name: Merge main into preview
         run: |
-          git fetch origin preview
-          MAIN_SHA=$(git rev-parse HEAD)
-          MERGE_BASE=$(git merge-base HEAD origin/preview)
+          git fetch origin main
+          MAIN_SHA=$(git rev-parse origin/main)
+          MERGE_BASE=$(git merge-base HEAD origin/main)
 
           if [[ "$MAIN_SHA" == "$MERGE_BASE" ]]; then
-            echo "✅ preview is already up to date with main"
+            echo "✅ preview already contains all of main"
             exit 0
           fi
 
-          echo "ℹ️  Rebasing preview onto main..."
-          git checkout origin/preview -B preview
+          echo "ℹ️  Merging main into preview..."
 
-          if git rebase origin/main; then
-            git push --force-with-lease origin preview
-            echo "✅ preview rebased and pushed"
+          if git merge origin/main --no-edit -m "chore: merge main into preview"; then
+            git push origin preview
+            echo "✅ main merged into preview and pushed"
           else
-            git rebase --abort
+            git merge --abort
             echo ""
-            echo "⚠️  Rebase had conflicts — skipping auto-sync."
-            echo "Manual rebase needed before next release:"
-            echo "  git checkout preview && git rebase main && git push --force-with-lease"
+            echo "⚠️  Merge had conflicts — skipping auto-sync."
+            echo "Manual merge needed before next release:"
+            echo "  git checkout preview && git merge main"
+            echo "  # resolve conflicts"
+            echo "  git push origin preview"
             echo ""
             echo "This is not a failure — preview just needs manual attention."
           fi

--- a/.github/workflows/sync-preview.yml
+++ b/.github/workflows/sync-preview.yml
@@ -1,0 +1,50 @@
+name: Sync Preview with Main
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    name: Rebase preview onto main
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Rebase preview onto main
+        run: |
+          git fetch origin preview
+          MAIN_SHA=$(git rev-parse HEAD)
+          MERGE_BASE=$(git merge-base HEAD origin/preview)
+
+          if [[ "$MAIN_SHA" == "$MERGE_BASE" ]]; then
+            echo "✅ preview is already up to date with main"
+            exit 0
+          fi
+
+          echo "ℹ️  Rebasing preview onto main..."
+          git checkout origin/preview -B preview
+
+          if git rebase origin/main; then
+            git push --force-with-lease origin preview
+            echo "✅ preview rebased and pushed"
+          else
+            git rebase --abort
+            echo ""
+            echo "⚠️  Rebase had conflicts — skipping auto-sync."
+            echo "Manual rebase needed before next release:"
+            echo "  git checkout preview && git rebase main && git push --force-with-lease"
+            echo ""
+            echo "This is not a failure — preview just needs manual attention."
+          fi

--- a/.github/workflows/sync-preview.yml
+++ b/.github/workflows/sync-preview.yml
@@ -10,7 +10,7 @@ concurrency:
 
 permissions:
   contents: write
-  issues: write
+  pull-requests: write
 
 jobs:
   sync:
@@ -52,30 +52,74 @@ jobs:
             echo "status=conflict" >> $GITHUB_OUTPUT
           fi
 
-      - name: Create issue on conflict
+      - name: Get original commit author
+        if: steps.merge.outputs.status == 'conflict'
+        id: author
+        run: |
+          AUTHOR=$(git log origin/main -1 --format='%an')
+          GH_USER=$(git log origin/main -1 --format='%ae' | grep -oP '.*(?=@users\.noreply\.github\.com)' || echo "")
+          if [[ -z "$GH_USER" ]]; then
+            # Try to get GitHub username from the commit
+            GH_USER=$(gh api "/repos/${{ github.repository }}/commits/$(git rev-parse origin/main)" --jq '.author.login // empty' 2>/dev/null || echo "")
+          fi
+          echo "name=$AUTHOR" >> $GITHUB_OUTPUT
+          echo "gh_user=$GH_USER" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Create PR for conflict resolution
         if: steps.merge.outputs.status == 'conflict'
         env:
           GH_TOKEN: ${{ github.token }}
+          AUTHOR_NAME: ${{ steps.author.outputs.name }}
+          AUTHOR_GH: ${{ steps.author.outputs.gh_user }}
         run: |
-          # Only create if no open issue with this title exists
-          EXISTING=$(gh issue list --state open --search "preview branch needs manual merge from main" --json number --jq 'length')
+          BRANCH="sync-preview/merge-main-$(date +%Y%m%d-%H%M%S)"
+
+          # Check if there's already an open sync PR
+          EXISTING=$(gh pr list --base preview --search "sync-preview: merge main into preview" --state open --json number --jq 'length')
           if [[ "$EXISTING" != "0" ]]; then
-            echo "ℹ️  Issue already open — skipping duplicate."
+            echo "ℹ️  Sync PR already open — skipping duplicate."
             exit 0
           fi
 
-          gh issue create \
-            --title "preview branch needs manual merge from main" \
-            --body "The automated sync-preview workflow failed to merge \`main\` into \`preview\` due to conflicts.
+          # Create a branch from preview with the conflict markers
+          git checkout -b "$BRANCH"
+          git merge origin/main --no-edit -m "chore: merge main into preview" || true
+          git add -A
+          git commit --no-edit -m "chore: merge main into preview (conflicts need resolution)" || true
+          git push origin "$BRANCH"
 
-          **To resolve:**
-          \`\`\`bash
-          git checkout preview
-          git merge main
-          # resolve conflicts
-          git push origin preview
-          \`\`\`
+          # Build mention string
+          MENTION=""
+          if [[ -n "$AUTHOR_GH" ]]; then
+            MENTION="cc @${AUTHOR_GH}"
+          fi
+
+          gh pr create \
+            --base preview \
+            --head "$BRANCH" \
+            --title "sync-preview: merge main into preview" \
+            --body "$(cat <<BODY
+          The automated sync-preview workflow could not cleanly merge \`main\` into \`preview\`.
+
+          **This PR contains the merge with conflict markers.** To resolve:
+
+          1. Check out this branch locally:
+             \`\`\`bash
+             gh pr checkout <this-pr-number>
+             \`\`\`
+          2. Search for conflict markers and resolve them:
+             \`\`\`bash
+             grep -rn '<<<<<<< HEAD' .
+             \`\`\`
+          3. Keep preview-specific values (package version, preview tests, etc.) — accept main's changes for everything else.
+          4. Commit and push, then merge this PR.
 
           This must be resolved before the next coordinated release.
 
-          _Opened automatically by the sync-preview workflow._"
+          ${MENTION}
+
+          _Opened automatically by the sync-preview workflow._
+          BODY
+          )"


### PR DESCRIPTION
## Summary

Two workflows to keep `main` and `preview` branches in sync and release them together.

### 1. `sync-preview.yml` — auto-merge main into preview

Runs on every push to `main`. Merges `main` into `preview` automatically so preview stays current while preserving its own divergent values (package version, preview-specific tests, etc.). If there are conflicts, it skips silently — no failed workflow, just a note that manual merge is needed.

### 2. `release-main-and-preview.yml` — coordinated release

Releases both branches to npm in a single run.

**How to use:**
1. Go to **Actions → Release Both (Main + Preview)**
2. Pick bump types (e.g., `patch` for main, `prerelease` for preview)
3. Click **Run workflow**

**What it does:**
- Verifies preview contains all of main (should already be, thanks to sync-preview)
- Bumps versions and creates release PRs for both branches in parallel
- Runs lint, typecheck, build, and unit tests on both
- Waits for **manual approval** — merge both PRs before approving
- **Verifies both PRs are merged** before either publish runs (prevents drift)
- Publishes main (`@latest`) and preview (`@preview`) to npm
- Creates git tags and GitHub releases for both

There's a `dry_run` option that creates PRs and runs tests without publishing.

### Why merge instead of rebase

The preview branch has intentionally different values from main (package version, some tests). Rebase would overwrite these. Merge preserves preview-specific changes and only conflicts when both branches edit the same lines.

## Test plan

- [ ] Trigger sync-preview by merging a commit to main — verify main is merged into preview
- [ ] Verify sync-preview skips cleanly when preview has merge conflicts
- [ ] Trigger release with `dry_run: true` to verify PR creation and test jobs
- [ ] Verify release fails at preflight if preview doesn't contain main
- [ ] Verify release fails at verify-merges if PRs aren't merged yet