### PR TITLE
fix(ci): install uv in release workflow prepare steps

### DIFF
--- a/.github/workflows/release-main-and-preview.yml
+++ b/.github/workflows/release-main-and-preview.yml
@@ -99,6 +99,9 @@ jobs:
         with:
           node-version: 20.x
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
       - name: Configure git
         run: |
           git config --global user.name "github-actions[bot]"
@@ -197,6 +200,9 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 20.x
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
 
       - name: Configure git
         run: |


### PR DESCRIPTION
## Summary
- Add `astral-sh/setup-uv@v7` to both Prepare Main Release and Prepare Preview Release jobs
- Matches the Build and Test workflow which already installs uv

## Root Cause
The `npm run test:update-snapshots` step runs all unit tests. `create.test.ts` tests require `uv` for Python project scaffolding, but the release workflow never installed it — causing 6 test failures and blocking the release.

## Test plan
- [ ] Re-run the release workflow — all tests in the snapshot update step should pass