### PR TITLE
fix: add --system-prompt and --tools CLI flags to add harness

### DIFF
--- a/src/cli/commands/add/__tests__/validate-harness.test.ts
+++ b/src/cli/commands/add/__tests__/validate-harness.test.ts
@@ -42,4 +42,56 @@ describe('validateAddHarnessOptions', () => {
     expect(result.valid).toBe(false);
     expect(result.error).toContain('OAuth client credentials are only valid with CUSTOM_JWT authorizer');
   });
+
+  it('rejects unknown tool name', () => {
+    const result = validateAddHarnessOptions({ tools: 'agentcore_browser,foo_tool' });
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("Unknown tool 'foo_tool'");
+  });
+
+  it('rejects remote_mcp without --mcp-name', () => {
+    const result = validateAddHarnessOptions({ tools: 'remote_mcp', mcpUrl: 'https://example.com' });
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('--mcp-name is required');
+  });
+
+  it('rejects remote_mcp without --mcp-url', () => {
+    const result = validateAddHarnessOptions({ tools: 'remote_mcp', mcpName: 'my-mcp' });
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('--mcp-url is required');
+  });
+
+  it('rejects agentcore_gateway without --gateway-arn', () => {
+    const result = validateAddHarnessOptions({ tools: 'agentcore_gateway' });
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('--gateway-arn is required');
+  });
+
+  it('rejects invalid --gateway-outbound-auth value', () => {
+    const result = validateAddHarnessOptions({ gatewayOutboundAuth: 'iam' });
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("Invalid --gateway-outbound-auth 'iam'");
+  });
+
+  it('rejects oauth gateway auth without --gateway-provider-arn', () => {
+    const result = validateAddHarnessOptions({ gatewayOutboundAuth: 'oauth', gatewayScopes: 'read' });
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('--gateway-provider-arn is required');
+  });
+
+  it('rejects oauth gateway auth without --gateway-scopes', () => {
+    const result = validateAddHarnessOptions({ gatewayOutboundAuth: 'oauth', gatewayProviderArn: 'arn:aws:...' });
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('--gateway-scopes is required');
+  });
+
+  it('accepts valid tools with required companion flags', () => {
+    const result = validateAddHarnessOptions({
+      tools: 'agentcore_browser,remote_mcp,agentcore_gateway',
+      mcpName: 'my-mcp',
+      mcpUrl: 'https://mcp.example.com',
+      gatewayArn: 'arn:aws:bedrock:us-east-1:123456789012:gateway/gw',
+    });
+    expect(result).toEqual({ valid: true });
+  });
 });

--- a/src/cli/commands/add/types.ts
+++ b/src/cli/commands/add/types.ts
@@ -126,6 +126,14 @@ export interface AddHarnessCliOptions {
   maxLifetime?: number;
   sessionStorage?: string;
   withInvokeScript?: boolean;
+  systemPrompt?: string;
+  tools?: string;
+  mcpName?: string;
+  mcpUrl?: string;
+  gatewayArn?: string;
+  gatewayOutboundAuth?: string;
+  gatewayProviderArn?: string;
+  gatewayScopes?: string;
   authorizerType?: RuntimeAuthorizerType;
   discoveryUrl?: string;
   allowedAudience?: string;

--- a/src/cli/commands/add/validate.ts
+++ b/src/cli/commands/add/validate.ts
@@ -793,8 +793,64 @@ export function validateAddCredentialOptions(options: AddCredentialOptions): Val
   return { valid: true };
 }
 
+const VALID_HARNESS_TOOLS = [
+  'agentcore_browser',
+  'agentcore_code_interpreter',
+  'remote_mcp',
+  'agentcore_gateway',
+] as const;
+
+const VALID_GATEWAY_OUTBOUND_AUTH = ['awsIam', 'none', 'oauth'] as const;
+
 // Harness validation
 export function validateAddHarnessOptions(options: AddHarnessCliOptions): ValidationResult {
+  if (options.tools) {
+    const toolNames = options.tools.split(',').map(s => s.trim());
+    for (const tool of toolNames) {
+      if (!VALID_HARNESS_TOOLS.includes(tool as (typeof VALID_HARNESS_TOOLS)[number])) {
+        return {
+          valid: false,
+          error: `Unknown tool '${tool}'. Valid tools: ${VALID_HARNESS_TOOLS.join(', ')}`,
+        };
+      }
+    }
+
+    if (toolNames.includes('remote_mcp')) {
+      if (!options.mcpName) {
+        return { valid: false, error: '--mcp-name is required when --tools includes remote_mcp' };
+      }
+      if (!options.mcpUrl) {
+        return { valid: false, error: '--mcp-url is required when --tools includes remote_mcp' };
+      }
+    }
+
+    if (toolNames.includes('agentcore_gateway')) {
+      if (!options.gatewayArn) {
+        return { valid: false, error: '--gateway-arn is required when --tools includes agentcore_gateway' };
+      }
+    }
+  }
+
+  if (options.gatewayOutboundAuth) {
+    if (
+      !VALID_GATEWAY_OUTBOUND_AUTH.includes(options.gatewayOutboundAuth as (typeof VALID_GATEWAY_OUTBOUND_AUTH)[number])
+    ) {
+      return {
+        valid: false,
+        error: `Invalid --gateway-outbound-auth '${options.gatewayOutboundAuth}'. Use: ${VALID_GATEWAY_OUTBOUND_AUTH.join(', ')}`,
+      };
+    }
+
+    if (options.gatewayOutboundAuth === 'oauth') {
+      if (!options.gatewayProviderArn) {
+        return { valid: false, error: '--gateway-provider-arn is required when --gateway-outbound-auth is oauth' };
+      }
+      if (!options.gatewayScopes) {
+        return { valid: false, error: '--gateway-scopes is required when --gateway-outbound-auth is oauth' };
+      }
+    }
+  }
+
   if (options.authorizerType) {
     const authResult = RuntimeAuthorizerTypeSchema.safeParse(options.authorizerType);
     if (!authResult.success) {

--- a/src/cli/primitives/HarnessPrimitive.ts
+++ b/src/cli/primitives/HarnessPrimitive.ts
@@ -342,6 +342,23 @@ export class HarnessPrimitive extends BasePrimitive<AddHarnessOptions, Removable
       .option('--max-lifetime <seconds>', 'Max lifetime in seconds', parseInt)
       .option('--session-storage <path>', 'Mount path for persistent session storage (e.g., /mnt/data/)')
       .option('--with-invoke-script', 'Generate a standalone Python invoke script')
+      .option(
+        '--system-prompt <text>',
+        'System prompt text (written to system-prompt.md; defaults to "You are a helpful assistant")'
+      )
+      .option(
+        '--tools <tools>',
+        'Comma-separated tools: agentcore_browser, agentcore_code_interpreter, remote_mcp, agentcore_gateway'
+      )
+      .option('--mcp-name <name>', 'Remote MCP tool name (required when --tools includes remote_mcp)')
+      .option('--mcp-url <url>', 'Remote MCP endpoint URL (required when --tools includes remote_mcp)')
+      .option('--gateway-arn <arn>', 'Gateway ARN (required when --tools includes agentcore_gateway)')
+      .option(
+        '--gateway-outbound-auth <type>',
+        'Gateway outbound auth: awsIam, none, oauth (requires --gateway-provider-arn and --gateway-scopes)'
+      )
+      .option('--gateway-provider-arn <arn>', 'OAuth provider ARN for gateway outbound auth')
+      .option('--gateway-scopes <scopes>', 'Comma-separated OAuth scopes for gateway outbound auth')
       .option('--authorizer-type <type>', 'Authorizer type: AWS_IAM or CUSTOM_JWT')
       .option('--discovery-url <url>', 'OIDC discovery URL (for CUSTOM_JWT)')
       .option('--allowed-audience <audiences>', 'Comma-separated allowed audiences (for CUSTOM_JWT)')
@@ -370,6 +387,14 @@ export class HarnessPrimitive extends BasePrimitive<AddHarnessOptions, Removable
           maxLifetime?: number;
           sessionStorage?: string;
           withInvokeScript?: boolean;
+          systemPrompt?: string;
+          tools?: string;
+          mcpName?: string;
+          mcpUrl?: string;
+          gatewayArn?: string;
+          gatewayOutboundAuth?: string;
+          gatewayProviderArn?: string;
+          gatewayScopes?: string;
           authorizerType?: string;
           discoveryUrl?: string;
           allowedAudience?: string;
@@ -437,6 +462,14 @@ export class HarnessPrimitive extends BasePrimitive<AddHarnessOptions, Removable
                 maxLifetime: cliOptions.maxLifetime,
                 sessionStoragePath: cliOptions.sessionStorage,
                 withInvokeScript: cliOptions.withInvokeScript,
+                systemPrompt: cliOptions.systemPrompt,
+                selectedTools: cliOptions.tools?.split(',').map(s => s.trim()),
+                mcpName: cliOptions.mcpName,
+                mcpUrl: cliOptions.mcpUrl,
+                gatewayArn: cliOptions.gatewayArn,
+                gatewayOutboundAuth: cliOptions.gatewayOutboundAuth as 'awsIam' | 'none' | 'oauth' | undefined,
+                gatewayProviderArn: cliOptions.gatewayProviderArn,
+                gatewayScopes: cliOptions.gatewayScopes?.split(',').map(s => s.trim()),
                 authorizerType: cliOptions.authorizerType as RuntimeAuthorizerType | undefined,
                 jwtConfig:
                   cliOptions.authorizerType === 'CUSTOM_JWT' && cliOptions.discoveryUrl

--- a/src/cli/primitives/__tests__/HarnessPrimitive.test.ts
+++ b/src/cli/primitives/__tests__/HarnessPrimitive.test.ts
@@ -295,6 +295,124 @@ describe('HarnessPrimitive', () => {
       );
     });
 
+    it('includes tools in harness spec when selectedTools provided', async () => {
+      mockReadProjectSpec.mockResolvedValue(JSON.parse(JSON.stringify(baseProject)));
+
+      const result = await primitive.add({
+        name: 'testHarness',
+        modelProvider: 'bedrock',
+        modelId: 'anthropic.claude-3-5-sonnet-20240620-v1:0',
+        selectedTools: ['agentcore_browser', 'agentcore_code_interpreter'],
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockWriteHarnessSpec).toHaveBeenCalledWith(
+        'testHarness',
+        expect.objectContaining({
+          tools: [
+            { type: 'agentcore_browser', name: 'browser' },
+            { type: 'agentcore_code_interpreter', name: 'code-interpreter' },
+          ],
+        })
+      );
+    });
+
+    it('includes remote_mcp tool with config when mcpName and mcpUrl provided', async () => {
+      mockReadProjectSpec.mockResolvedValue(JSON.parse(JSON.stringify(baseProject)));
+
+      const result = await primitive.add({
+        name: 'testHarness',
+        modelProvider: 'bedrock',
+        modelId: 'anthropic.claude-3-5-sonnet-20240620-v1:0',
+        selectedTools: ['remote_mcp'],
+        mcpName: 'my-mcp',
+        mcpUrl: 'https://mcp.example.com',
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockWriteHarnessSpec).toHaveBeenCalledWith(
+        'testHarness',
+        expect.objectContaining({
+          tools: [
+            {
+              type: 'remote_mcp',
+              name: 'my-mcp',
+              config: { remoteMcp: { url: 'https://mcp.example.com' } },
+            },
+          ],
+        })
+      );
+    });
+
+    it('includes gateway tool with config when gatewayArn provided', async () => {
+      mockReadProjectSpec.mockResolvedValue(JSON.parse(JSON.stringify(baseProject)));
+
+      const result = await primitive.add({
+        name: 'testHarness',
+        modelProvider: 'bedrock',
+        modelId: 'anthropic.claude-3-5-sonnet-20240620-v1:0',
+        selectedTools: ['agentcore_gateway'],
+        gatewayArn: 'arn:aws:bedrock:us-east-1:123456789012:gateway/my-gw',
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockWriteHarnessSpec).toHaveBeenCalledWith(
+        'testHarness',
+        expect.objectContaining({
+          tools: [
+            {
+              type: 'agentcore_gateway',
+              name: 'gateway',
+              config: {
+                agentCoreGateway: {
+                  gatewayArn: 'arn:aws:bedrock:us-east-1:123456789012:gateway/my-gw',
+                },
+              },
+            },
+          ],
+        })
+      );
+    });
+
+    it('includes gateway tool with outbound auth when gatewayOutboundAuth provided', async () => {
+      mockReadProjectSpec.mockResolvedValue(JSON.parse(JSON.stringify(baseProject)));
+
+      const result = await primitive.add({
+        name: 'testHarness',
+        modelProvider: 'bedrock',
+        modelId: 'anthropic.claude-3-5-sonnet-20240620-v1:0',
+        selectedTools: ['agentcore_gateway'],
+        gatewayArn: 'arn:aws:bedrock:us-east-1:123456789012:gateway/my-gw',
+        gatewayOutboundAuth: 'oauth',
+        gatewayProviderArn: 'arn:aws:bedrock:us-east-1:123456789012:provider/my-provider',
+        gatewayScopes: ['read', 'write'],
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockWriteHarnessSpec).toHaveBeenCalledWith(
+        'testHarness',
+        expect.objectContaining({
+          tools: [
+            {
+              type: 'agentcore_gateway',
+              name: 'gateway',
+              config: {
+                agentCoreGateway: {
+                  gatewayArn: 'arn:aws:bedrock:us-east-1:123456789012:gateway/my-gw',
+                  outboundAuth: {
+                    oauth: {
+                      providerArn: 'arn:aws:bedrock:us-east-1:123456789012:provider/my-provider',
+                      scopes: ['read', 'write'],
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        })
+      );
+    });
+
     it('includes system prompt when provided', async () => {
       mockReadProjectSpec.mockResolvedValue(JSON.parse(JSON.stringify(baseProject)));
 


### PR DESCRIPTION
## Summary

- Add missing `--system-prompt`, `--tools`, `--mcp-name`, `--mcp-url`, `--gateway-arn`, `--gateway-outbound-auth`, `--gateway-provider-arn`, and `--gateway-scopes` CLI option declarations to `agentcore add harness`
- Wire the new CLI options through the action handler type annotations and pass them to `this.add()`
- Add input validation in `validateAddHarnessOptions` to reject unknown tool names, missing companion flags, and invalid enum values — prevents silent tool omission
- Add unit tests for happy paths (4 tests) and error paths (8 tests)

## Context

The `AddHarnessOptions` interface and `add()` method have supported `systemPrompt`, `selectedTools`, `mcpName`, `mcpUrl`, `gatewayArn`, and the gateway outbound auth fields since they were introduced, and the TUI wizard correctly collects and passes them. However, the Commander `.option()` registrations in `registerCommands()` were never added, so these flags silently fail when passed via CLI.

The [DevGuide documentation](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-config-and-models.html) references `--system-prompt` and `--tools` on `agentcore add harness`, causing errors for customers using the preview release.

The `agentcore invoke` command already has both `--system-prompt` and `--tools` flags — this fix brings `agentcore add harness` to parity.

Verified that these flags were never present in any version of `HarnessPrimitive.ts` on the preview branch (checked all 9 commits that touched the file) — this is not a regression, but a gap from initial implementation.

## Validation

The tool-building logic in `add()` uses guarded branches that silently drop tools when companion flags are missing (e.g. `remote_mcp` without `--mcp-url`). Since these flags are being added specifically because docs reference them, a typo or missing flag would create a harness with `tools: []` and no error — worse than the current "unknown flag" error.

Added validation in `validateAddHarnessOptions` (consistent with existing patterns like JWT auth validation):
- Unknown tool names → clear error listing valid options
- `remote_mcp` without `--mcp-name` or `--mcp-url` → error
- `agentcore_gateway` without `--gateway-arn` → error
- Invalid `--gateway-outbound-auth` value → error listing valid options
- `oauth` auth without `--gateway-provider-arn` or `--gateway-scopes` → error

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (0 errors)
- [x] `npm run format:check` passes
- [x] HarnessPrimitive tests — 31/31 pass (4 new: tools, remote_mcp, gateway, gateway+outboundAuth)
- [x] validate-harness tests — 14/14 pass (8 new: unknown tool, missing mcp-name/url, missing gateway-arn, invalid outbound-auth, missing oauth fields, valid combo)
- [ ] Manual: `agentcore add harness --name test --system-prompt "You are a coding assistant" --tools agentcore_browser,agentcore_code_interpreter`