### PR TITLE
test: trim scheduled e2e matrix and harden dev-server process cleanup

### DIFF
--- a/.github/workflows/e2e-tests-full.yml
+++ b/.github/workflows/e2e-tests-full.yml
@@ -28,6 +28,17 @@ jobs:
       matrix:
         cdk-source: [npm, main]
         shard: ['1/6', '2/6', '3/6', '4/6', '5/6', '6/6']
+    env:
+      # Scheduled runs cover 6 priority suites spanning CodeZip, Container, Auth,
+      # Evals, Import, and local Dev paths. Manual workflow_dispatch runs the
+      # full e2e directory to exercise every framework/model-provider combo.
+      SCHEDULED_TESTS: >-
+        e2e-tests/strands-bedrock.test.ts
+        e2e-tests/container-strands-bedrock.test.ts
+        e2e-tests/byo-custom-jwt.test.ts
+        e2e-tests/evals-lifecycle.test.ts
+        e2e-tests/import-resources.test.ts
+        e2e-tests/dev-lifecycle.test.ts
     steps:
       - uses: actions/checkout@v6
         with:
@@ -79,7 +90,14 @@ jobs:
           OPENAI_API_KEY: ${{ env.E2E_OPENAI_API_KEY }}
           GEMINI_API_KEY: ${{ env.E2E_GEMINI_API_KEY }}
           CDK_TARBALL: ${{ env.CDK_TARBALL }}
-        run: npx vitest run --project e2e --shard=${{ matrix.shard }}
+        run: |
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            echo "Scheduled run: executing priority e2e suites"
+            npx vitest run --project e2e --shard=${{ matrix.shard }} $SCHEDULED_TESTS
+          else
+            echo "Manual/push run: executing full e2e suite"
+            npx vitest run --project e2e --shard=${{ matrix.shard }}
+          fi
   browser-tests:
     runs-on: ubuntu-latest
     environment: e2e-testing

--- a/.github/workflows/e2e-tests-full.yml
+++ b/.github/workflows/e2e-tests-full.yml
@@ -33,12 +33,8 @@ jobs:
       # Evals, Import, and local Dev paths. Manual workflow_dispatch runs the
       # full e2e directory to exercise every framework/model-provider combo.
       SCHEDULED_TESTS: >-
-        e2e-tests/strands-bedrock.test.ts
-        e2e-tests/container-strands-bedrock.test.ts
-        e2e-tests/byo-custom-jwt.test.ts
-        e2e-tests/evals-lifecycle.test.ts
-        e2e-tests/import-resources.test.ts
-        e2e-tests/dev-lifecycle.test.ts
+        e2e-tests/strands-bedrock.test.ts e2e-tests/container-strands-bedrock.test.ts e2e-tests/byo-custom-jwt.test.ts
+        e2e-tests/evals-lifecycle.test.ts e2e-tests/import-resources.test.ts e2e-tests/dev-lifecycle.test.ts
     steps:
       - uses: actions/checkout@v6
         with:

--- a/integ-tests/dev-server.test.ts
+++ b/integ-tests/dev-server.test.ts
@@ -69,18 +69,43 @@ describe('integration: dev server', () => {
     }
   }, 120000);
 
-  afterEach(() => {
-    // Kill dev server if running
-    if (devProcess) {
-      devProcess.kill('SIGTERM');
-      devProcess = null;
+  async function terminateDevProcess(timeoutMs = 5000): Promise<void> {
+    if (!devProcess) return;
+    const proc = devProcess;
+    devProcess = null;
+
+    if (proc.pid) {
+      try {
+        process.kill(-proc.pid, 'SIGTERM');
+      } catch {
+        // Process group already exited
+      }
     }
+
+    await new Promise<void>(resolve => {
+      const timer = setTimeout(() => {
+        if (proc.pid) {
+          try {
+            process.kill(-proc.pid, 'SIGKILL');
+          } catch {
+            // Already dead
+          }
+        }
+        resolve();
+      }, timeoutMs);
+      proc.on('exit', () => {
+        clearTimeout(timer);
+        resolve();
+      });
+    });
+  }
+
+  afterEach(async () => {
+    await terminateDevProcess();
   });
 
   afterAll(async () => {
-    if (devProcess) {
-      devProcess.kill('SIGKILL');
-    }
+    await terminateDevProcess();
     await rm(testDir, { recursive: true, force: true });
   });
 
@@ -95,15 +120,14 @@ describe('integration: dev server', () => {
       devProcess = spawn('node', [cliPath, 'dev', '--port', String(port), '--logs'], {
         cwd: projectPath,
         stdio: 'pipe',
+        detached: true,
         env: { ...process.env, INIT_CWD: undefined },
       });
 
       const serverReady = await waitForServer(port, 20000);
       expect(serverReady, 'Dev server should respond to ping within 20s').toBeTruthy();
 
-      // Clean shutdown
-      devProcess.kill('SIGTERM');
-      devProcess = null;
+      await terminateDevProcess();
     },
     30000
   );


### PR DESCRIPTION
## Summary
- Scheduled Monday e2e run now targets 6 priority suites (CodeZip, Container, custom JWT auth, evals, import, local dev). Manual dispatch still runs the full e2e directory to exercise every framework/model-provider combo — halves the weekly AWS test burn
- Replace fire-and-forget SIGTERM in \`integ-tests/dev-server.test.ts\` with a process-group terminator: signal via \`-pid\`, wait on exit event, SIGKILL after 5s timeout. Spawn uses \`detached:true\` so the group signal reaches subprocesses

## Paired PR
The CDK construct test isolation fix (\`setupMocks()\` mock pollution in \`evaluator.test.ts\`) lives in the \`agentcore-l3-cdk-constructs\` repo as a separate PR, since it's a different package.

## Test plan
- [x] Integ tests still pass — \`npm run test:integ\`
- [x] \`e2e-tests-full.yml\` YAML is valid (validated locally with Python yaml)
- [x] Manual workflow_dispatch of \`e2e-tests-full.yml\` still runs the full suite (sanity-check before relying on the schedule split)