### PR TITLE
fix: revert .optional() to .default([]) and strip empty evo arrays on write

### DIFF
--- a/src/lib/schemas/io/config-io.ts
+++ b/src/lib/schemas/io/config-io.ts
@@ -110,7 +110,12 @@ export class ConfigIO {
    */
   async writeProjectSpec(data: AgentCoreProjectSpec): Promise<void> {
     const filePath = this.pathResolver.getAgentConfigPath();
-    await this.validateAndWrite(filePath, 'AgentCore Project Config', AgentCoreProjectSpecSchema, data);
+    // TODO: extend this to all resource arrays so empty defaults never pollute agentcore.json
+    const cleaned = { ...data };
+    if (cleaned.configBundles?.length === 0) delete (cleaned as Record<string, unknown>).configBundles;
+    if (cleaned.abTests?.length === 0) delete (cleaned as Record<string, unknown>).abTests;
+    if (cleaned.httpGateways?.length === 0) delete (cleaned as Record<string, unknown>).httpGateways;
+    await this.validateAndWrite(filePath, 'AgentCore Project Config', AgentCoreProjectSpecSchema, cleaned);
   }
 
   /**

--- a/src/schema/schemas/agentcore-project.ts
+++ b/src/schema/schemas/agentcore-project.ts
@@ -325,39 +325,33 @@ export const AgentCoreProjectSpecSchema = z
 
     configBundles: z
       .array(ConfigBundleSchema)
-      .optional()
-      .superRefine((items, ctx) => {
-        if (items) {
-          uniqueBy(
-            (bundle: { name: string }) => bundle.name,
-            (name: string) => `Duplicate config bundle name: ${name}`
-          )(items, ctx);
-        }
-      }),
+      .default([])
+      .superRefine(
+        uniqueBy(
+          bundle => bundle.name,
+          name => `Duplicate config bundle name: ${name}`
+        )
+      ),
 
     abTests: z
       .array(ABTestSchema)
-      .optional()
-      .superRefine((items, ctx) => {
-        if (items) {
-          uniqueBy(
-            (test: { name: string }) => test.name,
-            (name: string) => `Duplicate AB test name: ${name}`
-          )(items, ctx);
-        }
-      }),
+      .default([])
+      .superRefine(
+        uniqueBy(
+          test => test.name,
+          name => `Duplicate AB test name: ${name}`
+        )
+      ),
 
     httpGateways: z
       .array(HttpGatewaySchema)
-      .optional()
-      .superRefine((items, ctx) => {
-        if (items) {
-          uniqueBy(
-            (gw: { name: string }) => gw.name,
-            (name: string) => `Duplicate HTTP gateway name: ${name}`
-          )(items, ctx);
-        }
-      }),
+      .default([])
+      .superRefine(
+        uniqueBy(
+          gw => gw.name,
+          name => `Duplicate HTTP gateway name: ${name}`
+        )
+      ),
   })
   .strict()
   .superRefine((spec, ctx) => {


### PR DESCRIPTION
## Summary

Fixes the JSON Schema generation failure introduced by #1073. The `.optional()` change causes Zod v4's `toJsonSchema()` to throw "Undefined cannot be represented in JSON Schema" during the release workflow.

### Approach
- **Schema**: Revert `configBundles`, `abTests`, `httpGateways` back to `.default([])` so JSON Schema generation and Zod parsing work correctly
- **writeProjectSpec**: Strip empty arrays for these three fields before writing to disk, so preview features don't appear in `agentcore.json` for users who haven't opted in

This gives us both: correct schema generation AND clean user files.

## Test plan
- [x] `npm run typecheck` passes
- [x] Pre-commit hooks pass (eslint, prettier, secretlint)
- [ ] `npm run generate-schema` succeeds (no "Undefined cannot be represented" error)
- [ ] `agentcore create` does not write configBundles/abTests/httpGateways
- [ ] `agentcore add config-bundle` correctly writes configBundles