### PR TITLE
fix: resolve e2e import test concurrency races

### DIFF
--- a/e2e-tests/fixtures/import/common.py
+++ b/e2e-tests/fixtures/import/common.py
@@ -2,6 +2,7 @@
 import json
 import os
 import time
+import uuid
 import zipfile
 import tempfile
 
@@ -9,6 +10,8 @@ import boto3
 
 REGION = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION") or "us-east-1"
 RESOURCE_SUFFIX = os.environ.get("RESOURCE_SUFFIX", "")
+# Unique suffix for resource names — avoids collisions across parallel CI shards.
+NAME_SUFFIX = RESOURCE_SUFFIX or uuid.uuid4().hex[:12]
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 APP_DIR = os.path.join(SCRIPT_DIR, "app")
 _resources_name = f"bugbash-resources-{RESOURCE_SUFFIX}.json" if RESOURCE_SUFFIX else "bugbash-resources.json"

--- a/e2e-tests/fixtures/import/setup_evaluator.py
+++ b/e2e-tests/fixtures/import/setup_evaluator.py
@@ -8,7 +8,6 @@ import sys
 import os
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-import time
 from common import (
     get_control_client, save_resource, tag_resource,
     wait_for_evaluator, print_import_command,

--- a/e2e-tests/fixtures/import/setup_evaluator.py
+++ b/e2e-tests/fixtures/import/setup_evaluator.py
@@ -12,6 +12,7 @@ import time
 from common import (
     get_control_client, save_resource, tag_resource,
     wait_for_evaluator, print_import_command,
+    NAME_SUFFIX,
 )
 
 DEFAULT_EVALUATOR_MODEL = os.environ.get("DEFAULT_EVALUATOR_MODEL", "us.anthropic.claude-sonnet-4-5-20250929-v1:0")
@@ -19,8 +20,7 @@ DEFAULT_EVALUATOR_MODEL = os.environ.get("DEFAULT_EVALUATOR_MODEL", "us.anthropi
 
 def main():
     client = get_control_client()
-    ts = int(time.time())
-    evaluator_name = f"bugbash_eval_{ts}"
+    evaluator_name = f"bugbash_eval_{NAME_SUFFIX}"
 
     print(f"Creating evaluator: {evaluator_name}")
     resp = client.create_evaluator(

--- a/e2e-tests/fixtures/import/setup_gateway.py
+++ b/e2e-tests/fixtures/import/setup_gateway.py
@@ -16,14 +16,14 @@ import time
 from common import (
     REGION, get_control_client, ensure_role, save_resource,
     tag_resource, wait_for_gateway, wait_for_gateway_target,
+    NAME_SUFFIX,
 )
 
 
 def main():
     role_arn = ensure_role()
     client = get_control_client()
-    ts = int(time.time())
-    gateway_name = f"bugbashGw{ts}"
+    gateway_name = f"bugbashGw{NAME_SUFFIX}"
 
     # ------------------------------------------------------------------
     # 1. Create gateway

--- a/e2e-tests/fixtures/import/setup_gateway.py
+++ b/e2e-tests/fixtures/import/setup_gateway.py
@@ -12,7 +12,6 @@ import sys
 import os
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-import time
 from common import (
     REGION, get_control_client, ensure_role, save_resource,
     tag_resource, wait_for_gateway, wait_for_gateway_target,

--- a/e2e-tests/fixtures/import/setup_memory_full.py
+++ b/e2e-tests/fixtures/import/setup_memory_full.py
@@ -8,7 +8,6 @@ import sys
 import os
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-import time
 from common import (
     ensure_role, get_control_client, wait_for_memory,
     save_resource, print_import_command, tag_resource,

--- a/e2e-tests/fixtures/import/setup_memory_full.py
+++ b/e2e-tests/fixtures/import/setup_memory_full.py
@@ -12,18 +12,19 @@ import time
 from common import (
     ensure_role, get_control_client, wait_for_memory,
     save_resource, print_import_command, tag_resource,
+    NAME_SUFFIX,
 )
 
 
 def main():
     role_arn = ensure_role()
     client = get_control_client()
-    memory_name = f"bugbash_memory_{int(time.time())}"
+    memory_name = f"bugbash_memory_{NAME_SUFFIX}"
 
     print(f"Creating memory: {memory_name}")
     resp = client.create_memory(
         name=memory_name,
-        clientToken=f"bugbash-{int(time.time())}",
+        clientToken=f"bugbash-{NAME_SUFFIX}",
         eventExpiryDuration=30,
         memoryExecutionRoleArn=role_arn,
         memoryStrategies=[

--- a/e2e-tests/fixtures/import/setup_runtime_basic.py
+++ b/e2e-tests/fixtures/import/setup_runtime_basic.py
@@ -11,16 +11,16 @@ import time
 from common import (
     ensure_role, get_control_client, wait_for_runtime,
     save_resource, print_import_command, upload_code,
+    NAME_SUFFIX,
 )
 
 
 def main():
     role_arn = ensure_role()
     client = get_control_client()
-    ts = int(time.time())
-    runtime_name = f"bugbash_basic_{ts}"
+    runtime_name = f"bugbash_basic_{NAME_SUFFIX}"
 
-    bucket, s3_key = upload_code(f"bugbash-basic-{ts}")
+    bucket, s3_key = upload_code(f"bugbash-basic-{NAME_SUFFIX}")
 
     print(f"Creating basic runtime: {runtime_name}")
     resp = client.create_agent_runtime(

--- a/e2e-tests/fixtures/import/setup_runtime_basic.py
+++ b/e2e-tests/fixtures/import/setup_runtime_basic.py
@@ -7,7 +7,6 @@ import sys
 import os
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-import time
 from common import (
     ensure_role, get_control_client, wait_for_runtime,
     save_resource, print_import_command, upload_code,

--- a/src/cli/commands/import/import-evaluator.ts
+++ b/src/cli/commands/import/import-evaluator.ts
@@ -10,6 +10,7 @@ import { ANSI } from './constants';
 import { failResult, parseAndValidateArn } from './import-utils';
 import { executeResourceImport } from './resource-import';
 import type { ImportResourceOptions, ImportResourceResult, ResourceImportDescriptor } from './types';
+import { ResourceNotFoundException } from '@aws-sdk/client-bedrock-agentcore-control';
 import type { Command } from '@commander-js/extra-typings';
 
 /**
@@ -92,11 +93,18 @@ const evaluatorDescriptor: ResourceImportDescriptor<GetEvaluatorResult, Evaluato
 
     const oecSummaries = await listAllOnlineEvaluationConfigs({ region: target.region });
     if (oecSummaries.length > 0) {
-      const oecDetails = await Promise.all(
-        oecSummaries.map(s =>
-          getOnlineEvaluationConfig({ region: target.region, configId: s.onlineEvaluationConfigId })
+      // Configs can be deleted between list and get (TOCTOU race).
+      // Skip ResourceNotFoundException — a deleted config can't be locking our evaluator.
+      const oecDetails = (
+        await Promise.all(
+          oecSummaries.map(s =>
+            getOnlineEvaluationConfig({ region: target.region, configId: s.onlineEvaluationConfigId }).catch(err => {
+              if (err instanceof ResourceNotFoundException) return null;
+              throw err;
+            })
+          )
         )
-      );
+      ).filter(r => r !== null);
 
       const referencingOec = oecDetails.find(oec => oec.evaluatorIds?.includes(detail.evaluatorId));
 


### PR DESCRIPTION
## Description

Two issues in running the e2e tests in parallel: 

### naming conflict
```
botocore.errorfactory.ConflictException: An error occurred (ConflictException) when calling the CreateAgentRuntime operation: An agent with the specified name already exists. Use a different name and try again.
```

Resource names are using time (in seconds) to suffix, but this creates an issue when they create at the same time. Switch to UUID or millisecond precision in resource name suffix. 

### list then get race condition
```
[error] Online evaluation configuration not found
```

The code performs a check that the given evaluator isn't already in an eval config, because if it is, the import will fail. 
When iterating through all online eval configs in the account, we call list then get, but its possible an eval config is deleted between the list and get. This will cause the promise to reject with a ResourceNotFoundError. Therefore we can ignore these errors. 

## Related Issue

Closes #https://github.com/aws/agentcore-cli/issues/1066

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.