### PR TITLE
fix: address formatting failure in docs

### DIFF
--- a/docs/frameworks.md
+++ b/docs/frameworks.md
@@ -162,8 +162,8 @@ agentcore add agent \
 
 Not all frameworks support all protocol modes. MCP protocol is a standalone tool server with no framework.
 
-| Protocol | Supported Frameworks                                          |
-| -------- | ------------------------------------------------------------- |
+| Protocol | Supported Frameworks                                  |
+| -------- | ----------------------------------------------------- |
 | **HTTP** | Strands, LangChain_LangGraph, GoogleADK, OpenAIAgents |
-| **MCP**  | None (standalone tool server)                                 |
-| **A2A**  | Strands, GoogleADK, LangChain_LangGraph                       |
+| **MCP**  | None (standalone tool server)                         |
+| **A2A**  | Strands, GoogleADK, LangChain_LangGraph               |


### PR DESCRIPTION
## Description

Failing CI Job: https://github.com/aws/agentcore-cli/actions/runs/25219128431/job/73946771605

## Related Issue

N/A — minor formatting fix.

## Documentation PR

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.