### PR TITLE
fix: add batch eval and recommendation IAM permissions to docs

### DIFF
--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -335,6 +335,20 @@ Required for all deployment operations (`deploy`, `status`, `diff`).
 | `bedrock-agentcore:Evaluate`                     | `run evals`                               | Run on-demand evaluation against agent traces |
 | `bedrock-agentcore:UpdateOnlineEvaluationConfig` | `pause online-eval`, `resume online-eval` | Pause or resume online evaluation             |
 
+### Batch evaluation and recommendations
+
+| Action                                    | CLI Commands     | Purpose                        |
+| ----------------------------------------- | ---------------- | ------------------------------ |
+| `bedrock-agentcore:StartBatchEvaluation`  | `run batch-eval` | Start a batch evaluation job   |
+| `bedrock-agentcore:GetBatchEvaluation`    | `run batch-eval` | Poll batch evaluation status   |
+| `bedrock-agentcore:ListBatchEvaluations`  | `evals history`  | List past batch evaluations    |
+| `bedrock-agentcore:StopBatchEvaluation`   | `run batch-eval` | Stop an in-progress batch eval |
+| `bedrock-agentcore:DeleteBatchEvaluation` | `run batch-eval` | Delete a batch evaluation      |
+| `bedrock-agentcore:StartRecommendation`   | `run recommend`  | Start a recommendation job     |
+| `bedrock-agentcore:GetRecommendation`     | `run recommend`  | Poll recommendation status     |
+| `bedrock-agentcore:ListRecommendations`   | `run recommend`  | List past recommendations      |
+| `bedrock-agentcore:DeleteRecommendation`  | `run recommend`  | Stop/delete a recommendation   |
+
 ### Identity and credential management
 
 | Action                                             | CLI Commands | Purpose                                   |
@@ -361,14 +375,19 @@ Required for all deployment operations (`deploy`, `status`, `diff`).
 
 ### Logging, traces, and observability
 
-| Action                          | CLI Commands                             | Purpose                                       |
-| ------------------------------- | ---------------------------------------- | --------------------------------------------- |
-| `logs:StartLiveTail`            | `logs`                                   | Stream agent logs in real-time                |
-| `logs:FilterLogEvents`          | `logs`                                   | Search agent logs                             |
-| `logs:StartQuery`               | `traces list`, `traces get`, `run evals` | Run CloudWatch Logs Insights queries          |
-| `logs:GetQueryResults`          | `traces list`, `traces get`, `run evals` | Retrieve query results                        |
-| `logs:DescribeResourcePolicies` | `deploy`                                 | Check for X-Ray log resource policy           |
-| `logs:PutResourcePolicy`        | `deploy`                                 | Create resource policy for X-Ray trace access |
+| Action                          | CLI Commands                             | Purpose                                                    |
+| ------------------------------- | ---------------------------------------- | ---------------------------------------------------------- |
+| `logs:StartLiveTail`            | `logs`                                   | Stream agent logs in real-time                             |
+| `logs:FilterLogEvents`          | `logs`                                   | Search agent logs                                          |
+| `logs:StartQuery`               | `traces list`, `traces get`, `run evals` | Run CloudWatch Logs Insights queries                       |
+| `logs:GetQueryResults`          | `traces list`, `traces get`, `run evals` | Retrieve query results                                     |
+| `logs:DescribeResourcePolicies` | `deploy`                                 | Check for X-Ray log resource policy                        |
+| `logs:PutResourcePolicy`        | `deploy`                                 | Create resource policy for X-Ray trace access              |
+| `logs:DescribeLogGroups`        | `run batch-eval`, `run recommend`        | Discover runtime log groups for evaluation data sources    |
+| `logs:CreateLogGroup`           | `run batch-eval`                         | Create log group for batch evaluation results output       |
+| `logs:CreateLogStream`          | `run batch-eval`                         | Create log stream for batch evaluation results             |
+| `logs:PutLogEvents`             | `run batch-eval`                         | Write batch evaluation results to CloudWatch Logs          |
+| `logs:PutRetentionPolicy`       | `run batch-eval`                         | Set retention policy on batch evaluation results log group |
 
 ### Transaction search setup
 

--- a/docs/policies/iam-policy-user.json
+++ b/docs/policies/iam-policy-user.json
@@ -90,6 +90,22 @@
       "Resource": "*"
     },
     {
+      "Sid": "BatchEvalAndRecommendations",
+      "Effect": "Allow",
+      "Action": [
+        "bedrock-agentcore:StartBatchEvaluation",
+        "bedrock-agentcore:GetBatchEvaluation",
+        "bedrock-agentcore:ListBatchEvaluations",
+        "bedrock-agentcore:StopBatchEvaluation",
+        "bedrock-agentcore:DeleteBatchEvaluation",
+        "bedrock-agentcore:StartRecommendation",
+        "bedrock-agentcore:GetRecommendation",
+        "bedrock-agentcore:ListRecommendations",
+        "bedrock-agentcore:DeleteRecommendation"
+      ],
+      "Resource": "*"
+    },
+    {
       "Sid": "LogsStreamingAndSearch",
       "Effect": "Allow",
       "Action": [
@@ -98,7 +114,12 @@
         "logs:StartQuery",
         "logs:GetQueryResults",
         "logs:DescribeResourcePolicies",
-        "logs:PutResourcePolicy"
+        "logs:PutResourcePolicy",
+        "logs:DescribeLogGroups",
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "logs:PutRetentionPolicy"
       ],
       "Resource": "*"
     },


### PR DESCRIPTION
## Summary

Adds missing IAM permissions to docs policy files for batch evaluation and recommendations:

- Add BatchEvalAndRecommendations statement to iam-policy-user.json (9 actions)
- Add CloudWatch Logs write permissions to LogsStreamingAndSearch (DescribeLogGroups, CreateLogGroup, CreateLogStream, PutLogEvents, PutRetentionPolicy)
- Update PERMISSIONS.md with batch eval/recommendations reference section and logging entries

Also applied logs:PutRetentionPolicy to the e2e-github-actions role in the test account.

## Context

E2E batch eval tests were failing with 403 on PutRetentionPolicy -- the batch eval API sets a retention policy on its results log group.

## Test plan

- [x] iam-policy-user.json is valid JSON
- [x] prettier passes
- [x] Applied PutRetentionPolicy to e2e-github-actions role
- [ ] Re-run E2E to confirm batch eval tests pass