### PR TITLE
fix(dev): detect and skip container runtime shims

### DIFF
--- a/src/cli/external-requirements/__tests__/detect.test.ts
+++ b/src/cli/external-requirements/__tests__/detect.test.ts
@@ -20,6 +20,7 @@ describe('detectContainerRuntime', () => {
     mockCheckSubprocess.mockResolvedValue(true);
     mockRunSubprocessCapture.mockImplementation((_bin: string, args: string[]) => {
       if (args[0] === '--version') return Promise.resolve({ code: 0, stdout: 'Docker version 24.0.0\n', stderr: '' });
+      if (args[0] === 'build') return Promise.resolve({ code: 0, stdout: '', stderr: '' });
       return Promise.resolve({ code: 1, stdout: '', stderr: '' });
     });
 
@@ -36,6 +37,7 @@ describe('detectContainerRuntime', () => {
     mockRunSubprocessCapture.mockImplementation((bin: string, args: string[]) => {
       if (bin === 'podman' && args[0] === '--version')
         return Promise.resolve({ code: 0, stdout: 'podman version 4.5.0\n', stderr: '' });
+      if (bin === 'podman' && args[0] === 'build') return Promise.resolve({ code: 0, stdout: '', stderr: '' });
       return Promise.resolve({ code: 1, stdout: '', stderr: '' });
     });
 
@@ -57,6 +59,7 @@ describe('detectContainerRuntime', () => {
       if (bin === 'docker' && args[0] === '--version') return Promise.resolve({ code: 1, stdout: '', stderr: 'error' });
       if (bin === 'podman' && args[0] === '--version')
         return Promise.resolve({ code: 0, stdout: 'podman version 4.5.0\n', stderr: '' });
+      if (bin === 'podman' && args[0] === 'build') return Promise.resolve({ code: 0, stdout: '', stderr: '' });
       // finch --version also fails
       if (bin === 'finch' && args[0] === '--version') return Promise.resolve({ code: 1, stdout: '', stderr: 'error' });
       return Promise.resolve({ code: 1, stdout: '', stderr: '' });
@@ -71,6 +74,7 @@ describe('detectContainerRuntime', () => {
     mockRunSubprocessCapture.mockImplementation((_bin: string, args: string[]) => {
       if (args[0] === '--version')
         return Promise.resolve({ code: 0, stdout: 'Docker version 24.0.0\nExtra info line\n', stderr: '' });
+      if (args[0] === 'build') return Promise.resolve({ code: 0, stdout: '', stderr: '' });
       return Promise.resolve({ code: 1, stdout: '', stderr: '' });
     });
 
@@ -82,6 +86,7 @@ describe('detectContainerRuntime', () => {
     mockCheckSubprocess.mockResolvedValue(true);
     mockRunSubprocessCapture.mockImplementation((_bin: string, args: string[]) => {
       if (args[0] === '--version') return Promise.resolve({ code: 0, stdout: '', stderr: '' });
+      if (args[0] === 'build') return Promise.resolve({ code: 0, stdout: '', stderr: '' });
       return Promise.resolve({ code: 1, stdout: '', stderr: '' });
     });
 
@@ -90,20 +95,30 @@ describe('detectContainerRuntime', () => {
     expect(result.runtime?.version).toBe('');
   });
 
-  it('does not call docker info to check daemon status', async () => {
+  it('skips runtime when build --help check fails with non-zero exit', async () => {
     mockCheckSubprocess.mockResolvedValue(true);
     mockRunSubprocessCapture.mockImplementation((_bin: string, args: string[]) => {
-      if (args[0] === '--version') return Promise.resolve({ code: 0, stdout: 'Docker version 24.0.0\n', stderr: '' });
+      if (args[0] === '--version') return Promise.resolve({ code: 0, stdout: '1.0.0\n', stderr: '' });
+      if (args[0] === 'build') return Promise.resolve({ code: 1, stdout: '', stderr: 'unknown command "build"' });
       return Promise.resolve({ code: 1, stdout: '', stderr: '' });
     });
 
-    await detectContainerRuntime();
+    const result = await detectContainerRuntime();
+    expect(result.runtime).toBeNull();
+  });
 
-    // Verify 'info' was never called — this is the key behavioral change
-    const infoCalls = mockRunSubprocessCapture.mock.calls.filter(
-      (call: unknown[]) => (call[1] as string[])[0] === 'info'
-    );
-    expect(infoCalls).toHaveLength(0);
+  it('skips runtime when build --help exits 0 but stderr indicates unknown command (shim/wrapper)', async () => {
+    mockCheckSubprocess.mockResolvedValue(true);
+    mockRunSubprocessCapture.mockImplementation((_bin: string, args: string[]) => {
+      // Shim exits 0 for everything but prints error to stderr
+      if (args[0] === '--version') return Promise.resolve({ code: 0, stdout: '1.0.0\n', stderr: '' });
+      if (args[0] === 'build')
+        return Promise.resolve({ code: 0, stdout: '', stderr: 'Error: unknown command "build" for "ada"' });
+      return Promise.resolve({ code: 0, stdout: '', stderr: '' });
+    });
+
+    const result = await detectContainerRuntime();
+    expect(result.runtime).toBeNull();
   });
 });
 
@@ -112,6 +127,7 @@ describe('requireContainerRuntime', () => {
     mockCheckSubprocess.mockResolvedValue(true);
     mockRunSubprocessCapture.mockImplementation((_bin: string, args: string[]) => {
       if (args[0] === '--version') return Promise.resolve({ code: 0, stdout: 'Docker version 24.0.0\n', stderr: '' });
+      if (args[0] === 'build') return Promise.resolve({ code: 0, stdout: '', stderr: '' });
       return Promise.resolve({ code: 1, stdout: '', stderr: '' });
     });
 

--- a/src/cli/external-requirements/detect.ts
+++ b/src/cli/external-requirements/detect.ts
@@ -20,11 +20,8 @@ export interface DetectionResult {
 
 /**
  * Detect available container runtime.
- * Checks docker, podman, finch in order; returns the first that is installed.
- * Does not probe the daemon (e.g., `docker info`) — that would require socket
- * access and can trigger OS password prompts on systems where the user is not
- * in the docker group. Actual daemon availability is validated when the runtime
- * is used (build, run, etc.).
+ * Checks docker, podman, finch in order; returns the first that is installed
+ * and capable of running container operations.
  */
 export async function detectContainerRuntime(): Promise<DetectionResult> {
   for (const runtime of CONTAINER_RUNTIMES) {
@@ -35,6 +32,14 @@ export async function detectContainerRuntime(): Promise<DetectionResult> {
     // Verify with --version
     const result = await runSubprocessCapture(runtime, ['--version']);
     if (result.code !== 0) continue;
+
+    // Validate the binary actually supports container operations.
+    // Some environments have shims (e.g., toolbox wrappers) that respond to
+    // --version but don't support build/run commands. These shims may exit 0
+    // even on failure, so also check stderr for error indicators.
+    const buildCheck = await runSubprocessCapture(runtime, ['build', '--help']);
+    if (buildCheck.code !== 0) continue;
+    if (buildCheck.stderr && /unknown command|not found/i.test(buildCheck.stderr)) continue;
 
     const version = result.stdout.trim().split('\n')[0] ?? 'unknown';
     return { runtime: { runtime, binary: runtime, version } };


### PR DESCRIPTION
## Summary
- Fixes `agentcore dev --logs` failing with "unknown command 'build' for 'ada'" when a toolbox shim (`~/.toolbox/bin/finch`) masquerades as a real container runtime
- Adds a `build --help` probe to `detectContainerRuntime()` that validates the binary actually supports container operations
- Handles shims that exit 0 on failure by also checking stderr for "unknown command" / "not found"

## Root Cause
The `finch` binary at `~/.toolbox/bin/finch` is a shell script that wraps `ada` (AWS Developer Account tool). It passes `which` and `--version` checks but doesn't support Docker-compatible commands (`build`, `run`). The CLI mistakenly treated it as a valid container runtime.

## Test plan
- [x] Unit tests pass (10/10 in `detect.test.ts`)
- [x] New test case: shim with non-zero exit code on `build --help`
- [x] New test case: shim that exits 0 but prints "unknown command" to stderr
- [x] End-to-end: `agentcore dev --logs` now shows "No container runtime found" instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)