### PR TITLE
fix(ci): move snapshot update after build and use SYNC_PAT for sync-preview

### DIFF
--- a/.github/workflows/release-main-and-preview.yml
+++ b/.github/workflows/release-main-and-preview.yml
@@ -120,7 +120,6 @@ jobs:
                 fs.writeFileSync('$TEMPLATE_PKG', JSON.stringify(pkg, null, 2) + '\n');
               "
               echo "✅ Updated @aws/agentcore-cdk: $CURRENT_CDK -> $LATEST_CDK"
-              npm run test:update-snapshots
             fi
           fi
 
@@ -146,6 +145,9 @@ jobs:
           npm run build
           node scripts/generate-schema.mjs
           npx prettier --write schemas/
+
+      - name: Update snapshots
+        run: npm run test:update-snapshots
 
       - name: Create release branch and PR
         env:
@@ -219,7 +221,6 @@ jobs:
                 fs.writeFileSync('$TEMPLATE_PKG', JSON.stringify(pkg, null, 2) + '\n');
               "
               echo "✅ Updated @aws/agentcore-cdk: $CURRENT_CDK -> $LATEST_CDK"
-              npm run test:update-snapshots
             fi
           fi
 
@@ -244,6 +245,9 @@ jobs:
           npm run build
           node scripts/generate-schema.mjs
           npx prettier --write schemas/
+
+      - name: Update snapshots
+        run: npm run test:update-snapshots
 
       - name: Create release branch and PR
         env:


### PR DESCRIPTION
## Summary
- **release-main-and-preview.yml**: Move `npm run test:update-snapshots` from inside the CDK sync step (before build) to its own step after `npm run build`. The test suite needs built artifacts to pass.
- **sync-preview.yml**: Use `SYNC_PAT` secret to bypass branch protection when pushing to preview. Direct pushes with `GITHUB_TOKEN` fail with `GH013: Changes must be made through a pull request`.

## Context
The previous fix (#1033) put `npm run test:update-snapshots` inside the CDK sync step, which runs before the build. This caused 18 test failures because most unit tests require built output. Moving it after the build step resolves this.

The sync-preview workflow has been failing on every push to main because the preview branch requires PRs. Using a PAT with bypass permissions allows direct pushes for clean merges.

## Test plan
- [ ] Re-run the release workflow — snapshot tests should pass
- [ ] Push to main — sync-preview should successfully push to preview (clean merges) or create a PR (conflicts)