### PR TITLE
fix: add Accept header to HTTP protocol dev invocation proxy

### DIFF
--- a/src/cli/operations/dev/web-ui/handlers/invocations.ts
+++ b/src/cli/operations/dev/web-ui/handlers/invocations.ts
@@ -68,6 +68,7 @@ export async function handleInvocations(
   return new Promise<void>((resolve, reject) => {
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
+      Accept: 'text/event-stream, */*',
       'x-amzn-bedrock-agentcore-runtime-session-id': sessionId ?? randomUUID(),
     };
     if (userId) {


### PR DESCRIPTION
## Problem

The dev web UI inspector doesn't send an `Accept` header when proxying invocation requests to HTTP protocol agents. The `bedrock-agentcore` runtime SDK relies on this header to determine whether SSE streaming is available, specifically, `@fastify/sse` only sets `reply.sse` when the request includes `Accept: text/event-stream`.

Without it, any agent that returns an async generator (streaming response) gets a 406:

```json
{"error":"Streaming response requires Accept: text/event-stream header. Please include this header in your request to receive streaming data."}
```

The A2A and AGUI protocol paths in the same file already include the Accept header — HTTP was the only one missing it.

## Fix

Add `Accept: text/event-stream, */*` to the HTTP invocation proxy headers.

- `text/event-stream` enables SSE for streaming agents
- `*/*` ensures non-streaming agents can still respond in whatever format they need (JSON, plain text, etc.) since the proxy pipes the response through as-is

## Testing

Verified locally with a streaming handler (async generator yielding SSE events). Responses now stream correctly through the inspector UI instead of returning a 406.