### PR TITLE
feat: replace credentialProviderName with outboundAuth for harness gateway tools

### DIFF
--- a/src/cli/commands/add/tool-action.ts
+++ b/src/cli/commands/add/tool-action.ts
@@ -68,10 +68,14 @@ export async function handleAddTool(options: AddToolOptions): Promise<AddToolRes
         error: `Invalid --outbound-auth '${options.outboundAuth}'. Valid: ${VALID_OUTBOUND_AUTH_TYPES.join(', ')}`,
       };
     }
-    if (options.outboundAuth === 'awsIam') {
-      outboundAuth = { awsIam: {} };
-    } else if (options.outboundAuth === 'none') {
-      outboundAuth = { none: {} };
+    if (options.outboundAuth === 'awsIam' || options.outboundAuth === 'none') {
+      if (options.providerArn || options.scopes || options.grantType) {
+        return {
+          success: false,
+          error: '--provider-arn, --scopes, and --grant-type are only valid with --outbound-auth oauth',
+        };
+      }
+      outboundAuth = options.outboundAuth === 'awsIam' ? { awsIam: {} } : { none: {} };
     } else {
       if (!options.providerArn) {
         return { success: false, error: '--provider-arn is required when --outbound-auth oauth' };

--- a/src/cli/commands/add/tool-action.ts
+++ b/src/cli/commands/add/tool-action.ts
@@ -1,5 +1,5 @@
 import { ConfigIO } from '../../../lib';
-import type { HarnessSpec } from '../../../schema';
+import type { HarnessGatewayOutboundAuth, HarnessSpec } from '../../../schema';
 import type { HarnessToolType } from '../../../schema/schemas/primitives/harness';
 
 export interface AddToolOptions {
@@ -11,8 +11,16 @@ export interface AddToolOptions {
   codeInterpreterArn?: string;
   gatewayArn?: string;
   gateway?: string;
+  outboundAuth?: string;
+  providerArn?: string;
+  scopes?: string;
+  grantType?: string;
   json?: boolean;
 }
+
+const VALID_OUTBOUND_AUTH_TYPES = ['awsIam', 'none', 'oauth'] as const;
+const VALID_GRANT_TYPES = ['CLIENT_CREDENTIALS', 'USER_FEDERATION'] as const;
+const ARN_PATTERN = /^arn:[^:]+:/;
 
 export interface AddToolResult {
   success: boolean;
@@ -47,6 +55,57 @@ export async function handleAddTool(options: AddToolOptions): Promise<AddToolRes
 
   if (toolType === 'agentcore_gateway' && !options.gatewayArn && !options.gateway) {
     return { success: false, error: '--gateway-arn or --gateway is required for agentcore_gateway tools' };
+  }
+
+  let outboundAuth: HarnessGatewayOutboundAuth | undefined;
+  if (options.outboundAuth !== undefined) {
+    if (toolType !== 'agentcore_gateway') {
+      return { success: false, error: '--outbound-auth is only valid for agentcore_gateway tools' };
+    }
+    if (!VALID_OUTBOUND_AUTH_TYPES.includes(options.outboundAuth as (typeof VALID_OUTBOUND_AUTH_TYPES)[number])) {
+      return {
+        success: false,
+        error: `Invalid --outbound-auth '${options.outboundAuth}'. Valid: ${VALID_OUTBOUND_AUTH_TYPES.join(', ')}`,
+      };
+    }
+    if (options.outboundAuth === 'awsIam') {
+      outboundAuth = { awsIam: {} };
+    } else if (options.outboundAuth === 'none') {
+      outboundAuth = { none: {} };
+    } else {
+      if (!options.providerArn) {
+        return { success: false, error: '--provider-arn is required when --outbound-auth oauth' };
+      }
+      if (!ARN_PATTERN.test(options.providerArn)) {
+        return { success: false, error: `Invalid --provider-arn '${options.providerArn}': must be a valid ARN` };
+      }
+      if (!options.scopes) {
+        return { success: false, error: '--scopes is required when --outbound-auth oauth' };
+      }
+      const scopes = options.scopes
+        .split(',')
+        .map(s => s.trim())
+        .filter(Boolean);
+      if (scopes.length === 0) {
+        return { success: false, error: '--scopes must contain at least one scope' };
+      }
+      if (
+        options.grantType !== undefined &&
+        !VALID_GRANT_TYPES.includes(options.grantType as (typeof VALID_GRANT_TYPES)[number])
+      ) {
+        return {
+          success: false,
+          error: `Invalid --grant-type '${options.grantType}'. Valid: ${VALID_GRANT_TYPES.join(', ')}`,
+        };
+      }
+      outboundAuth = {
+        oauth: {
+          providerArn: options.providerArn,
+          scopes,
+          ...(options.grantType && { grantType: options.grantType as (typeof VALID_GRANT_TYPES)[number] }),
+        },
+      };
+    }
   }
 
   const configIO = new ConfigIO();
@@ -98,7 +157,12 @@ export async function handleAddTool(options: AddToolOptions): Promise<AddToolRes
   } else if (toolType === 'agentcore_code_interpreter' && options.codeInterpreterArn) {
     toolEntry.config = { agentCoreCodeInterpreter: { codeInterpreterArn: options.codeInterpreterArn } };
   } else if (toolType === 'agentcore_gateway') {
-    toolEntry.config = { agentCoreGateway: { gatewayArn: resolvedGatewayArn! } };
+    toolEntry.config = {
+      agentCoreGateway: {
+        gatewayArn: resolvedGatewayArn!,
+        ...(outboundAuth && { outboundAuth }),
+      },
+    };
   }
 
   harnessSpec.tools.push(toolEntry);

--- a/src/cli/commands/add/tool-command.ts
+++ b/src/cli/commands/add/tool-command.ts
@@ -18,9 +18,15 @@ export function registerAddTool(addCmd: Command): void {
     .option('--code-interpreter-arn <arn>', 'Custom code interpreter ARN (optional for agentcore_code_interpreter)')
     .option('--gateway-arn <arn>', 'Gateway ARN (for agentcore_gateway)')
     .option('--gateway <name>', 'Project gateway name — resolves ARN from deployed state (for agentcore_gateway)')
-    .option('--outbound-auth <type>', 'Gateway outbound auth type: awsIam, none, or oauth (for agentcore_gateway)')
+    .option(
+      '--outbound-auth <type>',
+      'Gateway outbound auth: awsIam, none, or oauth (default: awsIam if omitted) [agentcore_gateway]'
+    )
     .option('--provider-arn <arn>', 'OAuth credential provider ARN (required when --outbound-auth oauth)')
-    .option('--scopes <scopes>', 'Comma-separated OAuth scopes (required when --outbound-auth oauth)')
+    .option(
+      '--scopes <scopes>',
+      'Comma-separated OAuth scopes (required when --outbound-auth oauth), e.g. "openid,profile" or "https://api.example.com/read"'
+    )
     .option(
       '--grant-type <type>',
       'OAuth grant type: CLIENT_CREDENTIALS or USER_FEDERATION (for --outbound-auth oauth)'

--- a/src/cli/commands/add/tool-command.ts
+++ b/src/cli/commands/add/tool-command.ts
@@ -18,6 +18,13 @@ export function registerAddTool(addCmd: Command): void {
     .option('--code-interpreter-arn <arn>', 'Custom code interpreter ARN (optional for agentcore_code_interpreter)')
     .option('--gateway-arn <arn>', 'Gateway ARN (for agentcore_gateway)')
     .option('--gateway <name>', 'Project gateway name — resolves ARN from deployed state (for agentcore_gateway)')
+    .option('--outbound-auth <type>', 'Gateway outbound auth type: awsIam, none, or oauth (for agentcore_gateway)')
+    .option('--provider-arn <arn>', 'OAuth credential provider ARN (required when --outbound-auth oauth)')
+    .option('--scopes <scopes>', 'Comma-separated OAuth scopes (required when --outbound-auth oauth)')
+    .option(
+      '--grant-type <type>',
+      'OAuth grant type: CLIENT_CREDENTIALS or USER_FEDERATION (for --outbound-auth oauth)'
+    )
     .option('--json', 'Output as JSON')
     .action(async cliOptions => {
       if (!findConfigRoot()) {
@@ -35,6 +42,10 @@ export function registerAddTool(addCmd: Command): void {
           codeInterpreterArn: cliOptions.codeInterpreterArn,
           gatewayArn: cliOptions.gatewayArn,
           gateway: cliOptions.gateway,
+          outboundAuth: cliOptions.outboundAuth,
+          providerArn: cliOptions.providerArn,
+          scopes: cliOptions.scopes,
+          grantType: cliOptions.grantType,
           json: cliOptions.json,
         });
 

--- a/src/cli/operations/deploy/imperative/deployers/__tests__/harness-mapper.test.ts
+++ b/src/cli/operations/deploy/imperative/deployers/__tests__/harness-mapper.test.ts
@@ -199,6 +199,146 @@ describe('mapHarnessSpecToCreateOptions', () => {
 
       expect(result.tools).toBeUndefined();
     });
+
+    it('passes gateway tool with outboundAuth awsIam through the mapper', async () => {
+      const spec = minimalSpec({
+        tools: [
+          {
+            type: 'agentcore_gateway',
+            name: 'my_gw',
+            config: {
+              agentCoreGateway: {
+                gatewayArn: 'arn:aws:bedrock-agentcore:us-west-2:123:gateway/abc',
+                outboundAuth: { awsIam: {} },
+              },
+            },
+          },
+        ],
+      });
+
+      const result = await mapHarnessSpecToCreateOptions({ ...BASE_OPTIONS, harnessSpec: spec });
+
+      expect(result.tools).toEqual([
+        {
+          type: 'agentcore_gateway',
+          name: 'my_gw',
+          config: {
+            agentCoreGateway: {
+              gatewayArn: 'arn:aws:bedrock-agentcore:us-west-2:123:gateway/abc',
+              outboundAuth: { awsIam: {} },
+            },
+          },
+        },
+      ]);
+    });
+
+    it('passes gateway tool with outboundAuth none through the mapper', async () => {
+      const spec = minimalSpec({
+        tools: [
+          {
+            type: 'agentcore_gateway',
+            name: 'my_gw',
+            config: {
+              agentCoreGateway: {
+                gatewayArn: 'arn:aws:bedrock-agentcore:us-west-2:123:gateway/abc',
+                outboundAuth: { none: {} },
+              },
+            },
+          },
+        ],
+      });
+
+      const result = await mapHarnessSpecToCreateOptions({ ...BASE_OPTIONS, harnessSpec: spec });
+
+      expect(result.tools).toEqual([
+        {
+          type: 'agentcore_gateway',
+          name: 'my_gw',
+          config: {
+            agentCoreGateway: {
+              gatewayArn: 'arn:aws:bedrock-agentcore:us-west-2:123:gateway/abc',
+              outboundAuth: { none: {} },
+            },
+          },
+        },
+      ]);
+    });
+
+    it('passes gateway tool with outboundAuth oauth through the mapper', async () => {
+      const spec = minimalSpec({
+        tools: [
+          {
+            type: 'agentcore_gateway',
+            name: 'my_gw',
+            config: {
+              agentCoreGateway: {
+                gatewayArn: 'arn:aws:bedrock-agentcore:us-west-2:123:gateway/abc',
+                outboundAuth: {
+                  oauth: {
+                    providerArn:
+                      'arn:aws:bedrock-agentcore:us-west-2:123:token-vault/default/oauth2credentialprovider/my-provider',
+                    scopes: ['read', 'write'],
+                    grantType: 'CLIENT_CREDENTIALS',
+                  },
+                },
+              },
+            },
+          },
+        ],
+      });
+
+      const result = await mapHarnessSpecToCreateOptions({ ...BASE_OPTIONS, harnessSpec: spec });
+
+      expect(result.tools).toEqual([
+        {
+          type: 'agentcore_gateway',
+          name: 'my_gw',
+          config: {
+            agentCoreGateway: {
+              gatewayArn: 'arn:aws:bedrock-agentcore:us-west-2:123:gateway/abc',
+              outboundAuth: {
+                oauth: {
+                  providerArn:
+                    'arn:aws:bedrock-agentcore:us-west-2:123:token-vault/default/oauth2credentialprovider/my-provider',
+                  scopes: ['read', 'write'],
+                  grantType: 'CLIENT_CREDENTIALS',
+                },
+              },
+            },
+          },
+        },
+      ]);
+    });
+
+    it('passes gateway tool without outboundAuth through the mapper', async () => {
+      const spec = minimalSpec({
+        tools: [
+          {
+            type: 'agentcore_gateway',
+            name: 'my_gw',
+            config: {
+              agentCoreGateway: {
+                gatewayArn: 'arn:aws:bedrock-agentcore:us-west-2:123:gateway/abc',
+              },
+            },
+          },
+        ],
+      });
+
+      const result = await mapHarnessSpecToCreateOptions({ ...BASE_OPTIONS, harnessSpec: spec });
+
+      expect(result.tools).toEqual([
+        {
+          type: 'agentcore_gateway',
+          name: 'my_gw',
+          config: {
+            agentCoreGateway: {
+              gatewayArn: 'arn:aws:bedrock-agentcore:us-west-2:123:gateway/abc',
+            },
+          },
+        },
+      ]);
+    });
   });
 
   // ── Skills mapping ─────────────────────────────────────────────────────

--- a/src/cli/primitives/HarnessPrimitive.ts
+++ b/src/cli/primitives/HarnessPrimitive.ts
@@ -1,5 +1,6 @@
 import { APP_DIR, ConfigIO, findConfigRoot } from '../../lib';
 import type {
+  HarnessGatewayOutboundAuth,
   HarnessModelProvider,
   HarnessSpec,
   MemoryStrategy,
@@ -45,6 +46,9 @@ export interface AddHarnessOptions {
   mcpName?: string;
   mcpUrl?: string;
   gatewayArn?: string;
+  gatewayOutboundAuth?: 'awsIam' | 'none' | 'oauth';
+  gatewayProviderArn?: string;
+  gatewayScopes?: string[];
   authorizerType?: RuntimeAuthorizerType;
   jwtConfig?: JwtConfigOptions;
   configBaseDir?: string;
@@ -104,10 +108,33 @@ export class HarnessPrimitive extends BasePrimitive<AddHarnessOptions, Removable
               config: { remoteMcp: { url: options.mcpUrl } },
             });
           } else if (toolType === 'agentcore_gateway' && options.gatewayArn) {
+            let outboundAuth: HarnessGatewayOutboundAuth | undefined;
+            if (options.gatewayOutboundAuth === 'awsIam') {
+              outboundAuth = { awsIam: {} };
+            } else if (options.gatewayOutboundAuth === 'none') {
+              outboundAuth = { none: {} };
+            } else if (
+              options.gatewayOutboundAuth === 'oauth' &&
+              options.gatewayProviderArn &&
+              options.gatewayScopes &&
+              options.gatewayScopes.length > 0
+            ) {
+              outboundAuth = {
+                oauth: {
+                  providerArn: options.gatewayProviderArn,
+                  scopes: options.gatewayScopes,
+                },
+              };
+            }
             tools.push({
               type: 'agentcore_gateway',
               name: 'gateway',
-              config: { agentCoreGateway: { gatewayArn: options.gatewayArn } },
+              config: {
+                agentCoreGateway: {
+                  gatewayArn: options.gatewayArn,
+                  ...(outboundAuth && { outboundAuth }),
+                },
+              },
             });
           }
         }

--- a/src/cli/tui/screens/harness/AddHarnessFlow.tsx
+++ b/src/cli/tui/screens/harness/AddHarnessFlow.tsx
@@ -68,6 +68,14 @@ export function AddHarnessFlow({ isInteractive = true, onExit, onBack, onDev, on
         mcpName: config.mcpName,
         mcpUrl: config.mcpUrl,
         gatewayArn: config.gatewayArn,
+        gatewayOutboundAuth: config.gatewayOutboundAuth,
+        gatewayProviderArn: config.gatewayProviderArn,
+        gatewayScopes: config.gatewayScopes
+          ? config.gatewayScopes
+              .split(',')
+              .map(s => s.trim())
+              .filter(Boolean)
+          : undefined,
         authorizerType: config.authorizerType,
         jwtConfig: config.jwtConfig
           ? {

--- a/src/cli/tui/screens/harness/AddHarnessScreen.tsx
+++ b/src/cli/tui/screens/harness/AddHarnessScreen.tsx
@@ -22,6 +22,7 @@ import {
   ADVANCED_SETTING_OPTIONS,
   AUTHORIZER_TYPE_OPTIONS,
   CONTAINER_MODE_OPTIONS,
+  GATEWAY_OUTBOUND_AUTH_OPTIONS,
   HARNESS_STEP_LABELS,
   MEMORY_OPTIONS,
   MODEL_PROVIDER_OPTIONS,
@@ -86,6 +87,11 @@ export function AddHarnessScreen({ existingHarnessNames, onComplete, onExit }: A
     []
   );
 
+  const gatewayOutboundAuthItems: SelectableItem[] = useMemo(
+    () => GATEWAY_OUTBOUND_AUTH_OPTIONS.map(opt => ({ id: opt.id, title: opt.title, description: opt.description })),
+    []
+  );
+
   const isNameStep = wizard.step === 'name';
   const isModelProviderStep = wizard.step === 'model-provider';
   const isApiKeyArnStep = wizard.step === 'api-key-arn';
@@ -97,6 +103,9 @@ export function AddHarnessScreen({ existingHarnessNames, onComplete, onExit }: A
   const isMcpNameStep = wizard.step === 'mcp-name';
   const isMcpUrlStep = wizard.step === 'mcp-url';
   const isGatewayArnStep = wizard.step === 'gateway-arn';
+  const isGatewayOutboundAuthStep = wizard.step === 'gateway-outbound-auth';
+  const isGatewayProviderArnStep = wizard.step === 'gateway-provider-arn';
+  const isGatewayScopesStep = wizard.step === 'gateway-scopes';
   const isMemoryStep = wizard.step === 'memory';
   const isAuthorizerTypeStep = wizard.step === 'authorizerType';
   const isJwtConfigStep = wizard.step === 'jwtConfig';
@@ -158,6 +167,13 @@ export function AddHarnessScreen({ existingHarnessNames, onComplete, onExit }: A
     isActive: isAuthorizerTypeStep,
   });
 
+  const gatewayOutboundAuthNav = useListNavigation({
+    items: gatewayOutboundAuthItems,
+    onSelect: item => wizard.setGatewayOutboundAuth(item.id as 'awsIam' | 'none' | 'oauth'),
+    onExit: () => wizard.goBack(),
+    isActive: isGatewayOutboundAuthStep,
+  });
+
   const networkModeNav = useListNavigation({
     items: networkModeItems,
     onSelect: item => wizard.setNetworkMode(NetworkModeSchema.parse(item.id)),
@@ -194,7 +210,8 @@ export function AddHarnessScreen({ existingHarnessNames, onComplete, onExit }: A
           isContainerStep ||
           isNetworkModeStep ||
           isTruncationStrategyStep ||
-          isAuthorizerTypeStep
+          isAuthorizerTypeStep ||
+          isGatewayOutboundAuthStep
         ? HELP_TEXT.NAVIGATE_SELECT
         : isConfirmStep
           ? HELP_TEXT.CONFIRM_CANCEL
@@ -255,6 +272,22 @@ export function AddHarnessScreen({ existingHarnessNames, onComplete, onExit }: A
       }
       if (wizard.config.gatewayArn) {
         fields.push({ label: 'Gateway ARN', value: wizard.config.gatewayArn });
+      }
+      if (wizard.config.gatewayOutboundAuth) {
+        fields.push({
+          label: 'Gateway Auth',
+          value:
+            GATEWAY_OUTBOUND_AUTH_OPTIONS.find(o => o.id === wizard.config.gatewayOutboundAuth)?.title ??
+            wizard.config.gatewayOutboundAuth,
+        });
+      }
+      if (wizard.config.gatewayOutboundAuth === 'oauth') {
+        if (wizard.config.gatewayProviderArn) {
+          fields.push({ label: 'Provider ARN', value: wizard.config.gatewayProviderArn });
+        }
+        if (wizard.config.gatewayScopes) {
+          fields.push({ label: 'OAuth Scopes', value: wizard.config.gatewayScopes });
+        }
       }
     }
 
@@ -434,6 +467,39 @@ export function AddHarnessScreen({ existingHarnessNames, onComplete, onExit }: A
             onSubmit={wizard.setGatewayArn}
             onCancel={() => wizard.goBack()}
             customValidation={value => (isValidArn(value) ? true : ARN_VALIDATION_MESSAGE)}
+          />
+        )}
+
+        {isGatewayOutboundAuthStep && (
+          <WizardSelect
+            title="Gateway outbound auth"
+            description="How should the harness authenticate when calling the gateway?"
+            items={gatewayOutboundAuthItems}
+            selectedIndex={gatewayOutboundAuthNav.selectedIndex}
+          />
+        )}
+
+        {isGatewayProviderArnStep && (
+          <TextInput
+            key="gateway-provider-arn"
+            prompt="Credential provider ARN"
+            description="ARN of the AgentCore Identity OAuth2 credential provider"
+            initialValue=""
+            onSubmit={wizard.setGatewayProviderArn}
+            onCancel={() => wizard.goBack()}
+            customValidation={value => (isValidArn(value) ? true : ARN_VALIDATION_MESSAGE)}
+          />
+        )}
+
+        {isGatewayScopesStep && (
+          <TextInput
+            key="gateway-scopes"
+            prompt="OAuth scopes (comma-separated)"
+            description="Scopes requested from the credential provider"
+            initialValue=""
+            onSubmit={wizard.setGatewayScopes}
+            onCancel={() => wizard.goBack()}
+            customValidation={value => (value.trim().length > 0 ? true : 'At least one scope is required')}
           />
         )}
 

--- a/src/cli/tui/screens/harness/types.ts
+++ b/src/cli/tui/screens/harness/types.ts
@@ -168,7 +168,7 @@ export const AUTHORIZER_TYPE_OPTIONS = [
 ] as const;
 
 export const GATEWAY_OUTBOUND_AUTH_OPTIONS = [
-  { id: 'awsIam', title: 'AWS IAM', description: 'SigV4 signing with the harness execution role (default)' },
+  { id: 'awsIam', title: 'AWS IAM (default)', description: 'SigV4 signing with the harness execution role' },
   { id: 'none', title: 'None', description: 'No authentication headers' },
   { id: 'oauth', title: 'OAuth', description: 'Bearer token via AgentCore Identity credential provider' },
 ];

--- a/src/cli/tui/screens/harness/types.ts
+++ b/src/cli/tui/screens/harness/types.ts
@@ -15,6 +15,9 @@ export type AddHarnessStep =
   | 'mcp-name'
   | 'mcp-url'
   | 'gateway-arn'
+  | 'gateway-outbound-auth'
+  | 'gateway-provider-arn'
+  | 'gateway-scopes'
   | 'memory'
   | 'authorizerType'
   | 'jwtConfig'
@@ -55,6 +58,9 @@ export interface AddHarnessConfig {
   mcpName?: string;
   mcpUrl?: string;
   gatewayArn?: string;
+  gatewayOutboundAuth?: 'awsIam' | 'none' | 'oauth';
+  gatewayProviderArn?: string;
+  gatewayScopes?: string;
 }
 
 export const HARNESS_STEP_LABELS: Record<AddHarnessStep, string> = {
@@ -69,6 +75,9 @@ export const HARNESS_STEP_LABELS: Record<AddHarnessStep, string> = {
   'mcp-name': 'MCP name',
   'mcp-url': 'MCP URL',
   'gateway-arn': 'Gateway ARN',
+  'gateway-outbound-auth': 'Gateway auth',
+  'gateway-provider-arn': 'Provider ARN',
+  'gateway-scopes': 'OAuth scopes',
   memory: 'Memory',
   authorizerType: 'Auth type',
   jwtConfig: 'JWT config',
@@ -157,3 +166,9 @@ export const AUTHORIZER_TYPE_OPTIONS = [
   { id: 'AWS_IAM' as const, title: 'AWS IAM', description: 'Use AWS IAM authentication (default)' },
   { id: 'CUSTOM_JWT' as const, title: 'Custom JWT', description: 'Use a custom JWT authorizer (OIDC)' },
 ] as const;
+
+export const GATEWAY_OUTBOUND_AUTH_OPTIONS = [
+  { id: 'awsIam', title: 'AWS IAM', description: 'SigV4 signing with the harness execution role (default)' },
+  { id: 'none', title: 'None', description: 'No authentication headers' },
+  { id: 'oauth', title: 'OAuth', description: 'Bearer token via AgentCore Identity credential provider' },
+];

--- a/src/cli/tui/screens/harness/useAddHarnessWizard.ts
+++ b/src/cli/tui/screens/harness/useAddHarnessWizard.ts
@@ -78,6 +78,10 @@ export function useAddHarnessWizard() {
       }
       if (config.selectedTools?.includes('agentcore_gateway')) {
         steps.push('gateway-arn');
+        steps.push('gateway-outbound-auth');
+        if (config.gatewayOutboundAuth === 'oauth') {
+          steps.push('gateway-provider-arn', 'gateway-scopes');
+        }
       }
     }
 
@@ -120,6 +124,7 @@ export function useAddHarnessWizard() {
     config.authorizerType,
     config.networkMode,
     config.selectedTools,
+    config.gatewayOutboundAuth,
     advancedSettings,
   ]);
 
@@ -238,9 +243,32 @@ export function useAddHarnessWizard() {
     [advancedSettings, config.selectedTools]
   );
 
-  const setGatewayArn = useCallback(
-    (gatewayArn: string) => {
-      setConfig(c => ({ ...c, gatewayArn }));
+  const setGatewayArn = useCallback((gatewayArn: string) => {
+    setConfig(c => ({ ...c, gatewayArn }));
+    setStep('gateway-outbound-auth');
+  }, []);
+
+  const setGatewayOutboundAuth = useCallback(
+    (authType: 'awsIam' | 'none' | 'oauth') => {
+      setConfig(c => ({ ...c, gatewayOutboundAuth: authType }));
+      if (authType === 'oauth') {
+        setStep('gateway-provider-arn');
+      } else {
+        const next = getNextAdvancedStep(advancedSettings, 'tools');
+        setStep(next ?? 'confirm');
+      }
+    },
+    [advancedSettings]
+  );
+
+  const setGatewayProviderArn = useCallback((gatewayProviderArn: string) => {
+    setConfig(c => ({ ...c, gatewayProviderArn }));
+    setStep('gateway-scopes');
+  }, []);
+
+  const setGatewayScopes = useCallback(
+    (gatewayScopes: string) => {
+      setConfig(c => ({ ...c, gatewayScopes }));
       const next = getNextAdvancedStep(advancedSettings, 'tools');
       setStep(next ?? 'confirm');
     },
@@ -405,6 +433,9 @@ export function useAddHarnessWizard() {
     setMcpName,
     setMcpUrl,
     setGatewayArn,
+    setGatewayOutboundAuth,
+    setGatewayProviderArn,
+    setGatewayScopes,
     setMemoryEnabled,
     setAuthorizerType,
     setJwtConfig,

--- a/src/schema/schemas/agentcore-project.ts
+++ b/src/schema/schemas/agentcore-project.ts
@@ -44,8 +44,10 @@ export type {
   RatingScale,
 } from './primitives/evaluator';
 export { BedrockModelIdSchema, isValidBedrockModelId, EvaluatorNameSchema } from './primitives/evaluator';
-export type { HarnessSpec, HarnessModelProvider } from './primitives/harness';
+export type { HarnessGatewayOutboundAuth, HarnessSpec, HarnessModelProvider } from './primitives/harness';
 export {
+  GatewayOAuthGrantTypeSchema,
+  HarnessGatewayOutboundAuthSchema,
   HarnessNameSchema,
   HarnessSpecSchema,
   HarnessToolTypeSchema,

--- a/src/schema/schemas/primitives/__tests__/harness.test.ts
+++ b/src/schema/schemas/primitives/__tests__/harness.test.ts
@@ -112,7 +112,83 @@ describe('HarnessToolSchema', () => {
     expect(result.success).toBe(true);
   });
 
-  it('accepts gateway tool with credentialProviderName', () => {
+  it('accepts gateway tool with outboundAuth awsIam', () => {
+    const result = HarnessToolSchema.safeParse({
+      type: 'agentcore_gateway',
+      name: 'my-gw',
+      config: {
+        agentCoreGateway: {
+          gatewayArn: 'arn:aws:bedrock-agentcore:us-west-2:123:gateway/abc',
+          outboundAuth: { awsIam: {} },
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts gateway tool with outboundAuth none', () => {
+    const result = HarnessToolSchema.safeParse({
+      type: 'agentcore_gateway',
+      name: 'my-gw',
+      config: {
+        agentCoreGateway: {
+          gatewayArn: 'arn:aws:bedrock-agentcore:us-west-2:123:gateway/abc',
+          outboundAuth: { none: {} },
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts gateway tool with outboundAuth oauth', () => {
+    const result = HarnessToolSchema.safeParse({
+      type: 'agentcore_gateway',
+      name: 'my-gw',
+      config: {
+        agentCoreGateway: {
+          gatewayArn: 'arn:aws:bedrock-agentcore:us-west-2:123:gateway/abc',
+          outboundAuth: {
+            oauth: {
+              providerArn:
+                'arn:aws:bedrock-agentcore:us-west-2:123:token-vault/default/oauth2credentialprovider/my-provider',
+              scopes: ['read', 'write'],
+              grantType: 'CLIENT_CREDENTIALS',
+            },
+          },
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts gateway tool without outboundAuth (defaults to SigV4)', () => {
+    const result = HarnessToolSchema.safeParse({
+      type: 'agentcore_gateway',
+      name: 'my-gw',
+      config: {
+        agentCoreGateway: {
+          gatewayArn: 'arn:aws:bedrock-agentcore:us-west-2:123:gateway/abc',
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects gateway tool with invalid outboundAuth variant', () => {
+    const result = HarnessToolSchema.safeParse({
+      type: 'agentcore_gateway',
+      name: 'my-gw',
+      config: {
+        agentCoreGateway: {
+          gatewayArn: 'arn:aws:bedrock-agentcore:us-west-2:123:gateway/abc',
+          outboundAuth: { unknownAuth: {} },
+        },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects gateway tool with credentialProviderName and shows migration message', () => {
     const result = HarnessToolSchema.safeParse({
       type: 'agentcore_gateway',
       name: 'my-gw',
@@ -123,7 +199,10 @@ describe('HarnessToolSchema', () => {
         },
       },
     });
-    expect(result.success).toBe(true);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some(i => i.message.includes('no longer supported'))).toBe(true);
+    }
   });
 
   it('accepts inline function tool', () => {

--- a/src/schema/schemas/primitives/harness.ts
+++ b/src/schema/schemas/primitives/harness.ts
@@ -89,11 +89,40 @@ export const AgentCoreCodeInterpreterConfigSchema = z.object({
   }),
 });
 
-export const AgentCoreGatewayConfigSchema = z.object({
-  agentCoreGateway: z.object({
-    gatewayArn: z.string().min(1),
-    credentialProviderName: z.string().optional(),
+export const GatewayOAuthGrantTypeSchema = z.enum(['CLIENT_CREDENTIALS', 'USER_FEDERATION']);
+
+export const HarnessGatewayOutboundAuthSchema = z.union([
+  z.object({ awsIam: z.object({}) }),
+  z.object({ none: z.object({}) }),
+  z.object({
+    oauth: z.object({
+      providerArn: z.string().min(1),
+      scopes: z.array(z.string().min(1)),
+      grantType: GatewayOAuthGrantTypeSchema.optional(),
+      customParameters: z.record(z.string(), z.string()).optional(),
+    }),
   }),
+]);
+
+export type HarnessGatewayOutboundAuth = z.infer<typeof HarnessGatewayOutboundAuthSchema>;
+
+export const AgentCoreGatewayConfigSchema = z.object({
+  agentCoreGateway: z
+    .object({
+      gatewayArn: z.string().min(1),
+      outboundAuth: HarnessGatewayOutboundAuthSchema.optional(),
+    })
+    .passthrough()
+    .superRefine((data, ctx) => {
+      if ('credentialProviderName' in data) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            'credentialProviderName is no longer supported. Use outboundAuth instead. Example: outboundAuth: { awsIam: {} } or outboundAuth: { oauth: { providerArn: "...", scopes: [...] } }',
+          path: ['credentialProviderName'],
+        });
+      }
+    }),
 });
 
 export const InlineFunctionConfigSchema = z.object({

--- a/src/schema/schemas/primitives/index.ts
+++ b/src/schema/schemas/primitives/index.ts
@@ -46,6 +46,7 @@ export {
 } from './policy';
 
 export type {
+  HarnessGatewayOutboundAuth,
   HarnessMemoryRef,
   HarnessModel,
   HarnessModelProvider,
@@ -56,6 +57,8 @@ export type {
 } from './harness';
 export {
   AllowedToolSchema,
+  GatewayOAuthGrantTypeSchema,
+  HarnessGatewayOutboundAuthSchema,
   HarnessMemoryRefSchema,
   HarnessModelProviderSchema,
   HarnessModelSchema,


### PR DESCRIPTION
## Summary

- Replace the incorrect `credentialProviderName` field on harness gateway tool config with the correct `outboundAuth` union to match the harness service model (Loopy)
- The service expects `outboundAuth` with three variants: `awsIam` (SigV4), `none`, and `oauth` (Bearer token via AgentCore Identity)
- Add CLI flags (`--outbound-auth`, `--provider-arn`, `--scopes`, `--grant-type`) to `agentcore add tool`
- Add outbound auth type selection to the TUI harness wizard (3 new steps)
- Add `superRefine` to reject legacy `credentialProviderName` with a helpful migration message
- Fix DX: default indication in help text, scopes format example, TUI default label

## Context

A customer reported that configuring a harness gateway tool to authenticate to a CUSTOM_JWT gateway via OAuth always fell back to SigV4, resulting in 401s. Investigation revealed the CLI schema had `credentialProviderName` (modeled after agent code gen) instead of `outboundAuth` (the actual service model). See `bugbash/harness-gateway-auth-analysis.md` for the full analysis.

## Changes

| File | Change |
|---|---|
| `src/schema/schemas/primitives/harness.ts` | Replace `credentialProviderName` with `outboundAuth` union schema + superRefine migration message |
| `src/schema/schemas/primitives/index.ts` | Export new types |
| `src/schema/schemas/agentcore-project.ts` | Re-export for consumer access |
| `src/cli/commands/add/tool-command.ts` | Add `--outbound-auth`, `--provider-arn`, `--scopes`, `--grant-type` flags with DX improvements |
| `src/cli/commands/add/tool-action.ts` | Validation + outboundAuth construction from flags |
| `src/cli/primitives/HarnessPrimitive.ts` | Build outboundAuth in gateway tool construction |
| `src/cli/tui/screens/harness/types.ts` | New wizard steps, config fields, options with default label |
| `src/cli/tui/screens/harness/useAddHarnessWizard.ts` | Auth step routing + new setters |
| `src/cli/tui/screens/harness/AddHarnessScreen.tsx` | Auth type select, provider ARN + scopes inputs |
| `src/cli/tui/screens/harness/AddHarnessFlow.tsx` | Pass auth config to primitive |
| `src/schema/schemas/primitives/__tests__/harness.test.ts` | 6 new outboundAuth tests |
| `src/cli/operations/deploy/imperative/deployers/__tests__/harness-mapper.test.ts` | 4 mapper round-trip tests |

## Test plan

- [x] Schema tests: all 3 outboundAuth variants accepted, invalid rejected, credentialProviderName rejected with migration message (6 tests)
- [x] Mapper tests: round-trip for awsIam/none/oauth/omitted (4 tests)
- [x] CLI happy paths: add tool with each auth type, verify harness.json output (5 cases)
- [x] CLI error cases: invalid auth type, missing oauth fields, invalid ARN, flag conflicts (9 cases)
- [x] TUI wizard: full interactive OAuth flow via TUI harness MCP
- [x] E2E: CreateHarness API accepts outboundAuth config, runtime differentiates auth types
- [x] Full test suite: 4081 passed, 8 failed (all pre-existing)
- [x] `agentcore validate` surfaces credentialProviderName migration message