### PR TITLE
feat: update @aws/agent-inspector to 0.3.0

### DIFF
--- a/browser-tests/tests/traces.test.ts
+++ b/browser-tests/tests/traces.test.ts
@@ -1,22 +1,38 @@
 import { expect, sendMessage, test } from '../fixtures';
 
 test.describe('Traces', () => {
-  test('traces panel shows trace after invocation', async ({ page }) => {
+  test('traces panel shows span tree after invocation', async ({ page }) => {
     await page.goto('/');
 
     await sendMessage(page, 'Say hello');
 
-    await page.getByRole('tab', { name: 'Traces' }).click();
+    const resourcePanel = page.getByTestId('resource-panel');
+    await expect(resourcePanel).toBeVisible({ timeout: 10_000 });
 
-    const traceList = page.getByTestId('trace-list');
+    const tracesTab = resourcePanel.getByRole('tab', { name: 'Traces' });
+    await tracesTab.click();
+
+    // Wait for trace list to populate
+    const traceList = resourcePanel.getByTestId('traces-trace-list');
     await expect(traceList).toBeVisible({ timeout: 30_000 });
 
+    // Click the first trace
     const traceButton = traceList.getByRole('button').first();
-    await expect(traceButton).toBeVisible({ timeout: 30_000 });
-
+    await expect(traceButton).toBeVisible({ timeout: 10_000 });
     await traceButton.click();
 
-    const spanRow = page.locator('[role="button"]').filter({ hasText: /.+/ });
-    await expect(spanRow.first()).toBeVisible({ timeout: 10_000 });
+    // Verify span tree renders
+    const spanTree = resourcePanel.getByTestId('traces-span-tree');
+    await expect(spanTree).toBeVisible({ timeout: 10_000 });
+
+    // Verify tree has at least one span row with a name
+    const spanRows = spanTree.getByRole('button');
+    await expect(spanRows.first()).toBeVisible();
+
+    // Click a span to open log panel
+    await spanRows.first().click();
+
+    const logPanel = resourcePanel.getByTestId('traces-log-panel');
+    await expect(logPanel).toBeVisible({ timeout: 5_000 });
   });
 });

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -415,6 +415,24 @@ Test configuration is in `vitest.config.ts` using Vitest projects:
 - Test timeout: 120 seconds
 - Hook timeout: 120 seconds
 
+## Troubleshooting
+
+### `Cannot find module '@playwright/test'`
+
+Playwright is not installed. Run:
+
+```bash
+npm install
+```
+
+### `browserType.launch: Executable doesn't exist` (Playwright browsers)
+
+Playwright browsers need to be downloaded after install. Run:
+
+```bash
+npx playwright install chromium
+```
+
 ## Integration Tests
 
 Integration tests require:

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@aws-sdk/client-sts": "^3.893.0",
         "@aws-sdk/client-xray": "^3.1003.0",
         "@aws-sdk/credential-providers": "^3.893.0",
-        "@aws/agent-inspector": "0.2.1",
+        "@aws/agent-inspector": "0.3.0",
         "@commander-js/extra-typings": "^14.0.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-metrics-otlp-http": "^0.214.0",
@@ -2903,9 +2903,9 @@
       }
     },
     "node_modules/@aws/agent-inspector": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@aws/agent-inspector/-/agent-inspector-0.2.1.tgz",
-      "integrity": "sha512-kyL6RBcTj1hYIchtrHDlDyeqm2viVYMBxhZKVn8wJn058YhI52GIDuUFlKD1avd57X+LJKlHr5VcKvBZp7Sg6A==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/agent-inspector/-/agent-inspector-0.3.0.tgz",
+      "integrity": "sha512-xD7QPr1WWkT9QWRWo6e9kq8kYxJLQ8egGscgSZ6jCyW3wNV5fcQ6THcAR/71hxxMFF2aleNUc3D8MoqgiS4DVw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ag-ui/core": "^0.0.52",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@aws-sdk/client-sts": "^3.893.0",
     "@aws-sdk/client-xray": "^3.1003.0",
     "@aws-sdk/credential-providers": "^3.893.0",
-    "@aws/agent-inspector": "0.2.1",
+    "@aws/agent-inspector": "0.3.0",
     "@commander-js/extra-typings": "^14.0.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.214.0",


### PR DESCRIPTION
## Description

Updates `@aws/agent-inspector` from 0.2.1 to 0.3.0 and updates browser tests to match the new traces UI.

### agent-inspector 0.3.0 changes

**Features:**
- **Span tree view** — traces panel now renders a hierarchical span tree instead of a flat list. Clicking a span opens a log panel with span details.
- **CloudWatch trace support** — traces can now be fetched and displayed from CloudWatch in addition to local OTLP traces.


### Browser test updates

- Updated `traces.test.ts` to exercise the new span tree UI: verifies the trace list, span tree rendering, span row visibility, and log panel opening on click
- Scoped selectors to `resource-panel` using new `data-testid` attributes (`traces-trace-list`, `traces-span-tree`, `traces-log-panel`)
- Added Playwright troubleshooting section to `docs/TESTING.md`

## Type of Change

- [x] New feature
- [x] Documentation update

## Testing

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`