### PR TITLE
fix: set iamRoleFallback to true for lambda gateway targets

### DIFF
--- a/docs/frameworks.md
+++ b/docs/frameworks.md
@@ -162,8 +162,8 @@ agentcore add agent \
 
 Not all frameworks support all protocol modes. MCP protocol is a standalone tool server with no framework.
 
-| Protocol | Supported Frameworks                                          |
-| -------- | ------------------------------------------------------------- |
+| Protocol | Supported Frameworks                                  |
+| -------- | ----------------------------------------------------- |
 | **HTTP** | Strands, LangChain_LangGraph, GoogleADK, OpenAIAgents |
-| **MCP**  | None (standalone tool server)                                 |
-| **A2A**  | Strands, GoogleADK, LangChain_LangGraph                       |
+| **MCP**  | None (standalone tool server)                         |
+| **A2A**  | Strands, GoogleADK, LangChain_LangGraph               |

--- a/src/schema/schemas/mcp.ts
+++ b/src/schema/schemas/mcp.ts
@@ -58,7 +58,7 @@ export const TARGET_TYPE_AUTH_CONFIG: Record<
   smithyModel: { authRequired: false, validAuthTypes: [], iamRoleFallback: true },
   apiGateway: { authRequired: false, validAuthTypes: ['API_KEY', 'NONE'], iamRoleFallback: true },
   mcpServer: { authRequired: false, validAuthTypes: ['OAUTH', 'NONE'], iamRoleFallback: false },
-  lambda: { authRequired: false, validAuthTypes: ['OAUTH', 'NONE'], iamRoleFallback: false },
+  lambda: { authRequired: false, validAuthTypes: ['OAUTH', 'NONE'], iamRoleFallback: true },
   lambdaFunctionArn: { authRequired: false, validAuthTypes: ['OAUTH', 'NONE'], iamRoleFallback: true },
 };
 


### PR DESCRIPTION
## Summary

- Syncs `TARGET_TYPE_AUTH_CONFIG` with `@aws/agentcore-cdk` — sets `iamRoleFallback: true` for the `lambda` target type, matching `lambdaFunctionArn`.
- Without this, the CLI's auth config would disagree with the CDK constructs on whether lambda targets use IAM role fallback.

Closes #1005

Companion CDK PR: https://github.com/aws/agentcore-l3-cdk-constructs/pull/197

## Test plan

- [x] Existing tests pass — schema change only affects CDK synthesis behavior (handled by CDK PR)
- [ ] Merge CDK PR first, then this one