### PR TITLE
ci: cut full e2e time in half via vitest sharding

### DIFF
--- a/.github/workflows/e2e-tests-full.yml
+++ b/.github/workflows/e2e-tests-full.yml
@@ -27,6 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         cdk-source: [npm, main]
+        shard: ['1/6', '2/6', '3/6', '4/6', '5/6', '6/6']
     steps:
       - uses: actions/checkout@v6
         with:
@@ -70,7 +71,7 @@ jobs:
           CDK_REPO: ${{ secrets.CDK_REPO_NAME }}
       - name: Install CLI globally
         run: npm install -g "$(npm pack | tail -1)"
-      - name: Run E2E tests (${{ matrix.cdk-source }})
+      - name: Run E2E tests (${{ matrix.cdk-source }}, shard ${{ matrix.shard }})
         env:
           AWS_ACCOUNT_ID: ${{ steps.aws.outputs.account_id }}
           AWS_REGION: ${{ inputs.aws_region || 'us-east-1' }}
@@ -78,7 +79,7 @@ jobs:
           OPENAI_API_KEY: ${{ env.E2E_OPENAI_API_KEY }}
           GEMINI_API_KEY: ${{ env.E2E_GEMINI_API_KEY }}
           CDK_TARBALL: ${{ env.CDK_TARBALL }}
-        run: npm run test:e2e
+        run: npx vitest run --project e2e --shard=${{ matrix.shard }}
   browser-tests:
     runs-on: ubuntu-latest
     environment: e2e-testing

--- a/e2e-tests/fixtures/import/cleanup_resources.py
+++ b/e2e-tests/fixtures/import/cleanup_resources.py
@@ -22,8 +22,12 @@ def cleanup_s3_code_objects():
     account_id = get_account_id()
     bucket_name = f"bugbash-agentcore-code-{account_id}-{REGION}"
     s3 = boto3.client("s3", region_name=REGION)
+    prefix = f"bugbash-{RESOURCE_SUFFIX}/" if RESOURCE_SUFFIX else ""
     try:
-        resp = s3.list_objects_v2(Bucket=bucket_name)
+        list_args = {"Bucket": bucket_name}
+        if prefix:
+            list_args["Prefix"] = prefix
+        resp = s3.list_objects_v2(**list_args)
         objects = resp.get("Contents", [])
         if not objects:
             return
@@ -31,7 +35,7 @@ def cleanup_s3_code_objects():
             Bucket=bucket_name,
             Delete={"Objects": [{"Key": o["Key"]} for o in objects]},
         )
-        print(f"Deleted {len(objects)} object(s) from s3://{bucket_name}")
+        print(f"Deleted {len(objects)} object(s) from s3://{bucket_name}/{prefix}")
     except Exception as e:
         print(f"Could not clean up S3 objects: {e}")
 

--- a/e2e-tests/fixtures/import/cleanup_resources.py
+++ b/e2e-tests/fixtures/import/cleanup_resources.py
@@ -12,7 +12,7 @@ import os
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from common import REGION, RESOURCES_FILE, get_control_client, get_account_id
+from common import REGION, RESOURCE_SUFFIX, RESOURCES_FILE, get_control_client, get_account_id
 
 import boto3
 

--- a/e2e-tests/fixtures/import/common.py
+++ b/e2e-tests/fixtures/import/common.py
@@ -8,9 +8,11 @@ import tempfile
 import boto3
 
 REGION = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION") or "us-east-1"
+RESOURCE_SUFFIX = os.environ.get("RESOURCE_SUFFIX", "")
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 APP_DIR = os.path.join(SCRIPT_DIR, "app")
-RESOURCES_FILE = os.path.join(SCRIPT_DIR, "bugbash-resources.json")
+_resources_name = f"bugbash-resources-{RESOURCE_SUFFIX}.json" if RESOURCE_SUFFIX else "bugbash-resources.json"
+RESOURCES_FILE = os.path.join(SCRIPT_DIR, _resources_name)
 INLINE_POLICY_NAME = "bugbash-agentcore-permissions"
 
 
@@ -35,6 +37,8 @@ def upload_code(prefix="bugbash"):
     """Zip APP_DIR and upload to S3. Returns (bucket, s3_key)."""
     bucket_name = get_code_bucket()
     s3 = boto3.client("s3", region_name=REGION)
+    if RESOURCE_SUFFIX:
+        prefix = f"{prefix}-{RESOURCE_SUFFIX}"
 
     # Create zip of app directory
     with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:

--- a/e2e-tests/import-gateway.test.ts
+++ b/e2e-tests/import-gateway.test.ts
@@ -43,6 +43,7 @@ describe.sequential('e2e: import gateway', () => {
 
     const result = await spawnAndCollect('uv', ['run', '--with', 'boto3', 'python3', 'setup_gateway.py'], fixtureDir, {
       AWS_REGION: region,
+      RESOURCE_SUFFIX: suffix,
     });
     if (result.exitCode !== 0) {
       throw new Error(
@@ -50,7 +51,7 @@ describe.sequential('e2e: import gateway', () => {
       );
     }
 
-    const resourcesPath = join(fixtureDir, 'bugbash-resources.json');
+    const resourcesPath = join(fixtureDir, `bugbash-resources-${suffix}.json`);
     const resources = JSON.parse(await readFile(resourcesPath, 'utf-8')) as Record<string, { arn: string; id: string }>;
     gatewayArn = resources.gateway!.arn;
 
@@ -80,6 +81,7 @@ describe.sequential('e2e: import gateway', () => {
     try {
       await spawnAndCollect('uv', ['run', '--with', 'boto3', 'python3', 'cleanup_resources.py'], fixtureDir, {
         AWS_REGION: region,
+        RESOURCE_SUFFIX: suffix,
       });
     } catch {
       /* ignore — resources may already be deleted by CFN teardown */

--- a/e2e-tests/import-resources.test.ts
+++ b/e2e-tests/import-resources.test.ts
@@ -54,6 +54,7 @@ describe.sequential('e2e: import runtime/memory/evaluator', () => {
       const result = await spawnAndCollect('uv', ['run', '--with', 'boto3', 'python3', script], fixtureDir, {
         AWS_REGION: region,
         DEFAULT_EVALUATOR_MODEL,
+        RESOURCE_SUFFIX: suffix,
       });
       if (result.exitCode !== 0) {
         throw new Error(
@@ -63,7 +64,7 @@ describe.sequential('e2e: import runtime/memory/evaluator', () => {
     }
 
     // 2. Read resource ARNs from bugbash-resources.json
-    const resourcesPath = join(fixtureDir, 'bugbash-resources.json');
+    const resourcesPath = join(fixtureDir, `bugbash-resources-${suffix}.json`);
     const resources = JSON.parse(await readFile(resourcesPath, 'utf-8')) as Record<string, { arn: string; id: string }>;
     runtimeArn = resources['runtime-basic']!.arn;
     memoryArn = resources['memory-full']!.arn;
@@ -102,6 +103,7 @@ describe.sequential('e2e: import runtime/memory/evaluator', () => {
     try {
       await spawnAndCollect('uv', ['run', '--with', 'boto3', 'python3', 'cleanup_resources.py'], fixtureDir, {
         AWS_REGION: region,
+        RESOURCE_SUFFIX: suffix,
       });
     } catch {
       /* ignore — resources may already be deleted by CFN teardown */


### PR DESCRIPTION
## Description

The full E2E suite takes 19-25 min because all 17 test files run on a single runner per CDK source. Each test deploys its own CloudFormation stack, and measured timings show parallel deploys have zero degradation (77s stays 77s with concurrent stacks).

This adds 6-way vitest sharding via the GitHub Actions matrix, going from 2 to 12 parallel runners. Also isolates import test resources per run to prevent conflicts when `npm` and `main` matrix entries hit the same AWS account concurrently.

**Measured results:**

| Shards | Wall-clock | Slowest shard |
|--------|-----------|---------------|
| 1 (baseline) | 19-25 min | — |
| 4 | ~15 min | 890s |
| 6 | **~11.5 min** | 691s |
| 8 | ~12.0 min | 717s |

6 shards appears to be the sweet spot. Adding more shards creates diminishing returns since the main bottleneck is the deploy (274s) and container build (204s). This is roughly what the e2e tests take on PRs when running minimal files so we're likely close to how fast we can get it. 

Inspired by https://github.com/aws/agentcore-cli/pull/989.

Docs: https://vitest.dev/guide/improving-performance.html#sharding

### Import test resource isolation

The `import-resources.test.ts` setup creates AWS resources (runtime, memory, evaluator) via Python scripts, then saves their ARNs to `bugbash-resources.json`. The cleanup script deletes those resources and also calls `cleanup_s3_code_objects()` which previously deleted **all** objects from the shared S3 bucket `bugbash-agentcore-code-{account}-{region}`.

The `npm` and `main` matrix entries are separate runners hitting the same AWS account simultaneously. Both run `import-resources.test.ts`. When one job's cleanup finishes first, it nuked all S3 objects — including the `code.zip` the other job uploaded and was still using, causing downstream resource creation failures.

The fix: each run now gets a unique `RESOURCE_SUFFIX` (the test's timestamp-based suffix). This scopes:
- The resources file: `bugbash-resources-{suffix}.json` instead of `bugbash-resources.json`
- The S3 prefix: `bugbash-{suffix}/code.zip` instead of `bugbash/code.zip`
- The S3 cleanup: only deletes objects under its own prefix

## Related Issue

N/A — CI performance improvement.

## Documentation PR

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe): CI performance — shard E2E tests for faster wall-clock time

## Testing

Tried different shard sizes, runs are here: https://github.com/aws/agentcore-cli/actions/runs/25165632571, https://github.com/aws/agentcore-cli/actions/runs/25166733599
- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [x] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.