### PR TITLE
fix(harness): add error handling for invoke_harness API call

### DIFF
--- a/.github/harness/harness_review.py
+++ b/.github/harness/harness_review.py
@@ -189,8 +189,12 @@ REVIEW_PROMPT = read_prompt("review.md").format(pr_url=PR_URL)
 
 messages = [{"role": "user", "content": [{"text": REVIEW_PROMPT}]}]
 
-event_stream = invoke_harness_streaming(
-    HARNESS_ARN, SESSION_ID, SYSTEM_PROMPT, messages, MODEL_ID, REGION
-)
+try:
+    event_stream = invoke_harness_streaming(
+        HARNESS_ARN, SESSION_ID, SYSTEM_PROMPT, messages, MODEL_ID, REGION
+    )
+except Exception as e:
+    print(f"{RED}ERROR: Failed to invoke harness: {e}{RESET}", file=sys.stderr)
+    sys.exit(1)
 
 print_stream(event_stream)


### PR DESCRIPTION
## Summary
- Wraps the `invoke_harness_streaming` call in a try/except block so boto3 errors (bad credentials, network issues, invalid ARN) produce a clean error message instead of a raw Python traceback in GitHub Actions logs.

## Test plan
- [x] Verified Python syntax is valid
- [ ] Trigger harness review workflow with an invalid ARN to confirm clean error output