### PR TITLE
fix: use correct resourceType for config bundle in E2E status test

### DIFF
--- a/e2e-tests/config-bundle-eval-rec.test.ts
+++ b/e2e-tests/config-bundle-eval-rec.test.ts
@@ -206,7 +206,7 @@ describe.sequential('e2e: config bundles, batch evaluation, and recommendations'
       };
       expect(json.success).toBe(true);
 
-      const bundle = json.resources.find(r => r.resourceType === 'configBundle' && r.name === bundleName);
+      const bundle = json.resources.find(r => r.resourceType === 'config-bundle' && r.name === bundleName);
       expect(bundle, `Config bundle "${bundleName}" should appear in status`).toBeDefined();
 
       const evaluator = json.resources.find(r => r.resourceType === 'evaluator' && r.name === evalName);


### PR DESCRIPTION
## Summary

- Fix `configBundle` → `config-bundle` in E2E status assertion

The `status --json` command outputs `resourceType: 'config-bundle'` (hyphenated) but the test was matching against `'configBundle'` (camelCase), causing the status test to always fail with "Config bundle should appear in status: expected undefined to be defined".

## Test plan

- [ ] `config-bundle-eval-rec.test.ts` status test should pass