### PR TITLE
fix: sync e2e IAM policy and fix run eval flag

### DIFF
--- a/docs/policies/iam-policy-user.json
+++ b/docs/policies/iam-policy-user.json
@@ -298,7 +298,9 @@
         "iam:DeleteRole",
         "iam:GetRole",
         "iam:PutRolePolicy",
-        "iam:DeleteRolePolicy"
+        "iam:DeleteRolePolicy",
+        "iam:TagRole",
+        "iam:PassRole"
       ],
       "Resource": "arn:aws:iam::*:role/AgentCore-*"
     },

--- a/docs/policies/iam-policy-user.json
+++ b/docs/policies/iam-policy-user.json
@@ -135,6 +135,32 @@
         "s3:GetObject"
       ],
       "Resource": "*"
+    },
+    {
+      "Sid": "ConfigBundleManagement",
+      "Effect": "Allow",
+      "Action": [
+        "bedrock-agentcore:CreateConfigurationBundle",
+        "bedrock-agentcore:UpdateConfigurationBundle",
+        "bedrock-agentcore:DeleteConfigurationBundle",
+        "bedrock-agentcore:GetConfigurationBundle",
+        "bedrock-agentcore:GetConfigurationBundleVersion",
+        "bedrock-agentcore:ListConfigurationBundles",
+        "bedrock-agentcore:ListConfigurationBundleVersions"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "HttpGatewayIamRoleManagement",
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreateRole",
+        "iam:DeleteRole",
+        "iam:GetRole",
+        "iam:PutRolePolicy",
+        "iam:DeleteRolePolicy"
+      ],
+      "Resource": "arn:aws:iam::*:role/AgentCore-*"
     }
   ]
 }

--- a/docs/policies/iam-policy-user.json
+++ b/docs/policies/iam-policy-user.json
@@ -161,6 +161,19 @@
         "iam:DeleteRolePolicy"
       ],
       "Resource": "arn:aws:iam::*:role/AgentCore-*"
+    },
+    {
+      "Sid": "BatchEvalAndRecommendation",
+      "Effect": "Allow",
+      "Action": [
+        "bedrock-agentcore:StartBatchEvaluation",
+        "bedrock-agentcore:GetBatchEvaluation",
+        "bedrock-agentcore:ListBatchEvaluations",
+        "bedrock-agentcore:StartRecommendation",
+        "bedrock-agentcore:GetRecommendation",
+        "bedrock-agentcore:ListRecommendations"
+      ],
+      "Resource": "*"
     }
   ]
 }

--- a/docs/policies/iam-policy-user.json
+++ b/docs/policies/iam-policy-user.json
@@ -116,10 +116,7 @@
     {
       "Sid": "BedrockModelInvocation",
       "Effect": "Allow",
-      "Action": [
-        "bedrock:InvokeModel",
-        "bedrock:InvokeModelWithResponseStream"
-      ],
+      "Action": ["bedrock:InvokeModel", "bedrock:InvokeModelWithResponseStream"],
       "Resource": "*"
     },
     {
@@ -184,10 +181,7 @@
     {
       "Sid": "SsmParameterLookup",
       "Effect": "Allow",
-      "Action": [
-        "ssm:GetParameters",
-        "ssm:GetParameter"
-      ],
+      "Action": ["ssm:GetParameters", "ssm:GetParameter"],
       "Resource": "*"
     },
     {
@@ -199,12 +193,7 @@
     {
       "Sid": "ImportTestIam",
       "Effect": "Allow",
-      "Action": [
-        "iam:GetRole",
-        "iam:CreateRole",
-        "iam:AttachRolePolicy",
-        "iam:PutRolePolicy"
-      ],
+      "Action": ["iam:GetRole", "iam:CreateRole", "iam:AttachRolePolicy", "iam:PutRolePolicy"],
       "Resource": "arn:aws:iam::ACCOUNT_ID:role/bugbash-agentcore-role"
     },
     {
@@ -221,21 +210,13 @@
     {
       "Sid": "ImportTestS3",
       "Effect": "Allow",
-      "Action": [
-        "s3:ListBucket",
-        "s3:CreateBucket",
-        "s3:PutObject"
-      ],
+      "Action": ["s3:ListBucket", "s3:CreateBucket", "s3:PutObject"],
       "Resource": "*"
     },
     {
       "Sid": "SecretsManager",
       "Effect": "Allow",
-      "Action": [
-        "secretsmanager:GetSecretValue",
-        "secretsmanager:CreateSecret",
-        "secretsmanager:DeleteSecret"
-      ],
+      "Action": ["secretsmanager:GetSecretValue", "secretsmanager:CreateSecret", "secretsmanager:DeleteSecret"],
       "Resource": "*"
     },
     {

--- a/docs/policies/iam-policy-user.json
+++ b/docs/policies/iam-policy-user.json
@@ -62,6 +62,8 @@
         "bedrock-agentcore:GetApiKeyCredentialProvider",
         "bedrock-agentcore:CreateApiKeyCredentialProvider",
         "bedrock-agentcore:UpdateApiKeyCredentialProvider",
+        "bedrock-agentcore:DeleteApiKeyCredentialProvider",
+        "bedrock-agentcore:ListApiKeyCredentialProviders",
         "bedrock-agentcore:GetOauth2CredentialProvider",
         "bedrock-agentcore:CreateOauth2CredentialProvider",
         "bedrock-agentcore:UpdateOauth2CredentialProvider",
@@ -114,7 +116,10 @@
     {
       "Sid": "BedrockModelInvocation",
       "Effect": "Allow",
-      "Action": "bedrock:InvokeModel",
+      "Action": [
+        "bedrock:InvokeModel",
+        "bedrock:InvokeModelWithResponseStream"
+      ],
       "Resource": "*"
     },
     {
@@ -135,6 +140,141 @@
         "s3:GetObject"
       ],
       "Resource": "*"
+    },
+    {
+      "Sid": "AgentCoreResourceManagement",
+      "Effect": "Allow",
+      "Action": [
+        "bedrock-agentcore:CreateAgentRuntime",
+        "bedrock-agentcore:UpdateAgentRuntime",
+        "bedrock-agentcore:DeleteAgentRuntime",
+        "bedrock-agentcore:ListAgentRuntimes",
+        "bedrock-agentcore:CreateAgentRuntimeEndpoint",
+        "bedrock-agentcore:CreateWorkloadIdentity",
+        "bedrock-agentcore:DeleteWorkloadIdentity",
+        "bedrock-agentcore:CreateMemory",
+        "bedrock-agentcore:GetMemory",
+        "bedrock-agentcore:UpdateMemory",
+        "bedrock-agentcore:DeleteMemory",
+        "bedrock-agentcore:ListMemories",
+        "bedrock-agentcore:CreateEvaluator",
+        "bedrock-agentcore:DeleteEvaluator",
+        "bedrock-agentcore:ListOnlineEvaluationConfigs",
+        "bedrock-agentcore:TagResource",
+        "bedrock-agentcore:ListTagsForResource",
+        "bedrock-agentcore:CreateGateway",
+        "bedrock-agentcore:UpdateGateway",
+        "bedrock-agentcore:DeleteGateway",
+        "bedrock-agentcore:GetGateway",
+        "bedrock-agentcore:ListGateways",
+        "bedrock-agentcore:CreateGatewayTarget",
+        "bedrock-agentcore:UpdateGatewayTarget",
+        "bedrock-agentcore:DeleteGatewayTarget",
+        "bedrock-agentcore:GetGatewayTarget",
+        "bedrock-agentcore:SynchronizeGatewayTargets"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "CloudFormationFull",
+      "Effect": "Allow",
+      "Action": "cloudformation:*",
+      "Resource": "*"
+    },
+    {
+      "Sid": "SsmParameterLookup",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:GetParameters",
+        "ssm:GetParameter"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "CloudFormationTemplateVerification",
+      "Effect": "Allow",
+      "Action": "cloudformation:GetTemplate",
+      "Resource": "*"
+    },
+    {
+      "Sid": "ImportTestIam",
+      "Effect": "Allow",
+      "Action": [
+        "iam:GetRole",
+        "iam:CreateRole",
+        "iam:AttachRolePolicy",
+        "iam:PutRolePolicy"
+      ],
+      "Resource": "arn:aws:iam::ACCOUNT_ID:role/bugbash-agentcore-role"
+    },
+    {
+      "Sid": "ImportTestPassRole",
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": "arn:aws:iam::ACCOUNT_ID:role/bugbash-agentcore-role",
+      "Condition": {
+        "StringEquals": {
+          "iam:PassedToService": "bedrock-agentcore.amazonaws.com"
+        }
+      }
+    },
+    {
+      "Sid": "ImportTestS3",
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket",
+        "s3:CreateBucket",
+        "s3:PutObject"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "SecretsManager",
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:CreateSecret",
+        "secretsmanager:DeleteSecret"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "CustomJwtCognitoSetup",
+      "Effect": "Allow",
+      "Action": [
+        "cognito-idp:CreateUserPool",
+        "cognito-idp:CreateUserPoolDomain",
+        "cognito-idp:CreateResourceServer",
+        "cognito-idp:CreateUserPoolClient",
+        "cognito-idp:DeleteResourceServer",
+        "cognito-idp:DeleteUserPoolDomain",
+        "cognito-idp:DeleteUserPool"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "HarnessManagement",
+      "Effect": "Allow",
+      "Action": [
+        "bedrock-agentcore:CreateHarness",
+        "bedrock-agentcore:GetHarness",
+        "bedrock-agentcore:UpdateHarness",
+        "bedrock-agentcore:DeleteHarness",
+        "bedrock-agentcore:ListHarnesses",
+        "bedrock-agentcore:InvokeHarness"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "HarnessPassRole",
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": "arn:aws:iam::ACCOUNT_ID:role/*",
+      "Condition": {
+        "StringEquals": {
+          "iam:PassedToService": "bedrock-agentcore.amazonaws.com"
+        }
+      }
     },
     {
       "Sid": "ConfigBundleManagement",

--- a/e2e-tests/config-bundle-eval-rec.test.ts
+++ b/e2e-tests/config-bundle-eval-rec.test.ts
@@ -446,7 +446,7 @@ describe.sequential('e2e: config bundles, batch evaluation, and recommendations'
             agentName,
             '--evaluator',
             'Builtin.Faithfulness',
-            '--lookback',
+            '--days',
             '1',
             '--json',
           ]);


### PR DESCRIPTION
## Summary

- Syncs `docs/policies/iam-policy-user.json` fully with the live `e2e-github-actions` role — the doc was significantly out of date
- Adds missing permissions that were causing e2e test failures:
  - `bedrock-agentcore:CreateConfigurationBundle` + CRUD (fixes `config-bundle-eval-rec.test.ts` 403s)
  - `iam:CreateRole/DeleteRole/GetRole/PutRolePolicy/DeleteRolePolicy` scoped to `AgentCore-*` (fixes HTTP gateway role creation in `ab-test-target-based.test.ts`)
  - `bedrock-agentcore:StartBatchEvaluation`, `StartRecommendation` + related Get/List actions (fixes 403s in batch eval and recommendation tests)
- Fixes `run eval` CLI flag: test was passing `--lookback` but the correct flag is `--days`

## Root cause

Several new post-deploy operations (config bundle sync, HTTP gateway IAM role creation, batch evaluation, recommendations) were added without updating the e2e role policy or the docs. The doc had also drifted significantly from the live role.

## Test plan

- [ ] `config-bundle-eval-rec.test.ts` — deploy warnings and 403s should clear
- [ ] `ab-test-target-based.test.ts` — HTTP gateway creation should succeed
- [ ] `run eval` test step — `--days` flag resolves the `unknown option` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)