### PR TITLE
chore: update CP semantics to expect redesigned namespaces field

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -244,7 +244,7 @@ Strategy configuration:
   "type": "SEMANTIC",
   "name": "custom_semantic",
   "description": "Custom semantic memory",
-  "namespaces": ["/users/facts", "/users/preferences"]
+  "namespaceTemplates": ["/users/facts", "/users/preferences"]
 }
 ```
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -196,17 +196,19 @@ Each strategy can have optional configuration:
   "type": "SEMANTIC",
   "name": "custom_semantic",
   "description": "Custom semantic memory",
-  "namespaces": ["/users/facts", "/users/preferences"]
+  "namespaceTemplates": ["/users/facts", "/users/preferences"]
 }
 ```
 
-| Field                  | Required      | Description                                                                 |
-| ---------------------- | ------------- | --------------------------------------------------------------------------- |
-| `type`                 | Yes           | Strategy type                                                               |
-| `name`                 | No            | Custom name (defaults to `<memoryName>-<type>`)                             |
-| `description`          | No            | Strategy description                                                        |
-| `namespaces`           | No            | Array of namespace paths for scoping                                        |
-| `reflectionNamespaces` | EPISODIC only | Namespaces for cross-episode reflections (must be a prefix of `namespaces`) |
+| Field                          | Required      | Description                                                                                   |
+| ------------------------------ | ------------- | --------------------------------------------------------------------------------------------- |
+| `type`                         | Yes           | Strategy type                                                                                 |
+| `name`                         | No            | Custom name (defaults to `<memoryName>-<type>`)                                               |
+| `description`                  | No            | Strategy description                                                                          |
+| `namespaceTemplates`           | No            | Array of namespace templates for scoping                                                      |
+| `reflectionNamespaceTemplates` | EPISODIC only | Templates for cross-episode reflections (must be a prefix of `namespaceTemplates`)            |
+| `namespaces`                   | No            | **Deprecated alias for `namespaceTemplates`.** Accepted for backward compatibility.           |
+| `reflectionNamespaces`         | EPISODIC only | **Deprecated alias for `reflectionNamespaceTemplates`.** Accepted for backward compatibility. |
 
 ## Event Expiry
 

--- a/e2e-tests/fixtures/import/setup_memory_full.py
+++ b/e2e-tests/fixtures/import/setup_memory_full.py
@@ -31,7 +31,7 @@ def main():
                 "semanticMemoryStrategy": {
                     "name": "bugbash_semantic",
                     "description": "Semantic strategy for bugbash testing",
-                    "namespaces": ["default"],
+                    "namespaceTemplates": ["default"],
                 }
             },
             {
@@ -68,7 +68,7 @@ def main():
     print(f"  eventExpiryDuration: 30")
     print(f"  executionRoleArn: {role_arn}")
     print("  strategies:")
-    print("    - type: SEMANTIC, name: bugbash_semantic, namespaces: [default]")
+    print("    - type: SEMANTIC, name: bugbash_semantic, namespaceTemplates: [default]")
     print("    - type: SUMMARIZATION, name: bugbash_summary")
     print("    - type: USER_PREFERENCE, name: bugbash_userpref")
     print("  tags: {env: bugbash, team: agentcore-cli}")

--- a/integ-tests/add-remove-resources.test.ts
+++ b/integ-tests/add-remove-resources.test.ts
@@ -44,7 +44,7 @@ describe('integration: add and remove resources', () => {
       telemetry.assertMetricEmitted({ command: 'add.memory', exit_reason: 'success' });
     });
 
-    it('adds a memory with EPISODIC strategy and verifies reflectionNamespaces', async () => {
+    it('adds a memory with EPISODIC strategy and verifies reflectionNamespaceTemplates', async () => {
       const episodicMemName = `EpiMem${Date.now().toString().slice(-6)}`;
       const result = await runCLI(
         ['add', 'memory', '--name', episodicMemName, '--strategies', 'EPISODIC', '--json'],
@@ -56,19 +56,19 @@ describe('integration: add and remove resources', () => {
       const json = JSON.parse(result.stdout);
       expect(json.success).toBe(true);
 
-      // Verify EPISODIC in config with reflectionNamespaces
+      // Verify EPISODIC in config with reflectionNamespaceTemplates
       const config = await readProjectConfig(project.projectPath);
       const memories = config.memories as {
         name: string;
-        strategies: { type: string; reflectionNamespaces?: string[] }[];
+        strategies: { type: string; reflectionNamespaceTemplates?: string[] }[];
       }[];
       const mem = memories.find(m => m.name === episodicMemName);
       expect(mem, 'Memory should exist').toBeTruthy();
 
       const episodic = mem!.strategies.find(s => s.type === 'EPISODIC');
       expect(episodic, 'EPISODIC strategy should exist').toBeTruthy();
-      expect(episodic!.reflectionNamespaces, 'Should have reflectionNamespaces').toBeDefined();
-      expect(episodic!.reflectionNamespaces!.length).toBeGreaterThan(0);
+      expect(episodic!.reflectionNamespaceTemplates, 'Should have reflectionNamespaceTemplates').toBeDefined();
+      expect(episodic!.reflectionNamespaceTemplates!.length).toBeGreaterThan(0);
 
       telemetry.assertMetricEmitted({
         command: 'add.memory',

--- a/integ-tests/create-memory.test.ts
+++ b/integ-tests/create-memory.test.ts
@@ -80,7 +80,7 @@ describe.skipIf(!prereqs.npm || !prereqs.git)('integration: create with memory o
 
     // longAndShortTerm should have strategies defined
     const memory = memories![0]!;
-    const strategies = memory.strategies as { type: string; reflectionNamespaces?: string[] }[] | undefined;
+    const strategies = memory.strategies as { type: string; reflectionNamespaceTemplates?: string[] }[] | undefined;
     expect(strategies, 'memory should have strategies').toBeDefined();
     expect(strategies!.length).toBe(4);
 
@@ -91,10 +91,10 @@ describe.skipIf(!prereqs.npm || !prereqs.git)('integration: create with memory o
     expect(types).toContain('SUMMARIZATION');
     expect(types).toContain('EPISODIC');
 
-    // Verify EPISODIC has reflectionNamespaces
+    // Verify EPISODIC has reflectionNamespaceTemplates
     const episodic = strategies!.find(s => s.type === 'EPISODIC');
     expect(episodic, 'EPISODIC strategy should exist').toBeTruthy();
-    expect(episodic!.reflectionNamespaces, 'EPISODIC should have reflectionNamespaces').toBeDefined();
-    expect(episodic!.reflectionNamespaces!.length).toBeGreaterThan(0);
+    expect(episodic!.reflectionNamespaceTemplates, 'EPISODIC should have reflectionNamespaceTemplates').toBeDefined();
+    expect(episodic!.reflectionNamespaceTemplates!.length).toBeGreaterThan(0);
   });
 });

--- a/integ-tests/tui/add-memory-episodic.test.ts
+++ b/integ-tests/tui/add-memory-episodic.test.ts
@@ -3,7 +3,7 @@
  *
  * Drives the "Add Memory" wizard through the TUI to verify that when a user
  * selects the EPISODIC strategy, it is correctly persisted in agentcore.json
- * with both namespaces and reflectionNamespaces.
+ * with both namespaceTemplates and reflectionNamespaceTemplates.
  *
  * Exercises:
  *   - Navigation from HelpScreen -> Add Resource -> Memory
@@ -11,7 +11,7 @@
  *   - Expiry selection (default 30 days)
  *   - Strategy multi-select including EPISODIC
  *   - Confirm review screen
- *   - Verification that agentcore.json contains EPISODIC with reflectionNamespaces
+ *   - Verification that agentcore.json contains EPISODIC with reflectionNamespaceTemplates
  */
 import { TuiSession, WaitForTimeoutError } from '../../src/tui-harness/index.js';
 import { createMinimalProjectDir } from './helpers.js';
@@ -176,14 +176,14 @@ describe('Add Memory with EPISODIC Strategy', () => {
     expect(found).toBe(true);
   });
 
-  it('Step 9: agentcore.json contains EPISODIC with reflectionNamespaces', async () => {
+  it('Step 9: agentcore.json contains EPISODIC with reflectionNamespaceTemplates', async () => {
     const configPath = join(projectDir.dir, 'agentcore', 'agentcore.json');
     const raw = await readFileAsync(configPath, 'utf-8');
     const config = JSON.parse(raw);
 
     const memories = config.memories as {
       name: string;
-      strategies: { type: string; namespaces?: string[]; reflectionNamespaces?: string[] }[];
+      strategies: { type: string; namespaceTemplates?: string[]; reflectionNamespaceTemplates?: string[] }[];
     }[];
     expect(memories.length).toBeGreaterThan(0);
 
@@ -197,12 +197,12 @@ describe('Add Memory with EPISODIC Strategy', () => {
     expect(types).toContain('USER_PREFERENCE');
     expect(types).toContain('EPISODIC');
 
-    // Verify EPISODIC has namespaces AND reflectionNamespaces
+    // Verify EPISODIC has namespaceTemplates AND reflectionNamespaceTemplates
     const episodic = memory!.strategies.find(s => s.type === 'EPISODIC');
     expect(episodic, 'EPISODIC strategy should exist').toBeTruthy();
-    expect(episodic!.namespaces, 'EPISODIC should have namespaces').toBeDefined();
-    expect(episodic!.namespaces!.length).toBeGreaterThan(0);
-    expect(episodic!.reflectionNamespaces, 'EPISODIC should have reflectionNamespaces').toBeDefined();
-    expect(episodic!.reflectionNamespaces!.length).toBeGreaterThan(0);
+    expect(episodic!.namespaceTemplates, 'EPISODIC should have namespaceTemplates').toBeDefined();
+    expect(episodic!.namespaceTemplates!.length).toBeGreaterThan(0);
+    expect(episodic!.reflectionNamespaceTemplates, 'EPISODIC should have reflectionNamespaceTemplates').toBeDefined();
+    expect(episodic!.reflectionNamespaceTemplates!.length).toBeGreaterThan(0);
   });
 });

--- a/src/cli/aws/agentcore-control.ts
+++ b/src/cli/aws/agentcore-control.ts
@@ -368,8 +368,8 @@ export interface MemoryDetail {
     type: string;
     name?: string;
     description?: string;
-    namespaces?: string[];
-    reflectionNamespaces?: string[];
+    namespaceTemplates?: string[];
+    reflectionNamespaceTemplates?: string[];
   }[];
   tags?: Record<string, string>;
   encryptionKeyArn?: string;
@@ -422,13 +422,17 @@ export async function getMemoryDetail(options: GetMemoryOptions): Promise<Memory
       if (!s.type) {
         throw new Error(`Memory ${options.memoryId} has a strategy with missing required field: type`);
       }
-      const episodicNamespaces = s.configuration?.reflection?.episodicReflectionConfiguration?.namespaces;
+      // Prefer the new `namespaceTemplates` field; fall back to the deprecated `namespaces` field.
+      const namespaceTemplates = s.namespaceTemplates ?? s.namespaces;
+      const reflectionConfig = s.configuration?.reflection?.episodicReflectionConfiguration;
+      const reflectionTemplates = reflectionConfig?.namespaceTemplates ?? reflectionConfig?.namespaces;
       return {
         type: s.type,
         name: s.name,
         description: s.description,
-        namespaces: s.namespaces,
-        ...(episodicNamespaces && episodicNamespaces.length > 0 && { reflectionNamespaces: episodicNamespaces }),
+        ...(namespaceTemplates && namespaceTemplates.length > 0 && { namespaceTemplates }),
+        ...(reflectionTemplates &&
+          reflectionTemplates.length > 0 && { reflectionNamespaceTemplates: reflectionTemplates }),
       };
     }),
   };

--- a/src/cli/commands/add/__tests__/add-memory.test.ts
+++ b/src/cli/commands/add/__tests__/add-memory.test.ts
@@ -138,20 +138,20 @@ describe('add memory command', () => {
       const memory = projectSpec.memories.find((m: { name: string }) => m.name === memoryName);
 
       const semantic = memory?.strategies?.find((s: { type: string }) => s.type === 'SEMANTIC');
-      expect(semantic?.namespaces).toEqual(['/users/{actorId}/facts']);
+      expect(semantic?.namespaceTemplates).toEqual(['/users/{actorId}/facts']);
 
       const userPref = memory?.strategies?.find((s: { type: string }) => s.type === 'USER_PREFERENCE');
-      expect(userPref?.namespaces).toEqual(['/users/{actorId}/preferences']);
+      expect(userPref?.namespaceTemplates).toEqual(['/users/{actorId}/preferences']);
 
       const summarization = memory?.strategies?.find((s: { type: string }) => s.type === 'SUMMARIZATION');
-      expect(summarization?.namespaces).toEqual(['/summaries/{actorId}/{sessionId}']);
+      expect(summarization?.namespaceTemplates).toEqual(['/summaries/{actorId}/{sessionId}']);
 
       const episodic = memory?.strategies?.find((s: { type: string }) => s.type === 'EPISODIC');
-      expect(episodic?.namespaces).toEqual(['/episodes/{actorId}/{sessionId}']);
-      expect(episodic?.reflectionNamespaces).toEqual(['/episodes/{actorId}']);
+      expect(episodic?.namespaceTemplates).toEqual(['/episodes/{actorId}/{sessionId}']);
+      expect(episodic?.reflectionNamespaceTemplates).toEqual(['/episodes/{actorId}']);
     });
 
-    it('creates memory with EPISODIC strategy including default namespaces and reflectionNamespaces', async () => {
+    it('creates memory with EPISODIC strategy including default namespaceTemplates and reflectionNamespaceTemplates', async () => {
       const memoryName = `epi${Date.now()}`;
       const result = await runCLI(
         ['add', 'memory', '--name', memoryName, '--strategies', 'EPISODIC', '--json'],
@@ -162,8 +162,8 @@ describe('add memory command', () => {
       const memory = projectSpec.memories.find((m: { name: string }) => m.name === memoryName);
       const episodic = memory?.strategies?.find((s: { type: string }) => s.type === 'EPISODIC');
       expect(episodic).toBeTruthy();
-      expect(episodic?.namespaces).toEqual(['/episodes/{actorId}/{sessionId}']);
-      expect(episodic?.reflectionNamespaces).toEqual(['/episodes/{actorId}']);
+      expect(episodic?.namespaceTemplates).toEqual(['/episodes/{actorId}/{sessionId}']);
+      expect(episodic?.reflectionNamespaceTemplates).toEqual(['/episodes/{actorId}']);
     });
   });
 });

--- a/src/cli/commands/create/__tests__/create.test.ts
+++ b/src/cli/commands/create/__tests__/create.test.ts
@@ -143,18 +143,18 @@ describe('create command', () => {
       const memory = projectSpec.memories[0];
 
       const semantic = memory?.strategies?.find((s: { type: string }) => s.type === 'SEMANTIC');
-      expect(semantic?.namespaces).toEqual(['/users/{actorId}/facts']);
+      expect(semantic?.namespaceTemplates).toEqual(['/users/{actorId}/facts']);
 
       const userPref = memory?.strategies?.find((s: { type: string }) => s.type === 'USER_PREFERENCE');
-      expect(userPref?.namespaces).toEqual(['/users/{actorId}/preferences']);
+      expect(userPref?.namespaceTemplates).toEqual(['/users/{actorId}/preferences']);
 
       const summarization = memory?.strategies?.find((s: { type: string }) => s.type === 'SUMMARIZATION');
-      expect(summarization?.namespaces).toEqual(['/summaries/{actorId}/{sessionId}']);
+      expect(summarization?.namespaceTemplates).toEqual(['/summaries/{actorId}/{sessionId}']);
 
       const episodic = memory?.strategies?.find((s: { type: string }) => s.type === 'EPISODIC');
       expect(episodic, 'EPISODIC strategy should exist in longAndShortTerm').toBeTruthy();
-      expect(episodic?.namespaces).toEqual(['/episodes/{actorId}/{sessionId}']);
-      expect(episodic?.reflectionNamespaces).toEqual(['/episodes/{actorId}']);
+      expect(episodic?.namespaceTemplates).toEqual(['/episodes/{actorId}/{sessionId}']);
+      expect(episodic?.reflectionNamespaceTemplates).toEqual(['/episodes/{actorId}']);
     });
 
     it('uses --project-name for project and --name for agent resource', async () => {

--- a/src/cli/commands/import/import-memory.ts
+++ b/src/cli/commands/import/import-memory.ts
@@ -42,14 +42,16 @@ function filterInternalNamespaces(namespaces: string[]): string[] {
 function toMemorySpec(memory: MemoryDetail, localName: string): Memory {
   const strategies: Memory['strategies'] = memory.strategies.map(s => {
     const mappedType = mapStrategyType(s.type);
-    const filteredNamespaces = s.namespaces ? filterInternalNamespaces(s.namespaces) : [];
+    const filteredTemplates = s.namespaceTemplates ? filterInternalNamespaces(s.namespaceTemplates) : [];
     return {
       type: mappedType as Memory['strategies'][number]['type'],
       ...(s.name && { name: s.name }),
       ...(s.description && { description: s.description }),
-      ...(filteredNamespaces.length > 0 && { namespaces: filteredNamespaces }),
-      ...(s.reflectionNamespaces &&
-        s.reflectionNamespaces.length > 0 && { reflectionNamespaces: s.reflectionNamespaces }),
+      ...(filteredTemplates.length > 0 && { namespaceTemplates: filteredTemplates }),
+      ...(s.reflectionNamespaceTemplates &&
+        s.reflectionNamespaceTemplates.length > 0 && {
+          reflectionNamespaceTemplates: s.reflectionNamespaceTemplates,
+        }),
     };
   });
 

--- a/src/cli/operations/agent/generate/__tests__/schema-mapper.test.ts
+++ b/src/cli/operations/agent/generate/__tests__/schema-mapper.test.ts
@@ -46,10 +46,10 @@ describe('mapGenerateInputToMemories', () => {
     expect(types).toContain('EPISODIC');
   });
 
-  it('includes default namespaces for strategies', () => {
+  it('includes default namespace templates for strategies', () => {
     const result = mapGenerateInputToMemories('longAndShortTerm', 'Proj');
     const semantic = result[0]!.strategies.find(s => s.type === 'SEMANTIC');
-    expect(semantic?.namespaces).toEqual(['/users/{actorId}/facts']);
+    expect(semantic?.namespaceTemplates).toEqual(['/users/{actorId}/facts']);
   });
 
   it('uses project name in memory name', () => {

--- a/src/cli/operations/agent/generate/schema-mapper.ts
+++ b/src/cli/operations/agent/generate/schema-mapper.ts
@@ -11,9 +11,9 @@ import type {
 } from '../../../../schema';
 import {
   DEFAULT_ENTRYPOINT_BY_LANGUAGE,
-  DEFAULT_EPISODIC_REFLECTION_NAMESPACES,
+  DEFAULT_EPISODIC_REFLECTION_NAMESPACE_TEMPLATES,
   DEFAULT_RUNTIME_BY_LANGUAGE,
-  DEFAULT_STRATEGY_NAMESPACES,
+  DEFAULT_STRATEGY_NAMESPACE_TEMPLATES,
 } from '../../../../schema';
 import { GatewayPrimitive } from '../../../primitives/GatewayPrimitive';
 import { buildAuthorizerConfigFromJwtConfig } from '../../../primitives/auth-utils';
@@ -74,11 +74,11 @@ export function mapGenerateInputToMemories(memory: MemoryOption, projectName: st
   if (memory === 'longAndShortTerm') {
     const strategyTypes: MemoryStrategyType[] = ['SEMANTIC', 'USER_PREFERENCE', 'SUMMARIZATION', 'EPISODIC'];
     for (const type of strategyTypes) {
-      const defaultNamespaces = DEFAULT_STRATEGY_NAMESPACES[type];
+      const defaultTemplates = DEFAULT_STRATEGY_NAMESPACE_TEMPLATES[type];
       strategies.push({
         type,
-        ...(defaultNamespaces && { namespaces: defaultNamespaces }),
-        ...(type === 'EPISODIC' && { reflectionNamespaces: DEFAULT_EPISODIC_REFLECTION_NAMESPACES }),
+        ...(defaultTemplates && { namespaceTemplates: defaultTemplates }),
+        ...(type === 'EPISODIC' && { reflectionNamespaceTemplates: DEFAULT_EPISODIC_REFLECTION_NAMESPACE_TEMPLATES }),
       });
     }
   }

--- a/src/cli/operations/dev/web-ui/api-types.ts
+++ b/src/cli/operations/dev/web-ui/api-types.ts
@@ -145,8 +145,8 @@ export interface ResourceMemory {
 /** Memory strategy with namespace patterns */
 export interface ResourceMemoryStrategy {
   type: string;
-  /** Namespace patterns, e.g. "/users/{actorId}/facts", "/summaries/{actorId}/{sessionId}" */
-  namespaces: string[];
+  /** Namespace templates, e.g. "/users/{actorId}/facts", "/summaries/{actorId}/{sessionId}" */
+  namespaceTemplates: string[];
 }
 
 /** Credential details in the resources response */

--- a/src/cli/operations/dev/web-ui/handlers/resources.ts
+++ b/src/cli/operations/dev/web-ui/handlers/resources.ts
@@ -112,7 +112,7 @@ export async function handleResources(ctx: RouteContext, res: ServerResponse, or
       name: m.name,
       strategies: m.strategies.map(s => ({
         type: s.type,
-        namespaces: s.namespaces ?? [],
+        namespaceTemplates: s.namespaceTemplates ?? s.namespaces ?? [],
       })),
       expiryDays: m.eventExpiryDuration,
       deploymentStatus: statusByTypeAndName.get(`memory:${m.name}`),

--- a/src/cli/operations/memory/__tests__/create-memory.test.ts
+++ b/src/cli/operations/memory/__tests__/create-memory.test.ts
@@ -82,7 +82,7 @@ describe('add', () => {
     expect(addedMemory).toBeDefined();
     expect(addedMemory.eventExpiryDuration).toBe(60);
     expect(addedMemory.strategies[0]!.type).toBe('SEMANTIC');
-    expect(addedMemory.strategies[0]!.namespaces).toEqual(['/users/{actorId}/facts']);
+    expect(addedMemory.strategies[0]!.namespaceTemplates).toEqual(['/users/{actorId}/facts']);
   });
 
   it('rejects invalid strategy type', async () => {

--- a/src/cli/primitives/MemoryPrimitive.tsx
+++ b/src/cli/primitives/MemoryPrimitive.tsx
@@ -8,8 +8,8 @@ import type {
   StreamDeliveryResources,
 } from '../../schema';
 import {
-  DEFAULT_EPISODIC_REFLECTION_NAMESPACES,
-  DEFAULT_STRATEGY_NAMESPACES,
+  DEFAULT_EPISODIC_REFLECTION_NAMESPACE_TEMPLATES,
+  DEFAULT_STRATEGY_NAMESPACE_TEMPLATES,
   MemorySchema,
   MemoryStrategyTypeSchema,
   StreamContentLevelSchema,
@@ -287,13 +287,13 @@ export class MemoryPrimitive extends BasePrimitive<AddMemoryOptions, RemovableMe
 
     this.checkDuplicate(project.memories, config.name);
 
-    // Map strategies with their default namespaces
+    // Map strategies with their default namespace templates
     const strategies: MemoryStrategy[] = config.strategies.map(s => {
-      const defaultNamespaces = DEFAULT_STRATEGY_NAMESPACES[s.type];
+      const defaultTemplates = DEFAULT_STRATEGY_NAMESPACE_TEMPLATES[s.type];
       return {
         type: s.type,
-        ...(defaultNamespaces && { namespaces: defaultNamespaces }),
-        ...(s.type === 'EPISODIC' && { reflectionNamespaces: DEFAULT_EPISODIC_REFLECTION_NAMESPACES }),
+        ...(defaultTemplates && { namespaceTemplates: defaultTemplates }),
+        ...(s.type === 'EPISODIC' && { reflectionNamespaceTemplates: DEFAULT_EPISODIC_REFLECTION_NAMESPACE_TEMPLATES }),
       };
     });
 

--- a/src/schema/llm-compacted/agentcore.ts
+++ b/src/schema/llm-compacted/agentcore.ts
@@ -103,8 +103,12 @@ interface MemoryStrategy {
   type: MemoryStrategyType;
   name?: string; // @regex ^[a-zA-Z][a-zA-Z0-9_]{0,47}$ @max 48
   description?: string;
+  namespaceTemplates?: string[];
+  reflectionNamespaceTemplates?: string[]; // EPISODIC only: templates for cross-episode reflections
+  /** @deprecated Use namespaceTemplates instead. */
   namespaces?: string[];
-  reflectionNamespaces?: string[]; // EPISODIC only: namespaces for cross-episode reflections
+  /** @deprecated Use reflectionNamespaceTemplates instead. */
+  reflectionNamespaces?: string[];
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/schema/schemas/agentcore-project.ts
+++ b/src/schema/schemas/agentcore-project.ts
@@ -20,7 +20,9 @@ import {
 import { HttpGatewaySchema } from './primitives/http-gateway';
 import {
   DEFAULT_EPISODIC_REFLECTION_NAMESPACES,
+  DEFAULT_EPISODIC_REFLECTION_NAMESPACE_TEMPLATES,
   DEFAULT_STRATEGY_NAMESPACES,
+  DEFAULT_STRATEGY_NAMESPACE_TEMPLATES,
   MemoryStrategySchema,
   MemoryStrategyTypeSchema,
 } from './primitives/memory';
@@ -32,7 +34,9 @@ import { z } from 'zod';
 
 // Re-export for convenience
 export {
+  DEFAULT_EPISODIC_REFLECTION_NAMESPACE_TEMPLATES,
   DEFAULT_EPISODIC_REFLECTION_NAMESPACES,
+  DEFAULT_STRATEGY_NAMESPACE_TEMPLATES,
   DEFAULT_STRATEGY_NAMESPACES,
   MemoryStrategySchema,
   MemoryStrategyTypeSchema,

--- a/src/schema/schemas/primitives/__tests__/memory.test.ts
+++ b/src/schema/schemas/primitives/__tests__/memory.test.ts
@@ -1,4 +1,11 @@
-import { DEFAULT_STRATEGY_NAMESPACES, MemoryStrategySchema, MemoryStrategyTypeSchema } from '../memory';
+import {
+  DEFAULT_EPISODIC_REFLECTION_NAMESPACES,
+  DEFAULT_EPISODIC_REFLECTION_NAMESPACE_TEMPLATES,
+  DEFAULT_STRATEGY_NAMESPACES,
+  DEFAULT_STRATEGY_NAMESPACE_TEMPLATES,
+  MemoryStrategySchema,
+  MemoryStrategyTypeSchema,
+} from '../memory';
 import { describe, expect, it } from 'vitest';
 
 describe('MemoryStrategyTypeSchema', () => {
@@ -26,9 +33,29 @@ describe('MemoryStrategySchema', () => {
       type: 'SEMANTIC',
       name: 'myStrategy',
       description: 'A description',
+      namespaceTemplates: ['/users/{actorId}/facts'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts deprecated namespaces field as backward-compat alias', () => {
+    const result = MemoryStrategySchema.safeParse({
+      type: 'SEMANTIC',
       namespaces: ['/users/{actorId}/facts'],
     });
     expect(result.success).toBe(true);
+  });
+
+  it('rejects strategy specifying both namespaces and namespaceTemplates', () => {
+    const result = MemoryStrategySchema.safeParse({
+      type: 'SEMANTIC',
+      namespaces: ['/users/{actorId}/facts'],
+      namespaceTemplates: ['/users/{actorId}/facts'],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toContain('mutually exclusive');
+    }
   });
 
   it('rejects strategy with CUSTOM type', () => {
@@ -46,7 +73,16 @@ describe('MemoryStrategySchema', () => {
     expect(result.success).toBe(false);
   });
 
-  it('accepts EPISODIC strategy with reflectionNamespaces', () => {
+  it('accepts EPISODIC strategy with reflectionNamespaceTemplates', () => {
+    const result = MemoryStrategySchema.safeParse({
+      type: 'EPISODIC',
+      namespaceTemplates: ['/episodes/{actorId}/{sessionId}'],
+      reflectionNamespaceTemplates: ['/episodes/{actorId}'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts EPISODIC strategy with deprecated reflectionNamespaces alias', () => {
     const result = MemoryStrategySchema.safeParse({
       type: 'EPISODIC',
       namespaces: ['/episodes/{actorId}/{sessionId}'],
@@ -55,29 +91,69 @@ describe('MemoryStrategySchema', () => {
     expect(result.success).toBe(true);
   });
 
-  it('rejects EPISODIC strategy without reflectionNamespaces', () => {
+  it('rejects EPISODIC strategy specifying both reflectionNamespaces and reflectionNamespaceTemplates', () => {
     const result = MemoryStrategySchema.safeParse({
       type: 'EPISODIC',
-      namespaces: ['/episodes/{actorId}/{sessionId}'],
+      namespaceTemplates: ['/episodes/{actorId}/{sessionId}'],
+      reflectionNamespaces: ['/episodes/{actorId}'],
+      reflectionNamespaceTemplates: ['/episodes/{actorId}'],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some(i => i.message.includes('mutually exclusive'))).toBe(true);
+    }
+  });
+
+  it('rejects EPISODIC strategy without reflectionNamespaceTemplates', () => {
+    const result = MemoryStrategySchema.safeParse({
+      type: 'EPISODIC',
+      namespaceTemplates: ['/episodes/{actorId}/{sessionId}'],
     });
     expect(result.success).toBe(false);
   });
 
-  it('rejects EPISODIC strategy with empty reflectionNamespaces', () => {
+  it('rejects EPISODIC strategy with empty reflectionNamespaceTemplates', () => {
     const result = MemoryStrategySchema.safeParse({
       type: 'EPISODIC',
-      namespaces: ['/episodes/{actorId}/{sessionId}'],
-      reflectionNamespaces: [],
+      namespaceTemplates: ['/episodes/{actorId}/{sessionId}'],
+      reflectionNamespaceTemplates: [],
     });
     expect(result.success).toBe(false);
   });
 
-  it('allows non-EPISODIC strategies without reflectionNamespaces', () => {
+  it('allows non-EPISODIC strategies without reflectionNamespaceTemplates', () => {
     const result = MemoryStrategySchema.safeParse({ type: 'SEMANTIC' });
     expect(result.success).toBe(true);
   });
 
-  it('rejects EPISODIC when reflectionNamespaces is not a prefix of namespaces', () => {
+  it('rejects EPISODIC when reflectionNamespaceTemplates is not a prefix of namespaceTemplates', () => {
+    const result = MemoryStrategySchema.safeParse({
+      type: 'EPISODIC',
+      namespaceTemplates: ['/episodes/{actorId}/{sessionId}'],
+      reflectionNamespaceTemplates: ['/reflections/{actorId}'],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts EPISODIC when reflectionNamespaceTemplates is a prefix of namespaceTemplates', () => {
+    const result = MemoryStrategySchema.safeParse({
+      type: 'EPISODIC',
+      namespaceTemplates: ['/episodes/{actorId}/{sessionId}'],
+      reflectionNamespaceTemplates: ['/episodes/{actorId}'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts EPISODIC when reflectionNamespaceTemplates equals namespaceTemplates', () => {
+    const result = MemoryStrategySchema.safeParse({
+      type: 'EPISODIC',
+      namespaceTemplates: ['/episodes/{actorId}/{sessionId}'],
+      reflectionNamespaceTemplates: ['/episodes/{actorId}/{sessionId}'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('evaluates prefix refinement using deprecated aliases when only they are provided', () => {
     const result = MemoryStrategySchema.safeParse({
       type: 'EPISODIC',
       namespaces: ['/episodes/{actorId}/{sessionId}'],
@@ -85,44 +161,34 @@ describe('MemoryStrategySchema', () => {
     });
     expect(result.success).toBe(false);
   });
-
-  it('accepts EPISODIC when reflectionNamespaces is a prefix of namespaces', () => {
-    const result = MemoryStrategySchema.safeParse({
-      type: 'EPISODIC',
-      namespaces: ['/episodes/{actorId}/{sessionId}'],
-      reflectionNamespaces: ['/episodes/{actorId}'],
-    });
-    expect(result.success).toBe(true);
-  });
-
-  it('accepts EPISODIC when reflectionNamespaces equals namespaces', () => {
-    const result = MemoryStrategySchema.safeParse({
-      type: 'EPISODIC',
-      namespaces: ['/episodes/{actorId}/{sessionId}'],
-      reflectionNamespaces: ['/episodes/{actorId}/{sessionId}'],
-    });
-    expect(result.success).toBe(true);
-  });
 });
 
-describe('DEFAULT_STRATEGY_NAMESPACES', () => {
-  it('has default namespaces for SEMANTIC', () => {
-    expect(DEFAULT_STRATEGY_NAMESPACES.SEMANTIC).toEqual(['/users/{actorId}/facts']);
+describe('DEFAULT_STRATEGY_NAMESPACE_TEMPLATES', () => {
+  it('has default templates for SEMANTIC', () => {
+    expect(DEFAULT_STRATEGY_NAMESPACE_TEMPLATES.SEMANTIC).toEqual(['/users/{actorId}/facts']);
   });
 
-  it('has default namespaces for USER_PREFERENCE', () => {
-    expect(DEFAULT_STRATEGY_NAMESPACES.USER_PREFERENCE).toEqual(['/users/{actorId}/preferences']);
+  it('has default templates for USER_PREFERENCE', () => {
+    expect(DEFAULT_STRATEGY_NAMESPACE_TEMPLATES.USER_PREFERENCE).toEqual(['/users/{actorId}/preferences']);
   });
 
-  it('has default namespaces for SUMMARIZATION', () => {
-    expect(DEFAULT_STRATEGY_NAMESPACES.SUMMARIZATION).toEqual(['/summaries/{actorId}/{sessionId}']);
+  it('has default templates for SUMMARIZATION', () => {
+    expect(DEFAULT_STRATEGY_NAMESPACE_TEMPLATES.SUMMARIZATION).toEqual(['/summaries/{actorId}/{sessionId}']);
   });
 
-  it('has default namespaces for EPISODIC', () => {
-    expect(DEFAULT_STRATEGY_NAMESPACES.EPISODIC).toEqual(['/episodes/{actorId}/{sessionId}']);
+  it('has default templates for EPISODIC', () => {
+    expect(DEFAULT_STRATEGY_NAMESPACE_TEMPLATES.EPISODIC).toEqual(['/episodes/{actorId}/{sessionId}']);
   });
 
-  it('does not have default namespaces for CUSTOM (removed)', () => {
-    expect(DEFAULT_STRATEGY_NAMESPACES).not.toHaveProperty('CUSTOM');
+  it('does not have default templates for CUSTOM (removed)', () => {
+    expect(DEFAULT_STRATEGY_NAMESPACE_TEMPLATES).not.toHaveProperty('CUSTOM');
+  });
+
+  it('deprecated alias DEFAULT_STRATEGY_NAMESPACES points to the same object', () => {
+    expect(DEFAULT_STRATEGY_NAMESPACES).toBe(DEFAULT_STRATEGY_NAMESPACE_TEMPLATES);
+  });
+
+  it('deprecated alias DEFAULT_EPISODIC_REFLECTION_NAMESPACES points to the same object', () => {
+    expect(DEFAULT_EPISODIC_REFLECTION_NAMESPACES).toBe(DEFAULT_EPISODIC_REFLECTION_NAMESPACE_TEMPLATES);
   });
 });

--- a/src/schema/schemas/primitives/index.ts
+++ b/src/schema/schemas/primitives/index.ts
@@ -21,7 +21,9 @@ export {
 
 export type { MemoryStrategy, MemoryStrategyType } from './memory';
 export {
+  DEFAULT_EPISODIC_REFLECTION_NAMESPACE_TEMPLATES,
   DEFAULT_EPISODIC_REFLECTION_NAMESPACES,
+  DEFAULT_STRATEGY_NAMESPACE_TEMPLATES,
   DEFAULT_STRATEGY_NAMESPACES,
   MemoryStrategyNameSchema,
   MemoryStrategySchema,

--- a/src/schema/schemas/primitives/memory.ts
+++ b/src/schema/schemas/primitives/memory.ts
@@ -17,10 +17,10 @@ export const MemoryStrategyTypeSchema = z.enum(['SEMANTIC', 'SUMMARIZATION', 'US
 export type MemoryStrategyType = z.infer<typeof MemoryStrategyTypeSchema>;
 
 /**
- * Default namespaces for each memory strategy type.
+ * Default namespace templates for each memory strategy type.
  * These match the patterns generated in CLI session.py templates.
  */
-export const DEFAULT_STRATEGY_NAMESPACES: Partial<Record<MemoryStrategyType, string[]>> = {
+export const DEFAULT_STRATEGY_NAMESPACE_TEMPLATES: Partial<Record<MemoryStrategyType, string[]>> = {
   SEMANTIC: ['/users/{actorId}/facts'],
   USER_PREFERENCE: ['/users/{actorId}/preferences'],
   SUMMARIZATION: ['/summaries/{actorId}/{sessionId}'],
@@ -28,10 +28,22 @@ export const DEFAULT_STRATEGY_NAMESPACES: Partial<Record<MemoryStrategyType, str
 };
 
 /**
- * Default reflection namespaces for the EPISODIC strategy.
- * The service requires reflection namespaces to be the same as or a prefix of episode namespaces.
+ * @deprecated Use {@link DEFAULT_STRATEGY_NAMESPACE_TEMPLATES} instead.
+ * Retained as an alias for backward compatibility.
  */
-export const DEFAULT_EPISODIC_REFLECTION_NAMESPACES: string[] = ['/episodes/{actorId}'];
+export const DEFAULT_STRATEGY_NAMESPACES = DEFAULT_STRATEGY_NAMESPACE_TEMPLATES;
+
+/**
+ * Default reflection namespace templates for the EPISODIC strategy.
+ * The service requires reflection templates to be the same as or a prefix of episode templates.
+ */
+export const DEFAULT_EPISODIC_REFLECTION_NAMESPACE_TEMPLATES: string[] = ['/episodes/{actorId}'];
+
+/**
+ * @deprecated Use {@link DEFAULT_EPISODIC_REFLECTION_NAMESPACE_TEMPLATES} instead.
+ * Retained as an alias for backward compatibility.
+ */
+export const DEFAULT_EPISODIC_REFLECTION_NAMESPACES = DEFAULT_EPISODIC_REFLECTION_NAMESPACE_TEMPLATES;
 
 /**
  * Memory strategy name validation.
@@ -50,6 +62,12 @@ export const MemoryStrategyNameSchema = z
 /**
  * Memory strategy configuration.
  * Each memory can have multiple strategies with optional namespace scoping.
+ *
+ * Field naming:
+ * - `namespaceTemplates` / `reflectionNamespaceTemplates` are the preferred field names.
+ * - `namespaces` / `reflectionNamespaces` are deprecated aliases retained for backward
+ *   compatibility. Specifying both the deprecated and preferred form for the same concept
+ *   is rejected by validation.
  */
 export const MemoryStrategySchema = z
   .object({
@@ -59,28 +77,50 @@ export const MemoryStrategySchema = z
     name: MemoryStrategyNameSchema.optional(),
     /** Optional description */
     description: z.string().optional(),
-    /** Optional namespaces for scoping memory access */
+    /** Optional namespace templates for scoping memory access */
+    namespaceTemplates: z.array(z.string()).optional(),
+    /** @deprecated Use `namespaceTemplates` instead. */
     namespaces: z.array(z.string()).optional(),
-    /** Reflection namespaces for EPISODIC strategy. Required by the service for episodic strategies. */
+    /** Reflection namespace templates for EPISODIC strategy. Required by the service for episodic strategies. */
+    reflectionNamespaceTemplates: z.array(z.string()).optional(),
+    /** @deprecated Use `reflectionNamespaceTemplates` instead. */
     reflectionNamespaces: z.array(z.string()).optional(),
   })
+  .refine(strategy => !(strategy.namespaces !== undefined && strategy.namespaceTemplates !== undefined), {
+    message:
+      "'namespaces' and 'namespaceTemplates' are mutually exclusive. Prefer 'namespaceTemplates' ('namespaces' is deprecated).",
+    path: ['namespaceTemplates'],
+  })
   .refine(
-    strategy =>
-      strategy.type !== 'EPISODIC' ||
-      (strategy.reflectionNamespaces !== undefined && strategy.reflectionNamespaces.length > 0),
+    strategy => !(strategy.reflectionNamespaces !== undefined && strategy.reflectionNamespaceTemplates !== undefined),
     {
-      message: 'EPISODIC strategy requires reflectionNamespaces',
-      path: ['reflectionNamespaces'],
+      message:
+        "'reflectionNamespaces' and 'reflectionNamespaceTemplates' are mutually exclusive. Prefer 'reflectionNamespaceTemplates' ('reflectionNamespaces' is deprecated).",
+      path: ['reflectionNamespaceTemplates'],
     }
   )
   .refine(
     strategy => {
-      if (strategy.type !== 'EPISODIC' || !strategy.reflectionNamespaces || !strategy.namespaces) return true;
-      return strategy.reflectionNamespaces.every(ref => strategy.namespaces!.some(ns => ns.startsWith(ref)));
+      if (strategy.type !== 'EPISODIC') return true;
+      const reflection = strategy.reflectionNamespaceTemplates ?? strategy.reflectionNamespaces;
+      return reflection !== undefined && reflection.length > 0;
     },
     {
-      message: 'Each reflectionNamespace must be a prefix of at least one namespace',
-      path: ['reflectionNamespaces'],
+      message: 'EPISODIC strategy requires reflectionNamespaceTemplates',
+      path: ['reflectionNamespaceTemplates'],
+    }
+  )
+  .refine(
+    strategy => {
+      if (strategy.type !== 'EPISODIC') return true;
+      const reflection = strategy.reflectionNamespaceTemplates ?? strategy.reflectionNamespaces;
+      const templates = strategy.namespaceTemplates ?? strategy.namespaces;
+      if (!reflection || !templates) return true;
+      return reflection.every(ref => templates.some(ns => ns.startsWith(ref)));
+    },
+    {
+      message: 'Each reflectionNamespaceTemplate must be a prefix of at least one namespaceTemplate',
+      path: ['reflectionNamespaceTemplates'],
     }
   );
 

--- a/src/schema/schemas/primitives/memory.ts
+++ b/src/schema/schemas/primitives/memory.ts
@@ -86,16 +86,26 @@ export const MemoryStrategySchema = z
     /** @deprecated Use `reflectionNamespaceTemplates` instead. */
     reflectionNamespaces: z.array(z.string()).optional(),
   })
-  .refine(strategy => !(strategy.namespaces !== undefined && strategy.namespaceTemplates !== undefined), {
+  .refine(strategy => !((strategy.namespaces?.length ?? 0) > 0 && (strategy.namespaceTemplates?.length ?? 0) > 0), {
     message:
       "'namespaces' and 'namespaceTemplates' are mutually exclusive. Prefer 'namespaceTemplates' ('namespaces' is deprecated).",
     path: ['namespaceTemplates'],
   })
   .refine(
-    strategy => !(strategy.reflectionNamespaces !== undefined && strategy.reflectionNamespaceTemplates !== undefined),
+    strategy =>
+      !((strategy.reflectionNamespaces?.length ?? 0) > 0 && (strategy.reflectionNamespaceTemplates?.length ?? 0) > 0),
     {
       message:
         "'reflectionNamespaces' and 'reflectionNamespaceTemplates' are mutually exclusive. Prefer 'reflectionNamespaceTemplates' ('reflectionNamespaces' is deprecated).",
+      path: ['reflectionNamespaceTemplates'],
+    }
+  )
+  .refine(
+    strategy =>
+      strategy.type === 'EPISODIC' ||
+      (strategy.reflectionNamespaceTemplates === undefined && strategy.reflectionNamespaces === undefined),
+    {
+      message: "'reflectionNamespaceTemplates' is only allowed on EPISODIC strategies",
       path: ['reflectionNamespaceTemplates'],
     }
   )


### PR DESCRIPTION
## Description

Adds support for the new `namespaceTemplates` control-plane field. `namespaceTemplates` replaces `namespaces` on strategy configurations with clearer naming, as strategy namespace values have always been templates resolved at ingestion time, not literal namespaces. The old namespaces field is deprecated but remains accepted for backward compatibility.

- **agentcore.json schema** accepts namespaceTemplates and reflectionNamespaceTemplates on strategy definitions. Old namespaces / reflectionNamespaces still validate. Specifying both the deprecated and preferred form for the same concept is rejected.
- **Strategy creation flows** (`agentcore create --memory longAndShortTerm`, `agentcore add memory`) now write namespaceTemplates / reflectionNamespaceTemplates in the generated config.
- **Response parsing** (getMemoryDetail) reads either field from the service and surfaces the new name to downstream code.
- **Import flow** (`agentcore import memory`) writes the new field names to local config regardless of which form the service returned.
- **Dev web UI resources view** exposes `namespaceTemplates` in the API, with fallback to `namespaces` for legacy data.
- **JSON schema** (schemas/agentcore.schema.v1.json) regenerated from Zod to include the new fields.
- **Docs** (docs/memory.md, docs/configuration.md) updated to show `namespaceTemplates` as primary with a deprecation note for the old name.

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ x ] Other (please describe): Deprecation of field and addition of replacement in CP methods

## Testing

How have you tested the change?

- [ x ] I ran `npm run test:unit` and `npm run test:integ`
- [ x ] I ran `npm run typecheck`
- [ x ] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [ x ] I have read the CONTRIBUTING document
- [ x ] I have added any necessary tests that prove my fix is effective or my feature works
- [ x ] I have updated the documentation accordingly
- [ x ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ x ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
