### PR TITLE
feat: add --harness-arn flag to invoke harnesses without a CLI project

### DIFF
--- a/src/cli/commands/invoke/action.ts
+++ b/src/cli/commands/invoke/action.ts
@@ -509,26 +509,64 @@ export async function handleInvoke(context: InvokeContext, options: InvokeOption
 }
 
 // ============================================================================
-// Direct Harness Invoke by ARN (no project required)
+// Shared Harness Helpers
 // ============================================================================
 
-export async function handleHarnessInvokeByArn(
-  harnessArn: string,
-  region: string,
-  options: InvokeOptions
-): Promise<InvokeResult> {
-  if (!options.prompt) {
-    return {
-      success: false,
-      error: 'No prompt provided. Usage: agentcore invoke --harness-arn <arn> --region <region> "your prompt"',
-    };
+interface HarnessModel {
+  provider?: string;
+  modelId?: string;
+  apiKeyArn?: string;
+}
+
+function buildHarnessBaseOpts(
+  options: InvokeOptions,
+  harnessSpec?: HarnessModel
+): Partial<import('../../aws/agentcore-harness').InvokeHarnessOptions> {
+  const baseOpts: Partial<import('../../aws/agentcore-harness').InvokeHarnessOptions> = {};
+  if (options.modelId || options.modelProvider || options.apiKeyArn) {
+    const provider = options.modelProvider ?? harnessSpec?.provider;
+    const modelId = options.modelId ?? harnessSpec?.modelId ?? '';
+    const apiKeyArn = options.apiKeyArn ?? harnessSpec?.apiKeyArn;
+    switch (provider) {
+      case 'open_ai':
+        baseOpts.model = { openAiModelConfig: { modelId, ...(apiKeyArn && { apiKeyArn }) } };
+        break;
+      case 'gemini':
+        baseOpts.model = { geminiModelConfig: { modelId, ...(apiKeyArn && { apiKeyArn }) } };
+        break;
+      default:
+        baseOpts.model = { bedrockModelConfig: { modelId } };
+        break;
+    }
   }
+  if (options.tools) {
+    baseOpts.tools = options.tools.split(',').map(t => {
+      const type = t.trim();
+      return { type, name: TOOL_TYPE_DEFAULT_NAMES[type] ?? type };
+    });
+  }
+  if (options.maxIterations != null) baseOpts.maxIterations = options.maxIterations;
+  if (options.maxTokens != null) baseOpts.maxTokens = options.maxTokens;
+  if (options.harnessTimeout != null) baseOpts.timeoutSeconds = options.harnessTimeout;
+  if (options.skills) baseOpts.skills = options.skills.split(',').map(p => ({ path: p.trim() }));
+  if (options.systemPrompt) baseOpts.systemPrompt = [{ text: options.systemPrompt }];
+  if (options.allowedTools) baseOpts.allowedTools = options.allowedTools.split(',').map(t => t.trim());
+  if (options.actorId) baseOpts.actorId = options.actorId;
+  return baseOpts;
+}
 
-  const sessionId = options.sessionId ?? randomUUID();
-  const logger = new InvokeLogger({ agentName: 'external-harness', runtimeArn: harnessArn, region, sessionId });
-  logger.logPrompt(options.prompt, sessionId, options.userId);
+interface StreamHarnessParams {
+  region: string;
+  harnessArn: string;
+  sessionId: string;
+  prompt: string;
+  options: InvokeOptions;
+  logger: InvokeLogger;
+  baseOpts: Partial<import('../../aws/agentcore-harness').InvokeHarnessOptions>;
+}
 
-  let fullResponse = '';
+async function streamHarnessInvoke(params: StreamHarnessParams): Promise<InvokeResult> {
+  const { region, harnessArn, sessionId, prompt, options, logger, baseOpts } = params;
   const dim = '\x1b[2m';
   const reset = '\x1b[0m';
   const cyan = '\x1b[36m';
@@ -553,72 +591,123 @@ export async function handleHarnessInvokeByArn(
     }
   };
 
+  let fullResponse = '';
+
   try {
     const messages: { role: string; content: Record<string, unknown>[] }[] = [
-      { role: 'user', content: [{ text: options.prompt }] },
+      { role: 'user', content: [{ text: prompt }] },
     ];
 
-    const baseOpts: Partial<import('../../aws/agentcore-harness').InvokeHarnessOptions> = {};
-    if (options.systemPrompt) baseOpts.systemPrompt = [{ text: options.systemPrompt }];
-    if (options.tools) {
-      baseOpts.tools = options.tools.split(',').map(t => {
-        const type = t.trim();
-        return { type, name: TOOL_TYPE_DEFAULT_NAMES[type] ?? type };
+    let pendingToolUseId: string | undefined;
+    let pendingToolName: string | undefined;
+    let pendingToolInput = '';
+
+    let continueLoop = true;
+    while (continueLoop) {
+      continueLoop = false;
+
+      const stream = invokeHarness({
+        region,
+        harnessArn,
+        runtimeSessionId: sessionId,
+        messages,
+        bearerToken: options.bearerToken,
+        ...baseOpts,
       });
-    }
-    if (options.maxIterations != null) baseOpts.maxIterations = options.maxIterations;
-    if (options.maxTokens != null) baseOpts.maxTokens = options.maxTokens;
-    if (options.harnessTimeout != null) baseOpts.timeoutSeconds = options.harnessTimeout;
-    if (options.allowedTools) baseOpts.allowedTools = options.allowedTools.split(',').map(t => t.trim());
-    if (options.actorId) baseOpts.actorId = options.actorId;
 
-    const stream = invokeHarness({
-      region,
-      harnessArn,
-      runtimeSessionId: sessionId,
-      messages,
-      bearerToken: options.bearerToken,
-      ...baseOpts,
-    });
+      pendingToolUseId = undefined;
+      pendingToolName = undefined;
+      pendingToolInput = '';
 
-    for await (const event of stream) {
-      if (options.verbose) {
-        clearSpinner();
-        console.log(JSON.stringify(event));
-        continue;
-      }
-
-      switch (event.type) {
-        case 'contentBlockDelta':
-          if (event.delta.type === 'text') {
-            clearSpinner();
-            fullResponse += event.delta.text;
-            if (!options.json) {
-              process.stdout.write(event.delta.text);
-            }
-          }
-          break;
-        case 'messageStop':
-          if (!options.json && !options.verbose) {
-            process.stdout.write('\n');
-          }
-          break;
-        case 'metadata':
-          if (!options.json) {
-            const { inputTokens, outputTokens } = event.usage;
-            const latency = (event.metrics.latencyMs / 1000).toFixed(1);
-            process.stderr.write(
-              `\n${dim}⚡ ${cyan}${inputTokens}${dim} in · ${cyan}${outputTokens}${dim} out · ${cyan}${latency}s${reset}\n`
-            );
-          }
-          break;
-        case 'error':
+      for await (const event of stream) {
+        if (options.verbose) {
           clearSpinner();
-          if (options.json) {
-            return { success: false, error: `${event.errorType}: ${event.message}` };
-          }
-          process.stderr.write(`\nError: ${event.message}\n`);
-          break;
+          console.log(JSON.stringify(event));
+          continue;
+        }
+
+        switch (event.type) {
+          case 'contentBlockDelta':
+            if (event.delta.type === 'text') {
+              clearSpinner();
+              fullResponse += event.delta.text;
+              if (!options.json) {
+                process.stdout.write(event.delta.text);
+              }
+            } else if (event.delta.type === 'toolUse') {
+              pendingToolInput += event.delta.input;
+            } else if (event.delta.type === 'toolResult') {
+              const results = event.delta.results;
+              for (const r of results) {
+                const text = (r.text as string) ?? (r.json ? JSON.stringify(r.json) : '');
+                if (text) {
+                  logger.logInfo(`Tool output: ${text.slice(0, 200)}`);
+                }
+              }
+            }
+            break;
+          case 'contentBlockStart':
+            if (event.start.type === 'toolUse') {
+              pendingToolUseId = event.start.toolUse.toolUseId;
+              pendingToolName = event.start.toolUse.name;
+              pendingToolInput = '';
+              logger.logInfo(`Tool call: ${pendingToolName} (id: ${pendingToolUseId})`);
+              if (!options.json) {
+                const serverName = event.start.toolUse.serverName;
+                const label = serverName ? `${serverName}/${pendingToolName}` : pendingToolName;
+                process.stderr.write(`\n${dim}🔧 Tool: ${label}${reset}\n`);
+              }
+            } else if (event.start.type === 'toolResult') {
+              const status = event.start.toolResult.status ?? 'success';
+              logger.logInfo(`Tool result (${pendingToolName}): status=${status}`);
+              if (!options.json) {
+                const icon = status === 'error' ? '❌' : '✓';
+                process.stderr.write(`${dim}  ${icon} `);
+              }
+            }
+            break;
+          case 'messageStop':
+            if (event.stopReason === 'tool_use' && pendingToolUseId) {
+              clearSpinner();
+              let inputObj: Record<string, unknown> = {};
+              try {
+                inputObj = JSON.parse(pendingToolInput) as Record<string, unknown>;
+              } catch {
+                // use empty
+              }
+              logger.logInfo(`Tool input (${pendingToolName}): ${JSON.stringify(inputObj)}`);
+            } else if (event.stopReason === 'tool_result') {
+              if (!options.json) {
+                process.stderr.write(`${reset}\n`);
+              }
+            } else if (!options.json) {
+              process.stdout.write('\n');
+            }
+            break;
+          case 'metadata':
+            logger.logInfo(
+              `Tokens: ${event.usage.inputTokens} in, ${event.usage.outputTokens} out | Latency: ${event.metrics.latencyMs}ms`
+            );
+            if (!options.json) {
+              const { inputTokens, outputTokens } = event.usage;
+              const latency = (event.metrics.latencyMs / 1000).toFixed(1);
+              process.stderr.write(
+                `\n${dim}⚡ ${cyan}${inputTokens}${dim} in · ${cyan}${outputTokens}${dim} out · ${cyan}${latency}s${reset}\n`
+              );
+              process.stderr.write(
+                `${dim}🔗 Session: ${cyan}${sessionId}${dim} (use --session-id to continue)${reset}\n`
+              );
+            }
+            break;
+          case 'error':
+            clearSpinner();
+            logger.logError(new Error(`${event.errorType}: ${event.message}`), 'stream error');
+            if (options.json) {
+              return { success: false, error: `${event.errorType}: ${event.message}` };
+            }
+            process.stderr.write(`\nError: ${event.message}\n`);
+            break;
+        }
       }
     }
 
@@ -643,6 +732,30 @@ export async function handleHarnessInvokeByArn(
       logFilePath: logger.logFilePath,
     };
   }
+}
+
+// ============================================================================
+// Direct Harness Invoke by ARN (no project required)
+// ============================================================================
+
+export async function handleHarnessInvokeByArn(
+  harnessArn: string,
+  region: string,
+  options: InvokeOptions
+): Promise<InvokeResult> {
+  if (!options.prompt) {
+    return {
+      success: false,
+      error: 'No prompt provided. Usage: agentcore invoke --harness-arn <arn> --region <region> "your prompt"',
+    };
+  }
+
+  const sessionId = options.sessionId ?? randomUUID();
+  const logger = new InvokeLogger({ agentName: 'external-harness', runtimeArn: harnessArn, region, sessionId });
+  logger.logPrompt(options.prompt, sessionId, options.userId);
+
+  const baseOpts = buildHarnessBaseOpts(options);
+  return streamHarnessInvoke({ region, harnessArn, sessionId, prompt: options.prompt, options, logger, baseOpts });
 }
 
 // ============================================================================
@@ -805,199 +918,17 @@ async function handleHarnessInvoke(
   });
   logger.logPrompt(options.prompt, sessionId, options.userId);
 
-  let fullResponse = '';
-  const dim = '\x1b[2m';
-  const reset = '\x1b[0m';
-  const cyan = '\x1b[36m';
+  const baseOpts = buildHarnessBaseOpts(options, harnessSpec?.model);
 
-  const SPINNER = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
-  let spinnerInterval: NodeJS.Timeout | undefined;
-  let spinnerIdx = 0;
-  if (!options.json && !options.verbose) {
-    process.stderr.write(`${dim}${SPINNER[0]} Thinking...${reset}`);
-    spinnerInterval = setInterval(() => {
-      spinnerIdx = (spinnerIdx + 1) % SPINNER.length;
-      process.stderr.write(`\r${dim}${SPINNER[spinnerIdx]} Thinking...${reset}`);
-    }, 80);
-  }
+  const result = await streamHarnessInvoke({
+    region,
+    harnessArn: harnessState.harnessArn,
+    sessionId,
+    prompt: options.prompt,
+    options,
+    logger,
+    baseOpts,
+  });
 
-  let spinnerCleared = false;
-  const clearSpinner = () => {
-    if (spinnerInterval && !spinnerCleared) {
-      clearInterval(spinnerInterval);
-      spinnerCleared = true;
-      process.stderr.write('\r\x1b[K');
-    }
-  };
-
-  try {
-    const messages: { role: string; content: Record<string, unknown>[] }[] = [
-      { role: 'user', content: [{ text: options.prompt }] },
-    ];
-
-    const baseOpts: Partial<import('../../aws/agentcore-harness').InvokeHarnessOptions> = {};
-    if (options.modelId || options.modelProvider || options.apiKeyArn) {
-      const provider = options.modelProvider ?? harnessSpec?.model?.provider;
-      const modelId = options.modelId ?? harnessSpec?.model?.modelId ?? '';
-      const apiKeyArn = options.apiKeyArn ?? harnessSpec?.model?.apiKeyArn;
-      switch (provider) {
-        case 'open_ai':
-          baseOpts.model = { openAiModelConfig: { modelId, ...(apiKeyArn && { apiKeyArn }) } };
-          break;
-        case 'gemini':
-          baseOpts.model = { geminiModelConfig: { modelId, ...(apiKeyArn && { apiKeyArn }) } };
-          break;
-        default:
-          baseOpts.model = { bedrockModelConfig: { modelId } };
-          break;
-      }
-    }
-    if (options.tools) {
-      baseOpts.tools = options.tools.split(',').map(t => {
-        const type = t.trim();
-        return { type, name: TOOL_TYPE_DEFAULT_NAMES[type] ?? type };
-      });
-    }
-    if (options.maxIterations != null) baseOpts.maxIterations = options.maxIterations;
-    if (options.maxTokens != null) baseOpts.maxTokens = options.maxTokens;
-    if (options.harnessTimeout != null) baseOpts.timeoutSeconds = options.harnessTimeout;
-    if (options.skills) baseOpts.skills = options.skills.split(',').map(p => ({ path: p.trim() }));
-    if (options.systemPrompt) baseOpts.systemPrompt = [{ text: options.systemPrompt }];
-    if (options.allowedTools) baseOpts.allowedTools = options.allowedTools.split(',').map(t => t.trim());
-    if (options.actorId) baseOpts.actorId = options.actorId;
-
-    let pendingToolUseId: string | undefined;
-    let pendingToolName: string | undefined;
-    let pendingToolInput = '';
-
-    let continueLoop = true;
-    while (continueLoop) {
-      continueLoop = false;
-
-      const stream = invokeHarness({
-        region,
-        harnessArn: harnessState.harnessArn,
-        runtimeSessionId: sessionId,
-        messages,
-        bearerToken: options.bearerToken,
-        ...baseOpts,
-      });
-
-      pendingToolUseId = undefined;
-      pendingToolName = undefined;
-      pendingToolInput = '';
-
-      for await (const event of stream) {
-        if (options.verbose) {
-          clearSpinner();
-          console.log(JSON.stringify(event));
-          continue;
-        }
-
-        switch (event.type) {
-          case 'contentBlockDelta':
-            if (event.delta.type === 'text') {
-              clearSpinner();
-              fullResponse += event.delta.text;
-              if (!options.json) {
-                process.stdout.write(event.delta.text);
-              }
-            } else if (event.delta.type === 'toolUse') {
-              pendingToolInput += event.delta.input;
-            } else if (event.delta.type === 'toolResult') {
-              const results = event.delta.results;
-              for (const r of results) {
-                const text = (r.text as string) ?? (r.json ? JSON.stringify(r.json) : '');
-                if (text) {
-                  logger.logInfo(`Tool output: ${text.slice(0, 200)}`);
-                }
-              }
-            }
-            break;
-          case 'contentBlockStart':
-            if (event.start.type === 'toolUse') {
-              pendingToolUseId = event.start.toolUse.toolUseId;
-              pendingToolName = event.start.toolUse.name;
-              pendingToolInput = '';
-              logger.logInfo(`Tool call: ${pendingToolName} (id: ${pendingToolUseId})`);
-              if (!options.json) {
-                const serverName = event.start.toolUse.serverName;
-                const label = serverName ? `${serverName}/${pendingToolName}` : pendingToolName;
-                process.stderr.write(`\n${dim}🔧 Tool: ${label}${reset}\n`);
-              }
-            } else if (event.start.type === 'toolResult') {
-              const status = event.start.toolResult.status ?? 'success';
-              logger.logInfo(`Tool result (${pendingToolName}): status=${status}`);
-              if (!options.json) {
-                const icon = status === 'error' ? '❌' : '✓';
-                process.stderr.write(`${dim}  ${icon} `);
-              }
-            }
-            break;
-          case 'messageStop':
-            if (event.stopReason === 'tool_use' && pendingToolUseId) {
-              clearSpinner();
-              let inputObj: Record<string, unknown> = {};
-              try {
-                inputObj = JSON.parse(pendingToolInput) as Record<string, unknown>;
-              } catch {
-                // use empty
-              }
-              logger.logInfo(`Tool input (${pendingToolName}): ${JSON.stringify(inputObj)}`);
-            } else if (event.stopReason === 'tool_result') {
-              if (!options.json) {
-                process.stderr.write(`${reset}\n`);
-              }
-            } else if (!options.json) {
-              process.stdout.write('\n');
-            }
-            break;
-          case 'metadata':
-            logger.logInfo(
-              `Tokens: ${event.usage.inputTokens} in, ${event.usage.outputTokens} out | Latency: ${event.metrics.latencyMs}ms`
-            );
-            if (!options.json) {
-              const { inputTokens, outputTokens } = event.usage;
-              const latency = (event.metrics.latencyMs / 1000).toFixed(1);
-              process.stderr.write(
-                `\n${dim}⚡ ${cyan}${inputTokens}${dim} in · ${cyan}${outputTokens}${dim} out · ${cyan}${latency}s${reset}\n`
-              );
-              process.stderr.write(
-                `${dim}🔗 Session: ${cyan}${sessionId}${dim} (use --session-id to continue)${reset}\n`
-              );
-            }
-            break;
-          case 'error':
-            clearSpinner();
-            logger.logError(new Error(`${event.errorType}: ${event.message}`), 'stream error');
-            if (options.json) {
-              return { success: false, error: `${event.errorType}: ${event.message}` };
-            }
-            process.stderr.write(`\nError: ${event.message}\n`);
-            break;
-        }
-      }
-    }
-
-    logger.logResponse(fullResponse);
-
-    if (options.json) {
-      return {
-        success: true,
-        targetName: selectedTargetName,
-        response: JSON.stringify({ text: fullResponse, sessionId }),
-        logFilePath: logger.logFilePath,
-      };
-    }
-
-    return { success: true, targetName: selectedTargetName, logFilePath: logger.logFilePath };
-  } catch (err) {
-    clearSpinner();
-    logger.logError(err, 'harness invoke failed');
-    return {
-      success: false,
-      error: `Harness invoke failed: ${err instanceof Error ? err.message : String(err)}`,
-      logFilePath: logger.logFilePath,
-    };
-  }
+  return { ...result, targetName: selectedTargetName };
 }

--- a/src/cli/commands/invoke/action.ts
+++ b/src/cli/commands/invoke/action.ts
@@ -806,13 +806,25 @@ async function handleHarnessInvoke(
     };
   }
 
+  const sessionId = options.sessionId ?? randomUUID();
+  const region = targetConfig.region;
+
+  const logger = new InvokeLogger({
+    agentName: harnessName,
+    runtimeArn: harnessState.harnessArn,
+    region,
+    sessionId,
+  });
+
   // Read harness spec for auth config
   const configIO = new ConfigIO();
   let harnessSpec;
   try {
     harnessSpec = await configIO.readHarnessSpec(harnessName);
-  } catch {
-    // If we can't read the spec, continue without auto-fetch
+  } catch (err) {
+    logger.logInfo(
+      `Could not read harness spec for '${harnessName}': ${err instanceof Error ? err.message : String(err)}`
+    );
   }
 
   // Auto-fetch bearer token for CUSTOM_JWT harnesses when not provided
@@ -907,15 +919,6 @@ async function handleHarnessInvoke(
     return { success: false, error: 'No prompt provided. Usage: agentcore invoke --harness <name> "your prompt"' };
   }
 
-  const sessionId = options.sessionId ?? randomUUID();
-  const region = targetConfig.region;
-
-  const logger = new InvokeLogger({
-    agentName: harnessName,
-    runtimeArn: harnessState.harnessArn,
-    region,
-    sessionId,
-  });
   logger.logPrompt(options.prompt, sessionId, options.userId);
 
   const baseOpts = buildHarnessBaseOpts(options, harnessSpec?.model);

--- a/src/cli/commands/invoke/action.ts
+++ b/src/cli/commands/invoke/action.ts
@@ -722,7 +722,7 @@ async function streamHarnessInvoke(params: StreamHarnessParams): Promise<InvokeR
       };
     }
 
-    return { success: true, sessionId, logFilePath: logger.logFilePath };
+    return { success: true, logFilePath: logger.logFilePath };
   } catch (err) {
     clearSpinner();
     logger.logError(err, 'harness invoke failed');

--- a/src/cli/commands/invoke/action.ts
+++ b/src/cli/commands/invoke/action.ts
@@ -509,6 +509,143 @@ export async function handleInvoke(context: InvokeContext, options: InvokeOption
 }
 
 // ============================================================================
+// Direct Harness Invoke by ARN (no project required)
+// ============================================================================
+
+export async function handleHarnessInvokeByArn(
+  harnessArn: string,
+  region: string,
+  options: InvokeOptions
+): Promise<InvokeResult> {
+  if (!options.prompt) {
+    return {
+      success: false,
+      error: 'No prompt provided. Usage: agentcore invoke --harness-arn <arn> --region <region> "your prompt"',
+    };
+  }
+
+  const sessionId = options.sessionId ?? randomUUID();
+  const logger = new InvokeLogger({ agentName: 'external-harness', runtimeArn: harnessArn, region, sessionId });
+  logger.logPrompt(options.prompt, sessionId, options.userId);
+
+  let fullResponse = '';
+  const dim = '\x1b[2m';
+  const reset = '\x1b[0m';
+  const cyan = '\x1b[36m';
+
+  const SPINNER = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+  let spinnerInterval: NodeJS.Timeout | undefined;
+  let spinnerIdx = 0;
+  if (!options.json && !options.verbose) {
+    process.stderr.write(`${dim}${SPINNER[0]} Thinking...${reset}`);
+    spinnerInterval = setInterval(() => {
+      spinnerIdx = (spinnerIdx + 1) % SPINNER.length;
+      process.stderr.write(`\r${dim}${SPINNER[spinnerIdx]} Thinking...${reset}`);
+    }, 80);
+  }
+
+  let spinnerCleared = false;
+  const clearSpinner = () => {
+    if (spinnerInterval && !spinnerCleared) {
+      clearInterval(spinnerInterval);
+      spinnerCleared = true;
+      process.stderr.write('\r\x1b[K');
+    }
+  };
+
+  try {
+    const messages: { role: string; content: Record<string, unknown>[] }[] = [
+      { role: 'user', content: [{ text: options.prompt }] },
+    ];
+
+    const baseOpts: Partial<import('../../aws/agentcore-harness').InvokeHarnessOptions> = {};
+    if (options.systemPrompt) baseOpts.systemPrompt = [{ text: options.systemPrompt }];
+    if (options.tools) {
+      baseOpts.tools = options.tools.split(',').map(t => {
+        const type = t.trim();
+        return { type, name: TOOL_TYPE_DEFAULT_NAMES[type] ?? type };
+      });
+    }
+    if (options.maxIterations != null) baseOpts.maxIterations = options.maxIterations;
+    if (options.maxTokens != null) baseOpts.maxTokens = options.maxTokens;
+    if (options.harnessTimeout != null) baseOpts.timeoutSeconds = options.harnessTimeout;
+    if (options.allowedTools) baseOpts.allowedTools = options.allowedTools.split(',').map(t => t.trim());
+    if (options.actorId) baseOpts.actorId = options.actorId;
+
+    const stream = invokeHarness({
+      region,
+      harnessArn,
+      runtimeSessionId: sessionId,
+      messages,
+      bearerToken: options.bearerToken,
+      ...baseOpts,
+    });
+
+    for await (const event of stream) {
+      if (options.verbose) {
+        clearSpinner();
+        console.log(JSON.stringify(event));
+        continue;
+      }
+
+      switch (event.type) {
+        case 'contentBlockDelta':
+          if (event.delta.type === 'text') {
+            clearSpinner();
+            fullResponse += event.delta.text;
+            if (!options.json) {
+              process.stdout.write(event.delta.text);
+            }
+          }
+          break;
+        case 'messageStop':
+          if (!options.json && !options.verbose) {
+            process.stdout.write('\n');
+          }
+          break;
+        case 'metadata':
+          if (!options.json) {
+            const { inputTokens, outputTokens } = event.usage;
+            const latency = (event.metrics.latencyMs / 1000).toFixed(1);
+            process.stderr.write(
+              `\n${dim}⚡ ${cyan}${inputTokens}${dim} in · ${cyan}${outputTokens}${dim} out · ${cyan}${latency}s${reset}\n`
+            );
+          }
+          break;
+        case 'error':
+          clearSpinner();
+          if (options.json) {
+            return { success: false, error: `${event.errorType}: ${event.message}` };
+          }
+          process.stderr.write(`\nError: ${event.message}\n`);
+          break;
+      }
+    }
+
+    logger.logResponse(fullResponse);
+
+    if (options.json) {
+      return {
+        success: true,
+        response: JSON.stringify({ text: fullResponse, sessionId }),
+        sessionId,
+        logFilePath: logger.logFilePath,
+      };
+    }
+
+    return { success: true, sessionId, logFilePath: logger.logFilePath };
+  } catch (err) {
+    clearSpinner();
+    logger.logError(err, 'harness invoke failed');
+    return {
+      success: false,
+      error: `Harness invoke failed: ${err instanceof Error ? err.message : String(err)}`,
+      logFilePath: logger.logFilePath,
+    };
+  }
+}
+
+// ============================================================================
 // Harness Invoke
 // ============================================================================
 

--- a/src/cli/commands/invoke/command.tsx
+++ b/src/cli/commands/invoke/command.tsx
@@ -55,12 +55,8 @@ async function handleInvokeCLI(options: InvokeOptions): Promise<void> {
       const result = await handleHarnessInvokeByArn(options.harnessArn, region, options);
       if (options.json) {
         console.log(JSON.stringify(result));
-      }
-      if (result.sessionId && !options.json) {
-        console.error(`\nSession: ${result.sessionId}`);
-        console.error(
-          `To resume: agentcore invoke --harness-arn ${options.harnessArn} --region ${region} --session-id ${result.sessionId}`
-        );
+      } else if (!result.success && result.error) {
+        console.error(result.error);
       }
       process.exit(result.success ? 0 : 1);
     }

--- a/src/cli/commands/invoke/command.tsx
+++ b/src/cli/commands/invoke/command.tsx
@@ -3,7 +3,7 @@ import { COMMAND_DESCRIPTIONS } from '../../tui/copy';
 import { requireProject, requireTTY } from '../../tui/guards';
 import { InvokeScreen } from '../../tui/screens/invoke';
 import { parseHeaderFlags } from '../shared/header-utils';
-import { handleInvoke, loadInvokeConfig } from './action';
+import { handleHarnessInvokeByArn, handleInvoke, loadInvokeConfig } from './action';
 import { resolvePrompt } from './resolve-prompt';
 import type { InvokeOptions } from './types';
 import { validateInvokeOptions } from './validate';
@@ -41,6 +41,30 @@ async function handleInvokeCLI(options: InvokeOptions): Promise<void> {
   let spinner: NodeJS.Timeout | undefined;
 
   try {
+    if (options.harnessArn) {
+      const region = options.region ?? process.env.AWS_REGION ?? process.env.AWS_DEFAULT_REGION;
+      if (!region) {
+        const msg = '--region is required with --harness-arn (or set AWS_REGION)';
+        if (options.json) {
+          console.log(JSON.stringify({ success: false, error: msg }));
+        } else {
+          console.error(msg);
+        }
+        process.exit(1);
+      }
+      const result = await handleHarnessInvokeByArn(options.harnessArn, region, options);
+      if (options.json) {
+        console.log(JSON.stringify(result));
+      }
+      if (result.sessionId && !options.json) {
+        console.error(`\nSession: ${result.sessionId}`);
+        console.error(
+          `To resume: agentcore invoke --harness-arn ${options.harnessArn} --region ${region} --session-id ${result.sessionId}`
+        );
+      }
+      process.exit(result.success ? 0 : 1);
+    }
+
     const context = await loadInvokeConfig();
 
     // Show spinner for non-streaming, non-json, non-exec invocations
@@ -131,6 +155,8 @@ export const registerInvoke = (program: Command) => {
     )
     .option('--bearer-token <token>', 'Bearer token for CUSTOM_JWT auth (bypasses SigV4) [non-interactive]')
     .option('--harness <name>', 'Select specific harness to invoke [non-interactive]')
+    .option('--harness-arn <arn>', 'Invoke a harness by ARN (no project required) [non-interactive]')
+    .option('--region <region>', 'AWS region (required with --harness-arn when no project) [non-interactive]')
     .option('--verbose', 'Print verbose streaming JSON events (harness only) [non-interactive]')
     .option('--model-id <id>', 'Override model for this invocation (harness only) [non-interactive]')
     .option(
@@ -165,6 +191,8 @@ export const registerInvoke = (program: Command) => {
           header?: string[];
           bearerToken?: string;
           harness?: string;
+          harnessArn?: string;
+          region?: string;
           verbose?: boolean;
           modelId?: string;
           modelProvider?: string;
@@ -180,7 +208,9 @@ export const registerInvoke = (program: Command) => {
         }
       ) => {
         try {
-          requireProject();
+          if (!cliOptions.harnessArn) {
+            requireProject();
+          }
           // Resolve prompt from flag / positional / --prompt-file / stdin
           const resolved = await resolvePrompt({
             flag: cliOptions.prompt,
@@ -215,12 +245,15 @@ export const registerInvoke = (program: Command) => {
             cliOptions.exec ||
             cliOptions.bearerToken ||
             cliOptions.harness ||
+            cliOptions.harnessArn ||
             cliOptions.verbose
           ) {
             await handleInvokeCLI({
               prompt,
               agentName: cliOptions.runtime,
               harnessName: cliOptions.harness,
+              harnessArn: cliOptions.harnessArn,
+              region: cliOptions.region,
               targetName: cliOptions.target ?? 'default',
               sessionId: cliOptions.sessionId,
               userId: cliOptions.userId,

--- a/src/cli/commands/invoke/types.ts
+++ b/src/cli/commands/invoke/types.ts
@@ -1,6 +1,10 @@
 export interface InvokeOptions {
   agentName?: string;
   harnessName?: string;
+  /** Direct harness ARN — bypasses project config and deployed state resolution */
+  harnessArn?: string;
+  /** AWS region (used with --harness-arn) */
+  region?: string;
   targetName?: string;
   prompt?: string;
   /** Path to a file containing the prompt (alternative to --prompt / positional) */

--- a/src/cli/commands/invoke/validate.ts
+++ b/src/cli/commands/invoke/validate.ts
@@ -6,6 +6,12 @@ export interface ValidationResult {
 }
 
 export function validateInvokeOptions(options: InvokeOptions): ValidationResult {
+  if (options.harnessArn && (options.harnessName || options.agentName)) {
+    return { valid: false, error: '--harness-arn cannot be combined with --harness or --runtime' };
+  }
+  if (options.harnessArn && options.exec) {
+    return { valid: false, error: '--exec is not supported with --harness-arn' };
+  }
   if (options.harnessName && options.agentName) {
     return { valid: false, error: '--harness and --runtime cannot be used together' };
   }

--- a/src/cli/commands/invoke/validate.ts
+++ b/src/cli/commands/invoke/validate.ts
@@ -9,8 +9,8 @@ export function validateInvokeOptions(options: InvokeOptions): ValidationResult 
   if (options.harnessName && options.agentName) {
     return { valid: false, error: '--harness and --runtime cannot be used together' };
   }
-  if (options.verbose && !options.harnessName) {
-    return { valid: false, error: '--verbose is only supported with --harness' };
+  if (options.verbose && !options.harnessName && !options.harnessArn) {
+    return { valid: false, error: '--verbose is only supported with --harness or --harness-arn' };
   }
   if (options.exec && !options.prompt) {
     return { valid: false, error: 'A command is required with --exec. Usage: agentcore invoke --exec "ls -la"' };


### PR DESCRIPTION
## Summary

Adds `--harness-arn` and `--region` flags to `agentcore invoke`, allowing users to invoke any harness by ARN — including harnesses created via the Console, AWS CLI, or SDK, not just those created through `agentcore create`.

Also refactors the harness streaming code to eliminate duplication between the project-based and ARN-based invoke paths.

## Problem

Currently, `agentcore invoke` requires:
1. An agentcore project directory (`requireProject()` check)
2. A `deployed-state.json` with the harness entry (`loadInvokeConfig()`)

This means harnesses created outside the CLI cannot be invoked through it.

## Solution

When `--harness-arn` is provided:
- `requireProject()` is skipped — no `agentcore/` directory needed
- `loadInvokeConfig()` is skipped — no `deployed-state.json` needed
- A new `handleHarnessInvokeByArn()` function calls `invokeHarness()` directly with the ARN
- Region is resolved from `--region` flag or `AWS_REGION`/`AWS_DEFAULT_REGION` env vars
- All harness override flags work (`--system-prompt`, `--tools`, `--model-id`, `--model-provider`, `--skills`, `--verbose`, etc.)
- Session continuity works via `--session-id`

### Shared streaming helper

Extracted `buildHarnessBaseOpts()` and `streamHarnessInvoke()` as shared helpers so both the project-based (`handleHarnessInvoke`) and ARN-based (`handleHarnessInvokeByArn`) paths use the same streaming loop, event handling, spinner, and option building. This eliminates ~70 lines of duplication and ensures both paths handle tool events, model overrides, skills, and all other options identically.

## Usage

```bash
# Basic invocation (no project needed)
agentcore invoke --harness-arn arn:aws:bedrock-agentcore:us-east-1:123456789012:harness/MyHarness-abc123 \
  --region us-east-1 "What is 2+2?"

# With overrides
agentcore invoke --harness-arn <arn> --region us-east-1 \
  --system-prompt "You are a coding assistant" \
  --tools agentcore_browser \
  "Help me debug this"

# Continue a session
agentcore invoke --harness-arn <arn> --region us-east-1 \
  --session-id <previous-session-id> "Follow up question"

# Verbose mode (raw event stream)
agentcore invoke --harness-arn <arn> --region us-east-1 --verbose "hello"
```

## Changes

- `src/cli/commands/invoke/types.ts` — Add `harnessArn` and `region` to `InvokeOptions`
- `src/cli/commands/invoke/command.tsx` — Add `--harness-arn` and `--region` CLI flags, skip `requireProject()` when ARN provided, early-return to `handleHarnessInvokeByArn()`
- `src/cli/commands/invoke/action.ts` — Extract `buildHarnessBaseOpts()` and `streamHarnessInvoke()` shared helpers; add `handleHarnessInvokeByArn()`; refactor `handleHarnessInvoke()` to use shared helpers
- `src/cli/commands/invoke/validate.ts` — Allow `--verbose` with `--harness-arn`

## Test plan

- [x] `npm run typecheck` passes
- [x] `npx eslint` on changed files passes (0 errors)
- [x] `npx prettier --check` passes
- [x] Existing invoke tests pass (32/32)
- [x] E2E: `agentcore invoke --harness-arn <arn> --region us-east-1 "What is 2+2?"` → "Four" (from `/tmp`, no project)
- [x] E2E: session continuity with `--session-id` — harness remembered previous question
- [x] E2E: missing `--region` → clear error message
- [x] E2E: verified after refactor — "Tokyo" returned correctly with shared streaming helper