### PR TITLE
fix(ci): publish from release branch instead of base branch

### DIFF
--- a/.github/workflows/release-main-and-preview.yml
+++ b/.github/workflows/release-main-and-preview.yml
@@ -375,10 +375,10 @@ jobs:
       contents: write
 
     steps:
-      - name: Checkout main
+      - name: Checkout release branch
         uses: actions/checkout@v6
         with:
-          ref: main
+          ref: release/v${{ needs.prepare-main.outputs.version }}
           fetch-depth: 0
 
       - uses: actions/setup-node@v6
@@ -389,6 +389,17 @@ jobs:
       - run: npm install -g npm@11.5.1
       - run: npm ci
       - run: npm run build
+
+      - name: Verify version before publish
+        env:
+          EXPECTED: ${{ needs.prepare-main.outputs.version }}
+        run: |
+          ACTUAL=$(node -p "require('./package.json').version")
+          if [ "$ACTUAL" != "$EXPECTED" ]; then
+            echo "❌ Version mismatch: expected $EXPECTED, got $ACTUAL"
+            exit 1
+          fi
+          echo "✅ Publishing version $ACTUAL"
 
       - name: Publish to npm
         run: npm publish --access public --provenance --tag latest
@@ -431,10 +442,10 @@ jobs:
       contents: write
 
     steps:
-      - name: Checkout preview
+      - name: Checkout release branch
         uses: actions/checkout@v6
         with:
-          ref: preview
+          ref: release/v${{ needs.prepare-preview.outputs.version }}
           fetch-depth: 0
 
       - uses: actions/setup-node@v6
@@ -445,6 +456,17 @@ jobs:
       - run: npm install -g npm@11.5.1
       - run: npm ci
       - run: npm run build
+
+      - name: Verify version before publish
+        env:
+          EXPECTED: ${{ needs.prepare-preview.outputs.version }}
+        run: |
+          ACTUAL=$(node -p "require('./package.json').version")
+          if [ "$ACTUAL" != "$EXPECTED" ]; then
+            echo "❌ Version mismatch: expected $EXPECTED, got $ACTUAL"
+            exit 1
+          fi
+          echo "✅ Publishing version $ACTUAL"
 
       - name: Publish to npm
         run: npm publish --access public --provenance --tag preview


### PR DESCRIPTION
## Description

The publish jobs were checking out `main`/`preview` which could serve a stale git ref that didn't include the version bump commit. This caused 0.12.1 to be published with the 0.12.0 package.json.

Now the publish jobs checkout `release/v<version>` directly, which is guaranteed to have the correct version. Added a version verification step before `npm publish` as a safety check.

### Prior art — how other OSS repos handle this

| Repo | Pattern | Publishes from main? |
|------|---------|---------------------|
| [Turborepo](https://github.com/vercel/turborepo/blob/main/.github/workflows/turborepo-release.yml) | Creates a staging branch, publishes from it | No — staging branch |
| [Nx](https://github.com/nrwl/nx/blob/master/.github/workflows/publish.yml) | Dynamic ref resolution, dedicated publish branch | No — PR branch or publish branch |
| [Next.js](https://github.com/vercel/next.js/blob/canary/.github/workflows/trigger_release.yml) | Clones canary branch explicitly | No — canary branch |
| [Vite](https://github.com/vitejs/vite/blob/main/.github/workflows/publish.yml) | Tag-triggered, checks out tag ref | No — tag ref |
| [Vue.js](https://github.com/vuejs/core/blob/main/.github/workflows/release.yml) | Tag-triggered, checks out tag ref | No — tag ref |

None of these projects publish from the base branch HEAD — they all publish from a release branch, staging branch, or tag ref.

## Related Issue

Closes #

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.