### PR TITLE
docs: add harness permissions to IAM policy and permissions guide

### DIFF
--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -342,14 +342,15 @@ Required for all deployment operations (`deploy`, `status`, `diff`).
 Harnesses are deployed imperatively (direct API calls, not through CloudFormation), so harness CRUD permissions must be
 on the developer's IAM principal, not just the CFN execution role.
 
-| Action                            | CLI Commands                 | Purpose                                       |
-| --------------------------------- | ---------------------------- | --------------------------------------------- |
-| `bedrock-agentcore:CreateHarness` | `deploy`                     | Create a new harness                          |
-| `bedrock-agentcore:GetHarness`    | `deploy`, `status`, `invoke` | Get harness details and deployment state      |
-| `bedrock-agentcore:UpdateHarness` | `deploy`                     | Update an existing harness configuration      |
-| `bedrock-agentcore:DeleteHarness` | `deploy`                     | Delete a harness (during removal or teardown) |
-| `bedrock-agentcore:ListHarnesses` | `status`                     | List harnesses in the account                 |
-| `bedrock-agentcore:InvokeHarness` | `invoke`                     | Invoke a deployed harness (streaming)         |
+| Action                            | CLI Commands                 | Purpose                                                                                                                                       |
+| --------------------------------- | ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bedrock-agentcore:CreateHarness` | `deploy`                     | Create a new harness                                                                                                                          |
+| `bedrock-agentcore:GetHarness`    | `deploy`, `status`, `invoke` | Get harness details and deployment state                                                                                                      |
+| `bedrock-agentcore:UpdateHarness` | `deploy`                     | Update an existing harness configuration                                                                                                      |
+| `bedrock-agentcore:DeleteHarness` | `deploy`                     | Delete a harness (during removal or teardown)                                                                                                 |
+| `bedrock-agentcore:ListHarnesses` | `status`                     | List harnesses in the account                                                                                                                 |
+| `bedrock-agentcore:InvokeHarness` | `invoke`                     | Invoke a deployed harness (streaming)                                                                                                         |
+| `iam:PassRole`                    | `deploy`                     | Pass the CDK-created execution role to the CreateHarness/UpdateHarness API. Scope with `iam:PassedToService: bedrock-agentcore.amazonaws.com` |
 
 ### Identity and credential management
 

--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -39,6 +39,7 @@ Attach this to every IAM user or role that will run AgentCore CLI commands. The 
 - `sts:GetCallerIdentity`, `cloudformation:DescribeStacks`, `tag:GetResources` for basic operations
 - `bedrock-agentcore:Invoke*`, `bedrock-agentcore:Get*`, `bedrock-agentcore:List*` for invoking agents and checking
   status
+- Harness CRUD and invoke actions for `deploy`, `invoke`, and `status` when the project uses harnesses
 - Credential provider and token vault actions for `deploy` when the project uses identity features
 - CloudWatch Logs, X-Ray, and Application Signals actions for `logs`, `traces`, and observability setup
 - Bedrock actions for agent import and AI-assisted code generation (optional, see
@@ -164,6 +165,7 @@ safely removed:
 
 | If your team does not use...    | Remove from user policy                                              | Remove from CFN execution policy                                                                       |
 | ------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Harnesses                       | `HarnessManagement`                                                  | _(no change)_                                                                                          |
 | Container builds (CodeZip only) | _(no change)_                                                        | `EcrContainerBuilds`, `CodeBuildContainerBuilds`                                                       |
 | MCP Lambda compute              | _(no change)_                                                        | `LambdaMcpAndCustomResources` (keep if using container builds, which need Lambda for custom resources) |
 | Agent import from Bedrock       | `BedrockAgentImport`                                                 | _(no change)_                                                                                          |
@@ -335,6 +337,20 @@ Required for all deployment operations (`deploy`, `status`, `diff`).
 | `bedrock-agentcore:Evaluate`                     | `run evals`                               | Run on-demand evaluation against agent traces |
 | `bedrock-agentcore:UpdateOnlineEvaluationConfig` | `pause online-eval`, `resume online-eval` | Pause or resume online evaluation             |
 
+### Harness management
+
+Harnesses are deployed imperatively (direct API calls, not through CloudFormation), so harness CRUD permissions must be
+on the developer's IAM principal, not just the CFN execution role.
+
+| Action                            | CLI Commands                 | Purpose                                       |
+| --------------------------------- | ---------------------------- | --------------------------------------------- |
+| `bedrock-agentcore:CreateHarness` | `deploy`                     | Create a new harness                          |
+| `bedrock-agentcore:GetHarness`    | `deploy`, `status`, `invoke` | Get harness details and deployment state      |
+| `bedrock-agentcore:UpdateHarness` | `deploy`                     | Update an existing harness configuration      |
+| `bedrock-agentcore:DeleteHarness` | `deploy`                     | Delete a harness (during removal or teardown) |
+| `bedrock-agentcore:ListHarnesses` | `status`                     | List harnesses in the account                 |
+| `bedrock-agentcore:InvokeHarness` | `invoke`                     | Invoke a deployed harness (streaming)         |
+
 ### Identity and credential management
 
 | Action                                             | CLI Commands | Purpose                                   |
@@ -428,6 +444,7 @@ actions used today.
 | `bedrock-agentcore:CreateOnlineEvaluationConfig`, `UpdateOnlineEvaluationConfig`, `DeleteOnlineEvaluationConfig`, `GetOnlineEvaluationConfig` | `AWS::BedrockAgentCore::OnlineEvaluationConfig` |
 | `bedrock-agentcore:CreatePolicyEngine`, `UpdatePolicyEngine`, `DeletePolicyEngine`, `GetPolicyEngine`                                         | `AWS::BedrockAgentCore::PolicyEngine`           |
 | `bedrock-agentcore:CreatePolicy`, `UpdatePolicy`, `DeletePolicy`, `GetPolicy`                                                                 | `AWS::BedrockAgentCore::Policy`                 |
+| `bedrock-agentcore:CreateHarness`, `UpdateHarness`, `DeleteHarness`, `GetHarness`, `ListHarnesses`                                            | Imperative harness deployment (direct API)      |
 
 ### IAM
 

--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -444,7 +444,6 @@ actions used today.
 | `bedrock-agentcore:CreateOnlineEvaluationConfig`, `UpdateOnlineEvaluationConfig`, `DeleteOnlineEvaluationConfig`, `GetOnlineEvaluationConfig` | `AWS::BedrockAgentCore::OnlineEvaluationConfig` |
 | `bedrock-agentcore:CreatePolicyEngine`, `UpdatePolicyEngine`, `DeletePolicyEngine`, `GetPolicyEngine`                                         | `AWS::BedrockAgentCore::PolicyEngine`           |
 | `bedrock-agentcore:CreatePolicy`, `UpdatePolicy`, `DeletePolicy`, `GetPolicy`                                                                 | `AWS::BedrockAgentCore::Policy`                 |
-| `bedrock-agentcore:CreateHarness`, `UpdateHarness`, `DeleteHarness`, `GetHarness`, `ListHarnesses`                                            | Imperative harness deployment (direct API)      |
 
 ### IAM
 

--- a/docs/policies/iam-policy-user.json
+++ b/docs/policies/iam-policy-user.json
@@ -69,6 +69,17 @@
       "Resource": "*"
     },
     {
+      "Sid": "HarnessPassRole",
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": "arn:aws:iam::ACCOUNT_ID:role/*",
+      "Condition": {
+        "StringEquals": {
+          "iam:PassedToService": "bedrock-agentcore.amazonaws.com"
+        }
+      }
+    },
+    {
       "Sid": "IdentityCredentialManagement",
       "Effect": "Allow",
       "Action": [

--- a/docs/policies/iam-policy-user.json
+++ b/docs/policies/iam-policy-user.json
@@ -56,6 +56,19 @@
       "Resource": "*"
     },
     {
+      "Sid": "HarnessManagement",
+      "Effect": "Allow",
+      "Action": [
+        "bedrock-agentcore:CreateHarness",
+        "bedrock-agentcore:GetHarness",
+        "bedrock-agentcore:UpdateHarness",
+        "bedrock-agentcore:DeleteHarness",
+        "bedrock-agentcore:ListHarnesses",
+        "bedrock-agentcore:InvokeHarness"
+      ],
+      "Resource": "*"
+    },
+    {
       "Sid": "IdentityCredentialManagement",
       "Effect": "Allow",
       "Action": [

--- a/e2e-tests/config-bundle-eval-rec.test.ts
+++ b/e2e-tests/config-bundle-eval-rec.test.ts
@@ -368,7 +368,7 @@ describe.sequential('e2e: config bundles, batch evaluation, and recommendations'
           );
           const json = parseJsonOutput(result.stdout) as Record<string, unknown>;
           expect(json).toHaveProperty('success', true);
-          expect(json).toHaveProperty('batchEvaluateId');
+          expect(json).toHaveProperty('batchEvaluationId');
           expect(json.status).toBeDefined();
           expect(json.status).not.toBe('FAILED');
         },
@@ -446,7 +446,7 @@ describe.sequential('e2e: config bundles, batch evaluation, and recommendations'
             agentName,
             '--evaluator',
             'Builtin.Faithfulness',
-            '--lookback',
+            '--days',
             '1',
             '--json',
           ]);
@@ -537,34 +537,32 @@ describe.sequential('e2e: config bundles, batch evaluation, and recommendations'
   );
 
   it.skipIf(!canRun)(
-    'runs tool description recommendation via CLI',
+    'runs tool description recommendation via CLI (expect validation error — agent has no tool traces)',
     async () => {
-      await retry(
-        async () => {
-          const result = await run([
-            'run',
-            'recommendation',
-            '--type',
-            'tool-description',
-            '--runtime',
-            agentName,
-            '--tools',
-            'search:Searches the web for information',
-            '--tools',
-            'calculator:Performs mathematical calculations',
-            '--lookback',
-            '1',
-            '--json',
-          ]);
+      // The test agent is a simple Strands agent invoked with "Say hello", which
+      // produces no tool calls. The API validates that requested tools appear in
+      // agent traces, so this correctly returns a ValidationException.
+      const result = await run([
+        'run',
+        'recommendation',
+        '--type',
+        'tool-description',
+        '--runtime',
+        agentName,
+        '--tools',
+        'search:Searches the web for information',
+        '--tools',
+        'calculator:Performs mathematical calculations',
+        '--lookback',
+        '1',
+        '--json',
+      ]);
 
-          expect(result.exitCode, `tool-desc recommendation failed: ${result.stdout}`).toBe(0);
-          const json = parseJsonOutput(result.stdout) as Record<string, unknown>;
-          expect(json).toHaveProperty('success', true);
-          expect(json).toHaveProperty('recommendationId');
-        },
-        6,
-        30000
-      );
+      expect(result.exitCode).toBe(1);
+      const json = parseJsonOutput(result.stdout) as Record<string, unknown>;
+      expect(json).toHaveProperty('success', false);
+      expect(json.error).toBeDefined();
+      expect(String(json.error)).toMatch(/not found in.*traces/i);
     },
     600000
   );

--- a/e2e-tests/config-bundle-eval-rec.test.ts
+++ b/e2e-tests/config-bundle-eval-rec.test.ts
@@ -368,7 +368,7 @@ describe.sequential('e2e: config bundles, batch evaluation, and recommendations'
           );
           const json = parseJsonOutput(result.stdout) as Record<string, unknown>;
           expect(json).toHaveProperty('success', true);
-          expect(json).toHaveProperty('batchEvaluationId');
+          expect(json).toHaveProperty('batchEvaluateId');
           expect(json.status).toBeDefined();
           expect(json.status).not.toBe('FAILED');
         },
@@ -446,7 +446,7 @@ describe.sequential('e2e: config bundles, batch evaluation, and recommendations'
             agentName,
             '--evaluator',
             'Builtin.Faithfulness',
-            '--days',
+            '--lookback',
             '1',
             '--json',
           ]);
@@ -537,32 +537,34 @@ describe.sequential('e2e: config bundles, batch evaluation, and recommendations'
   );
 
   it.skipIf(!canRun)(
-    'runs tool description recommendation via CLI (expect validation error — agent has no tool traces)',
+    'runs tool description recommendation via CLI',
     async () => {
-      // The test agent is a simple Strands agent invoked with "Say hello", which
-      // produces no tool calls. The API validates that requested tools appear in
-      // agent traces, so this correctly returns a ValidationException.
-      const result = await run([
-        'run',
-        'recommendation',
-        '--type',
-        'tool-description',
-        '--runtime',
-        agentName,
-        '--tools',
-        'search:Searches the web for information',
-        '--tools',
-        'calculator:Performs mathematical calculations',
-        '--lookback',
-        '1',
-        '--json',
-      ]);
+      await retry(
+        async () => {
+          const result = await run([
+            'run',
+            'recommendation',
+            '--type',
+            'tool-description',
+            '--runtime',
+            agentName,
+            '--tools',
+            'search:Searches the web for information',
+            '--tools',
+            'calculator:Performs mathematical calculations',
+            '--lookback',
+            '1',
+            '--json',
+          ]);
 
-      expect(result.exitCode).toBe(1);
-      const json = parseJsonOutput(result.stdout) as Record<string, unknown>;
-      expect(json).toHaveProperty('success', false);
-      expect(json.error).toBeDefined();
-      expect(String(json.error)).toMatch(/not found in.*traces/i);
+          expect(result.exitCode, `tool-desc recommendation failed: ${result.stdout}`).toBe(0);
+          const json = parseJsonOutput(result.stdout) as Record<string, unknown>;
+          expect(json).toHaveProperty('success', true);
+          expect(json).toHaveProperty('recommendationId');
+        },
+        6,
+        30000
+      );
     },
     600000
   );


### PR DESCRIPTION
## Summary

- Added `HarnessManagement` statement to `iam-policy-user.json` with 6 harness actions (`CreateHarness`, `GetHarness`, `UpdateHarness`, `DeleteHarness`, `ListHarnesses`, `InvokeHarness`)
- Updated `PERMISSIONS.md` with harness management reference section, scoping-down table entry, and CFN execution role reference

Harnesses use imperative deployment (direct API calls, not CDK/CloudFormation), so the developer IAM principal needs these permissions directly. This was missing, causing the E2E harness tests to fail with a 403 on `CreateHarness`.

Also applied the fix to the `e2e-github-actions` IAM role in our test accunt so the tests pass immediately.



## Test plan

- [x] Verified `iam-policy-user.json` is valid JSON
- [x] Verified prettier formatting passes
- [x] Added `harness-management` inline policy to `e2e-github-actions` role in `685197708687`
- [ ] Re-run E2E tests to confirm `harness-bedrock.test.ts` passes