### PR TITLE
fix: restore ^ caret prefix on @aws/agentcore-cdk dependency

### DIFF
--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -418,7 +418,7 @@ exports[`Assets Directory Snapshots > CDK assets > cdk/cdk/package.json should m
     "typescript": "~5.9.3"
   },
   "dependencies": {
-    "@aws/agentcore-cdk": "0.1.0-alpha.23",
+    "@aws/agentcore-cdk": "^0.1.0-alpha.19",
     "aws-cdk-lib": "^2.248.0",
     "constructs": "^10.0.0"
   }

--- a/src/assets/cdk/package.json
+++ b/src/assets/cdk/package.json
@@ -23,7 +23,7 @@
     "typescript": "~5.9.3"
   },
   "dependencies": {
-    "@aws/agentcore-cdk": "0.1.0-alpha.23",
+    "@aws/agentcore-cdk": "^0.1.0-alpha.19",
     "aws-cdk-lib": "^2.248.0",
     "constructs": "^10.0.0"
   }


### PR DESCRIPTION
## Summary

The release workflow's CDK sync step was writing bare versions (e.g., `"0.1.0-alpha.23"`) instead of caret ranges (`"^0.1.0-alpha.19"`), pinning the dependency to an exact version.

This restores the `^` prefix so `npm install` resolves compatible versions correctly.

## Changes

- `src/assets/cdk/package.json`: `"0.1.0-alpha.23"` → `"^0.1.0-alpha.19"`