### PR TITLE
fix: remove CONFIG_DIR exclusion from zip stage to preserve dependency agentcore/ packages

### DIFF
--- a/src/lib/packaging/__tests__/helpers.test.ts
+++ b/src/lib/packaging/__tests__/helpers.test.ts
@@ -477,8 +477,11 @@ describe('nested agentcore directory is preserved (issue #843)', () => {
   });
 
   // ── createZipFromDir (async) ──
+  // The zip stage should NOT exclude agentcore/ — that's copySourceTree's job.
+  // When zipping a staging directory, any agentcore/ present is a legitimate
+  // Python package installed by uv, not the project config dir.
 
-  it('zip: excludes top-level agentcore/ but includes nested agentcore/', async () => {
+  it('zip: does not exclude agentcore/ directories (staging has no project config)', async () => {
     const src = buildFixture(join(root, 'zip-async'));
     const zipPath = join(root, 'zip-async.zip');
 
@@ -487,21 +490,17 @@ describe('nested agentcore directory is preserved (issue #843)', () => {
     const zipBuffer = await readFile(zipPath);
     const entries = Object.keys(unzipSync(new Uint8Array(zipBuffer)));
 
-    // Top-level agentcore/ should NOT appear
-    expect(entries.some(e => e === 'agentcore/config.yaml')).toBe(false);
-    expect(entries.some(e => e.startsWith('agentcore/'))).toBe(false);
-
-    // Nested agentcore/ SHOULD appear
+    // Both top-level and nested agentcore/ are preserved in the zip —
+    // the zip function zips everything; exclusion is copySourceTree's concern
+    expect(entries).toContain('agentcore/config.yaml');
     expect(entries).toContain('lib/langgraph_checkpoint_aws/agentcore/__init__.py');
     expect(entries).toContain('lib/langgraph_checkpoint_aws/agentcore/core.py');
-
-    // Regular files present
     expect(entries).toContain('main.py');
   });
 
   // ── createZipFromDirSync ──
 
-  it('sync zip: excludes top-level agentcore/ but includes nested agentcore/', () => {
+  it('sync zip: does not exclude agentcore/ directories (staging has no project config)', () => {
     const src = buildFixture(join(root, 'zip-sync'));
     const zipPath = join(root, 'zip-sync.zip');
 
@@ -510,9 +509,61 @@ describe('nested agentcore directory is preserved (issue #843)', () => {
     const zipBuffer = readFileSync(zipPath);
     const entries = Object.keys(unzipSync(new Uint8Array(zipBuffer)));
 
-    expect(entries.some(e => e.startsWith('agentcore/'))).toBe(false);
+    expect(entries).toContain('agentcore/config.yaml');
     expect(entries).toContain('lib/langgraph_checkpoint_aws/agentcore/__init__.py');
     expect(entries).toContain('lib/langgraph_checkpoint_aws/agentcore/core.py');
+    expect(entries).toContain('main.py');
+  });
+
+  // ── Staging directory scenario (the actual bug) ──
+  // After uv installs deps into staging, copySourceTree copies user source on top.
+  // The staging dir may contain a top-level agentcore/ from a Python package.
+  // createZipFromDir must NOT strip it.
+
+  it('zip preserves top-level agentcore/ Python package in staging dir', async () => {
+    const staging = join(root, 'staging-zip-async');
+    mkdirSync(staging, { recursive: true });
+
+    // Simulate uv-installed dependency with top-level agentcore/ package
+    const agentcorePkg = join(staging, 'langgraph_checkpoint_aws', 'agentcore');
+    mkdirSync(agentcorePkg, { recursive: true });
+    writeFileSync(join(staging, 'langgraph_checkpoint_aws', '__init__.py'), '# init');
+    writeFileSync(join(agentcorePkg, '__init__.py'), '# agentcore init');
+    writeFileSync(join(agentcorePkg, 'saver.py'), 'class AgentCoreMemorySaver: pass');
+
+    // User source copied on top by copySourceTree
+    writeFileSync(join(staging, 'main.py'), 'print("hello")');
+
+    const zipPath = join(root, 'staging-async.zip');
+    await createZipFromDir(staging, zipPath);
+
+    const zipBuffer = await readFile(zipPath);
+    const entries = Object.keys(unzipSync(new Uint8Array(zipBuffer)));
+
+    expect(entries).toContain('langgraph_checkpoint_aws/agentcore/__init__.py');
+    expect(entries).toContain('langgraph_checkpoint_aws/agentcore/saver.py');
+    expect(entries).toContain('main.py');
+  });
+
+  it('sync zip preserves top-level agentcore/ Python package in staging dir', () => {
+    const staging = join(root, 'staging-zip-sync');
+    mkdirSync(staging, { recursive: true });
+
+    const agentcorePkg = join(staging, 'langgraph_checkpoint_aws', 'agentcore');
+    mkdirSync(agentcorePkg, { recursive: true });
+    writeFileSync(join(staging, 'langgraph_checkpoint_aws', '__init__.py'), '# init');
+    writeFileSync(join(agentcorePkg, '__init__.py'), '# agentcore init');
+    writeFileSync(join(agentcorePkg, 'saver.py'), 'class AgentCoreMemorySaver: pass');
+    writeFileSync(join(staging, 'main.py'), 'print("hello")');
+
+    const zipPath = join(root, 'staging-sync.zip');
+    createZipFromDirSync(staging, zipPath);
+
+    const zipBuffer = readFileSync(zipPath);
+    const entries = Object.keys(unzipSync(new Uint8Array(zipBuffer)));
+
+    expect(entries).toContain('langgraph_checkpoint_aws/agentcore/__init__.py');
+    expect(entries).toContain('langgraph_checkpoint_aws/agentcore/saver.py');
     expect(entries).toContain('main.py');
   });
 });

--- a/src/lib/packaging/helpers.ts
+++ b/src/lib/packaging/helpers.ts
@@ -192,24 +192,23 @@ export async function createZipFromDir(sourceDir: string, outputZip: string): Pr
   await rm(outputZip, { force: true });
   await mkdir(dirname(outputZip), { recursive: true });
 
-  const files = await collectFiles(sourceDir, sourceDir);
+  const files = await collectFiles(sourceDir);
   const zipped = zipSync(files);
   await writeFile(outputZip, zipped);
 }
 
-async function collectFiles(directory: string, rootDir: string, basePath = ''): Promise<Zippable> {
+async function collectFiles(directory: string, basePath = ''): Promise<Zippable> {
   const result: Zippable = {};
   const entries = await readdir(directory, { withFileTypes: true });
 
   for (const entry of entries) {
     if (EXCLUDED_ENTRIES.has(entry.name)) continue;
-    if (entry.name === CONFIG_DIR && resolve(directory) === resolve(rootDir)) continue;
 
     const fullPath = join(directory, entry.name);
     const zipPath = basePath ? `${basePath}/${entry.name}` : entry.name;
 
     if (entry.isDirectory()) {
-      Object.assign(result, await collectFiles(fullPath, rootDir, zipPath));
+      Object.assign(result, await collectFiles(fullPath, zipPath));
     } else if (entry.isFile()) {
       result[zipPath] = [await readFile(fullPath), { level: 6 }];
     }
@@ -325,19 +324,18 @@ export function ensureBinaryAvailableSync(binary: string, installHint?: string):
   throw new MissingDependencyError(binary, installHint);
 }
 
-function collectFilesSync(directory: string, rootDir: string, basePath = ''): Zippable {
+function collectFilesSync(directory: string, basePath = ''): Zippable {
   const result: Zippable = {};
   const entries = readdirSync(directory, { withFileTypes: true });
 
   for (const entry of entries) {
     if (EXCLUDED_ENTRIES.has(entry.name)) continue;
-    if (entry.name === CONFIG_DIR && resolve(directory) === resolve(rootDir)) continue;
 
     const fullPath = join(directory, entry.name);
     const zipPath = basePath ? `${basePath}/${entry.name}` : entry.name;
 
     if (entry.isDirectory()) {
-      Object.assign(result, collectFilesSync(fullPath, rootDir, zipPath));
+      Object.assign(result, collectFilesSync(fullPath, zipPath));
     } else if (entry.isFile()) {
       result[zipPath] = [readFileSync(fullPath), { level: 6 }];
     }
@@ -349,7 +347,7 @@ export function createZipFromDirSync(sourceDir: string, outputZip: string): void
   rmSync(outputZip, { force: true });
   mkdirSync(dirname(outputZip), { recursive: true });
 
-  const files = collectFilesSync(sourceDir, sourceDir);
+  const files = collectFilesSync(sourceDir);
   const zipped = zipSync(files);
   writeFileSync(outputZip, zipped);
 }


### PR DESCRIPTION
## Description

PR #844 fixed the flat name-based `agentcore` exclusion in `copySourceTree` by threading `rootDir` through the recursive traversal, so only the project-root `agentcore/` config directory is excluded during the copy stage. However, the same `CONFIG_DIR` exclusion remained in `collectFiles`/`collectFilesSync` (the zip stage).

The zip stage operates on the **staging directory** — not the project root. When `uv pip install --target stagingDir` installs a dependency that contains a top-level `agentcore/` Python package (e.g., `langgraph-checkpoint-aws` ships `langgraph_checkpoint_aws/agentcore/`), the check `entry.name === CONFIG_DIR && resolve(directory) === resolve(rootDir)` fires at the staging root, silently stripping the package from the deployment zip.

**Fix:** Remove the `CONFIG_DIR` exclusion from `collectFiles` and `collectFilesSync` entirely. The exclusion is only needed in `copySourceTree` (which copies from the project root into staging and already correctly filters the config dir). By the time we zip, the project config `agentcore/` was already excluded — the only `agentcore/` in staging is a legitimate dependency package.

**Changes:**
1. Removed `rootDir` parameter and `CONFIG_DIR` check from `collectFiles` (async)
2. Removed `rootDir` parameter and `CONFIG_DIR` check from `collectFilesSync`
3. Updated callers (`createZipFromDir`, `createZipFromDirSync`) to drop the `rootDir` argument
4. Updated 2 existing zip tests to reflect that the zip stage no longer excludes `agentcore/`
5. Added 2 new tests simulating the real staging directory scenario where a dependency's `agentcore/` subpackage must survive the zip step

## Related Issue

Closes #843

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

**Unit tests:** 41/41 packaging tests pass (39 existing + 2 new staging-scenario tests).

**End-to-end verification:**
1. Built and globally installed the patched CLI
2. `agentcore create` → `agentcore add agent` (Strands/Python)
3. `uv add langgraph-checkpoint-aws` (installs v1.0.7 with `agentcore/` subpackage)
4. `agentcore package` → inspected zip: all 11 `langgraph_checkpoint_aws/agentcore/*` files present
5. `agentcore deploy` → `agentcore invoke` → agent responded successfully, no `ModuleNotFoundError`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.