### PR TITLE
fix(ci): update snapshots after CDK version sync in release workflow

### DIFF
--- a/.github/workflows/release-main-and-preview.yml
+++ b/.github/workflows/release-main-and-preview.yml
@@ -120,6 +120,7 @@ jobs:
                 fs.writeFileSync('$TEMPLATE_PKG', JSON.stringify(pkg, null, 2) + '\n');
               "
               echo "✅ Updated @aws/agentcore-cdk: $CURRENT_CDK -> $LATEST_CDK"
+              npm run test:update-snapshots
             fi
           fi
 
@@ -218,6 +219,7 @@ jobs:
                 fs.writeFileSync('$TEMPLATE_PKG', JSON.stringify(pkg, null, 2) + '\n');
               "
               echo "✅ Updated @aws/agentcore-cdk: $CURRENT_CDK -> $LATEST_CDK"
+              npm run test:update-snapshots
             fi
           fi
 


### PR DESCRIPTION
## Summary
- Add `npm run test:update-snapshots` after the `@aws/agentcore-cdk` version sync step in both the main and preview prepare jobs
- Fixes the `cdk/cdk/package.json should match snapshot` test failure that occurs during releases

## Root Cause
The release workflow syncs `@aws/agentcore-cdk` to the latest npm version in `src/assets/cdk/package.json` (e.g. `^0.1.0-alpha.19` → `0.1.0-alpha.23`), but never regenerates the snapshot file. The subsequent test job sees a mismatch and fails.

## Test plan
- [ ] Re-run the "Release Both" workflow — snapshot test should pass now