### PR TITLE
fix(import): use GatewayNameSchema for gateway import name validation

### DIFF
--- a/src/cli/commands/import/__tests__/import-gateway-flow.test.ts
+++ b/src/cli/commands/import/__tests__/import-gateway-flow.test.ts
@@ -310,14 +310,13 @@ describe('handleImportGateway', () => {
   // ── Name validation ─────────────────────────────────────────────────────
 
   describe('Name validation', () => {
-    it('rejects invalid name starting with a number', async () => {
-      mockGetGatewayDetail.mockResolvedValue(makeGatewayDetail({ name: '123gateway' }));
+    it('rejects invalid name with special characters', async () => {
+      mockGetGatewayDetail.mockResolvedValue(makeGatewayDetail({ name: 'gateway_with_underscores!' }));
 
       const result = await handleImportGateway({ arn: GATEWAY_ARN });
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('Invalid name');
-      expect(result.error).toContain('must start with a letter');
       expect(mockConfigIOInstance.writeProjectSpec).not.toHaveBeenCalled();
     });
 

--- a/src/cli/commands/import/import-gateway.ts
+++ b/src/cli/commands/import/import-gateway.ts
@@ -9,6 +9,7 @@ import type {
   GatewayPolicyEngineConfiguration,
   OutboundAuth,
 } from '../../../schema';
+import { GatewayNameSchema } from '../../../schema';
 import type { GatewayDetail, GatewayTargetDetail } from '../../aws/agentcore-control';
 import {
   getGatewayDetail,
@@ -17,7 +18,7 @@ import {
   listAllGateways,
 } from '../../aws/agentcore-control';
 import { isAccessDeniedError } from '../../errors';
-import { ANSI, NAME_REGEX } from './constants';
+import { ANSI } from './constants';
 import { executeCdkImportPipeline } from './import-pipeline';
 import {
   failResult,
@@ -425,10 +426,11 @@ export async function handleImportGateway(options: ImportResourceOptions): Promi
     // 4. Validate name
     logger.startStep('Validate name');
     let localName = options.name ?? gatewayDetail.name;
-    if (!NAME_REGEX.test(localName)) {
+    const nameResult = GatewayNameSchema.safeParse(localName);
+    if (!nameResult.success) {
       return failResult(
         logger,
-        `Invalid name "${localName}". Name must start with a letter and contain only letters, numbers, and underscores (max 48 chars).`,
+        `Invalid name "${localName}". ${nameResult.error.issues[0]?.message ?? 'Invalid gateway name'}`,
         'gateway',
         localName
       );


### PR DESCRIPTION
## Summary
- `agentcore import gateway` used `NAME_REGEX` (`/^[a-zA-Z][a-zA-Z0-9_]{0,47}$/`) for name validation, which rejects valid gateway names containing hyphens (e.g. `agentcore-gateway`)
- Switched to `GatewayNameSchema` which matches the actual AWS CreateGateway API: alphanumeric with optional hyphens, up to 100 chars (`/^[0-9a-zA-Z](?:[0-9a-zA-Z-]*[0-9a-zA-Z])?$/`)
- Updated test to validate against a truly invalid name instead of a number-prefixed name (which is valid per the API)

## Test plan
- [x] Unit tests pass (`vitest run import-gateway` — 78/78 passing)
- [x] TypeScript type-check passes
- [x] E2E verified: created a gateway with name `bugbash-gw-1777461673` via AWS API, then successfully imported it with the fixed CLI