### PR TITLE
fix: replace z.undefined() with z.never() for JSON Schema compat

### DIFF
--- a/src/cli/operations/deploy/__tests__/post-deploy-config-bundles.test.ts
+++ b/src/cli/operations/deploy/__tests__/post-deploy-config-bundles.test.ts
@@ -537,7 +537,7 @@ describe('resolveConfigBundleComponentKeys', () => {
     });
 
     const result = resolveConfigBundleComponentKeys(spec, deployedState, 'target1');
-    const keys = Object.keys(result.configBundles![0]!.components);
+    const keys = Object.keys(result.configBundles[0]!.components);
     expect(keys).toEqual(['arn:aws:bedrock-agentcore:us-east-1:123:runtime/rt-1']);
   });
 
@@ -550,7 +550,7 @@ describe('resolveConfigBundleComponentKeys', () => {
     });
 
     const result = resolveConfigBundleComponentKeys(spec, deployedState, 'target1');
-    const keys = Object.keys(result.configBundles![0]!.components);
+    const keys = Object.keys(result.configBundles[0]!.components);
     expect(keys).toEqual(['arn:aws:bedrock-agentcore:us-east-1:123:gateway/gw-1']);
   });
 
@@ -563,7 +563,7 @@ describe('resolveConfigBundleComponentKeys', () => {
     });
 
     const result = resolveConfigBundleComponentKeys(spec, deployedState, 'target1');
-    const keys = Object.keys(result.configBundles![0]!.components);
+    const keys = Object.keys(result.configBundles[0]!.components);
     expect(keys).toEqual(['arn:mcp:gw:resolved']);
   });
 
@@ -574,7 +574,7 @@ describe('resolveConfigBundleComponentKeys', () => {
     const deployedState = makeDeployedState('target1', { runtimes: {} });
 
     const result = resolveConfigBundleComponentKeys(spec, deployedState, 'target1');
-    const keys = Object.keys(result.configBundles![0]!.components);
+    const keys = Object.keys(result.configBundles[0]!.components);
     expect(keys).toEqual(['arn:existing:key']);
   });
 
@@ -585,7 +585,7 @@ describe('resolveConfigBundleComponentKeys', () => {
     const deployedState = makeDeployedState('target1', { runtimes: {} });
 
     const result = resolveConfigBundleComponentKeys(spec, deployedState, 'target1');
-    const keys = Object.keys(result.configBundles![0]!.components);
+    const keys = Object.keys(result.configBundles[0]!.components);
     expect(keys).toEqual(['some-plain-key']);
   });
 
@@ -629,9 +629,9 @@ describe('resolveConfigBundleComponentKeys', () => {
 
     const result = resolveConfigBundleComponentKeys(spec, deployedState, 'target1');
     // Original should still have the placeholder
-    expect(Object.keys(spec.configBundles![0]!.components)).toEqual(['{{runtime:my-rt}}']);
+    expect(Object.keys(spec.configBundles[0]!.components)).toEqual(['{{runtime:my-rt}}']);
     // Result should have the resolved key
-    expect(Object.keys(result.configBundles![0]!.components)).toEqual(['arn:resolved']);
+    expect(Object.keys(result.configBundles[0]!.components)).toEqual(['arn:resolved']);
   });
 
   it('prefers HTTP gateway over MCP gateway when both exist with same name', () => {
@@ -644,7 +644,7 @@ describe('resolveConfigBundleComponentKeys', () => {
     });
 
     const result = resolveConfigBundleComponentKeys(spec, deployedState, 'target1');
-    const keys = Object.keys(result.configBundles![0]!.components);
+    const keys = Object.keys(result.configBundles[0]!.components);
     // HTTP gateway should take precedence (checked first in code)
     expect(keys).toEqual(['arn:http:gw']);
   });

--- a/src/cli/primitives/ABTestPrimitive.ts
+++ b/src/cli/primitives/ABTestPrimitive.ts
@@ -78,8 +78,8 @@ export class ABTestPrimitive extends BasePrimitive<AddABTestOptions, RemovableAB
         return { success: false, error: `AB test "${testName}" not found.` };
       }
 
-      const removedTest = project.abTests![index]!;
-      project.abTests!.splice(index, 1);
+      const removedTest = project.abTests[index]!;
+      project.abTests.splice(index, 1);
 
       // Cascade: remove auto-created online eval configs for target-based tests
       // Only remove eval configs that were auto-created (matching the {testName}_eval_ prefix pattern)

--- a/src/cli/primitives/ConfigBundlePrimitive.ts
+++ b/src/cli/primitives/ConfigBundlePrimitive.ts
@@ -50,7 +50,7 @@ export class ConfigBundlePrimitive extends BasePrimitive<AddConfigBundleOptions,
         return { success: false, error: `Configuration bundle "${bundleName}" not found.` };
       }
 
-      project.configBundles!.splice(index, 1);
+      project.configBundles.splice(index, 1);
       await this.writeProjectSpec(project);
 
       return { success: true };

--- a/src/schema/schemas/primitives/ab-test.ts
+++ b/src/schema/schemas/primitives/ab-test.ts
@@ -45,11 +45,11 @@ export type TargetRef = z.infer<typeof TargetRefSchema>;
 
 const ConfigBundleVariantConfigSchema = z.object({
   configurationBundle: ConfigurationBundleRefSchema,
-  target: z.undefined().optional(),
+  target: z.never().optional(),
 });
 
 const TargetVariantConfigSchema = z.object({
-  configurationBundle: z.undefined().optional(),
+  configurationBundle: z.never().optional(),
   target: TargetRefSchema,
 });
 


### PR DESCRIPTION
## Summary

Fixes Zod JSON Schema generation failure: `z.undefined()` cannot be represented in JSON Schema.

The AB test variant XOR union used `z.undefined().optional()` to exclude the alternate field. Replace with `z.never().optional()` which Zod can serialize.

## Test plan
- [x] `npm run build` passes
- [x] `node scripts/generate-schema.mjs` succeeds