### PR TITLE
fix: align E2E batch eval and recommendation tests with current API

### DIFF
--- a/e2e-tests/config-bundle-eval-rec.test.ts
+++ b/e2e-tests/config-bundle-eval-rec.test.ts
@@ -171,7 +171,14 @@ describe.sequential('e2e: config bundles, batch evaluation, and recommendations'
     async () => {
       await retry(
         async () => {
-          const result = await run(['invoke', '--prompt', 'Say hello', '--runtime', agentName, '--json']);
+          const result = await run([
+            'invoke',
+            '--prompt',
+            'What is 3 + 5? Use the add_numbers tool.',
+            '--runtime',
+            agentName,
+            '--json',
+          ]);
           expect(result.exitCode, `Invoke failed: ${result.stderr}`).toBe(0);
           const json = parseJsonOutput(result.stdout) as { success: boolean };
           expect(json.success).toBe(true);
@@ -368,7 +375,7 @@ describe.sequential('e2e: config bundles, batch evaluation, and recommendations'
           );
           const json = parseJsonOutput(result.stdout) as Record<string, unknown>;
           expect(json).toHaveProperty('success', true);
-          expect(json).toHaveProperty('batchEvaluateId');
+          expect(json).toHaveProperty('batchEvaluationId');
           expect(json.status).toBeDefined();
           expect(json.status).not.toBe('FAILED');
         },
@@ -549,9 +556,7 @@ describe.sequential('e2e: config bundles, batch evaluation, and recommendations'
             '--runtime',
             agentName,
             '--tools',
-            'search:Searches the web for information',
-            '--tools',
-            'calculator:Performs mathematical calculations',
+            'add_numbers:Adds two numbers together',
             '--lookback',
             '1',
             '--json',


### PR DESCRIPTION
## Summary

- `batchEvaluateId` → `batchEvaluationId` in assertion (field was renamed in API migration #142)
- Invoke prompt changed from "Say hello" to "What is 3 + 5? Use the add_numbers tool." so the agent generates tool traces in CloudWatch
- Tool recommendation test changed from `search`/`calculator` (which the agent doesn't have) to `add_numbers` (the actual tool in the Strands template)

## Root cause

The E2E test was written against the old batch evaluation schema before the API migration in `300a5168`. The tool recommendation test used tool names that don't exist in the Strands template agent, causing the API to return a `ValidationException` because those tools never appear in agent traces.

## Test plan

- [ ] `config-bundle-eval-rec.test.ts` batch eval tests should no longer fail on assertion mismatch
- [ ] Tool recommendation test should find `add_numbers` traces from the updated invoke