### PR TITLE
fix: use GitHub Teams for E2E test authorization

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -23,23 +23,35 @@ jobs:
     outputs:
       is_authorized: ${{ steps.check.outputs.is_authorized }}
     steps:
-      - name: Check authorization
+      - name: Check team membership
         id: check
-        run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "✅ Manual workflow dispatch — authorized"
-            echo "is_authorized=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          AUTHORIZED_USERS="${{ secrets.AUTHORIZED_USERS }}"
-          if [[ ",$AUTHORIZED_USERS," == *",${{ github.actor }},"* ]]; then
-            echo "✅ User ${{ github.actor }} is authorized"
-            echo "is_authorized=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "⏭️ User ${{ github.actor }} is not in AUTHORIZED_USERS — skipping E2E tests."
-            echo "ℹ️ External contributors: ask a maintainer to run the E2E tests manually via workflow_dispatch."
-            echo "is_authorized=false" >> "$GITHUB_OUTPUT"
-          fi
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.TEAM_CHECK_TOKEN }}
+          script: |
+            if (context.eventName === 'workflow_dispatch') {
+              core.info('✅ Manual workflow dispatch — authorized');
+              core.setOutput('is_authorized', 'true');
+              return;
+            }
+            try {
+              const { data } = await github.rest.teams.getMembershipForUserInOrg({
+                org: 'aws',
+                team_slug: 'agentcore-devex-devs',
+                username: context.actor,
+              });
+              if (data.state === 'active') {
+                core.info(`✅ User ${context.actor} is a member of aws/agentcore-devex-devs`);
+                core.setOutput('is_authorized', 'true');
+              } else {
+                core.info(`⏭️ User ${context.actor} has pending membership — skipping E2E tests.`);
+                core.setOutput('is_authorized', 'false');
+              }
+            } catch (error) {
+              core.info(`⏭️ User ${context.actor} is not a member of aws/agentcore-devex-devs — skipping E2E tests.`);
+              core.info('ℹ️ External contributors: ask a maintainer to run the E2E tests manually via workflow_dispatch.');
+              core.setOutput('is_authorized', 'false');
+            }
 
   e2e:
     needs: authorize


### PR DESCRIPTION
## Summary

Replace the `AUTHORIZED_USERS` secret-based authorization check in the E2E Tests workflow with a GitHub Teams membership check against `aws/agentcore-devex-devs`.

## Problem

The `AUTHORIZED_USERS` repo secret was silently overwritten on Apr 29, causing all E2E tests to skip on every PR since then with no visible error. The authorize job "passed" but set `is_authorized=false`, so the e2e job silently skipped. GitHub secrets are write-only — there's no way to see the current value or audit who changed it.

## Solution

Use the GitHub Teams API to check if the PR author is a member of `aws/agentcore-devex-devs`:

- Team membership is managed by org admins, not repo-level settings
- Changes are tracked in GitHub's org audit log
- Cannot be silently overwritten by anyone with repo write access
- New team members automatically get E2E access without secret updates

## Setup Required

A repo admin needs to create a `TEAM_CHECK_TOKEN` secret with a GitHub PAT that has `read:org` scope. This token is used to query team membership via the GitHub API.

## Changes

- `.github/workflows/e2e-tests.yml` — Replace bash secret check with `actions/github-script@v7` team membership check

## Test plan

- [ ] Create `TEAM_CHECK_TOKEN` secret with `read:org` PAT
- [ ] Open a test PR and verify the authorize job checks team membership
- [ ] Verify E2E tests run for team members
- [ ] Verify E2E tests skip for non-team members with a clear message