### PR TITLE
fix: stop rewriting agentcore.json on deploy and clean up evo resources on teardown

### DIFF
--- a/src/cli/operations/deploy/preflight.ts
+++ b/src/cli/operations/deploy/preflight.ts
@@ -6,7 +6,7 @@ import { CdkToolkitWrapper, createCdkToolkitWrapper, silentIoHost } from '../../
 import { checkBootstrapStatus, checkStacksStatus, formatCdkEnvironment } from '../../cloudformation';
 import { cleanupStaleLockFiles } from '../../tui/utils';
 import type { IIoHost } from '@aws-cdk/toolkit-lib';
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import * as path from 'node:path';
 
 export interface PreflightContext {
@@ -70,24 +70,6 @@ export async function validateProject(): Promise<PreflightContext> {
   cdkProject.validate();
 
   const configIO = new ConfigIO({ baseDir: configRoot });
-
-  // Patch config bundles on disk to include `type: "ConfigurationBundle"` if missing.
-  // The CDK package now requires this discriminator during synthesis validation.
-  const specPath = configIO.getPathResolver().getAgentConfigPath();
-  const rawJson = JSON.parse(readFileSync(specPath, 'utf-8')) as Record<string, unknown>;
-  const rawBundles = rawJson.configBundles;
-  if (Array.isArray(rawBundles) && rawBundles.length > 0) {
-    let patched = false;
-    for (const b of rawBundles as Record<string, unknown>[]) {
-      if (!b.type) {
-        b.type = 'ConfigurationBundle';
-        patched = true;
-      }
-    }
-    if (patched) {
-      writeFileSync(specPath, JSON.stringify(rawJson, null, 2), 'utf-8');
-    }
-  }
 
   const projectSpec = await configIO.readProjectSpec();
   const awsTargets = await configIO.resolveAWSDeploymentTargets();

--- a/src/cli/operations/deploy/teardown.ts
+++ b/src/cli/operations/deploy/teardown.ts
@@ -1,9 +1,11 @@
 import { CONFIG_DIR, ConfigIO } from '../../../lib';
 import type { AwsDeploymentTarget } from '../../../schema';
 import { withTargetRegion } from '../../aws';
+import { deleteConfigurationBundle } from '../../aws/agentcore-config-bundles';
 import { CdkToolkitWrapper, silentIoHost } from '../../cdk/toolkit-lib';
 import { type DiscoveredStack, findStack } from '../../cloudformation/stack-discovery';
-import { deleteHttpGatewayWithTargets } from './post-deploy-http-gateways';
+import { deleteOrphanedABTests } from './post-deploy-ab-tests';
+import { deleteOrphanedHttpGateways } from './post-deploy-http-gateways';
 import { StackSelectionStrategy } from '@aws-cdk/toolkit-lib';
 import { existsSync } from 'fs';
 import { join } from 'path';
@@ -113,11 +115,15 @@ export async function performStackTeardown(targetName: string): Promise<StackTea
   const discovered = await discoverDeployedTargets();
   const deployedTarget = discovered.deployedTargets.find(dt => dt.target.name === targetName);
 
-  // Clean up imperatively-created HTTP gateways before stack destruction
+  // Clean up imperatively-created resources before stack destruction.
+  // Ordering: AB tests first (they create rules on gateways), then gateways, then bundles.
+  // Delegates to the existing orphan-cleanup functions with an empty spec so everything
+  // is treated as orphaned — reuses stop/poll/delete/role-cleanup logic without duplication.
   try {
     const deployedState = await configIO.readDeployedState();
-    const httpGateways = deployedState.targets?.[targetName]?.resources?.httpGateways;
-    if (httpGateways) {
+    const resources = deployedState.targets?.[targetName]?.resources;
+
+    if (resources?.httpGateways || resources?.configBundles || resources?.abTests) {
       let region = deployedTarget?.target.region;
       if (!region) {
         try {
@@ -129,29 +135,49 @@ export async function performStackTeardown(targetName: string): Promise<StackTea
         }
       }
       if (!region) {
-        console.warn(
-          'Warning: Could not determine region for HTTP gateway cleanup — gateways may need manual deletion'
-        );
+        console.warn('Warning: Could not determine region for resource cleanup — resources may need manual deletion');
       }
       if (region) {
-        for (const [gwName, gwState] of Object.entries(httpGateways)) {
-          try {
-            const result = await deleteHttpGatewayWithTargets({
-              region,
-              gatewayId: gwState.gatewayId,
-              gatewayName: gwName,
-              knownTargetId: gwState.targetId,
-              roleArn: gwState.roleArn,
-              roleCreatedByCli: gwState.roleCreatedByCli,
-            });
-            if (result.success) {
-              console.log(`Deleted HTTP gateway "${gwName}"`);
-            } else {
-              console.warn(`Warning: Failed to delete HTTP gateway "${gwName}": ${result.error}`);
+        const projectSpec = await configIO.readProjectSpec();
+        const emptySpec = { ...projectSpec, abTests: [], httpGateways: [] };
+
+        if (resources.abTests) {
+          const abResult = await deleteOrphanedABTests({
+            region,
+            projectSpec: emptySpec,
+            existingABTests: resources.abTests,
+          });
+          for (const r of abResult.results) {
+            if (r.status === 'deleted') {
+              console.log(`Deleted AB test "${r.testName}"`);
+            } else if (r.error) {
+              console.warn(`Warning: Failed to delete AB test "${r.testName}": ${r.error}`);
             }
+          }
+        }
+
+        if (resources.httpGateways) {
+          const gwResult = await deleteOrphanedHttpGateways({
+            region,
+            projectSpec: emptySpec,
+            existingHttpGateways: resources.httpGateways,
+          });
+          for (const r of gwResult.results) {
+            if (r.status === 'deleted') {
+              console.log(`Deleted HTTP gateway "${r.gatewayName}"`);
+            } else if (r.error) {
+              console.warn(`Warning: Failed to delete HTTP gateway "${r.gatewayName}": ${r.error}`);
+            }
+          }
+        }
+
+        for (const [bundleName, bundleState] of Object.entries(resources.configBundles ?? {})) {
+          try {
+            await deleteConfigurationBundle({ region, bundleId: bundleState.bundleId });
+            console.log(`Deleted config bundle "${bundleName}"`);
           } catch (err) {
             console.warn(
-              `Warning: Error during HTTP gateway "${gwName}" cleanup: ${err instanceof Error ? err.message : String(err)}`
+              `Warning: Error during config bundle "${bundleName}" cleanup: ${err instanceof Error ? err.message : String(err)}`
             );
           }
         }
@@ -161,7 +187,7 @@ export async function performStackTeardown(targetName: string): Promise<StackTea
     // Only suppress "file not found" — other errors (corrupt state, permissions) should warn
     const msg = err instanceof Error ? err.message : String(err);
     if (!msg.includes('ENOENT') && !msg.includes('not found') && !msg.includes('does not exist')) {
-      console.warn(`Warning: Could not read deployed state for HTTP gateway cleanup: ${msg}`);
+      console.warn(`Warning: Could not read deployed state for resource cleanup: ${msg}`);
     }
   }
 


### PR DESCRIPTION
## Summary

Two fixes for issues identified during #1068 review:

### 1. Deploy preflight no longer rewrites agentcore.json
`validateProject()` was injecting `type: "ConfigurationBundle"` into config bundle entries and writing the file back to disk on every `agentcore deploy`. This caused surprise git diffs and clobbered file formatting. The type discriminator is now applied in-memory only — the CDK reads the patched object at synth time without touching the user's file.

### 2. Config bundles and AB tests cleaned up on stack teardown
`performStackTeardown` already deleted HTTP gateways before destroying the CFN stack, but config bundles and AB tests were left orphaned in AWS. Now iterates `deployedState.targets[target].resources.configBundles` and `.abTests` and deletes them, matching the existing HTTP gateway pattern.

Closes #1070

## Test plan
- [x] `npm run typecheck` passes
- [x] Pre-commit hooks pass (eslint, prettier, secretlint)
- [ ] Manual: `agentcore deploy` with config bundles does not modify agentcore.json on disk
- [ ] Manual: `agentcore remove all` + `agentcore deploy` cleans up config bundles and AB tests