### PR TITLE
fix(ci): enable coverage collection in sharded unit test runs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -87,7 +87,7 @@ jobs:
       - run: npm ci
       - run: npm run build --if-present
       - name: Run unit tests (shard ${{ matrix.shard }})
-        run: npx vitest run --project unit --shard=${{ matrix.shard }} --reporter=blob --reporter=verbose
+        run: npx vitest run --project unit --shard=${{ matrix.shard }} --reporter=blob --reporter=verbose --coverage
       - name: Upload blob report
         if: always()
         uses: actions/upload-artifact@v7
@@ -144,6 +144,6 @@ jobs:
         with:
           json-summary-path: coverage/coverage-summary.json
           json-final-path: coverage/coverage-final.json
-          vite-config-path: vitest.unit.config.ts
+          vite-config-path: vitest.config.ts
           file-coverage-mode: none
           coverage-thresholds: '{ "lines": 50, "branches": 50, "functions": 50, "statements": 50 }'


### PR DESCRIPTION
## Summary

- Adds `--coverage` to the sharded unit-test vitest commands so V8 coverage data is captured in blob reports. Without this flag, the merge-reports step merges empty coverage maps, producing the `0/0 Unknown%` report seen on every PR.
- Fixes `vite-config-path` in the coverage report action from `vitest.unit.config.ts` (doesn't exist) to `vitest.config.ts`.

## Test plan

- [ ] Open this PR and verify the coverage comment shows real percentages instead of `Unknown% 0/0`