### PR TITLE
docs: remove CrewAI from supported frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ agentcore invoke
 | ------------------- | ----------------------------- |
 | Strands Agents      | AWS-native, streaming support |
 | LangChain/LangGraph | Graph-based workflows         |
-| CrewAI              | Multi-agent orchestration     |
 | Google ADK          | Gemini models only            |
 | OpenAI Agents       | OpenAI models only            |
 

--- a/docs/frameworks.md
+++ b/docs/frameworks.md
@@ -9,7 +9,6 @@ for existing code.
 | ----------------------- | ---------------------------------- |
 | **Strands Agents**      | Bedrock, Anthropic, OpenAI, Gemini |
 | **LangChain_LangGraph** | Bedrock, Anthropic, OpenAI, Gemini |
-| **CrewAI**              | Bedrock, Anthropic, OpenAI, Gemini |
 | **GoogleADK**           | Gemini only                        |
 | **OpenAIAgents**        | OpenAI only                        |
 
@@ -60,21 +59,6 @@ Google's Agent Development Kit.
 
 ```bash
 agentcore create --framework GoogleADK --model-provider Gemini
-```
-
-### CrewAI
-
-Multi-agent orchestration framework.
-
-**Best for:**
-
-- Multi-agent workflows with role-based collaboration
-- Projects requiring agent coordination and task delegation
-
-**Model providers:** Bedrock, Anthropic, OpenAI, Gemini
-
-```bash
-agentcore create --framework CrewAI --model-provider Bedrock
 ```
 
 ### OpenAIAgents
@@ -167,12 +151,12 @@ agentcore add agent \
 
 ## Framework Comparison
 
-| Feature                | Strands | LangChain | CrewAI   | GoogleADK | OpenAIAgents |
-| ---------------------- | ------- | --------- | -------- | --------- | ------------ |
-| Multi-provider support | Yes     | Yes       | Yes      | No        | No           |
-| AWS Bedrock native     | Yes     | No        | No       | No        | No           |
-| Tool ecosystem         | Growing | Extensive | Moderate | Moderate  | Moderate     |
-| Memory integration     | Native  | Via libs  | Via libs | Via libs  | Via libs     |
+| Feature                | Strands | LangChain | GoogleADK | OpenAIAgents |
+| ---------------------- | ------- | --------- | --------- | ------------ |
+| Multi-provider support | Yes     | Yes       | No        | No           |
+| AWS Bedrock native     | Yes     | No        | No        | No           |
+| Tool ecosystem         | Growing | Extensive | Moderate  | Moderate     |
+| Memory integration     | Native  | Via libs  | Via libs  | Via libs     |
 
 ## Protocol Compatibility
 
@@ -180,6 +164,6 @@ Not all frameworks support all protocol modes. MCP protocol is a standalone tool
 
 | Protocol | Supported Frameworks                                          |
 | -------- | ------------------------------------------------------------- |
-| **HTTP** | Strands, LangChain_LangGraph, CrewAI, GoogleADK, OpenAIAgents |
+| **HTTP** | Strands, LangChain_LangGraph, GoogleADK, OpenAIAgents |
 | **MCP**  | None (standalone tool server)                                 |
 | **A2A**  | Strands, GoogleADK, LangChain_LangGraph                       |


### PR DESCRIPTION
CrewAI is not implemented as a framework option in the CLI — it does not exist in SDKFrameworkSchema, has no template assets, and is not in the SDK_MODEL_PROVIDER_MATRIX. Remove it from README and docs/frameworks.md to match the actual CLI capabilities.

Constraint: Only frameworks in src/schema/constants.ts SDKFrameworkSchema are valid
Rejected: Mark CrewAI as "BYO only" | no special BYO treatment exists for it
Confidence: high
Scope-risk: narrow

## Description

<!-- Provide a detailed description of the changes in this PR -->

## Related Issue

<!-- Every PR must be associated with an issue. Link it below using #issue-number format. -->

Closes #

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe):

## Testing

How have you tested the change?

- [] I ran `npm run test:unit` and `npm run test:integ`
- [ ] I ran `npm run typecheck`
- [ ] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
