### PR TITLE
refactor: unify result types with discriminated Result<T, E> union

### DIFF
--- a/src/cli/AGENTS.md
+++ b/src/cli/AGENTS.md
@@ -82,7 +82,7 @@ primitives/
 ├── registry.ts                # Singleton instances + ALL_PRIMITIVES array
 ├── credential-utils.ts        # Shared credential env var name computation
 ├── constants.ts               # SOURCE_CODE_NOTE and other shared constants
-├── types.ts                   # AddResult, RemovableResource, RemovalResult, etc.
+├── types.ts                   # RemovableResource, AddScreenComponent, etc.
 └── index.ts                   # Barrel exports
 ```
 
@@ -92,8 +92,8 @@ Every primitive extends `BasePrimitive<TAddOptions, TRemovable>` and implements:
 
 - `kind` — resource identifier (`'agent'`, `'memory'`, `'identity'`, `'gateway'`, `'mcp-tool'`)
 - `label` — human-readable name (`'Agent'`, `'Memory'`, `'Identity'`)
-- `add(options)` — create a resource, returns `AddResult`
-- `remove(name)` — remove a resource, returns `RemovalResult`
+- `add(options)` — create a resource, returns `Result<T>`
+- `remove(name)` — remove a resource, returns `Result`
 - `previewRemove(name)` — preview what removal will do
 - `getRemovable()` — list resources available for removal
 - `registerCommands(addCmd, removeCmd)` — register CLI subcommands
@@ -119,7 +119,8 @@ BasePrimitive provides shared helpers:
 - **Absorb, don't wrap.** Each primitive owns its logic directly. Do not create facade files that delegate to
   primitives.
 - **No backward-compatibility shims.** This is a CLI, not a library. If the CLI functions the same, delete old files.
-- **Use `{ success, error? }` result format** throughout (never `{ ok, error }`). See `AddResult` and `RemovalResult`.
+- **Use the discriminated `Result<T, E>` union** from `src/lib/result.ts` throughout. See typed error classes in
+  `src/lib/errors/types.ts`.
 - **Dynamic imports for ink/React only.** TUI components (ink, react, screen components) must be dynamically imported
   inside Commander action handlers to prevent esbuild async module propagation issues. All other imports go at the top
   of the file. See the esbuild section below.

--- a/src/cli/__tests__/errors.test.ts
+++ b/src/cli/__tests__/errors.test.ts
@@ -1,5 +1,5 @@
+import { AgentAlreadyExistsError, toError } from '../../lib';
 import {
-  AgentAlreadyExistsError,
   getErrorMessage,
   isChangesetInProgressError,
   isExpiredTokenError,
@@ -202,6 +202,37 @@ describe('errors', () => {
       expect(isChangesetInProgressError(null)).toBe(false);
       expect(isChangesetInProgressError(undefined)).toBe(false);
       expect(isChangesetInProgressError({})).toBe(false);
+    });
+  });
+
+  describe('toError', () => {
+    it('returns Error instance as-is', () => {
+      const err = new Error('original');
+      expect(toError(err)).toBe(err);
+    });
+
+    it('wraps string in Error', () => {
+      const result = toError('string error');
+      expect(result).toBeInstanceOf(Error);
+      expect(result.message).toBe('string error');
+    });
+
+    it('handles null', () => {
+      const result = toError(null);
+      expect(result).toBeInstanceOf(Error);
+      expect(result.message).toBe('null');
+    });
+
+    it('handles undefined', () => {
+      const result = toError(undefined);
+      expect(result).toBeInstanceOf(Error);
+      expect(result.message).toBe('undefined');
+    });
+
+    it('handles non-Error objects', () => {
+      const result = toError({ code: 42 });
+      expect(result).toBeInstanceOf(Error);
+      expect(result.message).toBe('[object Object]');
     });
   });
 });

--- a/src/cli/aws/__tests__/transaction-search.test.ts
+++ b/src/cli/aws/__tests__/transaction-search.test.ts
@@ -1,4 +1,5 @@
 import { enableTransactionSearch } from '../transaction-search.js';
+import assert from 'node:assert';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { mockAppSignalsSend, mockLogsSend, mockXRaySend } = vi.hoisted(() => ({
@@ -162,8 +163,8 @@ describe('enableTransactionSearch', () => {
 
       const result = await enableTransactionSearch('us-east-1', '123456789012');
 
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('Insufficient permissions to enable Application Signals');
+      assert(!result.success);
+      expect(result.error.message).toContain('Insufficient permissions to enable Application Signals');
     });
 
     it('returns error when Application Signals fails with generic error', async () => {
@@ -171,8 +172,8 @@ describe('enableTransactionSearch', () => {
 
       const result = await enableTransactionSearch('us-east-1', '123456789012');
 
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('Failed to enable Application Signals');
+      assert(!result.success);
+      expect(result.error.message).toContain('Failed to enable Application Signals');
     });
 
     it('returns error when CloudWatch Logs policy fails with AccessDenied', async () => {
@@ -183,8 +184,8 @@ describe('enableTransactionSearch', () => {
 
       const result = await enableTransactionSearch('us-east-1', '123456789012');
 
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('Insufficient permissions to configure CloudWatch Logs policy');
+      assert(!result.success);
+      expect(result.error.message).toContain('Insufficient permissions to configure CloudWatch Logs policy');
     });
 
     it('returns error when trace destination fails', async () => {
@@ -194,8 +195,8 @@ describe('enableTransactionSearch', () => {
 
       const result = await enableTransactionSearch('us-east-1', '123456789012');
 
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('Failed to configure trace destination');
+      assert(!result.success);
+      expect(result.error.message).toContain('Failed to configure trace destination');
     });
 
     it('returns error when indexing rule update fails', async () => {
@@ -214,8 +215,8 @@ describe('enableTransactionSearch', () => {
 
       const result = await enableTransactionSearch('us-east-1', '123456789012');
 
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('Failed to configure indexing rules');
+      assert(!result.success);
+      expect(result.error.message).toContain('Failed to configure indexing rules');
     });
 
     it('does not proceed to later steps when an earlier step fails', async () => {

--- a/src/cli/aws/index.ts
+++ b/src/cli/aws/index.ts
@@ -17,7 +17,7 @@ export {
   type GetAgentRuntimeStatusOptions,
 } from './agentcore-control';
 export { streamLogs, searchLogs, type LogEvent, type StreamLogsOptions, type SearchLogsOptions } from './cloudwatch';
-export { enableTransactionSearch, type TransactionSearchEnableResult } from './transaction-search';
+export { enableTransactionSearch } from './transaction-search';
 export {
   startPolicyGeneration,
   getPolicyGeneration,

--- a/src/cli/aws/transaction-search.ts
+++ b/src/cli/aws/transaction-search.ts
@@ -1,3 +1,5 @@
+import { AccessDeniedError } from '../../lib';
+import type { Result } from '../../lib/result';
 import { getErrorMessage, isAccessDeniedError } from '../errors';
 import { getCredentialProvider } from './account';
 import { arnPrefix } from './partition';
@@ -14,11 +16,6 @@ import {
   XRayClient,
 } from '@aws-sdk/client-xray';
 
-export interface TransactionSearchEnableResult {
-  success: boolean;
-  error?: string;
-}
-
 const RESOURCE_POLICY_NAME = 'TransactionSearchXRayAccess';
 
 /**
@@ -34,7 +31,7 @@ export async function enableTransactionSearch(
   region: string,
   accountId: string,
   indexPercentage = 100
-): Promise<TransactionSearchEnableResult> {
+): Promise<Result> {
   const credentials = getCredentialProvider();
 
   // Step 1: Enable Application Signals (creates service-linked role, idempotent)
@@ -44,9 +41,14 @@ export async function enableTransactionSearch(
   } catch (err: unknown) {
     const message = getErrorMessage(err);
     if (isAccessDeniedError(err)) {
-      return { success: false, error: `Insufficient permissions to enable Application Signals: ${message}` };
+      return {
+        success: false,
+        error: new AccessDeniedError(`Insufficient permissions to enable Application Signals: ${message}`, {
+          cause: err,
+        }),
+      };
     }
-    return { success: false, error: `Failed to enable Application Signals: ${message}` };
+    return { success: false, error: new Error(`Failed to enable Application Signals: ${message}`, { cause: err }) };
   }
 
   // Step 2: Create CloudWatch Logs resource policy for X-Ray (if needed)
@@ -80,9 +82,17 @@ export async function enableTransactionSearch(
   } catch (err: unknown) {
     const message = getErrorMessage(err);
     if (isAccessDeniedError(err)) {
-      return { success: false, error: `Insufficient permissions to configure CloudWatch Logs policy: ${message}` };
+      return {
+        success: false,
+        error: new AccessDeniedError(`Insufficient permissions to configure CloudWatch Logs policy: ${message}`, {
+          cause: err,
+        }),
+      };
     }
-    return { success: false, error: `Failed to configure CloudWatch Logs policy: ${message}` };
+    return {
+      success: false,
+      error: new Error(`Failed to configure CloudWatch Logs policy: ${message}`, { cause: err }),
+    };
   }
 
   const xrayClient = new XRayClient({ region, credentials });
@@ -96,9 +106,14 @@ export async function enableTransactionSearch(
   } catch (err: unknown) {
     const message = getErrorMessage(err);
     if (isAccessDeniedError(err)) {
-      return { success: false, error: `Insufficient permissions to configure trace destination: ${message}` };
+      return {
+        success: false,
+        error: new AccessDeniedError(`Insufficient permissions to configure trace destination: ${message}`, {
+          cause: err,
+        }),
+      };
     }
-    return { success: false, error: `Failed to configure trace destination: ${message}` };
+    return { success: false, error: new Error(`Failed to configure trace destination: ${message}`, { cause: err }) };
   }
 
   // Step 4: Set indexing to 100% on the built-in Default rule (always exists, idempotent)
@@ -112,9 +127,14 @@ export async function enableTransactionSearch(
   } catch (err: unknown) {
     const message = getErrorMessage(err);
     if (isAccessDeniedError(err)) {
-      return { success: false, error: `Insufficient permissions to configure indexing rules: ${message}` };
+      return {
+        success: false,
+        error: new AccessDeniedError(`Insufficient permissions to configure indexing rules: ${message}`, {
+          cause: err,
+        }),
+      };
     }
-    return { success: false, error: `Failed to configure indexing rules: ${message}` };
+    return { success: false, error: new Error(`Failed to configure indexing rules: ${message}`, { cause: err }) };
   }
 
   return { success: true };

--- a/src/cli/commands/add/types.ts
+++ b/src/cli/commands/add/types.ts
@@ -41,13 +41,6 @@ export interface AddAgentOptions extends VpcOptions {
   json?: boolean;
 }
 
-export interface AddAgentResult {
-  success: boolean;
-  agentName?: string;
-  agentPath?: string;
-  error?: string;
-}
-
 // Gateway types
 export interface AddGatewayOptions {
   name?: string;
@@ -66,12 +59,6 @@ export interface AddGatewayOptions {
   policyEngine?: string;
   policyEngineMode?: string;
   json?: boolean;
-}
-
-export interface AddGatewayResult {
-  success: boolean;
-  gatewayName?: string;
-  error?: string;
 }
 
 // Gateway Target types
@@ -100,13 +87,6 @@ export interface AddGatewayTargetOptions {
   json?: boolean;
 }
 
-export interface AddGatewayTargetResult {
-  success: boolean;
-  toolName?: string;
-  sourcePath?: string;
-  error?: string;
-}
-
 // Memory types (v2: no owner/user concept)
 export interface AddMemoryOptions {
   name?: string;
@@ -117,12 +97,6 @@ export interface AddMemoryOptions {
   contentLevel?: string;
   streamDeliveryResources?: string;
   json?: boolean;
-}
-
-export interface AddMemoryResult {
-  success: boolean;
-  memoryName?: string;
-  error?: string;
 }
 
 // Credential types (v2: credential, no owner/user concept)
@@ -139,9 +113,3 @@ export interface AddCredentialOptions {
 
 /** @deprecated Use AddCredentialOptions */
 export type AddIdentityOptions = AddCredentialOptions;
-
-export interface AddCredentialResult {
-  success: boolean;
-  credentialName?: string;
-  error?: string;
-}

--- a/src/cli/commands/create/action.ts
+++ b/src/cli/commands/create/action.ts
@@ -1,4 +1,13 @@
-import { APP_DIR, CONFIG_DIR, ConfigIO, setEnvVar, setSessionProjectRoot } from '../../../lib';
+import {
+  APP_DIR,
+  CONFIG_DIR,
+  ConfigIO,
+  DependencyCheckError,
+  GitInitError,
+  setEnvVar,
+  setSessionProjectRoot,
+  toError,
+} from '../../../lib';
 import type {
   BuildType,
   DeployedState,
@@ -8,7 +17,6 @@ import type {
   SDKFramework,
   TargetLanguage,
 } from '../../../schema';
-import { getErrorMessage } from '../../errors';
 import { checkCreateDependencies } from '../../external-requirements';
 import { initGitRepo, setupPythonProject, writeEnvFile, writeGitignore } from '../../operations';
 import { createConfigBundleForAgent } from '../../operations/agent/config-bundle-defaults';
@@ -57,7 +65,11 @@ export async function createProject(options: CreateProjectOptions): Promise<Crea
 
     // Fail on errors
     if (!depCheck.passed) {
-      return { success: false, error: depCheck.errors.join('\n'), warnings: depWarnings };
+      return {
+        success: false,
+        error: new DependencyCheckError(depCheck.errors),
+        warnings: depWarnings.length > 0 ? depWarnings : undefined,
+      };
     }
   }
 
@@ -93,7 +105,11 @@ export async function createProject(options: CreateProjectOptions): Promise<Crea
       const gitResult = await initGitRepo(projectRoot);
       if (gitResult.status === 'error') {
         onProgress?.('Initialize git repository', 'error');
-        return { success: false, error: gitResult.message, warnings: depWarnings };
+        return {
+          success: false,
+          error: new GitInitError(gitResult.message ?? 'Git initialization failed'),
+          warnings: depWarnings.length > 0 ? depWarnings : undefined,
+        };
       }
       onProgress?.('Initialize git repository', 'done');
     }
@@ -104,7 +120,7 @@ export async function createProject(options: CreateProjectOptions): Promise<Crea
       warnings: depWarnings.length > 0 ? depWarnings : undefined,
     };
   } catch (err) {
-    return { success: false, error: getErrorMessage(err), warnings: depWarnings };
+    return { success: false, error: toError(err), warnings: depWarnings.length > 0 ? depWarnings : undefined };
   }
 }
 
@@ -174,7 +190,11 @@ export async function createProjectWithAgent(options: CreateWithAgentOptions): P
 
   // Fail on errors
   if (!depCheck.passed) {
-    return { success: false, error: depCheck.errors.join('\n'), warnings: depWarnings };
+    return {
+      success: false,
+      error: new DependencyCheckError(depCheck.errors),
+      warnings: depWarnings.length > 0 ? depWarnings : undefined,
+    };
   }
 
   // First create the base project (skip dependency check since we already did it)
@@ -207,7 +227,11 @@ export async function createProjectWithAgent(options: CreateWithAgentOptions): P
       });
       if (!importResult.success) {
         onProgress?.('Import agent from Bedrock', 'error');
-        return { success: false, error: importResult.error, warnings: depWarnings };
+        return {
+          success: false,
+          error: importResult.error,
+          warnings: depWarnings.length > 0 ? depWarnings : undefined,
+        };
       }
       onProgress?.('Import agent from Bedrock', 'done');
       return {
@@ -217,7 +241,7 @@ export async function createProjectWithAgent(options: CreateWithAgentOptions): P
         warnings: depWarnings.length > 0 ? depWarnings : undefined,
       };
     } catch (err) {
-      return { success: false, error: getErrorMessage(err), warnings: depWarnings };
+      return { success: false, error: toError(err), warnings: depWarnings.length > 0 ? depWarnings : undefined };
     }
   }
 
@@ -310,7 +334,7 @@ export async function createProjectWithAgent(options: CreateWithAgentOptions): P
       warnings: depWarnings.length > 0 ? depWarnings : undefined,
     };
   } catch (err) {
-    return { success: false, error: getErrorMessage(err), warnings: depWarnings };
+    return { success: false, error: toError(err), warnings: depWarnings.length > 0 ? depWarnings : undefined };
   }
 }
 

--- a/src/cli/commands/create/command.tsx
+++ b/src/cli/commands/create/command.tsx
@@ -1,4 +1,4 @@
-import { getWorkingDirectory } from '../../../lib';
+import { getWorkingDirectory, serializeResult } from '../../../lib';
 import type {
   BuildType,
   ModelProvider,
@@ -104,8 +104,8 @@ async function handleCreateCLI(options: CreateOptions): Promise<void> {
     }
     const result = getDryRunInfo({ name: name!, projectName, cwd, language: options.language });
     if (options.json) {
-      console.log(JSON.stringify(result));
-    } else {
+      console.log(JSON.stringify(serializeResult(result)));
+    } else if (result.success) {
       console.log('Dry run - would create:');
       for (const path of result.wouldCreate ?? []) {
         console.log(`  ${path}`);
@@ -174,11 +174,11 @@ async function handleCreateCLI(options: CreateOptions): Promise<void> {
         });
 
     if (!result.success) {
-      throw new Error(result.error);
+      throw result.error;
     }
 
     if (options.json) {
-      console.log(JSON.stringify(result));
+      console.log(JSON.stringify(serializeResult(result)));
     } else {
       printCreateSummary(projectName!, result.agentName, options.language, options.framework);
       if (options.skipInstall) {

--- a/src/cli/commands/create/types.ts
+++ b/src/cli/commands/create/types.ts
@@ -1,3 +1,4 @@
+import type { Result } from '../../../lib/result';
 import type { VpcOptions } from '../shared/vpc-utils';
 
 export interface CreateOptions extends VpcOptions {
@@ -28,12 +29,9 @@ export interface CreateOptions extends VpcOptions {
   json?: boolean;
 }
 
-export interface CreateResult {
-  success: boolean;
+export type CreateResult = Result<{
   projectPath?: string;
   agentName?: string;
-  error?: string;
   dryRun?: boolean;
   wouldCreate?: string[];
-  warnings?: string[];
-}
+}> & { warnings?: string[] };

--- a/src/cli/commands/deploy/actions.ts
+++ b/src/cli/commands/deploy/actions.ts
@@ -1,4 +1,4 @@
-import { ConfigIO, SecureCredentials } from '../../../lib';
+import { ConfigIO, ResourceNotFoundError, SecureCredentials, ValidationError, toError } from '../../../lib';
 import type { AgentCoreMcpSpec, DeployedState } from '../../../schema';
 import { applyTargetRegionToEnv } from '../../aws';
 import { validateAwsCredentials } from '../../aws/account';
@@ -120,7 +120,7 @@ export async function handleDeploy(options: ValidatedDeployOptions): Promise<Dep
       logger.finalize(false);
       return {
         success: false,
-        error: `Target "${options.target}" not found in aws-targets.json`,
+        error: new ResourceNotFoundError(`Target "${options.target}" not found in aws-targets.json`),
         logPath: logger.getRelativeLogPath(),
       };
     }
@@ -149,8 +149,9 @@ export async function handleDeploy(options: ValidatedDeployOptions): Promise<Dep
       logger.finalize(false);
       return {
         success: false,
-        error:
-          'This will delete all deployed resources and the CloudFormation stack. Run with --yes to confirm teardown.',
+        error: new Error(
+          'This will delete all deployed resources and the CloudFormation stack. Run with --yes to confirm teardown.'
+        ),
         logPath: logger.getRelativeLogPath(),
       };
     }
@@ -204,7 +205,7 @@ export async function handleDeploy(options: ValidatedDeployOptions): Promise<Dep
           errorResult?.error && typeof errorResult.error === 'string' ? errorResult.error : 'Identity setup failed';
         endStep('error', errorMsg);
         logger.finalize(false);
-        return { success: false, error: errorMsg, logPath: logger.getRelativeLogPath() };
+        return { success: false, error: new Error(errorMsg), logPath: logger.getRelativeLogPath() };
       }
       identityKmsKeyArn = identityResult.kmsKeyArn;
 
@@ -236,7 +237,7 @@ export async function handleDeploy(options: ValidatedDeployOptions): Promise<Dep
         const errorMsg = 'OAuth credential setup failed. Check the log for details.';
         endStep('error', errorMsg);
         logger.finalize(false);
-        return { success: false, error: errorMsg, logPath: logger.getRelativeLogPath() };
+        return { success: false, error: new Error(errorMsg), logPath: logger.getRelativeLogPath() };
       }
 
       // Collect OAuth credential ARNs for deployed state
@@ -277,7 +278,11 @@ export async function handleDeploy(options: ValidatedDeployOptions): Promise<Dep
     if (stackNames.length === 0) {
       endStep('error', 'No stacks found');
       logger.finalize(false);
-      return { success: false, error: 'No stacks found to deploy', logPath: logger.getRelativeLogPath() };
+      return {
+        success: false,
+        error: new ValidationError('No stacks found to deploy'),
+        logPath: logger.getRelativeLogPath(),
+      };
     }
     const stackName = stackNames[0]!;
     endStep('success');
@@ -296,7 +301,7 @@ export async function handleDeploy(options: ValidatedDeployOptions): Promise<Dep
         logger.finalize(false);
         return {
           success: false,
-          error: 'AWS environment needs bootstrapping. Run with --yes to auto-bootstrap.',
+          error: new Error('AWS environment needs bootstrapping. Run with --yes to auto-bootstrap.'),
           logPath: logger.getRelativeLogPath(),
         };
       }
@@ -311,7 +316,7 @@ export async function handleDeploy(options: ValidatedDeployOptions): Promise<Dep
       logger.finalize(false);
       return {
         success: false,
-        error: deployabilityCheck.message ?? 'Stack is not in a deployable state',
+        error: new Error(deployabilityCheck.message ?? 'Stack is not in a deployable state'),
         logPath: logger.getRelativeLogPath(),
       };
     }
@@ -375,12 +380,12 @@ export async function handleDeploy(options: ValidatedDeployOptions): Promise<Dep
       startStep('Tear down stack');
       const teardown = await performStackTeardown(target.name);
       if (!teardown.success) {
-        const teardownError = typeof teardown.error === 'string' ? teardown.error : 'Unknown teardown error';
+        const teardownError = teardown.error.message;
         endStep('error', teardownError);
         logger.finalize(false);
         return {
           success: false,
-          error: `Stack teardown failed: ${teardownError}`,
+          error: new Error(`Stack teardown failed: ${teardownError}`),
           logPath: logger.getRelativeLogPath(),
         };
       }
@@ -660,8 +665,8 @@ export async function handleDeploy(options: ValidatedDeployOptions): Promise<Dep
           agentNames,
           hasGateways,
         });
-        if (tsResult.error) {
-          logger.log(`Transaction search setup warning: ${tsResult.error}`, 'warn');
+        if (!tsResult.success) {
+          logger.log(`Transaction search setup warning: ${tsResult.error.message}`, 'warn');
         } else {
           notes.push(
             'Transaction search enabled. It takes ~10 minutes for transaction search to be fully active and for traces from invocations to be indexed.'
@@ -687,7 +692,7 @@ export async function handleDeploy(options: ValidatedDeployOptions): Promise<Dep
   } catch (err: unknown) {
     logger.log(getErrorMessage(err), 'error');
     logger.finalize(false);
-    return { success: false, error: getErrorMessage(err), logPath: logger.getRelativeLogPath() };
+    return { success: false, error: toError(err), logPath: logger.getRelativeLogPath() };
   } finally {
     if (toolkitWrapper) {
       await toolkitWrapper.dispose();

--- a/src/cli/commands/deploy/command.tsx
+++ b/src/cli/commands/deploy/command.tsx
@@ -1,3 +1,4 @@
+import { serializeResult } from '../../../lib';
 import { getErrorMessage } from '../../errors';
 import { COMMAND_DESCRIPTIONS } from '../../tui/copy';
 import { requireProject, requireTTY } from '../../tui/guards';
@@ -85,7 +86,7 @@ async function handleDeployCLI(options: DeployOptions): Promise<void> {
   }
 
   if (options.json) {
-    console.log(JSON.stringify(result));
+    console.log(JSON.stringify(serializeResult(result)));
   } else if (result.success) {
     if (options.diff) {
       console.log(`\n✓ Diff complete for '${result.targetName}' (stack: ${result.stackName})`);
@@ -125,7 +126,7 @@ async function handleDeployCLI(options: DeployOptions): Promise<void> {
       console.log(`\nLog: ${result.logPath}`);
     }
   } else {
-    console.error(result.error);
+    console.error(result.error.message);
     if (result.logPath) {
       console.error(`Log: ${result.logPath}`);
     }

--- a/src/cli/commands/deploy/types.ts
+++ b/src/cli/commands/deploy/types.ts
@@ -1,3 +1,5 @@
+import type { Result } from '../../../lib/result';
+
 export interface DeployOptions {
   target?: string;
   yes?: boolean;
@@ -8,21 +10,16 @@ export interface DeployOptions {
   diff?: boolean;
 }
 
-export interface DeployResult {
-  success: boolean;
+export type DeployResult = Result<{
   targetName?: string;
   stackName?: string;
   outputs?: Record<string, string>;
-  logPath?: string;
   nextSteps?: string[];
   notes?: string[];
   postDeployWarnings?: string[];
-  error?: string;
-}
+}> & { logPath?: string };
 
-export interface PreflightResult {
-  success: boolean;
+export type PreflightResult = Result<{
   stackNames?: string[];
   needsBootstrap?: boolean;
-  error?: string;
-}
+}>;

--- a/src/cli/commands/dev/browser-mode.ts
+++ b/src/cli/commands/dev/browser-mode.ts
@@ -63,24 +63,26 @@ async function resolveDeployedHandlers(
       result.onListMemoryRecords = async (memoryName, namespace, strategyId) => {
         const memory = memories.find(m => m.name === memoryName);
         if (!memory) return { success: false, error: `Memory "${memoryName}" not found in deployed state` };
-        return listMemoryRecords({
+        const res = await listMemoryRecords({
           region: memory.region,
           memoryId: memory.memoryId,
           namespace,
           memoryStrategyId: strategyId,
         });
+        return res.success ? res : { success: false as const, error: res.error.message };
       };
 
       result.onRetrieveMemoryRecords = async (memoryName, namespace, searchQuery, strategyId) => {
         const memory = memories.find(m => m.name === memoryName);
         if (!memory) return { success: false, error: `Memory "${memoryName}" not found in deployed state` };
-        return retrieveMemoryRecords({
+        const res = await retrieveMemoryRecords({
           region: memory.region,
           memoryId: memory.memoryId,
           namespace,
           searchQuery,
           memoryStrategyId: strategyId,
         });
+        return res.success ? res : { success: false as const, error: res.error.message };
       };
     }
 
@@ -200,13 +202,14 @@ export async function runBrowserMode(opts: BrowserModeOptions): Promise<void> {
           const context = await loadDeployedProjectConfig(configIO);
           const resolved = resolveAgent(context, { runtime: agentName });
           if (!resolved.success) return { success: false, error: resolved.error };
-          return listTraces({
+          const res = await listTraces({
             region: resolved.agent.region,
             runtimeId: resolved.agent.runtimeId,
             agentName: resolved.agent.agentName,
             startTime,
             endTime,
           });
+          return res.success ? res : { success: false as const, error: res.error.message };
         } catch (err) {
           return {
             success: false,
@@ -220,7 +223,7 @@ export async function runBrowserMode(opts: BrowserModeOptions): Promise<void> {
           const context = await loadDeployedProjectConfig(configIO);
           const resolved = resolveAgent(context, { runtime: agentName });
           if (!resolved.success) return { success: false, error: resolved.error };
-          return fetchTraceRecords({
+          const res = await fetchTraceRecords({
             region: resolved.agent.region,
             runtimeId: resolved.agent.runtimeId,
             traceId,
@@ -228,6 +231,7 @@ export async function runBrowserMode(opts: BrowserModeOptions): Promise<void> {
             endTime,
             includeSpans: true,
           });
+          return res.success ? res : { success: false as const, error: res.error.message };
         } catch (err) {
           return {
             success: false,

--- a/src/cli/commands/eval/command.tsx
+++ b/src/cli/commands/eval/command.tsx
@@ -1,3 +1,4 @@
+import { serializeResult } from '../../../lib';
 import { getErrorMessage } from '../../errors';
 import { handleListEvalRuns } from '../../operations/eval';
 import { getResultsPath } from '../../operations/eval/storage';
@@ -27,13 +28,13 @@ export const registerEval = (program: Command) => {
         });
 
         if (cliOptions.json) {
-          console.log(JSON.stringify(result));
+          console.log(JSON.stringify(serializeResult(result)));
           process.exit(result.success ? 0 : 1);
           return;
         }
 
         if (!result.success) {
-          render(<Text color="red">{result.error}</Text>);
+          render(<Text color="red">{result.error.message}</Text>);
           process.exit(1);
         }
 

--- a/src/cli/commands/import/__tests__/idempotency.test.ts
+++ b/src/cli/commands/import/__tests__/idempotency.test.ts
@@ -10,6 +10,7 @@
 // ── Import the function under test AFTER mocks ────────────────────────────────
 import { handleImport } from '../actions';
 import type { ParsedStarterToolkitConfig } from '../types';
+import assert from 'node:assert';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ── Hoisted mock fns (available inside vi.mock factories) ─────────────────────
@@ -76,7 +77,20 @@ const {
 vi.mock('../../../../lib', () => ({
   APP_DIR: 'app',
   ConfigIO: MockConfigIOClass,
+  NoProjectError: class NoProjectError extends Error {
+    constructor(msg?: string) {
+      super(msg ?? 'No agentcore project found');
+      this.name = 'NoProjectError';
+    }
+  },
+  ValidationError: class extends Error {
+    constructor(m: string) {
+      super(m);
+      this.name = 'ValidationError';
+    }
+  },
   findConfigRoot: (...args: unknown[]) => mockFindConfigRoot(...args),
+  toError: (err: unknown) => (err instanceof Error ? err : new Error(String(err))),
 }));
 
 vi.mock('../../../aws/account', () => ({
@@ -279,7 +293,7 @@ describe('Import Idempotency (Test Group 7)', () => {
 
       const result = await handleImport({ source: '/tmp/config.yaml' });
 
-      expect(result.success).toBe(true);
+      assert(result.success);
       expect(result.importedAgents).toContain('my-agent');
       expect(result.importedMemories).toContain('my-memory');
 
@@ -393,7 +407,7 @@ describe('Import Idempotency (Test Group 7)', () => {
 
       const result = await handleImport({ source: '/tmp/config.yaml' });
 
-      expect(result.success).toBe(true);
+      assert(result.success);
       expect(result.importedAgents).toEqual([]);
       expect(result.importedMemories).toEqual([]);
     });
@@ -610,8 +624,8 @@ describe('Import Idempotency (Test Group 7)', () => {
 
       const result = await handleImport({ source: '/tmp/config.yaml' });
 
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('No agents found');
+      assert(!result.success);
+      expect(result.error.message).toContain('No agents found');
     });
 
     it('returns error when no project found', async () => {
@@ -619,8 +633,8 @@ describe('Import Idempotency (Test Group 7)', () => {
 
       const result = await handleImport({ source: '/tmp/config.yaml' });
 
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('No agentcore project found');
+      assert(!result.success);
+      expect(result.error.message).toContain('No agentcore project found');
     });
   });
 

--- a/src/cli/commands/import/__tests__/import-gateway-flow.test.ts
+++ b/src/cli/commands/import/__tests__/import-gateway-flow.test.ts
@@ -11,6 +11,7 @@
  * - Non-READY gateway warning
  */
 import { handleImportGateway } from '../import-gateway';
+import assert from 'node:assert';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ── Hoisted mock fns ────────────────────────────────────────────────────────
@@ -56,6 +57,12 @@ const {
 vi.mock('../../../../lib', () => ({
   APP_DIR: 'app',
   ConfigIO: MockConfigIOClass,
+  NoProjectError: class NoProjectError extends Error {
+    constructor(msg?: string) {
+      super(msg ?? 'No agentcore project found');
+      this.name = 'NoProjectError';
+    }
+  },
   findConfigRoot: (...args: unknown[]) => mockFindConfigRoot(...args),
 }));
 
@@ -177,7 +184,7 @@ describe('handleImportGateway', () => {
     it('successfully imports a gateway with --arn', async () => {
       const result = await handleImportGateway({ arn: GATEWAY_ARN });
 
-      expect(result.success).toBe(true);
+      assert(result.success);
       expect(result.resourceId).toBe(GATEWAY_ID);
       expect(result.resourceType).toBe('gateway');
       expect(result.resourceName).toBe(GATEWAY_NAME);
@@ -199,8 +206,8 @@ describe('handleImportGateway', () => {
 
       const result = await handleImportGateway({ arn: GATEWAY_ARN });
 
-      expect(result.success).toBe(false);
-      expect(result.error).toBe('Phase 2 failed');
+      assert(!result.success);
+      expect(result.error.message).toBe('Phase 2 failed');
 
       // First call = write merged config, second call = rollback
       expect(mockConfigIOInstance.writeProjectSpec).toHaveBeenCalledTimes(2);
@@ -213,8 +220,8 @@ describe('handleImportGateway', () => {
 
       const result = await handleImportGateway({ arn: GATEWAY_ARN });
 
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('Could not find logical ID');
+      assert(!result.success);
+      expect(result.error.message).toContain('Could not find logical ID');
 
       // First call = write merged config, second call = rollback
       expect(mockConfigIOInstance.writeProjectSpec).toHaveBeenCalledTimes(2);
@@ -231,8 +238,8 @@ describe('handleImportGateway', () => {
 
       const result = await handleImportGateway({ arn: GATEWAY_ARN });
 
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('already exists');
+      assert(!result.success);
+      expect(result.error.message).toContain('already exists');
       expect(mockConfigIOInstance.writeProjectSpec).not.toHaveBeenCalled();
     });
 
@@ -254,7 +261,7 @@ describe('handleImportGateway', () => {
 
       const result = await handleImportGateway({ arn: GATEWAY_ARN });
 
-      expect(result.success).toBe(true);
+      assert(result.success);
       expect(result.resourceName).toBe('ExistingGateway');
       expect(mockConfigIOInstance.writeProjectSpec).toHaveBeenCalledTimes(1);
       expect(mockExecuteCdkImportPipeline).toHaveBeenCalled();
@@ -278,7 +285,7 @@ describe('handleImportGateway', () => {
 
       const result = await handleImportGateway({ arn: GATEWAY_ARN, name: 'myCustomName' });
 
-      expect(result.success).toBe(true);
+      assert(result.success);
       expect(result.resourceName).toBe('myCustomName');
       expect(mockConfigIOInstance.writeProjectSpec).toHaveBeenCalledTimes(1);
       expect(mockExecuteCdkImportPipeline).toHaveBeenCalled();
@@ -302,8 +309,8 @@ describe('handleImportGateway', () => {
 
       const result = await handleImportGateway({ arn: GATEWAY_ARN });
 
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('already exists');
+      assert(!result.success);
+      expect(result.error.message).toContain('already exists');
     });
   });
 
@@ -315,15 +322,15 @@ describe('handleImportGateway', () => {
 
       const result = await handleImportGateway({ arn: GATEWAY_ARN });
 
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('Invalid name');
+      assert(!result.success);
+      expect(result.error.message).toContain('Invalid name');
       expect(mockConfigIOInstance.writeProjectSpec).not.toHaveBeenCalled();
     });
 
     it('uses --name override with original resourceName preserved', async () => {
       const result = await handleImportGateway({ arn: GATEWAY_ARN, name: 'myCustomName' });
 
-      expect(result.success).toBe(true);
+      assert(result.success);
       expect(result.resourceName).toBe('myCustomName');
 
       const writtenSpec = mockConfigIOInstance.writeProjectSpec.mock.calls[0]![0];
@@ -343,7 +350,7 @@ describe('handleImportGateway', () => {
 
       const result = await handleImportGateway({});
 
-      expect(result.success).toBe(true);
+      assert(result.success);
       expect(result.resourceId).toBe(GATEWAY_ID);
       expect(mockGetGatewayDetail).toHaveBeenCalledWith({ region: REGION, gatewayId: GATEWAY_ID });
     });
@@ -356,8 +363,8 @@ describe('handleImportGateway', () => {
 
       const result = await handleImportGateway({});
 
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('Multiple gateways found');
+      assert(!result.success);
+      expect(result.error.message).toContain('Multiple gateways found');
     });
 
     it('fails when no gateways exist and no --arn', async () => {
@@ -365,8 +372,8 @@ describe('handleImportGateway', () => {
 
       const result = await handleImportGateway({});
 
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('No gateways found');
+      assert(!result.success);
+      expect(result.error.message).toContain('No gateways found');
     });
   });
 
@@ -399,7 +406,7 @@ describe('handleImportGateway', () => {
         onProgress: (msg: string) => progressMessages.push(msg),
       });
 
-      expect(result.success).toBe(true);
+      assert(result.success);
 
       // Verify warning about unmapped targets
       expect(progressMessages.some(m => m.includes('1 target(s) could not be mapped'))).toBe(true);
@@ -414,7 +421,7 @@ describe('handleImportGateway', () => {
         onProgress: (msg: string) => progressMessages.push(msg),
       });
 
-      expect(result.success).toBe(true);
+      assert(result.success);
       expect(progressMessages.some(m => m.includes('CREATING') && m.includes('not READY'))).toBe(true);
     });
   });

--- a/src/cli/commands/import/__tests__/import-no-deploy.test.ts
+++ b/src/cli/commands/import/__tests__/import-no-deploy.test.ts
@@ -5,6 +5,7 @@
  * that were created but never deployed (no agent_id/memory_id in YAML).
  */
 import { parseStarterToolkitYaml } from '../yaml-parser.js';
+import assert from 'node:assert';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -29,6 +30,12 @@ vi.mock('../../../../lib', () => ({
     writeAWSDeploymentTargets = mockWriteAWSDeploymentTargets;
     readDeployedState = mockReadDeployedState;
     writeDeployedState = mockWriteDeployedState;
+  },
+  NoProjectError: class NoProjectError extends Error {
+    constructor(msg?: string) {
+      super(msg ?? 'No agentcore project found');
+      this.name = 'NoProjectError';
+    }
   },
   findConfigRoot: (...args: unknown[]) => mockFindConfigRoot(...args),
 }));
@@ -488,7 +495,7 @@ agents:
       onProgress: (msg: string) => progressMessages.push(msg),
     });
 
-    expect(result.success).toBe(true);
+    assert(result.success);
     expect(result.importedAgents).toEqual([]);
     expect(result.importedMemories).toEqual([]);
     expect(result.stackName).toBeDefined();
@@ -645,6 +652,7 @@ agents:
     const { handleImport } = await import('../actions.js');
     const result = await handleImport({ source: yamlPath });
 
+    assert(result.success);
     expect(result.stackName).toBe('AgentCore-myproject-default');
   });
 });
@@ -724,7 +732,7 @@ agents:
 
     // No physical IDs means target resolution is skipped entirely.
     // The import succeeds -- config merge + source copy still happen.
-    expect(result.success).toBe(true);
+    assert(result.success);
     expect(result.importedAgents).toEqual([]);
     expect(result.importedMemories).toEqual([]);
   });
@@ -768,7 +776,7 @@ agents:
     const { handleImport } = await import('../actions.js');
     const result = await handleImport({ source: yamlPath });
 
-    expect(result.success).toBe(true);
+    assert(result.success);
     expect(result.importedAgents).toEqual([]);
     expect(result.importedMemories).toEqual([]);
   });
@@ -812,7 +820,7 @@ agents:
     const { handleImport } = await import('../actions.js');
     const result = await handleImport({ source: yamlPath });
 
-    expect(result.success).toBe(true);
+    assert(result.success);
     // No physical IDs means target is not written to disk
     expect(mockWriteAWSDeploymentTargets).not.toHaveBeenCalled();
     // But the stackName should still be computed using 'default' fallback

--- a/src/cli/commands/import/__tests__/import-runtime-handler.test.ts
+++ b/src/cli/commands/import/__tests__/import-runtime-handler.test.ts
@@ -10,6 +10,7 @@
  * - Fails when runtime name already exists in project
  */
 import { handleImportRuntime } from '../import-runtime';
+import assert from 'node:assert';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // ── Mock dependencies ────────────────────────────────────────────────────────
@@ -25,7 +26,7 @@ const mockParseAndValidateArn = vi.fn();
 const mockFindResourceInDeployedState = vi.fn();
 const mockFailResult = vi.fn((...args: unknown[]) => ({
   success: false,
-  error: args[1] as string,
+  error: new Error(args[1] as string),
   resourceType: args[2] as string,
   resourceName: args[3] as string,
   logPath: 'test.log',
@@ -205,8 +206,9 @@ describe('handleImportRuntime', () => {
       });
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('Could not determine entrypoint');
-      expect(result.error).toContain('--entrypoint');
+      assert(!result.success);
+      expect(result.error.message).toContain('Could not determine entrypoint');
+      expect(result.error.message).toContain('--entrypoint');
     });
 
     it('fails with clear error when entryPoint is undefined', async () => {
@@ -231,7 +233,8 @@ describe('handleImportRuntime', () => {
       });
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('Could not determine entrypoint');
+      assert(!result.success);
+      expect(result.error.message).toContain('Could not determine entrypoint');
     });
 
     it('fails with clear error when entryPoint is empty array', async () => {
@@ -256,7 +259,8 @@ describe('handleImportRuntime', () => {
       });
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('Could not determine entrypoint');
+      assert(!result.success);
+      expect(result.error.message).toContain('Could not determine entrypoint');
     });
 
     it('uses --entrypoint flag when provided, bypassing auto-detection', async () => {
@@ -369,7 +373,8 @@ describe('handleImportRuntime', () => {
       });
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('Multiple runtimes found');
+      assert(!result.success);
+      expect(result.error.message).toContain('Multiple runtimes found');
     });
 
     it('errors when no runtimes exist', async () => {
@@ -382,7 +387,8 @@ describe('handleImportRuntime', () => {
       });
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('No runtimes found');
+      assert(!result.success);
+      expect(result.error.message).toContain('No runtimes found');
     });
   });
 
@@ -546,7 +552,8 @@ describe('handleImportRuntime', () => {
       });
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('--code');
+      assert(!result.success);
+      expect(result.error.message).toContain('--code');
     });
 
     it('fails when source path does not exist', async () => {
@@ -574,7 +581,8 @@ describe('handleImportRuntime', () => {
       });
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('does not exist');
+      assert(!result.success);
+      expect(result.error.message).toContain('does not exist');
     });
 
     it('fails when runtime name already exists in project', async () => {
@@ -606,7 +614,8 @@ describe('handleImportRuntime', () => {
       });
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('already exists');
+      assert(!result.success);
+      expect(result.error.message).toContain('already exists');
     });
   });
 });

--- a/src/cli/commands/import/__tests__/jwt-authorizer.test.ts
+++ b/src/cli/commands/import/__tests__/jwt-authorizer.test.ts
@@ -27,7 +27,20 @@ vi.mock('../../../../lib', () => ({
     readDeployedState = mockReadDeployedState;
     writeDeployedState = mockWriteDeployedState;
   },
+  NoProjectError: class NoProjectError extends Error {
+    constructor(msg?: string) {
+      super(msg ?? 'No agentcore project found');
+      this.name = 'NoProjectError';
+    }
+  },
+  ValidationError: class extends Error {
+    constructor(m: string) {
+      super(m);
+      this.name = 'ValidationError';
+    }
+  },
   findConfigRoot: (...args: unknown[]) => mockFindConfigRoot(...args),
+  toError: (err: unknown) => (err instanceof Error ? err : new Error(String(err))),
 }));
 
 vi.mock('../../../aws/account', () => ({

--- a/src/cli/commands/import/__tests__/phase-failure-rollback.test.ts
+++ b/src/cli/commands/import/__tests__/phase-failure-rollback.test.ts
@@ -7,6 +7,7 @@
  */
 import { handleImport } from '../actions';
 import type { ParsedStarterToolkitConfig } from '../types';
+import assert from 'node:assert';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ── Hoisted mock fns ────────────────────────────────────────────────────────
@@ -73,7 +74,20 @@ const {
 vi.mock('../../../../lib', () => ({
   APP_DIR: 'app',
   ConfigIO: MockConfigIOClass,
+  NoProjectError: class NoProjectError extends Error {
+    constructor(msg?: string) {
+      super(msg ?? 'No agentcore project found');
+      this.name = 'NoProjectError';
+    }
+  },
+  ValidationError: class ValidationError extends Error {
+    constructor(msg: string) {
+      super(msg);
+      this.name = 'ValidationError';
+    }
+  },
   findConfigRoot: (...args: unknown[]) => mockFindConfigRoot(...args),
+  toError: (err: unknown) => (err instanceof Error ? err : new Error(String(err))),
 }));
 
 vi.mock('../../../aws/account', () => ({
@@ -249,8 +263,8 @@ describe('Config Rollback on Import Failure', () => {
 
     const result = await handleImport({ source: '/tmp/config.yaml' });
 
-    expect(result.success).toBe(false);
-    expect(result.error).toContain('Phase 1 failed');
+    assert(!result.success);
+    expect(result.error.message).toContain('Phase 1 failed');
 
     // First call = merge write, second call = rollback with original (empty) runtimes
     expect(mockConfigIOInstance.writeProjectSpec).toHaveBeenCalledTimes(2);
@@ -265,8 +279,8 @@ describe('Config Rollback on Import Failure', () => {
 
     const result = await handleImport({ source: '/tmp/config.yaml' });
 
-    expect(result.success).toBe(false);
-    expect(result.error).toContain('Phase 2 failed');
+    assert(!result.success);
+    expect(result.error.message).toContain('Phase 2 failed');
 
     expect(mockConfigIOInstance.writeProjectSpec).toHaveBeenCalledTimes(2);
     const rollbackData = mockConfigIOInstance.writeProjectSpec.mock.calls[1]![0];
@@ -280,8 +294,8 @@ describe('Config Rollback on Import Failure', () => {
 
     const result = await handleImport({ source: '/tmp/config.yaml' });
 
-    expect(result.success).toBe(false);
-    expect(result.error).toContain('CDK build failed');
+    assert(!result.success);
+    expect(result.error.message).toContain('CDK build failed');
 
     expect(mockConfigIOInstance.writeProjectSpec).toHaveBeenCalledTimes(2);
     const rollbackData = mockConfigIOInstance.writeProjectSpec.mock.calls[1]![0];
@@ -294,7 +308,7 @@ describe('Config Rollback on Import Failure', () => {
 
     const result = await handleImport({ source: '/tmp/config.yaml' });
 
-    expect(result.success).toBe(true);
+    assert(result.success);
     // Only one write: the merge write
     expect(mockConfigIOInstance.writeProjectSpec).toHaveBeenCalledTimes(1);
   });
@@ -311,8 +325,8 @@ describe('Config Rollback on Import Failure', () => {
 
     const result = await handleImport({ source: '/tmp/config.yaml' });
 
-    expect(result.success).toBe(false);
-    expect(result.error).toContain('No agents found');
+    assert(!result.success);
+    expect(result.error.message).toContain('No agents found');
     // Config was never written, so no rollback
     expect(mockConfigIOInstance.writeProjectSpec).not.toHaveBeenCalled();
   });
@@ -338,8 +352,8 @@ describe('Config Rollback on Import Failure', () => {
 
     const result = await handleImport({ source: '/tmp/config.yaml' });
 
-    expect(result.success).toBe(false);
-    expect(result.error).toContain('Could not read deployed template');
+    assert(!result.success);
+    expect(result.error.message).toContain('Could not read deployed template');
 
     expect(mockConfigIOInstance.writeProjectSpec).toHaveBeenCalledTimes(2);
     const rollbackData = mockConfigIOInstance.writeProjectSpec.mock.calls[1]![0];

--- a/src/cli/commands/import/actions.ts
+++ b/src/cli/commands/import/actions.ts
@@ -1,4 +1,4 @@
-import { APP_DIR, ConfigIO, findConfigRoot } from '../../../lib';
+import { APP_DIR, ConfigIO, NoProjectError, ValidationError, findConfigRoot, toError } from '../../../lib';
 import type {
   AgentCoreProjectSpec,
   AgentCoreRegion,
@@ -124,9 +124,10 @@ export async function handleImport(options: ImportOptions): Promise<ImportResult
     logger.startStep('Validate project context');
     const configRoot = findConfigRoot(process.cwd());
     if (!configRoot) {
-      const error =
-        'No agentcore project found in the current directory.\nRun `agentcore create <name>` first, then run import from inside the project.';
-      logger.endStep('error', error);
+      const error = new NoProjectError(
+        'No agentcore project found in the current directory.\nRun `agentcore create <name>` first, then run import from inside the project.'
+      );
+      logger.endStep('error', error.message);
       logger.finalize(false);
       return {
         success: false,
@@ -160,7 +161,7 @@ export async function handleImport(options: ImportOptions): Promise<ImportResult
       const error = 'No agents found in the YAML config';
       logger.endStep('error', error);
       logger.finalize(false);
-      return { success: false, error, logPath: logger.getRelativeLogPath() };
+      return { success: false, error: new ValidationError(error), logPath: logger.getRelativeLogPath() };
     }
 
     logger.log(
@@ -199,7 +200,7 @@ export async function handleImport(options: ImportOptions): Promise<ImportResult
           logger.finalize(false);
           return {
             success: false,
-            error,
+            error: new Error(error),
             logPath: logger.getRelativeLogPath(),
           };
         }
@@ -223,7 +224,7 @@ export async function handleImport(options: ImportOptions): Promise<ImportResult
           logger.finalize(false);
           return {
             success: false,
-            error,
+            error: new Error(error),
             logPath: logger.getRelativeLogPath(),
           };
         }
@@ -237,7 +238,7 @@ export async function handleImport(options: ImportOptions): Promise<ImportResult
         logger.finalize(false);
         return {
           success: false,
-          error,
+          error: new Error(error),
           logPath: logger.getRelativeLogPath(),
         };
       }
@@ -501,7 +502,7 @@ export async function handleImport(options: ImportOptions): Promise<ImportResult
       const error = 'No deployment target available for import.';
       logger.endStep('error', error);
       logger.finalize(false);
-      return { success: false, error, logPath: logger.getRelativeLogPath() };
+      return { success: false, error: new ValidationError(error), logPath: logger.getRelativeLogPath() };
     }
     logger.endStep('success');
 
@@ -640,7 +641,7 @@ export async function handleImport(options: ImportOptions): Promise<ImportResult
       await rollbackConfig();
       logger.endStep('error', error);
       logger.finalize(false);
-      return { success: false, error, logPath: logger.getRelativeLogPath() };
+      return { success: false, error: new Error(error), logPath: logger.getRelativeLogPath() };
     }
     logger.endStep('success');
 
@@ -658,6 +659,6 @@ export async function handleImport(options: ImportOptions): Promise<ImportResult
     await rollbackConfig();
     logger.log(message, 'error');
     logger.finalize(false);
-    return { success: false, error: message, logPath: logger.getRelativeLogPath() };
+    return { success: false, error: toError(err), logPath: logger.getRelativeLogPath() };
   }
 }

--- a/src/cli/commands/import/command.ts
+++ b/src/cli/commands/import/command.ts
@@ -140,7 +140,7 @@ export const registerImport = (program: Command) => {
           console.log(`Log: ${result.logPath}`);
         }
       } else {
-        console.error(`\n\x1b[31m[error]${reset} Import failed: ${result.error}`);
+        console.error(`\n\x1b[31m[error]${reset} Import failed: ${result.error.message}`);
         if (result.logPath) {
           console.error(`Log: ${result.logPath}`);
         }

--- a/src/cli/commands/import/import-evaluator.ts
+++ b/src/cli/commands/import/import-evaluator.ts
@@ -151,7 +151,7 @@ export function registerImportEvaluator(importCmd: Command): void {
         console.log(`  ID: ${result.resourceId}`);
         console.log('');
       } else {
-        console.error(`\n${ANSI.red}[error]${ANSI.reset} ${result.error}`);
+        console.error(`\n${ANSI.red}[error]${ANSI.reset} ${result.error.message}`);
         if (result.logPath) {
           console.error(`Log: ${result.logPath}`);
         }

--- a/src/cli/commands/import/import-gateway.ts
+++ b/src/cli/commands/import/import-gateway.ts
@@ -1,3 +1,4 @@
+import { toError } from '../../../lib';
 import type {
   AgentCoreGateway,
   AgentCoreGatewayTarget,
@@ -612,7 +613,7 @@ export async function handleImportGateway(options: ImportResourceOptions): Promi
       logger.finalize(false);
       return {
         success: false,
-        error: pipelineResult.error,
+        error: new Error(pipelineResult.error ?? 'Pipeline failed'),
         resourceType: 'gateway',
         resourceName: localName,
         logPath: logger.getRelativeLogPath(),
@@ -638,7 +639,7 @@ export async function handleImportGateway(options: ImportResourceOptions): Promi
     }
     return {
       success: false,
-      error: message,
+      error: toError(err),
       resourceType: 'gateway',
       resourceName: options.name ?? '',
       logPath: importCtx?.logger.getRelativeLogPath(),
@@ -680,7 +681,7 @@ export function registerImportGateway(importCmd: Command): void {
         console.log(`  agentcore fetch access  ${ANSI.dim}Get gateway URL and token${ANSI.reset}`);
         console.log('');
       } else {
-        console.error(`\n${ANSI.red}[error]${ANSI.reset} ${result.error}`);
+        console.error(`\n${ANSI.red}[error]${ANSI.reset} ${result.error.message}`);
         if (result.logPath) {
           console.error(`Log: ${result.logPath}`);
         }

--- a/src/cli/commands/import/import-memory.ts
+++ b/src/cli/commands/import/import-memory.ts
@@ -121,7 +121,7 @@ export function registerImportMemory(importCmd: Command): void {
         console.log(`  ID: ${result.resourceId}`);
         console.log('');
       } else {
-        console.error(`\n${ANSI.red}[error]${ANSI.reset} ${result.error}`);
+        console.error(`\n${ANSI.red}[error]${ANSI.reset} ${result.error.message}`);
         if (result.logPath) {
           console.error(`Log: ${result.logPath}`);
         }

--- a/src/cli/commands/import/import-online-eval.ts
+++ b/src/cli/commands/import/import-online-eval.ts
@@ -209,7 +209,7 @@ export function registerImportOnlineEval(importCmd: Command): void {
         console.log(`  ID: ${result.resourceId}`);
         console.log('');
       } else {
-        console.error(`\n${ANSI.red}[error]${ANSI.reset} ${result.error}`);
+        console.error(`\n${ANSI.red}[error]${ANSI.reset} ${result.error.message}`);
         if (result.logPath) {
           console.error(`Log: ${result.logPath}`);
         }

--- a/src/cli/commands/import/import-runtime.ts
+++ b/src/cli/commands/import/import-runtime.ts
@@ -225,7 +225,7 @@ export function registerImportRuntime(importCmd: Command): void {
         console.log(`  agentcore invoke     ${ANSI.dim}Test your agent${ANSI.reset}`);
         console.log('');
       } else {
-        console.error(`\n${ANSI.red}[error]${ANSI.reset} ${result.error}`);
+        console.error(`\n${ANSI.red}[error]${ANSI.reset} ${result.error.message}`);
         if (result.logPath) {
           console.error(`Log: ${result.logPath}`);
         }

--- a/src/cli/commands/import/import-utils.ts
+++ b/src/cli/commands/import/import-utils.ts
@@ -67,7 +67,7 @@ export function failResult(
   logger.finalize(false);
   return {
     success: false,
-    error,
+    error: new Error(error),
     resourceType,
     resourceName,
     logPath: logger.getRelativeLogPath(),

--- a/src/cli/commands/import/resource-import.ts
+++ b/src/cli/commands/import/resource-import.ts
@@ -1,3 +1,4 @@
+import { toError } from '../../../lib';
 import type { AgentCoreProjectSpec } from '../../../schema';
 import { NAME_REGEX } from './constants';
 import { executeCdkImportPipeline } from './import-pipeline';
@@ -228,7 +229,7 @@ export async function executeResourceImport<TDetail, TSummary>(
       logger.finalize(false);
       return {
         success: false,
-        error: pipelineResult.error,
+        error: new Error(pipelineResult.error ?? 'Pipeline failed'),
         resourceType: descriptor.resourceType,
         resourceName: localName,
         logPath: logger.getRelativeLogPath(),
@@ -254,7 +255,7 @@ export async function executeResourceImport<TDetail, TSummary>(
     }
     return {
       success: false,
-      error: message,
+      error: toError(err),
       resourceType: descriptor.resourceType,
       resourceName: options.name ?? '',
       logPath: importCtx?.logger.getRelativeLogPath(),

--- a/src/cli/commands/import/types.ts
+++ b/src/cli/commands/import/types.ts
@@ -1,3 +1,4 @@
+import type { Result } from '../../../lib/result';
 import type {
   AgentCoreProjectSpec,
   AuthorizerConfig,
@@ -89,27 +90,19 @@ export interface ResourceToImport {
 /**
  * Result of the import command.
  */
-export interface ImportResult {
-  success: boolean;
-  error?: string;
+export type ImportResult = Result<{
   projectSpec?: AgentCoreProjectSpec;
   importedAgents?: string[];
   importedMemories?: string[];
   stackName?: string;
-  logPath?: string;
-}
+}> & { logPath?: string };
 
 /**
  * Result for single-resource import (runtime, memory, evaluator, etc.).
  */
-export interface ImportResourceResult {
-  success: boolean;
-  error?: string;
-  resourceType: ImportableResourceType;
-  resourceName: string;
+export type ImportResourceResult = Result<{
   resourceId?: string;
-  logPath?: string;
-}
+}> & { resourceType: ImportableResourceType; resourceName: string; logPath?: string };
 
 /**
  * Options shared across import subcommands.

--- a/src/cli/commands/invoke/action.ts
+++ b/src/cli/commands/invoke/action.ts
@@ -1,4 +1,4 @@
-import { ConfigIO } from '../../../lib';
+import { ConfigIO, ResourceNotFoundError, ValidationError } from '../../../lib';
 import type { AgentCoreProjectSpec, AwsDeploymentTargets, DeployedState } from '../../../schema';
 import {
   buildAguiRunInput,
@@ -43,41 +43,58 @@ export async function handleInvoke(context: InvokeContext, options: InvokeOption
   // Resolve target
   const targetNames = Object.keys(deployedState.targets);
   if (targetNames.length === 0) {
-    return { success: false, error: 'No deployed targets found. Run `agentcore deploy` first.' };
+    return {
+      success: false,
+      error: new ResourceNotFoundError('No deployed targets found. Run `agentcore deploy` first.'),
+    };
   }
 
   const selectedTargetName = options.targetName ?? targetNames[0]!;
 
   if (options.targetName && !targetNames.includes(options.targetName)) {
-    return { success: false, error: `Target '${options.targetName}' not found. Available: ${targetNames.join(', ')}` };
+    return {
+      success: false,
+      error: new ResourceNotFoundError(
+        `Target '${options.targetName}' not found. Available: ${targetNames.join(', ')}`
+      ),
+    };
   }
 
   const targetState = deployedState.targets[selectedTargetName];
   const targetConfig = awsTargets.find(t => t.name === selectedTargetName);
 
   if (!targetConfig) {
-    return { success: false, error: `Target config '${selectedTargetName}' not found in aws-targets` };
+    return {
+      success: false,
+      error: new ResourceNotFoundError(`Target config '${selectedTargetName}' not found in aws-targets`),
+    };
   }
 
   if (project.runtimes.length === 0) {
-    return { success: false, error: 'No agents defined in configuration' };
+    return { success: false, error: new ValidationError('No agents defined in configuration') };
   }
 
   // Resolve agent
   const agentNames = project.runtimes.map(a => a.name);
 
   if (!options.agentName && project.runtimes.length > 1) {
-    return { success: false, error: `Multiple runtimes found. Use --runtime to specify one: ${agentNames.join(', ')}` };
+    return {
+      success: false,
+      error: new ValidationError(`Multiple runtimes found. Use --runtime to specify one: ${agentNames.join(', ')}`),
+    };
   }
 
   const agentSpec = options.agentName ? project.runtimes.find(a => a.name === options.agentName) : project.runtimes[0];
 
   if (options.agentName && !agentSpec) {
-    return { success: false, error: `Agent '${options.agentName}' not found. Available: ${agentNames.join(', ')}` };
+    return {
+      success: false,
+      error: new ResourceNotFoundError(`Agent '${options.agentName}' not found. Available: ${agentNames.join(', ')}`),
+    };
   }
 
   if (!agentSpec) {
-    return { success: false, error: 'No agents defined in configuration' };
+    return { success: false, error: new ValidationError('No agents defined in configuration') };
   }
 
   // Warn about VPC mode endpoint requirements
@@ -91,7 +108,10 @@ export async function handleInvoke(context: InvokeContext, options: InvokeOption
   const agentState = targetState?.resources?.runtimes?.[agentSpec.name];
 
   if (!agentState) {
-    return { success: false, error: `Agent '${agentSpec.name}' is not deployed to target '${selectedTargetName}'` };
+    return {
+      success: false,
+      error: new ValidationError(`Agent '${agentSpec.name}' is not deployed to target '${selectedTargetName}'`),
+    };
   }
 
   // Build config bundle baggage if a bundle is associated with this agent
@@ -118,13 +138,18 @@ export async function handleInvoke(context: InvokeContext, options: InvokeOption
       } catch (err) {
         return {
           success: false,
-          error: `CUSTOM_JWT agent requires a bearer token. Auto-fetch failed: ${err instanceof Error ? err.message : String(err)}\nProvide one manually with --bearer-token.`,
+          error: new ValidationError(
+            `CUSTOM_JWT agent requires a bearer token. Auto-fetch failed: ${err instanceof Error ? err.message : String(err)}\nProvide one manually with --bearer-token.`,
+            { cause: err }
+          ),
         };
       }
     } else {
       return {
         success: false,
-        error: `Agent '${agentSpec.name}' is configured for CUSTOM_JWT but no bearer token is available.\nEither provide --bearer-token or re-add the agent with --client-id and --client-secret to enable auto-fetch.`,
+        error: new ValidationError(
+          `Agent '${agentSpec.name}' is configured for CUSTOM_JWT but no bearer token is available.\nEither provide --bearer-token or re-add the agent with --client-id and --client-secret to enable auto-fetch.`
+        ),
       };
     }
   }
@@ -147,7 +172,7 @@ export async function handleInvoke(context: InvokeContext, options: InvokeOption
     });
     const command = options.prompt;
     if (!command) {
-      return { success: false, error: '--exec requires a command (prompt)' };
+      return { success: false, error: new ValidationError('--exec requires a command (prompt)') };
     }
     logger.logPrompt(command, options.sessionId, options.userId);
 
@@ -195,8 +220,18 @@ export async function handleInvoke(context: InvokeContext, options: InvokeOption
       logger.logResponse(stdout || stderr || `exit code: ${exitCode}`);
 
       if (options.json) {
+        if (exitCode === 0) {
+          return {
+            success: true,
+            agentName: agentSpec.name,
+            targetName: selectedTargetName,
+            response: JSON.stringify({ stdout, stderr, exitCode, status }),
+            logFilePath: logger.logFilePath,
+          };
+        }
         return {
-          success: exitCode === 0,
+          success: false,
+          error: new Error(`Command exited with code ${exitCode}`),
           agentName: agentSpec.name,
           targetName: selectedTargetName,
           response: JSON.stringify({ stdout, stderr, exitCode, status }),
@@ -207,9 +242,9 @@ export async function handleInvoke(context: InvokeContext, options: InvokeOption
       if (exitCode === undefined) {
         return {
           success: false,
+          error: new Error('Command stream ended without exit code'),
           agentName: agentSpec.name,
           targetName: selectedTargetName,
-          error: 'Command stream ended without exit code',
           logFilePath: logger.logFilePath,
         };
       }
@@ -217,9 +252,10 @@ export async function handleInvoke(context: InvokeContext, options: InvokeOption
       if (exitCode !== 0) {
         return {
           success: false,
+          error: new Error(`Command exited with code ${exitCode}${status === 'TIMED_OUT' ? ' (timed out)' : ''}`),
           agentName: agentSpec.name,
           targetName: selectedTargetName,
-          error: `Command exited with code ${exitCode}${status === 'TIMED_OUT' ? ' (timed out)' : ''}`,
+          response: JSON.stringify({ stdout, stderr, exitCode, status }),
           logFilePath: logger.logFilePath,
         };
       }
@@ -261,7 +297,9 @@ export async function handleInvoke(context: InvokeContext, options: InvokeOption
       } catch (err) {
         return {
           success: false,
-          error: `Failed to list MCP tools: ${err instanceof Error ? err.message : String(err)}`,
+          error: new Error(`Failed to list MCP tools: ${err instanceof Error ? err.message : String(err)}`, {
+            cause: err,
+          }),
         };
       }
     }
@@ -271,7 +309,7 @@ export async function handleInvoke(context: InvokeContext, options: InvokeOption
       if (!options.tool) {
         return {
           success: false,
-          error: 'MCP call-tool requires --tool <name>. Use "list-tools" to see available tools.',
+          error: new Error('MCP call-tool requires --tool <name>. Use "list-tools" to see available tools.'),
         };
       }
       let args: Record<string, unknown> = {};
@@ -279,7 +317,7 @@ export async function handleInvoke(context: InvokeContext, options: InvokeOption
         try {
           args = JSON.parse(options.input) as Record<string, unknown>;
         } catch {
-          return { success: false, error: `Invalid JSON for --input: ${options.input}` };
+          return { success: false, error: new ValidationError(`Invalid JSON for --input: ${options.input}`) };
         }
       }
       try {
@@ -295,7 +333,9 @@ export async function handleInvoke(context: InvokeContext, options: InvokeOption
       } catch (err) {
         return {
           success: false,
-          error: `Failed to call MCP tool: ${err instanceof Error ? err.message : String(err)}`,
+          error: new Error(`Failed to call MCP tool: ${err instanceof Error ? err.message : String(err)}`, {
+            cause: err,
+          }),
         };
       }
     }
@@ -303,14 +343,15 @@ export async function handleInvoke(context: InvokeContext, options: InvokeOption
     if (!options.prompt) {
       return {
         success: false,
-        error:
-          'MCP agents require a command. Usage:\n  agentcore invoke list-tools\n  agentcore invoke call-tool --tool <name> --input \'{"arg": "value"}\'',
+        error: new ValidationError(
+          'MCP agents require a command. Usage:\n  agentcore invoke list-tools\n  agentcore invoke call-tool --tool <name> --input \'{"arg": "value"}\''
+        ),
       };
     }
   }
 
   if (!options.prompt) {
-    return { success: false, error: 'No prompt provided. Usage: agentcore invoke "your prompt"' };
+    return { success: false, error: new ValidationError('No prompt provided. Usage: agentcore invoke "your prompt"') };
   }
 
   // A2A protocol handling — send JSON-RPC message/send via InvokeAgentRuntime
@@ -343,7 +384,10 @@ export async function handleInvoke(context: InvokeContext, options: InvokeOption
         response,
       };
     } catch (err) {
-      return { success: false, error: `A2A invoke failed: ${err instanceof Error ? err.message : String(err)}` };
+      return {
+        success: false,
+        error: new Error(`A2A invoke failed: ${err instanceof Error ? err.message : String(err)}`, { cause: err }),
+      };
     }
   }
 
@@ -388,8 +432,20 @@ export async function handleInvoke(context: InvokeContext, options: InvokeOption
 
       logger.logResponse(response);
 
+      if (hasError) {
+        return {
+          success: false,
+          error: new Error(response),
+          agentName: agentSpec.name,
+          targetName: selectedTargetName,
+          response,
+          sessionId: aguiResult.sessionId,
+          logFilePath: logger.logFilePath,
+        };
+      }
+
       return {
-        success: !hasError,
+        success: true,
         agentName: agentSpec.name,
         targetName: selectedTargetName,
         response,
@@ -398,7 +454,10 @@ export async function handleInvoke(context: InvokeContext, options: InvokeOption
       };
     } catch (err) {
       logger.logError(err, 'AGUI invoke failed');
-      return { success: false, error: `AGUI invoke failed: ${err instanceof Error ? err.message : String(err)}` };
+      return {
+        success: false,
+        error: new Error(`AGUI invoke failed: ${err instanceof Error ? err.message : String(err)}`, { cause: err }),
+      };
     }
   }
 

--- a/src/cli/commands/invoke/command.tsx
+++ b/src/cli/commands/invoke/command.tsx
@@ -1,3 +1,4 @@
+import { serializeResult } from '../../../lib';
 import { getErrorMessage } from '../../errors';
 import { COMMAND_DESCRIPTIONS } from '../../tui/copy';
 import { requireProject, requireTTY } from '../../tui/guards';
@@ -55,7 +56,7 @@ async function handleInvokeCLI(options: InvokeOptions): Promise<void> {
     }
 
     if (options.json) {
-      console.log(JSON.stringify(result));
+      console.log(JSON.stringify(serializeResult(result)));
     } else if (options.stream) {
       // Streaming already wrote to stdout, just show session and log path
       if (result.sessionId) {
@@ -70,7 +71,7 @@ async function handleInvokeCLI(options: InvokeOptions): Promise<void> {
       if (result.success && result.response) {
         console.log(result.response);
       } else if (!result.success && result.error) {
-        console.error(result.error);
+        console.error(result.error.message);
       }
       if (result.sessionId) {
         console.error(`\nSession: ${result.sessionId}`);

--- a/src/cli/commands/invoke/types.ts
+++ b/src/cli/commands/invoke/types.ts
@@ -1,3 +1,5 @@
+import type { Result } from '../../../lib/result';
+
 export interface InvokeOptions {
   agentName?: string;
   targetName?: string;
@@ -22,12 +24,10 @@ export interface InvokeOptions {
   bearerToken?: string;
 }
 
-export interface InvokeResult {
-  success: boolean;
+export type InvokeResult = Result & {
+  logFilePath?: string;
   agentName?: string;
   targetName?: string;
   response?: string;
   sessionId?: string;
-  error?: string;
-  logFilePath?: string;
-}
+};

--- a/src/cli/commands/logs/__tests__/action.test.ts
+++ b/src/cli/commands/logs/__tests__/action.test.ts
@@ -132,9 +132,9 @@ describe('resolveAgentContext', () => {
     const result = resolveAgentContext(context, {});
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error).toContain('Multiple runtimes found');
-      expect(result.error).toContain('AgentA');
-      expect(result.error).toContain('AgentB');
+      expect(result.error.message).toContain('Multiple runtimes found');
+      expect(result.error.message).toContain('AgentA');
+      expect(result.error.message).toContain('AgentB');
     }
   });
 
@@ -205,7 +205,7 @@ describe('resolveAgentContext', () => {
     const result = resolveAgentContext(makeContext(), { runtime: 'UnknownAgent' });
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error).toContain("Runtime 'UnknownAgent' not found");
+      expect(result.error.message).toContain("Runtime 'UnknownAgent' not found");
     }
   });
 
@@ -230,7 +230,7 @@ describe('resolveAgentContext', () => {
     const result = resolveAgentContext(context, {});
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error).toContain('No runtimes defined');
+      expect(result.error.message).toContain('No runtimes defined');
     }
   });
 
@@ -249,7 +249,7 @@ describe('resolveAgentContext', () => {
     const result = resolveAgentContext(context, {});
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error).toContain('is not deployed');
+      expect(result.error.message).toContain('is not deployed');
     }
   });
 });

--- a/src/cli/commands/logs/action.ts
+++ b/src/cli/commands/logs/action.ts
@@ -1,3 +1,5 @@
+import { ResourceNotFoundError, ValidationError } from '../../../lib';
+import type { Result } from '../../../lib/result';
 import { parseTimeString } from '../../../lib/utils';
 import { searchLogs, streamLogs } from '../../aws/cloudwatch';
 import { DEFAULT_ENDPOINT_NAME } from '../../constants';
@@ -15,11 +17,6 @@ export interface AgentContext {
   region: string;
   endpointName: string;
   logGroupName: string;
-}
-
-export interface LogsResult {
-  success: boolean;
-  error?: string;
 }
 
 /**
@@ -49,10 +46,10 @@ export function formatLogLine(event: { timestamp: number; message: string }, jso
 export function resolveAgentContext(
   context: DeployedProjectConfig,
   options: LogsOptions
-): { success: true; agentContext: AgentContext } | { success: false; error: string } {
+): Result<{ agentContext: AgentContext }> {
   const result = resolveAgent(context, options);
   if (!result.success) {
-    return { success: false, error: result.error };
+    return { success: false, error: new ResourceNotFoundError(result.error) };
   }
   const { agent } = result;
   const endpointName = DEFAULT_ENDPOINT_NAME;
@@ -73,12 +70,12 @@ export function resolveAgentContext(
 /**
  * Main logs handler
  */
-export async function handleLogs(options: LogsOptions): Promise<LogsResult> {
+export async function handleLogs(options: LogsOptions): Promise<Result> {
   // Validate level early
   if (options.level && !VALID_LEVELS.includes(options.level.toLowerCase())) {
     return {
       success: false,
-      error: `Invalid log level: "${options.level}". Valid levels: ${VALID_LEVELS.join(', ')}`,
+      error: new ValidationError(`Invalid log level: "${options.level}". Valid levels: ${VALID_LEVELS.join(', ')}`),
     };
   }
 
@@ -96,7 +93,7 @@ export async function handleLogs(options: LogsOptions): Promise<LogsResult> {
   try {
     filterPattern = buildFilterPattern({ level: options.level, query: options.query });
   } catch (err) {
-    return { success: false, error: (err as Error).message };
+    return { success: false, error: err instanceof Error ? err : new Error(String(err)) };
   }
 
   const mode = detectMode(options);
@@ -143,7 +140,9 @@ export async function handleLogs(options: LogsOptions): Promise<LogsResult> {
     if (errorName === 'ResourceNotFoundException') {
       return {
         success: false,
-        error: `No logs found for agent '${agentContext.agentName}'. Has the agent been invoked?`,
+        error: new ResourceNotFoundError(
+          `No logs found for agent '${agentContext.agentName}'. Has the agent been invoked?`
+        ),
       };
     }
 

--- a/src/cli/commands/logs/command.tsx
+++ b/src/cli/commands/logs/command.tsx
@@ -34,7 +34,7 @@ export const registerLogs = (program: Command) => {
         const result = await handleLogs(cliOptions);
 
         if (!result.success) {
-          render(<Text color="red">{result.error}</Text>);
+          render(<Text color="red">{result.error.message}</Text>);
           process.exit(1);
         }
       } catch (error) {
@@ -59,7 +59,7 @@ export const registerLogs = (program: Command) => {
         const result = await handleLogsEval(cliOptions);
 
         if (!result.success) {
-          render(<Text color="red">{result.error}</Text>);
+          render(<Text color="red">{result.error.message}</Text>);
           process.exit(1);
         }
       } catch (error) {

--- a/src/cli/commands/pause/command.tsx
+++ b/src/cli/commands/pause/command.tsx
@@ -1,4 +1,4 @@
-import { ConfigIO } from '../../../lib';
+import { ConfigIO, serializeResult } from '../../../lib';
 import { listABTests, updateABTest } from '../../aws/agentcore-ab-tests';
 import { stopBatchEvaluation } from '../../aws/agentcore-batch-evaluation';
 import { getErrorMessage } from '../../errors';
@@ -52,12 +52,12 @@ function registerOnlineEvalSubcommand(parent: Command, action: 'pause' | 'resume
         const result = await handlePauseResume(options, action);
 
         if (cliOptions.json) {
-          console.log(JSON.stringify(result));
+          console.log(JSON.stringify(serializeResult(result)));
         } else if (result.success) {
           const displayName = cliOptions.arn ? result.configId : name;
           console.log(`${pastTense} online eval config "${displayName}" (status: ${result.executionStatus})`);
         } else {
-          render(<Text color="red">{result.error}</Text>);
+          render(<Text color="red">{result.error.message}</Text>);
         }
 
         process.exit(result.success ? 0 : 1);

--- a/src/cli/commands/remove/command.tsx
+++ b/src/cli/commands/remove/command.tsx
@@ -1,4 +1,4 @@
-import { ConfigIO } from '../../../lib';
+import { ConfigIO, serializeResult, toError } from '../../../lib';
 import { getErrorMessage } from '../../errors';
 import { runCliCommand } from '../../telemetry/cli-command-run.js';
 import { COMMAND_DESCRIPTIONS } from '../../tui/copy';
@@ -49,7 +49,7 @@ async function handleRemoveAll(_options: RemoveAllOptions): Promise<RemoveResult
       note: 'Your source code has not been modified. Run `agentcore deploy` to apply changes to AWS.',
     };
   } catch (err) {
-    return { success: false, error: getErrorMessage(err) };
+    return { success: false, error: toError(err) };
   }
 }
 
@@ -57,8 +57,8 @@ async function handleRemoveAllCLI(options: RemoveAllOptions): Promise<void> {
   validateRemoveAllOptions(options);
   await runCliCommand('remove.all', !!options.json, async () => {
     const result = await handleRemoveAll(options);
-    if (!result.success) throw new Error(result.error);
-    console.log(JSON.stringify(result));
+    if (!result.success) throw result.error;
+    console.log(JSON.stringify(serializeResult(result)));
     return {};
   });
 }

--- a/src/cli/commands/remove/types.ts
+++ b/src/cli/commands/remove/types.ts
@@ -1,3 +1,5 @@
+import type { Result } from '../../../lib/result';
+
 export type ResourceType =
   | 'agent'
   | 'gateway'
@@ -25,11 +27,9 @@ export interface RemoveAllOptions {
   json?: boolean;
 }
 
-export interface RemoveResult {
-  success: boolean;
+export type RemoveResult = Result<{
   resourceType?: ResourceType;
   resourceName?: string;
   message?: string;
   note?: string;
-  error?: string;
-}
+}>;

--- a/src/cli/commands/run/command.tsx
+++ b/src/cli/commands/run/command.tsx
@@ -1,3 +1,4 @@
+import { serializeResult } from '../../../lib';
 import type { RecommendationType } from '../../aws/agentcore-recommendation';
 import { getErrorMessage } from '../../errors';
 import { handleRunEval } from '../../operations/eval';
@@ -25,7 +26,7 @@ const RECOMMENDATION_TYPE_MAP: Record<string, RecommendationType> = {
 };
 
 function formatRunOutput(result: Awaited<ReturnType<typeof handleRunEval>>): void {
-  if (!result.run) return;
+  if (!result.success) return;
 
   const { run } = result;
   const date = new Date(run.timestamp).toLocaleString([], {
@@ -56,7 +57,7 @@ function formatRunOutput(result: Awaited<ReturnType<typeof handleRunEval>>): voi
 
   for (const r of run.results) {
     const score = r.aggregateScore.toFixed(2);
-    const errors = r.sessionScores.filter(s => s.errorMessage).length;
+    const errors = r.sessionScores.filter((s: { errorMessage?: string }) => s.errorMessage).length;
     const errorSuffix = errors > 0 ? ` (${errors} errors)` : '';
     console.log(`  ${r.evaluator}: ${score}${errorSuffix}`);
   }
@@ -146,12 +147,12 @@ export const registerRun = (program: Command) => {
           const result = await handleRunEval(options);
 
           if (cliOptions.json) {
-            console.log(JSON.stringify(result));
+            console.log(JSON.stringify(serializeResult(result)));
           } else if (result.success) {
             formatRunOutput(result);
           } else {
             formatRunOutput(result);
-            render(<Text color="red">{result.error}</Text>);
+            render(<Text color="red">{result.error.message}</Text>);
           }
 
           process.exit(result.success ? 0 : 1);
@@ -240,11 +241,11 @@ export const registerRun = (program: Command) => {
           }
 
           if (cliOptions.json) {
-            console.log(JSON.stringify(result));
+            console.log(JSON.stringify(serializeResult(result)));
           } else if (result.success) {
             formatBatchEvalOutput(result);
           } else {
-            render(<Text color="red">{result.error}</Text>);
+            render(<Text color="red">{result.error.message}</Text>);
             if (result.logFilePath) {
               console.error(`\nLog: ${result.logFilePath}`);
             }
@@ -401,9 +402,9 @@ export const registerRun = (program: Command) => {
 
           if (!result.success) {
             if (cliOptions.json) {
-              console.log(JSON.stringify(result));
+              console.log(JSON.stringify(serializeResult(result)));
             } else {
-              render(<Text color="red">{result.error}</Text>);
+              render(<Text color="red">{result.error.message}</Text>);
               if (result.logFilePath) {
                 console.error(`\nLog: ${result.logFilePath}`);
               }
@@ -428,7 +429,7 @@ export const registerRun = (program: Command) => {
           }
 
           if (cliOptions.json) {
-            console.log(JSON.stringify(result));
+            console.log(JSON.stringify(serializeResult(result)));
           } else {
             console.log(`\nRecommendation ID: ${result.recommendationId}`);
 
@@ -467,7 +468,7 @@ export const registerRun = (program: Command) => {
                   );
                   console.log(`Local config for "${cliOptions.bundleName}" has been updated to match.`);
                 } else {
-                  console.log(`\nCould not sync config bundle: ${applyResult.error}`);
+                  console.log(`\nCould not sync config bundle: ${applyResult.error.message}`);
                 }
               } catch {
                 // Non-fatal — user can manually sync

--- a/src/cli/commands/status/__tests__/action.test.ts
+++ b/src/cli/commands/status/__tests__/action.test.ts
@@ -1,7 +1,8 @@
 import type { AgentCoreProjectSpec, DeployedResourceState } from '../../../../schema/index.js';
 import { computeResourceStatuses, handleProjectStatus } from '../action.js';
-import type { StatusContext } from '../action.js';
+import type { ResourceStatusEntry, StatusContext } from '../action.js';
 import { buildRuntimeInvocationUrl } from '../constants.js';
+import assert from 'node:assert';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockGetAgentRuntimeStatus = vi.fn();
@@ -508,9 +509,11 @@ describe('handleProjectStatus — live enrichment', () => {
 
     const result = await handleProjectStatus(makeContext());
 
-    expect(result.success).toBe(true);
+    assert(result.success);
 
-    const evalEntry = result.resources.find(r => r.resourceType === 'evaluator' && r.name === 'MyEval');
+    const evalEntry = result.resources.find(
+      (r: ResourceStatusEntry) => r.resourceType === 'evaluator' && r.name === 'MyEval'
+    );
     expect(evalEntry).toBeDefined();
     expect(evalEntry!.detail).toContain('ACTIVE');
 
@@ -536,9 +539,11 @@ describe('handleProjectStatus — live enrichment', () => {
 
     const result = await handleProjectStatus(makeContext());
 
-    expect(result.success).toBe(true);
+    assert(result.success);
 
-    const configEntry = result.resources.find(r => r.resourceType === 'online-eval' && r.name === 'MyConfig');
+    const configEntry = result.resources.find(
+      (r: ResourceStatusEntry) => r.resourceType === 'online-eval' && r.name === 'MyConfig'
+    );
     expect(configEntry).toBeDefined();
     expect(configEntry!.detail).toContain('ACTIVE');
     expect(configEntry!.detail).toContain('ENABLED');
@@ -560,9 +565,11 @@ describe('handleProjectStatus — live enrichment', () => {
 
     const result = await handleProjectStatus(makeContext());
 
-    expect(result.success).toBe(true);
+    assert(result.success);
 
-    const evalEntry = result.resources.find(r => r.resourceType === 'evaluator' && r.name === 'MyEval');
+    const evalEntry = result.resources.find(
+      (r: ResourceStatusEntry) => r.resourceType === 'evaluator' && r.name === 'MyEval'
+    );
     expect(evalEntry).toBeDefined();
     expect(evalEntry!.error).toBe('AccessDenied');
   });
@@ -578,9 +585,11 @@ describe('handleProjectStatus — live enrichment', () => {
 
     const result = await handleProjectStatus(makeContext());
 
-    expect(result.success).toBe(true);
+    assert(result.success);
 
-    const configEntry = result.resources.find(r => r.resourceType === 'online-eval' && r.name === 'MyConfig');
+    const configEntry = result.resources.find(
+      (r: ResourceStatusEntry) => r.resourceType === 'online-eval' && r.name === 'MyConfig'
+    );
     expect(configEntry).toBeDefined();
     expect(configEntry!.error).toBe('ResourceNotFound');
   });
@@ -624,9 +633,11 @@ describe('handleProjectStatus — live enrichment', () => {
 
     const result = await handleProjectStatus(ctx);
 
-    expect(result.success).toBe(true);
+    assert(result.success);
 
-    const evalEntry = result.resources.find(r => r.resourceType === 'evaluator' && r.name === 'MyEval');
+    const evalEntry = result.resources.find(
+      (r: ResourceStatusEntry) => r.resourceType === 'evaluator' && r.name === 'MyEval'
+    );
     expect(evalEntry).toBeDefined();
     expect(evalEntry!.deploymentState).toBe('local-only');
     expect(mockGetEvaluator).not.toHaveBeenCalled();
@@ -697,8 +708,10 @@ describe('handleProjectStatus — invocation URL enrichment', () => {
 
     const result = await handleProjectStatus(ctx);
 
-    expect(result.success).toBe(true);
-    const agentEntry = result.resources.find(r => r.resourceType === 'agent' && r.name === 'MyAgent');
+    assert(result.success);
+    const agentEntry = result.resources.find(
+      (r: ResourceStatusEntry) => r.resourceType === 'agent' && r.name === 'MyAgent'
+    );
     expect(agentEntry).toBeDefined();
     expect(agentEntry!.invocationUrl).toBe(
       `https://bedrock-agentcore.us-east-1.amazonaws.com/runtimes/${encodeURIComponent(runtimeArn)}/invocations`
@@ -723,8 +736,10 @@ describe('handleProjectStatus — invocation URL enrichment', () => {
 
     const result = await handleProjectStatus(ctx);
 
-    expect(result.success).toBe(true);
-    const agentEntry = result.resources.find(r => r.resourceType === 'agent' && r.name === 'LocalAgent');
+    assert(result.success);
+    const agentEntry = result.resources.find(
+      (r: ResourceStatusEntry) => r.resourceType === 'agent' && r.name === 'LocalAgent'
+    );
     expect(agentEntry).toBeDefined();
     expect(agentEntry!.invocationUrl).toBeUndefined();
   });
@@ -758,8 +773,10 @@ describe('handleProjectStatus — invocation URL enrichment', () => {
 
     const result = await handleProjectStatus(ctx);
 
-    expect(result.success).toBe(true);
-    const agentEntry = result.resources.find(r => r.resourceType === 'agent' && r.name === 'FailAgent');
+    assert(result.success);
+    const agentEntry = result.resources.find(
+      (r: ResourceStatusEntry) => r.resourceType === 'agent' && r.name === 'FailAgent'
+    );
     expect(agentEntry).toBeDefined();
     expect(agentEntry!.error).toBe('Timeout');
     expect(agentEntry!.invocationUrl).toBe(
@@ -798,8 +815,10 @@ describe('handleProjectStatus — invocation URL enrichment', () => {
 
     const result = await handleProjectStatus(ctx);
 
-    expect(result.success).toBe(true);
-    const agentEntry = result.resources.find(r => r.resourceType === 'agent' && r.name === 'OldAgent');
+    assert(result.success);
+    const agentEntry = result.resources.find(
+      (r: ResourceStatusEntry) => r.resourceType === 'agent' && r.name === 'OldAgent'
+    );
     expect(agentEntry).toBeDefined();
     expect(agentEntry!.deploymentState).toBe('pending-removal');
     expect(agentEntry!.invocationUrl).toBeUndefined();

--- a/src/cli/commands/status/action.ts
+++ b/src/cli/commands/status/action.ts
@@ -1,4 +1,5 @@
-import { ConfigIO } from '../../../lib';
+import { ConfigIO, ResourceNotFoundError, toError } from '../../../lib';
+import type { Result } from '../../../lib/result';
 import type { AgentCoreProjectSpec, AwsDeploymentTargets, DeployedResourceState, DeployedState } from '../../../schema';
 import { getAgentRuntimeStatus } from '../../aws';
 import { getEvaluator, getOnlineEvaluationConfig } from '../../aws/agentcore-control';
@@ -32,15 +33,10 @@ export interface ResourceStatusEntry {
   invocationUrl?: string;
 }
 
-export interface ProjectStatusResult {
-  success: boolean;
-  projectName: string;
-  targetName: string;
+export type ProjectStatusResult = Result<{
   targetRegion?: string;
   resources: ResourceStatusEntry[];
-  error?: string;
-  logPath?: string;
-}
+}> & { projectName?: string; targetName?: string; logPath?: string; resources?: ResourceStatusEntry[] };
 
 export interface StatusContext {
   project: AgentCoreProjectSpec;
@@ -48,14 +44,11 @@ export interface StatusContext {
   awsTargets: AwsDeploymentTargets;
 }
 
-export interface RuntimeLookupResult {
-  success: boolean;
+export type RuntimeLookupResult = Result<{
   targetName?: string;
   runtimeId?: string;
   runtimeStatus?: string;
-  error?: string;
-  logPath?: string;
-}
+}> & { logPath?: string };
 
 /**
  * Loads configuration required for status check.
@@ -333,10 +326,10 @@ export async function handleProjectStatus(
     logger.finalize(false);
     return {
       success: false,
+      error: new Error(error),
       projectName: project.name,
       targetName: options.targetName,
       resources: [],
-      error,
       logPath: logger.getRelativeLogPath(),
     };
   }
@@ -504,7 +497,7 @@ export async function handleRuntimeLookup(
     const error = 'No deployment targets found. Run `agentcore create` first.';
     logger.endStep('error', error);
     logger.finalize(false);
-    return { success: false, error, logPath: logger.getRelativeLogPath() };
+    return { success: false, error: new ResourceNotFoundError(error), logPath: logger.getRelativeLogPath() };
   }
 
   const selectedTargetName = options.targetName ?? targetNames[0]!;
@@ -513,7 +506,7 @@ export async function handleRuntimeLookup(
     const error = `Target '${options.targetName}' not found. Available: ${targetNames.join(', ')}`;
     logger.endStep('error', error);
     logger.finalize(false);
-    return { success: false, error, logPath: logger.getRelativeLogPath() };
+    return { success: false, error: new ResourceNotFoundError(error), logPath: logger.getRelativeLogPath() };
   }
 
   const targetConfig = awsTargets.find(target => target.name === selectedTargetName);
@@ -522,7 +515,7 @@ export async function handleRuntimeLookup(
     const error = `Target config '${selectedTargetName}' not found in aws-targets`;
     logger.endStep('error', error);
     logger.finalize(false);
-    return { success: false, error, logPath: logger.getRelativeLogPath() };
+    return { success: false, error: new ResourceNotFoundError(error), logPath: logger.getRelativeLogPath() };
   }
 
   logger.log(`Target: ${selectedTargetName} (${targetConfig.region})`);
@@ -550,6 +543,6 @@ export async function handleRuntimeLookup(
     const errorMsg = getErrorMessage(error);
     logger.endStep('error', errorMsg);
     logger.finalize(false);
-    return { success: false, error: errorMsg, logPath: logger.getRelativeLogPath() };
+    return { success: false, error: toError(error), logPath: logger.getRelativeLogPath() };
   }
 }

--- a/src/cli/commands/status/command.tsx
+++ b/src/cli/commands/status/command.tsx
@@ -1,3 +1,4 @@
+import { serializeResult } from '../../../lib';
 import { getErrorMessage } from '../../errors';
 import { COMMAND_DESCRIPTIONS } from '../../tui/copy';
 import { requireProject } from '../../tui/guards';
@@ -100,12 +101,12 @@ export const registerStatus = (program: Command) => {
           });
 
           if (cliOptions.json) {
-            console.log(JSON.stringify(result, null, 2));
+            console.log(JSON.stringify(serializeResult(result), null, 2));
             return;
           }
 
           if (!result.success) {
-            render(<Text color="red">{result.error}</Text>);
+            render(<Text color="red">{result.error.message}</Text>);
             return;
           }
 
@@ -126,13 +127,17 @@ export const registerStatus = (program: Command) => {
         });
 
         if (cliOptions.json) {
-          const filtered = filterResources(result.resources, cliOptions);
-          console.log(JSON.stringify({ ...result, resources: filtered }, null, 2));
+          if (result.success) {
+            const filtered = filterResources(result.resources, cliOptions);
+            console.log(JSON.stringify({ ...result, resources: filtered }, null, 2));
+          } else {
+            console.log(JSON.stringify(serializeResult(result), null, 2));
+          }
           return;
         }
 
         if (!result.success) {
-          render(<Text color="red">{result.error}</Text>);
+          render(<Text color="red">{result.error.message}</Text>);
           return;
         }
 
@@ -153,7 +158,7 @@ export const registerStatus = (program: Command) => {
         render(
           <Box flexDirection="column">
             <Text bold>
-              AgentCore Status (target: {result.targetName || 'No target configured'}
+              AgentCore Status (target: {result.targetName ?? 'No target configured'}
               {result.targetRegion ? `, ${result.targetRegion}` : ''})
             </Text>
 

--- a/src/cli/commands/traces/action.ts
+++ b/src/cli/commands/traces/action.ts
@@ -1,17 +1,16 @@
+import { ResourceNotFoundError, ValidationError } from '../../../lib';
+import type { Result } from '../../../lib/result';
 import { parseTimeString } from '../../../lib/utils';
 import type { DeployedProjectConfig } from '../../operations/resolve-agent';
 import { resolveAgent } from '../../operations/resolve-agent';
 import { buildTraceConsoleUrl, getTrace, listTraces } from '../../operations/traces';
 import type { TracesGetOptions, TracesListOptions } from './types';
 
-export interface TracesListResult {
-  success: boolean;
+export type TracesListResult = Result<{
   agentName?: string;
   targetName?: string;
-  consoleUrl?: string;
-  traces?: { traceId: string; timestamp: string; sessionId?: string }[];
-  error?: string;
-}
+  traces: { traceId: string; timestamp: string; sessionId?: string }[];
+}> & { consoleUrl?: string };
 
 export async function handleTracesList(
   context: DeployedProjectConfig,
@@ -19,7 +18,7 @@ export async function handleTracesList(
 ): Promise<TracesListResult> {
   const resolved = resolveAgent(context, options);
   if (!resolved.success) {
-    return { success: false, error: resolved.error };
+    return { success: false, error: new ResourceNotFoundError(resolved.error) };
   }
 
   const { agent } = resolved;
@@ -33,7 +32,7 @@ export async function handleTracesList(
 
   const limit = options.limit ? parseInt(options.limit, 10) : 20;
   if (isNaN(limit)) {
-    return { success: false, error: '--limit must be a number' };
+    return { success: false, error: new ValidationError('--limit must be a number') };
   }
 
   // Parse time options
@@ -68,14 +67,11 @@ export async function handleTracesList(
   };
 }
 
-export interface TracesGetResult {
-  success: boolean;
+export type TracesGetResult = Result<{
   agentName?: string;
   targetName?: string;
-  consoleUrl?: string;
   filePath?: string;
-  error?: string;
-}
+}> & { consoleUrl?: string };
 
 export async function handleTracesGet(
   context: DeployedProjectConfig,
@@ -84,7 +80,7 @@ export async function handleTracesGet(
 ): Promise<TracesGetResult> {
   const resolved = resolveAgent(context, options);
   if (!resolved.success) {
-    return { success: false, error: resolved.error };
+    return { success: false, error: new ResourceNotFoundError(resolved.error) };
   }
 
   const { agent } = resolved;

--- a/src/cli/commands/traces/command.tsx
+++ b/src/cli/commands/traces/command.tsx
@@ -37,7 +37,7 @@ export const registerTraces = (program: Command) => {
         if (!result.success) {
           render(
             <Box flexDirection="column">
-              <Text color="red">Error: {result.error}</Text>
+              <Text color="red">Error: {result.error.message}</Text>
               {result.consoleUrl && <Text color="gray">Console: {result.consoleUrl}</Text>}
             </Box>
           );
@@ -109,7 +109,7 @@ export const registerTraces = (program: Command) => {
         if (!result.success) {
           render(
             <Box flexDirection="column">
-              <Text color="red">Error: {result.error}</Text>
+              <Text color="red">Error: {result.error.message}</Text>
               {result.consoleUrl && <Text color="gray">Console: {result.consoleUrl}</Text>}
             </Box>
           );

--- a/src/cli/commands/validate/__tests__/action.test.ts
+++ b/src/cli/commands/validate/__tests__/action.test.ts
@@ -1,4 +1,5 @@
 import { handleValidate } from '../action.js';
+import assert from 'node:assert';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const {
@@ -74,7 +75,8 @@ describe('handleValidate', () => {
     const result = await handleValidate({});
 
     expect(result.success).toBe(false);
-    expect(result.error).toContain('No agentcore project found');
+    assert(!result.success);
+    expect(result.error.message).toContain('No agentcore project found');
   });
 
   it('returns success when all configs are valid', async () => {
@@ -95,7 +97,8 @@ describe('handleValidate', () => {
     const result = await handleValidate({});
 
     expect(result.success).toBe(false);
-    expect(result.error).toContain('invalid project');
+    assert(!result.success);
+    expect(result.error.message).toContain('invalid project');
   });
 
   it('returns error when AWS targets fails', async () => {
@@ -106,7 +109,8 @@ describe('handleValidate', () => {
     const result = await handleValidate({});
 
     expect(result.success).toBe(false);
-    expect(result.error).toContain('bad targets');
+    assert(!result.success);
+    expect(result.error.message).toContain('bad targets');
   });
 
   it('validates state file when it exists', async () => {
@@ -132,7 +136,8 @@ describe('handleValidate', () => {
     const result = await handleValidate({});
 
     expect(result.success).toBe(false);
-    expect(result.error).toContain('bad state');
+    assert(!result.success);
+    expect(result.error.message).toContain('bad state');
   });
 
   it('uses custom directory when provided', async () => {
@@ -155,7 +160,8 @@ describe('handleValidate', () => {
     const result = await handleValidate({});
 
     expect(result.success).toBe(false);
-    expect(result.error).toBe('field "name" is required');
+    assert(!result.success);
+    expect(result.error.message).toBe('field "name" is required');
   });
 
   it('formats ConfigParseError with cause', async () => {
@@ -166,8 +172,9 @@ describe('handleValidate', () => {
     const result = await handleValidate({});
 
     expect(result.success).toBe(false);
-    expect(result.error).toContain('Invalid JSON in agentcore.json');
-    expect(result.error).toContain('Unexpected token');
+    assert(!result.success);
+    expect(result.error.message).toContain('Invalid JSON in agentcore.json');
+    expect(result.error.message).toContain('Unexpected token');
   });
 
   it('formats ConfigReadError with cause', async () => {
@@ -180,8 +187,9 @@ describe('handleValidate', () => {
     const result = await handleValidate({});
 
     expect(result.success).toBe(false);
-    expect(result.error).toContain('Failed to read agentcore.json');
-    expect(result.error).toContain('EACCES');
+    assert(!result.success);
+    expect(result.error.message).toContain('Failed to read agentcore.json');
+    expect(result.error.message).toContain('EACCES');
   });
 
   it('formats ConfigNotFoundError with file name', async () => {
@@ -192,7 +200,8 @@ describe('handleValidate', () => {
     const result = await handleValidate({});
 
     expect(result.success).toBe(false);
-    expect(result.error).toBe('Required file not found: agentcore.json');
+    assert(!result.success);
+    expect(result.error.message).toBe('Required file not found: agentcore.json');
   });
 
   it('formats non-Error values as strings', async () => {
@@ -202,6 +211,7 @@ describe('handleValidate', () => {
     const result = await handleValidate({});
 
     expect(result.success).toBe(false);
-    expect(result.error).toBe('string error');
+    assert(!result.success);
+    expect(result.error.message).toBe('string error');
   });
 });

--- a/src/cli/commands/validate/action.ts
+++ b/src/cli/commands/validate/action.ts
@@ -7,21 +7,17 @@ import {
   NoProjectError,
   findConfigRoot,
 } from '../../../lib';
+import type { Result } from '../../../lib/result';
 
 export interface ValidateOptions {
   directory?: string;
-}
-
-export interface ValidateResult {
-  success: boolean;
-  error?: string;
 }
 
 /**
  * Validates all AgentCore schema files in the project.
  * Returns a binary success/fail result with an error message if validation fails.
  */
-export async function handleValidate(options: ValidateOptions): Promise<ValidateResult> {
+export async function handleValidate(options: ValidateOptions): Promise<Result> {
   const baseDir = options.directory ?? process.cwd();
 
   // Check if project exists
@@ -29,7 +25,7 @@ export async function handleValidate(options: ValidateOptions): Promise<Validate
   if (!configRoot) {
     return {
       success: false,
-      error: new NoProjectError().message,
+      error: new NoProjectError(),
     };
   }
 
@@ -39,14 +35,14 @@ export async function handleValidate(options: ValidateOptions): Promise<Validate
   try {
     await configIO.readProjectSpec();
   } catch (err) {
-    return { success: false, error: formatError(err, 'agentcore.json') };
+    return { success: false, error: new Error(formatError(err, 'agentcore.json'), { cause: err }) };
   }
 
   // Validate AWS targets (aws-targets.json)
   try {
     await configIO.readAWSDeploymentTargets();
   } catch (err) {
-    return { success: false, error: formatError(err, 'aws-targets.json') };
+    return { success: false, error: new Error(formatError(err, 'aws-targets.json'), { cause: err }) };
   }
 
   // Validate deployed state if it exists (.cli/state.json)
@@ -54,7 +50,7 @@ export async function handleValidate(options: ValidateOptions): Promise<Validate
     try {
       await configIO.readDeployedState();
     } catch (err) {
-      return { success: false, error: formatError(err, '.cli/state.json') };
+      return { success: false, error: new Error(formatError(err, '.cli/state.json'), { cause: err }) };
     }
   }
 

--- a/src/cli/commands/validate/command.tsx
+++ b/src/cli/commands/validate/command.tsx
@@ -15,7 +15,7 @@ export const registerValidate = (program: Command) => {
         render(<Text color="green">Valid</Text>);
         process.exit(0);
       } else {
-        render(<Text color="red">{result.error}</Text>);
+        render(<Text color="red">{result.error.message}</Text>);
         process.exit(1);
       }
     });

--- a/src/cli/commands/validate/index.ts
+++ b/src/cli/commands/validate/index.ts
@@ -1,2 +1,2 @@
 export { registerValidate } from './command';
-export { handleValidate, type ValidateOptions, type ValidateResult } from './action';
+export { handleValidate, type ValidateOptions } from './action';

--- a/src/cli/errors.ts
+++ b/src/cli/errors.ts
@@ -1,14 +1,4 @@
 /**
- * Error thrown when an agent with the same name already exists.
- */
-export class AgentAlreadyExistsError extends Error {
-  constructor(agentName: string) {
-    super(`An agent named "${agentName}" already exists in the schema.`);
-    this.name = 'AgentAlreadyExistsError';
-  }
-}
-
-/**
  * Converts an unknown error to a string message.
  * Handles Error instances and other thrown values consistently.
  */

--- a/src/cli/operations/agent/generate/write-agent-to-project.ts
+++ b/src/cli/operations/agent/generate/write-agent-to-project.ts
@@ -1,7 +1,6 @@
-import { ConfigIO, requireConfigRoot } from '../../../../lib';
+import { AgentAlreadyExistsError, ConfigIO, requireConfigRoot } from '../../../../lib';
 import type { AgentCoreProjectSpec } from '../../../../schema';
 import { SCHEMA_VERSION } from '../../../constants';
-import { AgentAlreadyExistsError } from '../../../errors';
 import type { CredentialStrategy } from '../../../primitives/CredentialPrimitive';
 import type { GenerateConfig } from '../../../tui/screens/generate/types';
 import { mapGenerateConfigToAgent, mapGenerateInputToMemories, mapModelProviderToCredentials } from './schema-mapper';

--- a/src/cli/operations/agent/import/index.ts
+++ b/src/cli/operations/agent/import/index.ts
@@ -3,10 +3,9 @@
  * Provides executeImportAgent() as the shared handler called by both
  * the TUI hook (useAddAgent) and the non-interactive CLI (AgentPrimitive).
  */
-import { APP_DIR, ConfigIO } from '../../../../lib';
+import { APP_DIR, ConfigIO, toError } from '../../../../lib';
 import type { RuntimeAuthorizerType, SDKFramework } from '../../../../schema';
 import { getBedrockAgentConfig } from '../../../aws/bedrock-import';
-import { getErrorMessage } from '../../../errors';
 import type { JwtConfigOptions } from '../../../primitives/auth-utils';
 import { createManagedOAuthCredential } from '../../../primitives/auth-utils';
 import type { AddResult } from '../../../primitives/types';
@@ -120,6 +119,6 @@ export async function executeImportAgent(
 
     return { success: true, agentName: name, agentPath };
   } catch (err) {
-    return { success: false, error: getErrorMessage(err) };
+    return { success: false, error: toError(err) };
   }
 }

--- a/src/cli/operations/deploy/__tests__/post-deploy-observability.test.ts
+++ b/src/cli/operations/deploy/__tests__/post-deploy-observability.test.ts
@@ -70,7 +70,7 @@ describe('setupTransactionSearch', () => {
   });
 
   it('propagates error from enableTransactionSearch', async () => {
-    mockEnableTransactionSearch.mockResolvedValue({ success: false, error: 'Insufficient permissions' });
+    mockEnableTransactionSearch.mockResolvedValue({ success: false, error: new Error('Insufficient permissions') });
 
     const result = await setupTransactionSearch({
       region: 'us-east-1',
@@ -78,7 +78,10 @@ describe('setupTransactionSearch', () => {
       agentNames: ['agent-1'],
     });
 
-    expect(result).toEqual({ success: false, error: 'Insufficient permissions' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.message).toBe('Insufficient permissions');
+    }
   });
 
   it('triggers when hasGateways is true and agentNames is empty', async () => {

--- a/src/cli/operations/deploy/index.ts
+++ b/src/cli/operations/deploy/index.ts
@@ -39,11 +39,10 @@ export {
   type DeployedTarget,
   type DiscoverDeployedResult,
   type DestroyTargetOptions,
-  type StackTeardownResult,
 } from './teardown';
 
 // Post-deploy observability setup
-export { setupTransactionSearch, type TransactionSearchSetupResult } from './post-deploy-observability';
+export { setupTransactionSearch } from './post-deploy-observability';
 
 // Post-deploy HTTP gateways
 export {

--- a/src/cli/operations/deploy/post-deploy-observability.ts
+++ b/src/cli/operations/deploy/post-deploy-observability.ts
@@ -1,3 +1,4 @@
+import type { Result } from '../../../lib/result';
 import { readGlobalConfigSync } from '../../../lib/schemas/io/global-config';
 import { enableTransactionSearch } from '../../aws/transaction-search';
 
@@ -6,11 +7,6 @@ export interface TransactionSearchSetupOptions {
   accountId: string;
   agentNames: string[];
   hasGateways?: boolean;
-}
-
-export interface TransactionSearchSetupResult {
-  success: boolean;
-  error?: string;
 }
 
 /**
@@ -22,9 +18,7 @@ export interface TransactionSearchSetupResult {
  *
  * This is a non-blocking best-effort operation — failures do not fail the deploy.
  */
-export async function setupTransactionSearch(
-  options: TransactionSearchSetupOptions
-): Promise<TransactionSearchSetupResult> {
+export async function setupTransactionSearch(options: TransactionSearchSetupOptions): Promise<Result> {
   const { region, accountId, agentNames } = options;
 
   if (agentNames.length === 0 && !options.hasGateways) {

--- a/src/cli/operations/deploy/teardown.ts
+++ b/src/cli/operations/deploy/teardown.ts
@@ -1,4 +1,5 @@
 import { CONFIG_DIR, ConfigIO } from '../../../lib';
+import type { Result } from '../../../lib/result';
 import type { AwsDeploymentTarget } from '../../../schema';
 import { withTargetRegion } from '../../aws';
 import { deleteConfigurationBundle } from '../../aws/agentcore-config-bundles';
@@ -99,16 +100,11 @@ export function getCdkProjectDir(cwd?: string): string {
   return join(baseDir, CONFIG_DIR, 'cdk');
 }
 
-export interface StackTeardownResult {
-  success: boolean;
-  error?: string;
-}
-
 /**
  * Perform full stack teardown for a target: destroy CloudFormation stack,
  * remove deployed-state entry, and remove the target from aws-targets.json.
  */
-export async function performStackTeardown(targetName: string): Promise<StackTeardownResult> {
+export async function performStackTeardown(targetName: string): Promise<Result> {
   const cdkProjectDir = getCdkProjectDir();
   const configIO = new ConfigIO();
 

--- a/src/cli/operations/eval/__tests__/list-eval-runs.test.ts
+++ b/src/cli/operations/eval/__tests__/list-eval-runs.test.ts
@@ -1,5 +1,6 @@
 import { handleListEvalRuns } from '../list-eval-runs.js';
 import type { EvalRunResult } from '../types.js';
+import assert from 'node:assert';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const mockListEvalRuns = vi.fn();
@@ -28,7 +29,7 @@ describe('handleListEvalRuns', () => {
 
     const result = handleListEvalRuns({});
 
-    expect(result.success).toBe(true);
+    assert(result.success);
     expect(result.runs).toHaveLength(2);
   });
 
@@ -42,9 +43,9 @@ describe('handleListEvalRuns', () => {
 
     const result = handleListEvalRuns({ agent: 'agent-a' });
 
-    expect(result.success).toBe(true);
+    assert(result.success);
     expect(result.runs).toHaveLength(2);
-    expect(result.runs!.every(r => r.agent === 'agent-a')).toBe(true);
+    expect(result.runs.every((r: EvalRunResult) => r.agent === 'agent-a')).toBe(true);
   });
 
   it('limits the number of results', () => {
@@ -57,7 +58,7 @@ describe('handleListEvalRuns', () => {
 
     const result = handleListEvalRuns({ limit: 2 });
 
-    expect(result.success).toBe(true);
+    assert(result.success);
     expect(result.runs).toHaveLength(2);
   });
 
@@ -72,9 +73,10 @@ describe('handleListEvalRuns', () => {
 
     const result = handleListEvalRuns({ agent: 'a', limit: 2 });
 
+    assert(result.success);
     expect(result.runs).toHaveLength(2);
-    expect(result.runs![0]!.timestamp).toBe('2025-01-15T10:00:00.000Z');
-    expect(result.runs![1]!.timestamp).toBe('2025-01-15T12:00:00.000Z');
+    expect(result.runs[0]!.timestamp).toBe('2025-01-15T10:00:00.000Z');
+    expect(result.runs[1]!.timestamp).toBe('2025-01-15T12:00:00.000Z');
   });
 
   it('returns empty array when no runs exist', () => {
@@ -82,7 +84,7 @@ describe('handleListEvalRuns', () => {
 
     const result = handleListEvalRuns({});
 
-    expect(result.success).toBe(true);
+    assert(result.success);
     expect(result.runs).toEqual([]);
   });
 
@@ -93,9 +95,8 @@ describe('handleListEvalRuns', () => {
 
     const result = handleListEvalRuns({});
 
-    expect(result.success).toBe(false);
-    expect(result.error).toBe('disk error');
-    expect(result.runs).toBeUndefined();
+    assert(!result.success);
+    expect(result.error.message).toBe('disk error');
   });
 
   it('handles non-Error thrown values', () => {
@@ -105,7 +106,7 @@ describe('handleListEvalRuns', () => {
 
     const result = handleListEvalRuns({});
 
-    expect(result.success).toBe(false);
-    expect(result.error).toBe('42');
+    assert(!result.success);
+    expect(result.error.message).toBe('42');
   });
 });

--- a/src/cli/operations/eval/__tests__/logs-eval.test.ts
+++ b/src/cli/operations/eval/__tests__/logs-eval.test.ts
@@ -1,4 +1,5 @@
 import { handleLogsEval } from '../logs-eval.js';
+import assert from 'node:assert';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockLoadDeployedProjectConfig = vi.fn();
@@ -100,8 +101,8 @@ describe('handleLogsEval', () => {
 
     const result = await handleLogsEval({});
 
-    expect(result.success).toBe(false);
-    expect(result.error).toBe('No agents defined');
+    assert(!result.success);
+    expect(result.error.message).toBe('No agents defined');
   });
 
   it('returns error when no online eval configs exist for the agent', async () => {
@@ -111,8 +112,8 @@ describe('handleLogsEval', () => {
 
     const result = await handleLogsEval({});
 
-    expect(result.success).toBe(false);
-    expect(result.error).toContain('No deployed online eval configs found');
+    assert(!result.success);
+    expect(result.error.message).toContain('No deployed online eval configs found');
   });
 
   it('returns error when online eval configs exist but none are deployed', async () => {
@@ -122,8 +123,8 @@ describe('handleLogsEval', () => {
 
     const result = await handleLogsEval({});
 
-    expect(result.success).toBe(false);
-    expect(result.error).toContain('No deployed online eval configs found');
+    assert(!result.success);
+    expect(result.error.message).toContain('No deployed online eval configs found');
   });
 
   it('searches logs with time range when --since is specified', async () => {

--- a/src/cli/operations/eval/__tests__/pause-resume.test.ts
+++ b/src/cli/operations/eval/__tests__/pause-resume.test.ts
@@ -1,4 +1,5 @@
 import { handlePauseResume } from '../pause-resume.js';
+import assert from 'node:assert';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const mockLoadDeployedProjectConfig = vi.fn();
@@ -46,7 +47,7 @@ describe('handlePauseResume', () => {
 
     const result = await handlePauseResume({ name: 'my-config' }, 'pause');
 
-    expect(result.success).toBe(true);
+    assert(result.success);
     expect(result.executionStatus).toBe('DISABLED');
     expect(mockUpdateOnlineEvalExecutionStatus).toHaveBeenCalledWith({
       region: 'us-east-1',
@@ -65,7 +66,7 @@ describe('handlePauseResume', () => {
 
     const result = await handlePauseResume({ name: 'my-config' }, 'resume');
 
-    expect(result.success).toBe(true);
+    assert(result.success);
     expect(result.executionStatus).toBe('ENABLED');
     expect(mockUpdateOnlineEvalExecutionStatus).toHaveBeenCalledWith({
       region: 'us-east-1',
@@ -83,8 +84,8 @@ describe('handlePauseResume', () => {
 
     const result = await handlePauseResume({ name: 'my-config' }, 'pause');
 
-    expect(result.success).toBe(false);
-    expect(result.error).toContain('No deployed targets found');
+    assert(!result.success);
+    expect(result.error.message).toContain('No deployed targets found');
   });
 
   it('returns error when config name is not found in deployed state', async () => {
@@ -92,9 +93,9 @@ describe('handlePauseResume', () => {
 
     const result = await handlePauseResume({ name: 'missing-config' }, 'pause');
 
-    expect(result.success).toBe(false);
-    expect(result.error).toContain('missing-config');
-    expect(result.error).toContain('not found');
+    assert(!result.success);
+    expect(result.error.message).toContain('missing-config');
+    expect(result.error.message).toContain('not found');
   });
 
   it('returns error when target config is missing from aws-targets', async () => {
@@ -105,9 +106,9 @@ describe('handlePauseResume', () => {
 
     const result = await handlePauseResume({ name: 'my-config' }, 'pause');
 
-    expect(result.success).toBe(false);
-    expect(result.error).toContain('Target config');
-    expect(result.error).toContain('not found');
+    assert(!result.success);
+    expect(result.error.message).toContain('Target config');
+    expect(result.error.message).toContain('not found');
   });
 
   it('returns error when the SDK call fails', async () => {
@@ -116,8 +117,8 @@ describe('handlePauseResume', () => {
 
     const result = await handlePauseResume({ name: 'my-config' }, 'pause');
 
-    expect(result.success).toBe(false);
-    expect(result.error).toBe('Service unavailable');
+    assert(!result.success);
+    expect(result.error.message).toBe('Service unavailable');
   });
 
   describe('ARN mode', () => {
@@ -131,7 +132,7 @@ describe('handlePauseResume', () => {
       const arn = 'arn:aws:bedrock-agentcore:us-west-2:123456789012:online-evaluation-config/my-cfg-id';
       const result = await handlePauseResume({ name: '', arn }, 'pause');
 
-      expect(result.success).toBe(true);
+      assert(result.success);
       expect(result.executionStatus).toBe('DISABLED');
       expect(mockLoadDeployedProjectConfig).not.toHaveBeenCalled();
       expect(mockUpdateOnlineEvalExecutionStatus).toHaveBeenCalledWith({
@@ -151,7 +152,7 @@ describe('handlePauseResume', () => {
       const arn = 'arn:aws:bedrock-agentcore:us-west-2:123456789012:online-evaluation-config/my-cfg-id';
       const result = await handlePauseResume({ name: '', arn, region: 'eu-west-1' }, 'resume');
 
-      expect(result.success).toBe(true);
+      assert(result.success);
       expect(result.executionStatus).toBe('ENABLED');
       expect(mockUpdateOnlineEvalExecutionStatus).toHaveBeenCalledWith({
         region: 'eu-west-1',
@@ -163,16 +164,16 @@ describe('handlePauseResume', () => {
     it('returns error for invalid ARN', async () => {
       const result = await handlePauseResume({ name: '', arn: 'not-an-arn' }, 'pause');
 
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('Invalid online eval config ARN');
+      assert(!result.success);
+      expect(result.error.message).toContain('Invalid online eval config ARN');
     });
 
     it('returns error when config ID cannot be extracted from ARN', async () => {
       const arn = 'arn:aws:bedrock-agentcore:us-east-1:123456789012:some-other-resource/foo';
       const result = await handlePauseResume({ name: '', arn }, 'pause');
 
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('Could not extract config ID');
+      assert(!result.success);
+      expect(result.error.message).toContain('Could not extract config ID');
     });
   });
 });

--- a/src/cli/operations/eval/__tests__/run-eval.test.ts
+++ b/src/cli/operations/eval/__tests__/run-eval.test.ts
@@ -1,4 +1,5 @@
 import { handleRunEval } from '../run-eval.js';
+import assert from 'node:assert';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
@@ -150,8 +151,8 @@ describe('handleRunEval', () => {
 
     const result = await handleRunEval({ evaluator: ['Builtin.GoalSuccessRate'], days: 7 });
 
-    expect(result.success).toBe(false);
-    expect(result.error).toBe('No agents defined');
+    assert(!result.success);
+    expect(result.error.message).toBe('No agents defined');
   });
 
   it('returns error when a custom evaluator is not found in deployed state', async () => {
@@ -170,9 +171,9 @@ describe('handleRunEval', () => {
 
     const result = await handleRunEval({ evaluator: ['MissingEval'], days: 7 });
 
-    expect(result.success).toBe(false);
-    expect(result.error).toContain('MissingEval');
-    expect(result.error).toContain('not found in deployed state');
+    assert(!result.success);
+    expect(result.error.message).toContain('MissingEval');
+    expect(result.error.message).toContain('not found in deployed state');
   });
 
   it('resolves builtin evaluators without deployed state lookup', async () => {
@@ -195,7 +196,8 @@ describe('handleRunEval', () => {
     const result = await handleRunEval({ evaluator: ['Builtin.GoalSuccessRate'], days: 7 });
 
     // Fails because no spans, but NOT because evaluator wasn't found
-    expect(result.error).toContain('No session spans found');
+    assert(!result.success);
+    expect(result.error.message).toContain('No session spans found');
   });
 
   it('resolves custom evaluator name to deployed evaluator ID', async () => {
@@ -278,9 +280,9 @@ describe('handleRunEval', () => {
 
     const result = await handleRunEval({ evaluator: ['Builtin.GoalSuccessRate'], days: 7 });
 
-    expect(result.success).toBe(false);
-    expect(result.error).toContain('No session spans found');
-    expect(result.error).toContain('my-agent');
+    assert(!result.success);
+    expect(result.error.message).toContain('No session spans found');
+    expect(result.error.message).toContain('my-agent');
   });
 
   // ─── Successful evaluation ────────────────────────────────────────────────
@@ -324,12 +326,12 @@ describe('handleRunEval', () => {
 
     const result = await handleRunEval({ evaluator: ['Builtin.GoalSuccessRate'], days: 7 });
 
-    expect(result.success).toBe(true);
+    assert(result.success);
     expect(result.run).toBeDefined();
-    expect(result.run!.sessionCount).toBe(2);
-    expect(result.run!.results).toHaveLength(1);
+    expect(result.run.sessionCount).toBe(2);
+    expect(result.run.results).toHaveLength(1);
 
-    const evalResult = result.run!.results[0]!;
+    const evalResult = result.run.results[0]!;
     expect(evalResult.aggregateScore).toBe(3.0); // (4 + 2) / 2
     expect(evalResult.sessionScores).toHaveLength(2);
     expect(evalResult.tokenUsage).toEqual({ inputTokens: 180, outputTokens: 90, totalTokens: 270 });
@@ -361,8 +363,8 @@ describe('handleRunEval', () => {
 
     const result = await handleRunEval({ evaluator: ['Builtin.GoalSuccessRate'], days: 7 });
 
-    expect(result.success).toBe(true);
-    const evalResult = result.run!.results[0]!;
+    assert(result.success);
+    const evalResult = result.run.results[0]!;
     // Only the non-errored session (value 5.0) should be in the aggregate
     expect(evalResult.aggregateScore).toBe(5.0);
     expect(evalResult.sessionScores).toHaveLength(2);
@@ -391,7 +393,7 @@ describe('handleRunEval', () => {
 
     const result = await handleRunEval({ evaluator: ['Builtin.GoalSuccessRate'], days: 7 });
 
-    expect(result.success).toBe(true);
+    assert(result.success);
     expect(mockSaveEvalRun).toHaveBeenCalled();
     expect(mockWriteFileSync).not.toHaveBeenCalled();
     expect(result.filePath).toBe('/tmp/eval-results/eval_2025-01-15_10-00-00.json');
@@ -422,7 +424,7 @@ describe('handleRunEval', () => {
       output: '/tmp/my-output.json',
     });
 
-    expect(result.success).toBe(true);
+    assert(result.success);
     expect(mockWriteFileSync).toHaveBeenCalledWith('/tmp/my-output.json', expect.any(String));
     expect(mockSaveEvalRun).not.toHaveBeenCalled();
     expect(result.filePath).toBe('/tmp/my-output.json');
@@ -461,12 +463,12 @@ describe('handleRunEval', () => {
       days: 7,
     });
 
-    expect(result.success).toBe(true);
-    expect(result.run!.results).toHaveLength(2);
-    expect(result.run!.results[0]!.evaluator).toBe('Builtin.GoalSuccessRate');
-    expect(result.run!.results[0]!.aggregateScore).toBe(0.9);
-    expect(result.run!.results[1]!.evaluator).toBe('CustomEval');
-    expect(result.run!.results[1]!.aggregateScore).toBe(4.5);
+    assert(result.success);
+    expect(result.run.results).toHaveLength(2);
+    expect(result.run.results[0]!.evaluator).toBe('Builtin.GoalSuccessRate');
+    expect(result.run.results[0]!.aggregateScore).toBe(0.9);
+    expect(result.run.results[1]!.evaluator).toBe('CustomEval');
+    expect(result.run.results[1]!.aggregateScore).toBe(4.5);
   });
 
   // ─── ARN mode ─────────────────────────────────────────────────────────────
@@ -484,8 +486,8 @@ describe('handleRunEval', () => {
       days: 3,
     });
 
-    expect(result.success).toBe(true);
-    expect(result.run!.agent).toBe('rt-arn-test');
+    assert(result.success);
+    expect(result.run.agent).toBe('rt-arn-test');
     expect(mockLoadDeployedProjectConfig).not.toHaveBeenCalled();
     expect(mockResolveAgent).not.toHaveBeenCalled();
   });
@@ -532,8 +534,8 @@ describe('handleRunEval', () => {
       days: 7,
     });
 
-    expect(result.success).toBe(false);
-    expect(result.error).toContain('Invalid agent runtime ARN');
+    assert(!result.success);
+    expect(result.error.message).toContain('Invalid agent runtime ARN');
   });
 
   it('rejects custom evaluator names in ARN mode', async () => {
@@ -543,8 +545,8 @@ describe('handleRunEval', () => {
       days: 7,
     });
 
-    expect(result.success).toBe(false);
-    expect(result.error).toContain('cannot be resolved in ARN mode');
+    assert(!result.success);
+    expect(result.error.message).toContain('cannot be resolved in ARN mode');
   });
 
   it('saves to cwd in ARN mode when no --output is specified', async () => {
@@ -559,7 +561,7 @@ describe('handleRunEval', () => {
       days: 7,
     });
 
-    expect(result.success).toBe(true);
+    assert(result.success);
     // Should write to cwd, not call saveEvalRun (which requires a project)
     expect(mockSaveEvalRun).not.toHaveBeenCalled();
     expect(mockWriteFileSync).toHaveBeenCalledWith(
@@ -582,7 +584,7 @@ describe('handleRunEval', () => {
       output: '/tmp/custom-eval.json',
     });
 
-    expect(result.success).toBe(true);
+    assert(result.success);
     expect(mockWriteFileSync).toHaveBeenCalledWith('/tmp/custom-eval.json', expect.any(String));
     expect(result.filePath).toBe('/tmp/custom-eval.json');
   });
@@ -594,8 +596,8 @@ describe('handleRunEval', () => {
       days: 7,
     });
 
-    expect(result.success).toBe(false);
-    expect(result.error).toContain('No evaluators specified');
+    assert(!result.success);
+    expect(result.error.message).toContain('No evaluators specified');
   });
 
   // ─── Endpoint selection ──────────────────────────────────────────────────
@@ -1199,8 +1201,8 @@ describe('handleRunEval', () => {
       expectedTrajectory: ['tool_1', 'tool_2'],
     });
 
-    expect(result.success).toBe(true);
-    expect(result.run!.referenceInputs).toEqual({
+    assert(result.success);
+    expect(result.run.referenceInputs).toEqual({
       expectedTrajectory: ['tool_1', 'tool_2'],
     });
   });
@@ -1215,7 +1217,7 @@ describe('handleRunEval', () => {
       assertions: ['Agent should greet user'],
     });
 
-    expect(result.success).toBe(false);
-    expect(result.error).toContain('require exactly one session');
+    assert(!result.success);
+    expect(result.error.message).toContain('require exactly one session');
   });
 });

--- a/src/cli/operations/eval/index.ts
+++ b/src/cli/operations/eval/index.ts
@@ -5,6 +5,5 @@ export type { ListEvalRunsResult } from './list-eval-runs';
 export { handlePauseResume } from './pause-resume';
 export type { PauseResumeResult } from './pause-resume';
 export { handleLogsEval } from './logs-eval';
-export type { LogsEvalResult } from './logs-eval';
 export type { EvalRunResult, RunEvalOptions, ListEvalRunsOptions, OnlineEvalActionOptions, SessionInfo } from './types';
 export type { LogsEvalOptions } from './logs-eval';

--- a/src/cli/operations/eval/list-eval-runs.ts
+++ b/src/cli/operations/eval/list-eval-runs.ts
@@ -1,12 +1,9 @@
-import { getErrorMessage } from '../../errors';
+import { toError } from '../../../lib';
+import type { Result } from '../../../lib/result';
 import { listEvalRuns } from './storage';
 import type { EvalRunResult, ListEvalRunsOptions } from './types';
 
-export interface ListEvalRunsResult {
-  success: boolean;
-  error?: string;
-  runs?: EvalRunResult[];
-}
+export type ListEvalRunsResult = Result<{ runs: EvalRunResult[] }>;
 
 export function handleListEvalRuns(options: ListEvalRunsOptions): ListEvalRunsResult {
   try {
@@ -22,6 +19,6 @@ export function handleListEvalRuns(options: ListEvalRunsOptions): ListEvalRunsRe
 
     return { success: true, runs };
   } catch (err) {
-    return { success: false, error: getErrorMessage(err) };
+    return { success: false, error: toError(err) };
   }
 }

--- a/src/cli/operations/eval/logs-eval.ts
+++ b/src/cli/operations/eval/logs-eval.ts
@@ -1,3 +1,5 @@
+import { ResourceNotFoundError, ValidationError } from '../../../lib';
+import type { Result } from '../../../lib/result';
 import { parseTimeString } from '../../../lib/utils';
 import { getOnlineEvaluationConfig } from '../../aws/agentcore-control';
 import { searchLogs, streamLogs } from '../../aws/cloudwatch';
@@ -11,11 +13,6 @@ export interface LogsEvalOptions {
   limit?: string;
   json?: boolean;
   follow?: boolean;
-}
-
-export interface LogsEvalResult {
-  success: boolean;
-  error?: string;
 }
 
 function formatLogLine(event: { timestamp: number; message: string }, json: boolean): string {
@@ -70,12 +67,12 @@ async function resolveEvalLogGroups(
   return results;
 }
 
-export async function handleLogsEval(options: LogsEvalOptions): Promise<LogsEvalResult> {
+export async function handleLogsEval(options: LogsEvalOptions): Promise<Result> {
   const context = await loadDeployedProjectConfig();
   const agentResult = resolveAgent(context, { runtime: options.agent });
 
   if (!agentResult.success) {
-    return { success: false, error: agentResult.error };
+    return { success: false, error: new ResourceNotFoundError(agentResult.error) };
   }
 
   const { agent } = agentResult;
@@ -85,7 +82,9 @@ export async function handleLogsEval(options: LogsEvalOptions): Promise<LogsEval
   if (resolvedLogGroups.length === 0) {
     return {
       success: false,
-      error: `No deployed online eval configs found. Add one with 'agentcore add online-eval' and deploy.`,
+      error: new ValidationError(
+        `No deployed online eval configs found. Add one with 'agentcore add online-eval' and deploy.`
+      ),
     };
   }
 

--- a/src/cli/operations/eval/pause-resume.ts
+++ b/src/cli/operations/eval/pause-resume.ts
@@ -1,14 +1,11 @@
+import { ResourceNotFoundError, toError } from '../../../lib';
+import type { Result } from '../../../lib/result';
 import type { OnlineEvalExecutionStatus } from '../../aws/agentcore-control';
 import { updateOnlineEvalExecutionStatus } from '../../aws/agentcore-control';
 import { loadDeployedProjectConfig } from '../resolve-agent';
 import type { OnlineEvalActionOptions } from './types';
 
-export interface PauseResumeResult {
-  success: boolean;
-  error?: string;
-  configId?: string;
-  executionStatus?: string;
-}
+export type PauseResumeResult = Result<{ configId?: string; executionStatus?: string }>;
 
 async function resolveOnlineEvalConfig(
   configName: string
@@ -88,7 +85,7 @@ export async function handlePauseResume(
 ): Promise<PauseResumeResult> {
   const resolution = await resolveConfig(options);
   if (!resolution.success) {
-    return resolution;
+    return { success: false, error: new ResourceNotFoundError(resolution.error) };
   }
 
   const executionStatus: OnlineEvalExecutionStatus = action === 'pause' ? 'DISABLED' : 'ENABLED';
@@ -106,6 +103,6 @@ export async function handlePauseResume(
       executionStatus: result.executionStatus,
     };
   } catch (err) {
-    return { success: false, error: (err as Error).message };
+    return { success: false, error: toError(err) };
   }
 }

--- a/src/cli/operations/eval/run-batch-evaluation.ts
+++ b/src/cli/operations/eval/run-batch-evaluation.ts
@@ -6,7 +6,8 @@
  *   4. Poll GetBatchEvaluation until terminal status
  *   5. Return results
  */
-import { ConfigIO } from '../../../lib';
+import { ConfigIO, ResourceNotFoundError, ValidationError, toError } from '../../../lib';
+import type { Result } from '../../../lib/result';
 import type { DeployedState } from '../../../schema';
 import { generateClientToken, getBatchEvaluation, startBatchEvaluation } from '../../aws/agentcore-batch-evaluation';
 import type {
@@ -54,9 +55,7 @@ export interface BatchEvaluationResult {
   error?: string;
 }
 
-export interface RunBatchEvaluationCommandResult {
-  success: boolean;
-  error?: string;
+export type RunBatchEvaluationCommandResult = Result & {
   batchEvaluationId?: string;
   name?: string;
   status?: string;
@@ -65,7 +64,7 @@ export interface RunBatchEvaluationCommandResult {
   startedAt?: string;
   completedAt?: string;
   logFilePath?: string;
-}
+};
 
 // ============================================================================
 // Constants
@@ -116,7 +115,7 @@ export async function runBatchEvaluationCommand(
       logger?.log(error, 'error');
       logger?.endStep('error', error);
       logger?.finalize(false);
-      return { success: false, error, results: [], logFilePath: logger?.logFilePath };
+      return { success: false, error: new ResourceNotFoundError(error), results: [], logFilePath: logger?.logFilePath };
     }
 
     const runtimeId = agentState.runtimeId;
@@ -152,7 +151,9 @@ export async function runBatchEvaluationCommand(
       if (!/^[a-zA-Z][a-zA-Z0-9_]{0,47}$/.test(options.name)) {
         return {
           success: false,
-          error: `Batch evaluation name must start with a letter and contain only letters, digits, and underscores (max 48 chars). Got: "${options.name}"`,
+          error: new ValidationError(
+            `Batch evaluation name must start with a letter and contain only letters, digits, and underscores (max 48 chars). Got: "${options.name}"`
+          ),
           results: [],
           logFilePath: logger?.logFilePath,
         };
@@ -242,7 +243,7 @@ export async function runBatchEvaluationCommand(
       logger?.finalize(false);
       return {
         success: false,
-        error,
+        error: new Error(error),
         batchEvaluationId: startResult.batchEvaluationId,
         name: evalName,
         status: current.status,
@@ -287,7 +288,7 @@ export async function runBatchEvaluationCommand(
     const error = err instanceof Error ? err.message : String(err);
     logger?.log(error, 'error');
     logger?.finalize(false);
-    return { success: false, error, results: [], logFilePath: logger?.logFilePath };
+    return { success: false, error: toError(err), results: [], logFilePath: logger?.logFilePath };
   }
 }
 

--- a/src/cli/operations/eval/run-eval.ts
+++ b/src/cli/operations/eval/run-eval.ts
@@ -1,3 +1,5 @@
+import { ResourceNotFoundError, ValidationError } from '../../../lib';
+import type { Result } from '../../../lib/result';
 import { getCredentialProvider } from '../../aws';
 import { evaluate } from '../../aws/agentcore';
 import type { EvaluationReferenceInput } from '../../aws/agentcore';
@@ -551,12 +553,7 @@ async function fetchSessionSpans(opts: FetchSpansOptions): Promise<SessionSpans[
   return sessions;
 }
 
-export interface RunEvalResult {
-  success: boolean;
-  error?: string;
-  run?: EvalRunResult;
-  filePath?: string;
-}
+export type RunEvalResult = Result<{ run: EvalRunResult; filePath: string }>;
 
 export async function handleRunEval(options: RunEvalOptions): Promise<RunEvalResult> {
   let resolution: ResolveResult;
@@ -569,7 +566,7 @@ export async function handleRunEval(options: RunEvalOptions): Promise<RunEvalRes
   }
 
   if (!resolution.success) {
-    return { success: false, error: resolution.error };
+    return { success: false, error: new ResourceNotFoundError(resolution.error) };
   }
 
   const { ctx } = resolution;
@@ -593,7 +590,9 @@ export async function handleRunEval(options: RunEvalOptions): Promise<RunEvalRes
   if (sessions.length === 0) {
     return {
       success: false,
-      error: `No session spans found for agent "${ctx.agentLabel}" in the last ${options.days} day(s). Has the agent been invoked?`,
+      error: new ResourceNotFoundError(
+        `No session spans found for agent "${ctx.agentLabel}" in the last ${options.days} day(s). Has the agent been invoked?`
+      ),
     };
   }
 
@@ -610,8 +609,9 @@ export async function handleRunEval(options: RunEvalOptions): Promise<RunEvalRes
   if (hasRefInputs && sessions.length !== 1) {
     return {
       success: false,
-      error:
-        'Ground truth flags (-A, --expected-trajectory, --expected-response) require exactly one session. Use -s/--session-id to target a single session.',
+      error: new ValidationError(
+        'Ground truth flags (-A, --expected-trajectory, --expected-response) require exactly one session. Use -s/--session-id to target a single session.'
+      ),
     };
   }
   if (hasRefInputs) {
@@ -642,7 +642,9 @@ export async function handleRunEval(options: RunEvalOptions): Promise<RunEvalRes
       if (!traceId) {
         return {
           success: false,
-          error: 'Expected response provided but no trace IDs found in session spans. Use -t/--trace-id to specify.',
+          error: new ValidationError(
+            'Expected response provided but no trace IDs found in session spans. Use -t/--trace-id to specify.'
+          ),
         };
       }
       refInputs.push({

--- a/src/cli/operations/mcp/__tests__/create-mcp-utils.test.ts
+++ b/src/cli/operations/mcp/__tests__/create-mcp-utils.test.ts
@@ -15,6 +15,17 @@ vi.mock('../../../../lib/index.js', () => ({
     configExists = mockConfigExists;
   },
   requireConfigRoot: () => '/project/agentcore',
+  findConfigRoot: () => '/project/agentcore',
+  toError: (err: unknown) => (err instanceof Error ? err : new Error(String(err))),
+  serializeResult: (r: unknown) => r,
+  ResourceNotFoundError: class extends Error {
+    constructor(m: string) {
+      super(m);
+      this.name = 'ResourceNotFoundError';
+    }
+  },
+  APP_DIR: 'app',
+  MCP_APP_SUBDIR: 'mcp',
 }));
 
 const computeDefaultGatewayEnvVarName = (name: string) => GatewayPrimitive.computeDefaultGatewayEnvVarName(name);
@@ -200,7 +211,10 @@ describe('GatewayPrimitive.add (createGateway)', () => {
     });
 
     expect(result).toEqual(
-      expect.objectContaining({ success: false, error: expect.stringContaining('Gateway "dup-gw" already exists') })
+      expect.objectContaining({
+        success: false,
+        error: expect.objectContaining({ message: expect.stringContaining('Gateway "dup-gw" already exists') }),
+      })
     );
   });
 

--- a/src/cli/operations/memory/__tests__/create-memory.test.ts
+++ b/src/cli/operations/memory/__tests__/create-memory.test.ts
@@ -15,6 +15,15 @@ vi.mock('../../../../lib/index.js', () => ({
     readProjectSpec = mockReadProjectSpec;
     writeProjectSpec = mockWriteProjectSpec;
   },
+  findConfigRoot: () => '/fake/root',
+  toError: (err: unknown) => (err instanceof Error ? err : new Error(String(err))),
+  serializeResult: (r: unknown) => r,
+  ResourceNotFoundError: class extends Error {
+    constructor(m: string) {
+      super(m);
+      this.name = 'ResourceNotFoundError';
+    }
+  },
 }));
 
 const makeProject = (memoryNames: string[]) => ({
@@ -86,7 +95,7 @@ describe('add', () => {
       expiry: 30,
     });
 
-    expect(result).toEqual(expect.objectContaining({ success: false, error: expect.any(String) }));
+    expect(result).toEqual(expect.objectContaining({ success: false, error: expect.any(Error) }));
     expect(mockWriteProjectSpec).not.toHaveBeenCalled();
   });
 
@@ -96,7 +105,10 @@ describe('add', () => {
     const result = await primitive.add({ name: 'Existing', strategies: '', expiry: 30 });
 
     expect(result).toEqual(
-      expect.objectContaining({ success: false, error: expect.stringContaining('Memory "Existing" already exists') })
+      expect.objectContaining({
+        success: false,
+        error: expect.objectContaining({ message: expect.stringContaining('Memory "Existing" already exists') }),
+      })
     );
   });
 });

--- a/src/cli/operations/memory/list-memory-records.ts
+++ b/src/cli/operations/memory/list-memory-records.ts
@@ -1,3 +1,5 @@
+import { ResourceNotFoundError, toError } from '../../../lib';
+import type { Result } from '../../../lib/result';
 import { getCredentialProvider } from '../../aws';
 import { BedrockAgentCoreClient, ListMemoryRecordsCommand } from '@aws-sdk/client-bedrock-agentcore';
 
@@ -20,12 +22,7 @@ export interface ListMemoryRecordsOptions {
   nextToken?: string;
 }
 
-export interface ListMemoryRecordsResult {
-  success: boolean;
-  records?: MemoryRecordEntry[];
-  nextToken?: string;
-  error?: string;
-}
+export type ListMemoryRecordsResult = Result<{ records: MemoryRecordEntry[]; nextToken?: string }>;
 
 /**
  * Lists memory records for a deployed memory resource via the AWS SDK.
@@ -63,8 +60,11 @@ export async function listMemoryRecords(options: ListMemoryRecordsOptions): Prom
   } catch (error: unknown) {
     const err = error as Error;
     if (err.name === 'ResourceNotFoundException') {
-      return { success: false, error: `Memory '${memoryId}' not found. It may not have been deployed yet.` };
+      return {
+        success: false,
+        error: new ResourceNotFoundError(`Memory '${memoryId}' not found. It may not have been deployed yet.`),
+      };
     }
-    return { success: false, error: err.message ?? String(error) };
+    return { success: false, error: toError(error) };
   }
 }

--- a/src/cli/operations/memory/retrieve-memory-records.ts
+++ b/src/cli/operations/memory/retrieve-memory-records.ts
@@ -1,3 +1,5 @@
+import { ResourceNotFoundError, toError } from '../../../lib';
+import type { Result } from '../../../lib/result';
 import { getCredentialProvider } from '../../aws';
 import type { MemoryRecordEntry } from './list-memory-records';
 import { BedrockAgentCoreClient, RetrieveMemoryRecordsCommand } from '@aws-sdk/client-bedrock-agentcore';
@@ -13,12 +15,7 @@ export interface RetrieveMemoryRecordsOptions {
   nextToken?: string;
 }
 
-export interface RetrieveMemoryRecordsResult {
-  success: boolean;
-  records?: MemoryRecordEntry[];
-  nextToken?: string;
-  error?: string;
-}
+export type RetrieveMemoryRecordsResult = Result<{ records: MemoryRecordEntry[]; nextToken?: string }>;
 
 /**
  * Searches memory records using semantic retrieval via the AWS SDK.
@@ -62,8 +59,11 @@ export async function retrieveMemoryRecords(
   } catch (error: unknown) {
     const err = error as Error;
     if (err.name === 'ResourceNotFoundException') {
-      return { success: false, error: `Memory '${memoryId}' not found. It may not have been deployed yet.` };
+      return {
+        success: false,
+        error: new ResourceNotFoundError(`Memory '${memoryId}' not found. It may not have been deployed yet.`),
+      };
     }
-    return { success: false, error: err.message ?? String(error) };
+    return { success: false, error: toError(error) };
   }
 }

--- a/src/cli/operations/recommendation/__tests__/apply-to-bundle.test.ts
+++ b/src/cli/operations/recommendation/__tests__/apply-to-bundle.test.ts
@@ -1,6 +1,7 @@
 import type { ConfigIO } from '../../../../lib';
 import type { RecommendationResult } from '../../../aws/agentcore-recommendation';
 import { applyRecommendationToBundle } from '../apply-to-bundle';
+import assert from 'node:assert';
 import { describe, expect, it, vi } from 'vitest';
 
 const { RUNTIME_ARN, BUNDLE_ARN, NEW_VERSION_ID } = vi.hoisted(() => ({
@@ -98,7 +99,7 @@ describe('applyRecommendationToBundle', () => {
       configIO
     );
 
-    expect(applyResult.success).toBe(true);
+    assert(applyResult.success);
     expect(applyResult.newVersionId).toBe(NEW_VERSION_ID);
 
     // Verify spec was written with server components
@@ -132,7 +133,7 @@ describe('applyRecommendationToBundle', () => {
       configIO
     );
 
-    expect(applyResult.success).toBe(true);
+    assert(applyResult.success);
     expect(applyResult.newVersionId).toBe(NEW_VERSION_ID);
   });
 
@@ -152,7 +153,7 @@ describe('applyRecommendationToBundle', () => {
       configIO
     );
 
-    expect(applyResult.success).toBe(true);
+    assert(applyResult.success);
     expect(applyResult.newVersionId).toBe(NEW_VERSION_ID);
   });
 
@@ -171,8 +172,8 @@ describe('applyRecommendationToBundle', () => {
       configIO
     );
 
-    expect(applyResult.success).toBe(false);
-    expect(applyResult.error).toContain('does not contain a new config bundle version');
+    assert(!applyResult.success);
+    expect(applyResult.error.message).toContain('does not contain a new config bundle version');
     expect(writeSpecSpy).not.toHaveBeenCalled();
   });
 
@@ -192,8 +193,8 @@ describe('applyRecommendationToBundle', () => {
       configIO
     );
 
-    expect(applyResult.success).toBe(false);
-    expect(applyResult.error).toContain('NonExistent');
+    assert(!applyResult.success);
+    expect(applyResult.error.message).toContain('NonExistent');
     expect(writeSpecSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/operations/recommendation/__tests__/recommendation-storage.test.ts
+++ b/src/cli/operations/recommendation/__tests__/recommendation-storage.test.ts
@@ -17,7 +17,9 @@ function makeTmpDir(): string {
   return dir;
 }
 
-function makeResult(overrides: Partial<RunRecommendationCommandResult> = {}): RunRecommendationCommandResult {
+function makeResult(
+  overrides: Partial<Extract<RunRecommendationCommandResult, { success: true }>> = {}
+): RunRecommendationCommandResult {
   return {
     success: true,
     recommendationId: 'rec-123',

--- a/src/cli/operations/recommendation/__tests__/run-recommendation.test.ts
+++ b/src/cli/operations/recommendation/__tests__/run-recommendation.test.ts
@@ -1,4 +1,5 @@
 import { runRecommendationCommand } from '../run-recommendation';
+import assert from 'node:assert';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock dependencies — paths are relative to the file under test (run-recommendation.ts)
@@ -28,6 +29,25 @@ vi.mock('../../../../lib', () => ({
     readProjectSpec = mockReadProjectSpec;
     readDeployedState = mockReadDeployedState;
     resolveAWSDeploymentTargets = vi.fn().mockResolvedValue([{ region: 'us-east-1' }]);
+  },
+  toError: (err: unknown) => (err instanceof Error ? err : new Error(String(err))),
+  ResourceNotFoundError: class extends Error {
+    constructor(m: string) {
+      super(m);
+      this.name = 'ResourceNotFoundError';
+    }
+  },
+  ValidationError: class extends Error {
+    constructor(m: string) {
+      super(m);
+      this.name = 'ValidationError';
+    }
+  },
+  TimeoutError: class extends Error {
+    constructor(m: string) {
+      super(m);
+      this.name = 'TimeoutError';
+    }
   },
 }));
 
@@ -71,9 +91,9 @@ describe('runRecommendationCommand', () => {
       traceSource: 'cloudwatch',
     });
 
-    expect(result.success).toBe(false);
-    expect(result.error).toContain('NonExistentAgent');
-    expect(result.error).toContain('not deployed');
+    assert(!result.success);
+    expect(result.error.message).toContain('NonExistentAgent');
+    expect(result.error.message).toContain('not deployed');
   });
 
   it('returns error when evaluator cannot be resolved', async () => {
@@ -86,9 +106,9 @@ describe('runRecommendationCommand', () => {
       traceSource: 'cloudwatch',
     });
 
-    expect(result.success).toBe(false);
-    expect(result.error).toContain('UnknownEvaluator');
-    expect(result.error).toContain('not found');
+    assert(!result.success);
+    expect(result.error.message).toContain('UnknownEvaluator');
+    expect(result.error.message).toContain('not found');
   });
 
   it('returns result on COMPLETED status', async () => {
@@ -123,7 +143,7 @@ describe('runRecommendationCommand', () => {
       pollIntervalMs: 0,
     });
 
-    expect(result.success).toBe(true);
+    assert(result.success);
     expect(result.recommendationId).toBe('rec-001');
     expect(result.status).toBe('COMPLETED');
     expect(result.result?.systemPromptRecommendationResult?.recommendedSystemPrompt).toBe('Optimized prompt');
@@ -153,8 +173,8 @@ describe('runRecommendationCommand', () => {
       pollIntervalMs: 0,
     });
 
-    expect(result.success).toBe(false);
-    expect(result.error).toContain('FAILED');
+    assert(!result.success);
+    expect(result.error.message).toContain('FAILED');
     expect(result.recommendationId).toBe('rec-002');
   });
 
@@ -287,8 +307,8 @@ describe('runRecommendationCommand', () => {
       traceSource: 'cloudwatch',
     });
 
-    expect(result.success).toBe(false);
-    expect(result.error).toContain('API timeout');
+    assert(!result.success);
+    expect(result.error.message).toContain('API timeout');
   });
 
   it('retries transient poll failures and succeeds', async () => {
@@ -345,10 +365,10 @@ describe('runRecommendationCommand', () => {
       pollIntervalMs: 0,
     });
 
-    expect(result.success).toBe(false);
-    expect(result.error).toContain('consecutive errors');
-    expect(result.error).toContain('fetch failed');
-    expect(result.error).toContain('rec-retry-fail');
+    assert(!result.success);
+    expect(result.error.message).toContain('consecutive errors');
+    expect(result.error.message).toContain('fetch failed');
+    expect(result.error.message).toContain('rec-retry-fail');
     expect(mockGetRecommendation).toHaveBeenCalledTimes(3);
   });
 
@@ -377,9 +397,9 @@ describe('runRecommendationCommand', () => {
       maxPollDurationMs: 0, // Immediately timeout
     });
 
-    expect(result.success).toBe(false);
-    expect(result.error).toContain('Polling timed out');
-    expect(result.error).toContain('rec-timeout');
+    assert(!result.success);
+    expect(result.error.message).toContain('Polling timed out');
+    expect(result.error.message).toContain('rec-timeout');
   });
 
   it('reads system prompt from file when inputSource is file', async () => {
@@ -538,8 +558,8 @@ describe('runRecommendationCommand', () => {
       pollIntervalMs: 0,
     });
 
-    expect(result.success).toBe(false);
-    expect(result.error).toContain('No spans found');
+    assert(!result.success);
+    expect(result.error.message).toContain('No spans found');
   });
 
   it('derives service name from runtimeId by stripping hash suffix', async () => {
@@ -664,10 +684,10 @@ describe('runRecommendationCommand', () => {
       pollIntervalMs: 0,
     });
 
-    expect(result.success).toBe(false);
-    expect(result.error).toContain('Insufficient trace data');
-    expect(result.error).toContain('INSUFFICIENT_DATA');
-    expect(result.error).toContain('Not enough traces');
+    assert(!result.success);
+    expect(result.error.message).toContain('Insufficient trace data');
+    expect(result.error.message).toContain('INSUFFICIENT_DATA');
+    expect(result.error.message).toContain('Not enough traces');
     // Request IDs are logged to file only, not included in the error message
   });
 

--- a/src/cli/operations/recommendation/apply-to-bundle.ts
+++ b/src/cli/operations/recommendation/apply-to-bundle.ts
@@ -9,7 +9,8 @@
  * This module fetches that new version via GetConfigurationBundleVersion and
  * updates the local agentcore.json components to match the server state.
  */
-import { ConfigIO } from '../../../lib';
+import { ConfigIO, ResourceNotFoundError } from '../../../lib';
+import type { Result } from '../../../lib/result';
 import { getConfigurationBundleVersion } from '../../aws/agentcore-config-bundles';
 import type { RecommendationResult } from '../../aws/agentcore-recommendation';
 
@@ -24,12 +25,7 @@ export interface ApplyRecommendationOptions {
   region: string;
 }
 
-export interface ApplyRecommendationResult {
-  success: boolean;
-  error?: string;
-  /** New version ID that was synced from the server */
-  newVersionId?: string;
-}
+export type ApplyRecommendationResult = Result<{ newVersionId?: string }>;
 
 /**
  * Extract the bundleId from a bundle ARN.
@@ -58,8 +54,9 @@ export async function applyRecommendationToBundle(
   if (!resultBundle) {
     return {
       success: false,
-      error:
-        'Recommendation result does not contain a new config bundle version. The server may not have applied the recommendation to the bundle.',
+      error: new Error(
+        'Recommendation result does not contain a new config bundle version. The server may not have applied the recommendation to the bundle.'
+      ),
     };
   }
 
@@ -67,7 +64,7 @@ export async function applyRecommendationToBundle(
   if (!bundleId) {
     return {
       success: false,
-      error: `Could not extract bundle ID from ARN: ${resultBundle.bundleArn}`,
+      error: new Error(`Could not extract bundle ID from ARN: ${resultBundle.bundleArn}`),
     };
   }
 
@@ -107,7 +104,7 @@ export async function applyRecommendationToBundle(
   if (!bundle) {
     return {
       success: false,
-      error: `Config bundle "${identifier}" not found in agentcore.json.`,
+      error: new ResourceNotFoundError(`Config bundle "${identifier}" not found in agentcore.json.`),
     };
   }
 

--- a/src/cli/operations/recommendation/recommendation-storage.ts
+++ b/src/cli/operations/recommendation/recommendation-storage.ts
@@ -43,9 +43,9 @@ export function saveRecommendationRun(
     agent,
     evaluators,
     status: result.status ?? 'unknown',
-    startedAt: result.startedAt,
-    completedAt: result.completedAt,
-    result: result.result,
+    startedAt: result.success ? result.startedAt : undefined,
+    completedAt: result.success ? result.completedAt : undefined,
+    result: result.success ? result.result : undefined,
   };
 
   writeFileSync(filePath, JSON.stringify(record, null, 2));

--- a/src/cli/operations/recommendation/run-recommendation.ts
+++ b/src/cli/operations/recommendation/run-recommendation.ts
@@ -6,7 +6,7 @@
  *   4. Poll GetRecommendation until terminal status
  *   5. Return result with optimized artifact
  */
-import { ConfigIO } from '../../../lib';
+import { ConfigIO, ResourceNotFoundError, TimeoutError, ValidationError, toError } from '../../../lib';
 import type { DeployedState } from '../../../schema';
 import type {
   RecommendationConfig,
@@ -60,7 +60,7 @@ export async function runRecommendationCommand(
       logger?.finalize(false);
       return {
         success: false,
-        error: `Agent "${options.agent}" not deployed. Run \`agentcore deploy\` first.`,
+        error: new Error(`Agent "${options.agent}" not deployed. Run \`agentcore deploy\` first.`),
         logFilePath: logger?.logFilePath,
       };
     }
@@ -73,7 +73,9 @@ export async function runRecommendationCommand(
       if (!evaluatorId) {
         return {
           success: false,
-          error: `Evaluator "${evaluator}" not found in deployed state. Use a Builtin.* name, a full ARN, or deploy a custom evaluator first.`,
+          error: new Error(
+            `Evaluator "${evaluator}" not found in deployed state. Use a Builtin.* name, a full ARN, or deploy a custom evaluator first.`
+          ),
           logFilePath: logger?.logFilePath,
         };
       }
@@ -82,7 +84,7 @@ export async function runRecommendationCommand(
     if (options.type === 'SYSTEM_PROMPT_RECOMMENDATION' && evaluatorIds.length !== 1) {
       return {
         success: false,
-        error: 'System prompt recommendations require exactly one evaluator.',
+        error: new ValidationError('System prompt recommendations require exactly one evaluator.'),
         logFilePath: logger?.logFilePath,
       };
     }
@@ -105,7 +107,9 @@ export async function runRecommendationCommand(
     ) {
       return {
         success: false,
-        error: 'System prompt content is required. Provide via --inline, --prompt-file, or --bundle-name.',
+        error: new ValidationError(
+          'System prompt content is required. Provide via --inline, --prompt-file, or --bundle-name.'
+        ),
         logFilePath: logger?.logFilePath,
       };
     }
@@ -132,7 +136,9 @@ export async function runRecommendationCommand(
         if (!bundleArn) {
           return {
             success: false,
-            error: `Config bundle "${options.bundleName}" not found in deployed state. Run \`agentcore deploy\` first.`,
+            error: new ResourceNotFoundError(
+              `Config bundle "${options.bundleName}" not found in deployed state. Run \`agentcore deploy\` first.`
+            ),
             logFilePath: logger?.logFilePath,
           };
         }
@@ -230,7 +236,9 @@ export async function runRecommendationCommand(
         logger?.finalize(false);
         return {
           success: false,
-          error: `Polling timed out after ${Math.round(maxDurationMs / 60000)} minutes. The recommendation may still be running server-side.\nRecommendation ID: ${startResult.recommendationId}`,
+          error: new TimeoutError(
+            `Polling timed out after ${Math.round(maxDurationMs / 60000)} minutes. The recommendation may still be running server-side.\nRecommendation ID: ${startResult.recommendationId}`
+          ),
           recommendationId: startResult.recommendationId,
           status: currentStatus,
           logFilePath: logger?.logFilePath,
@@ -255,7 +263,9 @@ export async function runRecommendationCommand(
           logger?.finalize(false);
           return {
             success: false,
-            error: `Polling failed after ${MAX_POLL_RETRIES} consecutive errors: ${pollErrMsg}\nThe recommendation may still be running server-side.\nRecommendation ID: ${startResult.recommendationId}`,
+            error: new TimeoutError(
+              `Polling failed after ${MAX_POLL_RETRIES} consecutive errors: ${pollErrMsg}\nThe recommendation may still be running server-side.\nRecommendation ID: ${startResult.recommendationId}`
+            ),
             recommendationId: startResult.recommendationId,
             status: currentStatus,
             logFilePath: logger?.logFilePath,
@@ -303,9 +313,11 @@ export async function runRecommendationCommand(
 
         return {
           success: false,
-          error: failureDetails
-            ? `Recommendation failed: ${failureDetails}`
-            : `Recommendation finished with status: ${currentStatus}`,
+          error: new Error(
+            failureDetails
+              ? `Recommendation failed: ${failureDetails}`
+              : `Recommendation finished with status: ${currentStatus}`
+          ),
           recommendationId: startResult.recommendationId,
           status: currentStatus,
           logFilePath: logger?.logFilePath,
@@ -319,7 +331,7 @@ export async function runRecommendationCommand(
     logger?.finalize(false);
     return {
       success: false,
-      error: `Recommendation ended with unexpected status: ${currentStatus}`,
+      error: new Error(`Recommendation ended with unexpected status: ${currentStatus}`),
       recommendationId: startResult.recommendationId,
       status: currentStatus,
       logFilePath: logger?.logFilePath,
@@ -331,7 +343,7 @@ export async function runRecommendationCommand(
     logger?.finalize(false);
     return {
       success: false,
-      error: errorMsg,
+      error: toError(err),
       logFilePath: logger?.logFilePath,
     };
   }

--- a/src/cli/operations/recommendation/types.ts
+++ b/src/cli/operations/recommendation/types.ts
@@ -1,6 +1,7 @@
 /**
  * Shared types for the recommendation feature.
  */
+import type { Result } from '../../../lib/result';
 import type { RecommendationResult, RecommendationType } from '../../aws/agentcore-recommendation';
 
 export type { RecommendationType } from '../../aws/agentcore-recommendation';
@@ -56,17 +57,9 @@ export interface RunRecommendationCommandOptions {
   onStarted?: (info: { recommendationId: string; region: string }) => void;
 }
 
-export interface RunRecommendationCommandResult {
-  success: boolean;
-  error?: string;
-  recommendationId?: string;
-  status?: string;
-  /** The recommendation result from the API (populated on COMPLETED) */
+export type RunRecommendationCommandResult = Result<{
   result?: RecommendationResult;
-  /** Resolved AWS region used for the recommendation */
   region?: string;
   startedAt?: string;
   completedAt?: string;
-  /** Path to the execution log file */
-  logFilePath?: string;
-}
+}> & { recommendationId?: string; status?: string; logFilePath?: string };

--- a/src/cli/operations/remove/__tests__/remove-agent-ops.test.ts
+++ b/src/cli/operations/remove/__tests__/remove-agent-ops.test.ts
@@ -1,3 +1,4 @@
+import { ResourceNotFoundError } from '../../../../lib';
 import { AgentPrimitive } from '../../../primitives/AgentPrimitive.js';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -15,6 +16,29 @@ vi.mock('../../../../lib/index.js', () => ({
     readProjectSpec = mockReadProjectSpec;
     writeProjectSpec = mockWriteProjectSpec;
   },
+  findConfigRoot: () => '/fake/root',
+  toError: (err: unknown) => (err instanceof Error ? err : new Error(String(err))),
+  serializeResult: (r: unknown) => r,
+  ResourceNotFoundError: class extends Error {
+    constructor(m: string) {
+      super(m);
+      this.name = 'ResourceNotFoundError';
+    }
+  },
+  ConflictError: class extends Error {
+    constructor(m: string) {
+      super(m);
+      this.name = 'ConflictError';
+    }
+  },
+  NoProjectError: class extends Error {
+    constructor(m: string) {
+      super(m);
+      this.name = 'NoProjectError';
+    }
+  },
+  APP_DIR: 'app',
+  setEnvVar: vi.fn().mockResolvedValue(undefined),
 }));
 
 const makeProject = (agentNames: string[]) => ({
@@ -87,7 +111,7 @@ describe('remove', () => {
 
     const result = await primitive.remove('Missing');
 
-    expect(result).toEqual({ success: false, error: 'Agent "Missing" not found.' });
+    expect(result).toEqual({ success: false, error: new ResourceNotFoundError('Agent "Missing" not found.') });
   });
 
   it('returns error on exception', async () => {
@@ -95,6 +119,6 @@ describe('remove', () => {
 
     const result = await primitive.remove('Agent1');
 
-    expect(result).toEqual({ success: false, error: 'read fail' });
+    expect(result).toEqual({ success: false, error: new Error('read fail') });
   });
 });

--- a/src/cli/operations/remove/__tests__/remove-gateway-ops.test.ts
+++ b/src/cli/operations/remove/__tests__/remove-gateway-ops.test.ts
@@ -1,3 +1,4 @@
+import { ResourceNotFoundError } from '../../../../lib';
 import { GatewayPrimitive } from '../../../primitives/GatewayPrimitive.js';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -10,6 +11,15 @@ vi.mock('../../../../lib/index.js', () => ({
     readProjectSpec = mockReadProjectSpec;
     writeProjectSpec = mockWriteProjectSpec;
     configExists = mockConfigExists;
+  },
+  findConfigRoot: () => '/fake/root',
+  toError: (err: unknown) => (err instanceof Error ? err : new Error(String(err))),
+  serializeResult: (r: unknown) => r,
+  ResourceNotFoundError: class extends Error {
+    constructor(m: string) {
+      super(m);
+      this.name = 'ResourceNotFoundError';
+    }
   },
 }));
 
@@ -101,7 +111,7 @@ describe('remove', () => {
 
     const result = await primitive.remove('missing');
 
-    expect(result).toEqual({ success: false, error: 'Gateway "missing" not found.' });
+    expect(result).toEqual({ success: false, error: new ResourceNotFoundError('Gateway "missing" not found.') });
   });
 
   it('returns error on exception', async () => {
@@ -109,6 +119,6 @@ describe('remove', () => {
 
     const result = await primitive.remove('gw1');
 
-    expect(result).toEqual({ success: false, error: 'read fail' });
+    expect(result).toEqual({ success: false, error: new Error('read fail') });
   });
 });

--- a/src/cli/operations/remove/__tests__/remove-identity-ops.test.ts
+++ b/src/cli/operations/remove/__tests__/remove-identity-ops.test.ts
@@ -1,3 +1,4 @@
+import { ResourceNotFoundError } from '../../../../lib';
 import { CredentialPrimitive } from '../../../primitives/CredentialPrimitive.js';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -16,6 +17,23 @@ vi.mock('../../../../lib/index.js', () => ({
     writeProjectSpec = mockWriteProjectSpec;
     configExists = vi.fn().mockReturnValue(false);
   },
+  findConfigRoot: () => '/fake/root',
+  toError: (err: unknown) => (err instanceof Error ? err : new Error(String(err))),
+  serializeResult: (r: unknown) => r,
+  ResourceNotFoundError: class extends Error {
+    constructor(m: string) {
+      super(m);
+      this.name = 'ResourceNotFoundError';
+    }
+  },
+  ConflictError: class extends Error {
+    constructor(m: string) {
+      super(m);
+      this.name = 'ConflictError';
+    }
+  },
+  setEnvVar: vi.fn().mockResolvedValue(undefined),
+  getEnvVar: vi.fn(),
 }));
 
 const makeProject = (
@@ -93,7 +111,7 @@ describe('remove', () => {
 
     const result = await primitive.remove('Missing');
 
-    expect(result).toEqual({ success: false, error: 'Credential "Missing" not found.' });
+    expect(result).toEqual({ success: false, error: new ResourceNotFoundError('Credential "Missing" not found.') });
   });
 
   it('returns error on exception', async () => {
@@ -101,6 +119,6 @@ describe('remove', () => {
 
     const result = await primitive.remove('Cred1');
 
-    expect(result).toEqual({ success: false, error: 'read fail' });
+    expect(result).toEqual({ success: false, error: new Error('read fail') });
   });
 });

--- a/src/cli/operations/remove/__tests__/remove-memory-ops.test.ts
+++ b/src/cli/operations/remove/__tests__/remove-memory-ops.test.ts
@@ -1,3 +1,4 @@
+import { ResourceNotFoundError } from '../../../../lib';
 import { MemoryPrimitive } from '../../../primitives/MemoryPrimitive.js';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -14,6 +15,15 @@ vi.mock('../../../../lib/index.js', () => ({
   ConfigIO: class {
     readProjectSpec = mockReadProjectSpec;
     writeProjectSpec = mockWriteProjectSpec;
+  },
+  findConfigRoot: () => '/fake/root',
+  toError: (err: unknown) => (err instanceof Error ? err : new Error(String(err))),
+  serializeResult: (r: unknown) => r,
+  ResourceNotFoundError: class extends Error {
+    constructor(m: string) {
+      super(m);
+      this.name = 'ResourceNotFoundError';
+    }
   },
 }));
 
@@ -84,7 +94,7 @@ describe('remove', () => {
 
     const result = await primitive.remove('Missing');
 
-    expect(result).toEqual({ success: false, error: 'Memory "Missing" not found.' });
+    expect(result).toEqual({ success: false, error: new ResourceNotFoundError('Memory "Missing" not found.') });
   });
 
   it('returns error on exception', async () => {
@@ -92,6 +102,6 @@ describe('remove', () => {
 
     const result = await primitive.remove('Mem1');
 
-    expect(result).toEqual({ success: false, error: 'read fail' });
+    expect(result).toEqual({ success: false, error: new Error('read fail') });
   });
 });

--- a/src/cli/operations/remove/remove-gateway-target.ts
+++ b/src/cli/operations/remove/remove-gateway-target.ts
@@ -1,6 +1,7 @@
-import { ConfigIO } from '../../../lib';
+import { ConfigIO, ResourceNotFoundError, toError } from '../../../lib';
+import type { Result } from '../../../lib/result';
 import type { AgentCoreCliMcpDefs, AgentCoreMcpSpec } from '../../../schema';
-import type { RemovalPreview, RemovalResult, SchemaChange } from './types';
+import type { RemovalPreview, SchemaChange } from './types';
 import { existsSync } from 'fs';
 import { rm } from 'fs/promises';
 import { join } from 'path';
@@ -155,7 +156,7 @@ function computeRemovedToolMcpDefs(
 /**
  * Remove a gateway target from the project.
  */
-export async function removeGatewayTarget(tool: RemovableGatewayTarget): Promise<RemovalResult> {
+export async function removeGatewayTarget(tool: RemovableGatewayTarget): Promise<Result> {
   try {
     const configIO = new ConfigIO();
     const project = await configIO.readProjectSpec();
@@ -172,11 +173,14 @@ export async function removeGatewayTarget(tool: RemovableGatewayTarget): Promise
 
     const gateway = mcpSpec.agentCoreGateways.find(g => g.name === tool.gatewayName);
     if (!gateway) {
-      return { success: false, error: `Gateway "${tool.gatewayName}" not found.` };
+      return { success: false, error: new ResourceNotFoundError(`Gateway "${tool.gatewayName}" not found.`) };
     }
     const target = gateway.targets.find(t => t.name === tool.name);
     if (!target) {
-      return { success: false, error: `Target "${tool.name}" not found in gateway "${tool.gatewayName}".` };
+      return {
+        success: false,
+        error: new ResourceNotFoundError(`Target "${tool.name}" not found in gateway "${tool.gatewayName}".`),
+      };
     }
     if (target.compute?.implementation && 'path' in target.compute.implementation) {
       toolPath = target.compute.implementation.path;
@@ -200,7 +204,6 @@ export async function removeGatewayTarget(tool: RemovableGatewayTarget): Promise
 
     return { success: true };
   } catch (err) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    return { success: false, error: message };
+    return { success: false, error: toError(err) };
   }
 }

--- a/src/cli/operations/remove/types.ts
+++ b/src/cli/operations/remove/types.ts
@@ -22,11 +22,6 @@ export interface RemovalPreview {
 }
 
 /**
- * Result of a removal operation.
- */
-export type RemovalResult = { success: true } | { success: false; error: string };
-
-/**
  * Snapshot of all schemas before removal (for diff computation).
  */
 export interface SchemaSnapshot {

--- a/src/cli/operations/traces/__tests__/get-trace.test.ts
+++ b/src/cli/operations/traces/__tests__/get-trace.test.ts
@@ -1,5 +1,6 @@
 import { fetchTraceRecords, getTrace } from '../get-trace';
 import type { FetchTraceRecordsOptions } from '../types';
+import assert from 'node:assert';
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -57,14 +58,14 @@ describe('fetchTraceRecords', () => {
 
     const result = await fetchTraceRecords(baseOptions);
 
-    expect(result.success).toBe(true);
+    assert(result.success);
     expect(result.records).toHaveLength(2);
-    expect(result.records![0]).toEqual({
+    expect(result.records[0]).toEqual({
       '@timestamp': '2024-01-01T00:00:00Z',
       '@message': { traceId: 'abc123', spanId: 'span1' },
       '@ptr': 'ptr-value-1',
     });
-    expect(result.records![1]).toEqual({
+    expect(result.records[1]).toEqual({
       '@timestamp': '2024-01-01T00:00:01Z',
       '@message': { traceId: 'abc123', spanId: 'span2' },
     });
@@ -76,8 +77,8 @@ describe('fetchTraceRecords', () => {
       traceId: 'invalid!@#$',
     });
 
-    expect(result.success).toBe(false);
-    expect(result.error).toContain('Invalid trace ID format');
+    assert(!result.success);
+    expect(result.error.message).toContain('Invalid trace ID format');
     expect(mockSend).not.toHaveBeenCalled();
   });
 
@@ -89,8 +90,8 @@ describe('fetchTraceRecords', () => {
 
     const result = await fetchTraceRecords(baseOptions);
 
-    expect(result.success).toBe(false);
-    expect(result.error).toContain('No trace data found');
+    assert(!result.success);
+    expect(result.error.message).toContain('No trace data found');
   });
 
   it('returns error when query fails to start', async () => {
@@ -98,8 +99,8 @@ describe('fetchTraceRecords', () => {
 
     const result = await fetchTraceRecords(baseOptions);
 
-    expect(result.success).toBe(false);
-    expect(result.error).toContain('Failed to start CloudWatch Logs Insights query');
+    assert(!result.success);
+    expect(result.error.message).toContain('Failed to start CloudWatch Logs Insights query');
   });
 
   it('returns error when query status is Failed', async () => {
@@ -107,8 +108,8 @@ describe('fetchTraceRecords', () => {
 
     const result = await fetchTraceRecords(baseOptions);
 
-    expect(result.success).toBe(false);
-    expect(result.error).toContain('failed');
+    assert(!result.success);
+    expect(result.error.message).toContain('failed');
   });
 
   it('preserves @ptr when present in CloudWatch response', async () => {
@@ -125,9 +126,9 @@ describe('fetchTraceRecords', () => {
 
     const result = await fetchTraceRecords(baseOptions);
 
-    expect(result.success).toBe(true);
+    assert(result.success);
     expect(result.records).toHaveLength(1);
-    expect(result.records![0]!['@ptr']).toBe('cw-ptr-123');
+    expect(result.records[0]!['@ptr']).toBe('cw-ptr-123');
   });
 
   it('omits @ptr when not present in CloudWatch response', async () => {
@@ -143,8 +144,8 @@ describe('fetchTraceRecords', () => {
 
     const result = await fetchTraceRecords(baseOptions);
 
-    expect(result.success).toBe(true);
-    expect(result.records![0]).not.toHaveProperty('@ptr');
+    assert(result.success);
+    expect(result.records[0]).not.toHaveProperty('@ptr');
   });
 
   it('handles non-JSON @message gracefully', async () => {
@@ -160,9 +161,9 @@ describe('fetchTraceRecords', () => {
 
     const result = await fetchTraceRecords(baseOptions);
 
-    expect(result.success).toBe(true);
+    assert(result.success);
     expect(result.records).toHaveLength(1);
-    expect(result.records![0]!['@message']).toBe('plain text message');
+    expect(result.records[0]!['@message']).toBe('plain text message');
   });
 
   it('handles ResourceNotFoundException', async () => {
@@ -172,9 +173,9 @@ describe('fetchTraceRecords', () => {
 
     const result = await fetchTraceRecords(baseOptions);
 
-    expect(result.success).toBe(false);
-    expect(result.error).toContain('Log group');
-    expect(result.error).toContain('not found');
+    assert(!result.success);
+    expect(result.error.message).toContain('Log group');
+    expect(result.error.message).toContain('not found');
   });
 });
 
@@ -212,7 +213,7 @@ describe('getTrace', () => {
       endTime: 2000000,
     });
 
-    expect(result.success).toBe(true);
+    assert(result.success);
     expect(result.filePath).toContain('test-trace.json');
     const content = JSON.parse(readFileSync(outputPath, 'utf-8'));
     expect(content).toHaveLength(1);
@@ -231,8 +232,8 @@ describe('getTrace', () => {
       endTime: 2000000,
     });
 
-    expect(result.success).toBe(false);
-    expect(result.error).toContain('Invalid trace ID format');
+    assert(!result.success);
+    expect(result.error.message).toContain('Invalid trace ID format');
     expect(existsSync(outputPath)).toBe(false);
   });
 });

--- a/src/cli/operations/traces/__tests__/list-traces.test.ts
+++ b/src/cli/operations/traces/__tests__/list-traces.test.ts
@@ -1,5 +1,7 @@
+import { ResourceNotFoundError } from '../../../../lib';
 import { listTraces } from '../list-traces';
 import type { ListTracesOptions } from '../types';
+import assert from 'node:assert';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const { mockRunInsightsQuery } = vi.hoisted(() => ({
@@ -38,15 +40,15 @@ describe('listTraces', () => {
 
     const result = await listTraces(baseOptions);
 
-    expect(result.success).toBe(true);
+    assert(result.success);
     expect(result.traces).toHaveLength(2);
-    expect(result.traces![0]).toEqual({
+    expect(result.traces[0]).toEqual({
       traceId: 'trace-1',
       timestamp: '2024-01-01T00:05:00Z',
       sessionId: 'sess-1',
       spanCount: '12',
     });
-    expect(result.traces![1]).toEqual({
+    expect(result.traces[1]).toEqual({
       traceId: 'trace-2',
       timestamp: '2024-01-01T00:03:00Z',
       sessionId: undefined,
@@ -66,9 +68,9 @@ describe('listTraces', () => {
 
     const result = await listTraces(baseOptions);
 
-    expect(result.success).toBe(true);
+    assert(result.success);
     expect(result.traces).toHaveLength(1);
-    expect(result.traces![0]!.traceId).toBe('trace-1');
+    expect(result.traces[0]!.traceId).toBe('trace-1');
   });
 
   it('falls back to firstSeen when lastSeen is missing', async () => {
@@ -79,8 +81,8 @@ describe('listTraces', () => {
 
     const result = await listTraces(baseOptions);
 
-    expect(result.success).toBe(true);
-    expect(result.traces![0]!.timestamp).toBe('2024-01-01T00:00:00Z');
+    assert(result.success);
+    expect(result.traces[0]!.timestamp).toBe('2024-01-01T00:00:00Z');
   });
 
   it('returns empty traces for empty query results', async () => {
@@ -91,20 +93,20 @@ describe('listTraces', () => {
 
     const result = await listTraces(baseOptions);
 
-    expect(result.success).toBe(true);
+    assert(result.success);
     expect(result.traces).toHaveLength(0);
   });
 
   it('propagates errors from runInsightsQuery', async () => {
     mockRunInsightsQuery.mockResolvedValueOnce({
       success: false,
-      error: 'Log group not found',
+      error: new ResourceNotFoundError('Log group not found'),
     });
 
     const result = await listTraces(baseOptions);
 
-    expect(result.success).toBe(false);
-    expect(result.error).toBe('Log group not found');
+    assert(!result.success);
+    expect(result.error.message).toBe('Log group not found');
   });
 
   it('passes correct log group name and default limit', async () => {

--- a/src/cli/operations/traces/get-trace.ts
+++ b/src/cli/operations/traces/get-trace.ts
@@ -1,3 +1,5 @@
+import { ResourceNotFoundError, ValidationError } from '../../../lib';
+import type { Result } from '../../../lib/result';
 import { DEFAULT_ENDPOINT_NAME } from '../../constants';
 import { runInsightsQuery } from './insights-query';
 import type {
@@ -23,9 +25,12 @@ async function fetchSpans(
   traceId: string,
   startTime?: number,
   endTime?: number
-): Promise<{ success: boolean; spans?: CloudWatchSpanRecord[]; error?: string }> {
+): Promise<Result<{ spans: CloudWatchSpanRecord[] }>> {
   if (!TRACE_ID_PATTERN.test(traceId)) {
-    return { success: false, error: 'Invalid trace ID format. Expected a hex string (e.g., abc123def456).' };
+    return {
+      success: false,
+      error: new ValidationError('Invalid trace ID format. Expected a hex string (e.g., abc123def456).'),
+    };
   }
 
   const result = await runInsightsQuery({
@@ -50,7 +55,7 @@ async function fetchSpans(
 
   if (!result.success) return { success: false, error: result.error };
 
-  const spans: CloudWatchSpanRecord[] = (result.rows ?? [])
+  const spans: CloudWatchSpanRecord[] = result.rows
     .filter(row => row.traceId && row.spanId)
     .map(row => ({
       traceId: row.traceId!,
@@ -82,7 +87,10 @@ export async function fetchTraceRecords(options: FetchTraceRecordsOptions): Prom
   const { region, runtimeId, traceId, includeSpans } = options;
 
   if (!TRACE_ID_PATTERN.test(traceId)) {
-    return { success: false, error: 'Invalid trace ID format. Expected a hex string (e.g., abc123def456).' };
+    return {
+      success: false,
+      error: new ValidationError('Invalid trace ID format. Expected a hex string (e.g., abc123def456).'),
+    };
   }
 
   const [recordsResult, spansResult] = await Promise.all([
@@ -103,10 +111,10 @@ export async function fetchTraceRecords(options: FetchTraceRecordsOptions): Prom
     return { success: false, error: recordsResult.error };
   }
 
-  const traceData = recordsResult.rows ?? [];
+  const traceData = recordsResult.rows;
 
-  if (traceData.length === 0 && (!spansResult || (spansResult.spans ?? []).length === 0)) {
-    return { success: false, error: `No trace data found for trace ID: ${traceId}` };
+  if (traceData.length === 0 && (!spansResult || !spansResult.success || spansResult.spans.length === 0)) {
+    return { success: false, error: new ResourceNotFoundError(`No trace data found for trace ID: ${traceId}`) };
   }
 
   const records: CloudWatchTraceRecord[] = traceData.map(entry => {
@@ -129,11 +137,9 @@ export async function fetchTraceRecords(options: FetchTraceRecordsOptions): Prom
     return record;
   });
 
-  const result: FetchTraceRecordsResult = { success: true, records };
-
-  if (spansResult?.success && spansResult.spans) {
-    result.spans = spansResult.spans;
-  }
+  const result: FetchTraceRecordsResult = spansResult?.success
+    ? { success: true, records, spans: spansResult.spans }
+    : { success: true, records };
 
   return result;
 }
@@ -146,7 +152,10 @@ export async function getTrace(options: GetTraceOptions): Promise<GetTraceResult
   const { region, runtimeId, agentName, traceId, outputPath } = options;
 
   if (!TRACE_ID_PATTERN.test(traceId)) {
-    return { success: false, error: 'Invalid trace ID format. Expected a hex string (e.g., abc123def456).' };
+    return {
+      success: false,
+      error: new ValidationError('Invalid trace ID format. Expected a hex string (e.g., abc123def456).'),
+    };
   }
 
   const result = await runInsightsQuery({
@@ -163,9 +172,9 @@ export async function getTrace(options: GetTraceOptions): Promise<GetTraceResult
     return { success: false, error: result.error };
   }
 
-  const traceData = result.rows ?? [];
+  const traceData = result.rows;
   if (traceData.length === 0) {
-    return { success: false, error: `No trace data found for trace ID: ${traceId}` };
+    return { success: false, error: new ResourceNotFoundError(`No trace data found for trace ID: ${traceId}`) };
   }
 
   const parsedTrace = traceData.map(entry => {

--- a/src/cli/operations/traces/insights-query.ts
+++ b/src/cli/operations/traces/insights-query.ts
@@ -1,3 +1,5 @@
+import { ResourceNotFoundError, TimeoutError, toError } from '../../../lib';
+import type { Result } from '../../../lib/result';
 import { getCredentialProvider } from '../../aws';
 import { CloudWatchLogsClient, GetQueryResultsCommand, StartQueryCommand } from '@aws-sdk/client-cloudwatch-logs';
 
@@ -11,11 +13,7 @@ export interface InsightsQueryOptions {
   endTime?: number;
 }
 
-export interface InsightsQueryResult {
-  success: boolean;
-  rows?: Record<string, string>[];
-  error?: string;
-}
+export type InsightsQueryResult = Result<{ rows: Record<string, string>[] }>;
 
 async function pollQueryResults(client: CloudWatchLogsClient, queryId: string): Promise<InsightsQueryResult> {
   for (let i = 0; i < 60; i++) {
@@ -26,7 +24,7 @@ async function pollQueryResults(client: CloudWatchLogsClient, queryId: string): 
 
     if (status === 'Complete' || status === 'Failed' || status === 'Cancelled') {
       if (status !== 'Complete') {
-        return { success: false, error: `Query ${status.toLowerCase()}` };
+        return { success: false, error: new Error(`Query ${status.toLowerCase()}`) };
       }
 
       const rows = (queryResults.results ?? []).map(row => {
@@ -42,7 +40,7 @@ async function pollQueryResults(client: CloudWatchLogsClient, queryId: string): 
     }
   }
 
-  return { success: false, error: 'Query timed out after 60 seconds' };
+  return { success: false, error: new TimeoutError('Query timed out after 60 seconds') };
 }
 
 export async function runInsightsQuery(options: InsightsQueryOptions): Promise<InsightsQueryResult> {
@@ -68,7 +66,7 @@ export async function runInsightsQuery(options: InsightsQueryOptions): Promise<I
     );
 
     if (!startQuery.queryId) {
-      return { success: false, error: 'Failed to start CloudWatch Logs Insights query' };
+      return { success: false, error: new Error('Failed to start CloudWatch Logs Insights query') };
     }
 
     return await pollQueryResults(client, startQuery.queryId);
@@ -77,9 +75,11 @@ export async function runInsightsQuery(options: InsightsQueryOptions): Promise<I
     if (err.name === 'ResourceNotFoundException') {
       return {
         success: false,
-        error: `Log group '${logGroupName}' not found. The agent may not have been invoked yet, or traces may not be enabled.`,
+        error: new ResourceNotFoundError(
+          `Log group '${logGroupName}' not found. The agent may not have been invoked yet, or traces may not be enabled.`
+        ),
       };
     }
-    return { success: false, error: err.message ?? String(error) };
+    return { success: false, error: toError(error) };
   }
 }

--- a/src/cli/operations/traces/list-traces.ts
+++ b/src/cli/operations/traces/list-traces.ts
@@ -27,7 +27,7 @@ export async function listTraces(options: ListTracesOptions): Promise<ListTraces
     return { success: false, error: result.error };
   }
 
-  const traces = (result.rows ?? []).reduce<TraceEntry[]>((acc, row) => {
+  const traces = result.rows.reduce<TraceEntry[]>((acc, row) => {
     if (row.traceId) {
       acc.push({
         traceId: row.traceId,

--- a/src/cli/operations/traces/types.ts
+++ b/src/cli/operations/traces/types.ts
@@ -1,3 +1,5 @@
+import type { Result } from '../../../lib/result';
+
 export interface CloudWatchTraceRecord {
   '@timestamp': string;
   '@message': unknown;
@@ -31,12 +33,10 @@ export interface FetchTraceRecordsOptions {
   includeSpans?: boolean;
 }
 
-export interface FetchTraceRecordsResult {
-  success: boolean;
-  records?: CloudWatchTraceRecord[];
+export type FetchTraceRecordsResult = Result<{
+  records: CloudWatchTraceRecord[];
   spans?: CloudWatchSpanRecord[];
-  error?: string;
-}
+}>;
 
 export interface GetTraceOptions {
   region: string;
@@ -48,11 +48,7 @@ export interface GetTraceOptions {
   endTime?: number;
 }
 
-export interface GetTraceResult {
-  success: boolean;
-  filePath?: string;
-  error?: string;
-}
+export type GetTraceResult = Result<{ filePath: string }>;
 
 export interface TraceEntry {
   traceId: string;
@@ -70,8 +66,4 @@ export interface ListTracesOptions {
   endTime?: number;
 }
 
-export interface ListTracesResult {
-  success: boolean;
-  traces?: TraceEntry[];
-  error?: string;
-}
+export type ListTracesResult = Result<{ traces: TraceEntry[] }>;

--- a/src/cli/primitives/ABTestPrimitive.ts
+++ b/src/cli/primitives/ABTestPrimitive.ts
@@ -1,8 +1,9 @@
-import { findConfigRoot } from '../../lib';
+import { ResourceNotFoundError, findConfigRoot, serializeResult, toError } from '../../lib';
+import type { Result } from '../../lib/result';
 import type { ABTest } from '../../schema/schemas/primitives/ab-test';
 import { ABTestSchema } from '../../schema/schemas/primitives/ab-test';
 import { getErrorMessage } from '../errors';
-import type { RemovalPreview, RemovalResult, SchemaChange } from '../operations/remove/types';
+import type { RemovalPreview, SchemaChange } from '../operations/remove/types';
 import { withCommandRunTelemetry } from '../telemetry/cli-command-run.js';
 import { requireTTY } from '../tui/guards/tty';
 import { BasePrimitive } from './BasePrimitive';
@@ -66,17 +67,17 @@ export class ABTestPrimitive extends BasePrimitive<AddABTestOptions, RemovableAB
       const abTest = await this.createABTest(options);
       return { success: true, abTestName: abTest.name };
     } catch (err) {
-      return { success: false, error: getErrorMessage(err) };
+      return { success: false, error: toError(err) };
     }
   }
 
-  async remove(testName: string, options?: { deleteGateway?: boolean }): Promise<RemovalResult> {
+  async remove(testName: string, options?: { deleteGateway?: boolean }): Promise<Result> {
     try {
       const project = await this.readProjectSpec();
 
       const index = (project.abTests ?? []).findIndex(t => t.name === testName);
       if (index === -1) {
-        return { success: false, error: `AB test "${testName}" not found.` };
+        return { success: false, error: new ResourceNotFoundError(`AB test "${testName}" not found.`) };
       }
 
       const removedTest = project.abTests[index]!;
@@ -124,7 +125,7 @@ export class ABTestPrimitive extends BasePrimitive<AddABTestOptions, RemovableAB
 
       return { success: true };
     } catch (err) {
-      return { success: false, error: getErrorMessage(err) };
+      return { success: false, error: toError(err) };
     }
   }
 
@@ -365,11 +366,11 @@ Target-Based Mode (--mode target-based)
               });
 
               if (cliOptions.json) {
-                console.log(JSON.stringify(result));
+                console.log(JSON.stringify(serializeResult(result)));
               } else if (result.success) {
                 console.log(`Added target-based AB test '${result.abTestName}'`);
               } else {
-                console.error(result.error);
+                console.error(result.error.message);
               }
               process.exit(result.success ? 0 : 1);
               return;
@@ -412,11 +413,11 @@ Target-Based Mode (--mode target-based)
             });
 
             if (cliOptions.json) {
-              console.log(JSON.stringify(result));
+              console.log(JSON.stringify(serializeResult(result)));
             } else if (result.success) {
               console.log(`Added AB test '${result.abTestName}'`);
             } else {
-              console.error(result.error);
+              console.error(result.error.message);
             }
             process.exit(result.success ? 0 : 1);
           } else {
@@ -478,7 +479,7 @@ Target-Based Mode (--mode target-based)
                 resourceType: this.kind,
                 resourceName: cliOptions.name,
                 message: result.success ? `Removed ${this.label.toLowerCase()} '${cliOptions.name}'` : undefined,
-                error: !result.success ? result.error : undefined,
+                error: !result.success ? result.error.message : undefined,
               })
             );
             process.exit(result.success ? 0 : 1);
@@ -606,7 +607,7 @@ Target-Based Mode (--mode target-based)
       const abTest = await this.createTargetBasedABTest(options);
       return { success: true, abTestName: abTest.name };
     } catch (err) {
-      return { success: false, error: getErrorMessage(err) };
+      return { success: false, error: toError(err) };
     }
   }
 

--- a/src/cli/primitives/AgentPrimitive.tsx
+++ b/src/cli/primitives/AgentPrimitive.tsx
@@ -1,4 +1,15 @@
-import { APP_DIR, ConfigIO, NoProjectError, findConfigRoot, setEnvVar } from '../../lib';
+import {
+  APP_DIR,
+  ConfigIO,
+  ConflictError,
+  NoProjectError,
+  ResourceNotFoundError,
+  findConfigRoot,
+  serializeResult,
+  setEnvVar,
+  toError,
+} from '../../lib';
+import type { Result } from '../../lib/result';
 import type {
   AgentEnvSpec,
   BuildType,
@@ -34,7 +45,7 @@ import {
 } from '../operations/agent/generate';
 import { executeImportAgent } from '../operations/agent/import';
 import { setupPythonProject } from '../operations/python';
-import type { RemovalPreview, RemovalResult, SchemaChange } from '../operations/remove/types';
+import type { RemovalPreview, SchemaChange } from '../operations/remove/types';
 import { runCliCommand } from '../telemetry/cli-command-run.js';
 import {
   AgentType,
@@ -119,13 +130,13 @@ export class AgentPrimitive extends BasePrimitive<AddAgentOptions, RemovableReso
     try {
       const configBaseDir = findConfigRoot();
       if (!configBaseDir) {
-        return { success: false, error: new NoProjectError().message };
+        return { success: false, error: new NoProjectError() };
       }
 
       const configIO = new ConfigIO({ baseDir: configBaseDir });
 
       if (!configIO.configExists('project')) {
-        return { success: false, error: new NoProjectError().message };
+        return { success: false, error: new NoProjectError() };
       }
 
       const project = await configIO.readProjectSpec();
@@ -133,7 +144,9 @@ export class AgentPrimitive extends BasePrimitive<AddAgentOptions, RemovableReso
       if (existingAgent) {
         return {
           success: false,
-          error: `Agent "${options.name}" already exists. To update its configuration, edit agentcore/agentcore.json directly.`,
+          error: new ConflictError(
+            `Agent "${options.name}" already exists. To update its configuration, edit agentcore/agentcore.json directly.`
+          ),
         };
       }
 
@@ -145,17 +158,17 @@ export class AgentPrimitive extends BasePrimitive<AddAgentOptions, RemovableReso
         return await this.handleCreatePath(options, configBaseDir);
       }
     } catch (err) {
-      return { success: false, error: getErrorMessage(err) };
+      return { success: false, error: toError(err) };
     }
   }
 
-  async remove(agentName: string): Promise<RemovalResult> {
+  async remove(agentName: string): Promise<Result> {
     try {
       const project = await this.readProjectSpec();
 
       const agentIndex = project.runtimes.findIndex(a => a.name === agentName);
       if (agentIndex === -1) {
-        return { success: false, error: `Agent "${agentName}" not found.` };
+        return { success: false, error: new ResourceNotFoundError(`Agent "${agentName}" not found.`) };
       }
 
       // Remove agent (credentials preserved for potential reuse)
@@ -164,8 +177,7 @@ export class AgentPrimitive extends BasePrimitive<AddAgentOptions, RemovableReso
 
       return { success: true };
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Unknown error';
-      return { success: false, error: message };
+      return { success: false, error: toError(err) };
     }
   }
 
@@ -333,11 +345,11 @@ export class AgentPrimitive extends BasePrimitive<AddAgentOptions, RemovableReso
             });
 
             if (!result.success) {
-              throw new Error(result.error);
+              throw result.error;
             }
 
             if (cliOptions.json) {
-              console.log(JSON.stringify(result));
+              console.log(JSON.stringify(serializeResult(result)));
             } else {
               console.log(`Added agent '${result.agentName}'`);
               if (result.agentPath) {

--- a/src/cli/primitives/BasePrimitive.ts
+++ b/src/cli/primitives/BasePrimitive.ts
@@ -1,4 +1,5 @@
 import { ConfigIO, findConfigRoot } from '../../lib';
+import type { Result } from '../../lib/result';
 import type { AgentCoreProjectSpec } from '../../schema';
 import type { ResourceType } from '../commands/remove/types';
 import { getErrorMessage } from '../errors';
@@ -6,7 +7,7 @@ import { withCommandRunTelemetry } from '../telemetry/cli-command-run.js';
 import type { SubCommand } from '../telemetry/schemas/command-run.js';
 import { requireTTY } from '../tui/guards/tty';
 import { SOURCE_CODE_NOTE } from './constants';
-import type { AddResult, AddScreenComponent, RemovableResource, RemovalPreview, RemovalResult } from './types';
+import type { AddResult, AddScreenComponent, RemovableResource, RemovalPreview } from './types';
 import type { Command } from '@commander-js/extra-typings';
 import type { z } from 'zod';
 
@@ -44,7 +45,7 @@ export abstract class BasePrimitive<
   /**
    * Remove a resource by name.
    */
-  abstract remove(name: string): Promise<RemovalResult>;
+  abstract remove(name: string): Promise<Result>;
 
   /**
    * Preview what will be removed.
@@ -122,7 +123,7 @@ export abstract class BasePrimitive<
               process.exit(1);
             }
 
-            const result = await withCommandRunTelemetry<SubCommand<'remove', typeof this.kind>, RemovalResult>(
+            const result = await withCommandRunTelemetry<SubCommand<'remove', typeof this.kind>, Result>(
               `remove.${this.kind}`,
               {},
               () => this.remove(cliOptions.name!)
@@ -134,7 +135,7 @@ export abstract class BasePrimitive<
                 resourceName: cliOptions.name,
                 message: result.success ? `Removed ${this.label.toLowerCase()} '${cliOptions.name}'` : undefined,
                 note: result.success ? SOURCE_CODE_NOTE : undefined,
-                error: !result.success ? result.error : undefined,
+                error: !result.success ? result.error.message : undefined,
               })
             );
             process.exit(result.success ? 0 : 1);

--- a/src/cli/primitives/ConfigBundlePrimitive.ts
+++ b/src/cli/primitives/ConfigBundlePrimitive.ts
@@ -1,8 +1,9 @@
-import { findConfigRoot } from '../../lib';
+import { ResourceNotFoundError, findConfigRoot, serializeResult, toError } from '../../lib';
+import type { Result } from '../../lib/result';
 import type { ConfigBundle } from '../../schema';
 import { ConfigBundleSchema } from '../../schema';
 import { getErrorMessage } from '../errors';
-import type { RemovalPreview, RemovalResult, SchemaChange } from '../operations/remove/types';
+import type { RemovalPreview, SchemaChange } from '../operations/remove/types';
 import { BasePrimitive } from './BasePrimitive';
 import type { AddResult, AddScreenComponent, RemovableResource } from './types';
 import type { Command } from '@commander-js/extra-typings';
@@ -37,17 +38,17 @@ export class ConfigBundlePrimitive extends BasePrimitive<AddConfigBundleOptions,
       const bundle = await this.createConfigBundle(options);
       return { success: true, bundleName: bundle.name };
     } catch (err) {
-      return { success: false, error: getErrorMessage(err) };
+      return { success: false, error: toError(err) };
     }
   }
 
-  async remove(bundleName: string): Promise<RemovalResult> {
+  async remove(bundleName: string): Promise<Result> {
     try {
       const project = await this.readProjectSpec();
 
       const index = (project.configBundles ?? []).findIndex(b => b.name === bundleName);
       if (index === -1) {
-        return { success: false, error: `Configuration bundle "${bundleName}" not found.` };
+        return { success: false, error: new ResourceNotFoundError(`Configuration bundle "${bundleName}" not found.`) };
       }
 
       project.configBundles.splice(index, 1);
@@ -55,7 +56,7 @@ export class ConfigBundlePrimitive extends BasePrimitive<AddConfigBundleOptions,
 
       return { success: true };
     } catch (err) {
-      return { success: false, error: getErrorMessage(err) };
+      return { success: false, error: toError(err) };
     }
   }
 
@@ -170,11 +171,11 @@ export class ConfigBundlePrimitive extends BasePrimitive<AddConfigBundleOptions,
               });
 
               if (cliOptions.json) {
-                console.log(JSON.stringify(result));
+                console.log(JSON.stringify(serializeResult(result)));
               } else if (result.success) {
                 console.log(`Added configuration bundle '${result.bundleName}'`);
               } else {
-                console.error(result.error);
+                console.error(result.error.message);
               }
               process.exit(result.success ? 0 : 1);
             } else {

--- a/src/cli/primitives/CredentialPrimitive.tsx
+++ b/src/cli/primitives/CredentialPrimitive.tsx
@@ -1,9 +1,18 @@
-import { findConfigRoot, getEnvVar, setEnvVar } from '../../lib';
+import {
+  ConflictError,
+  ResourceNotFoundError,
+  findConfigRoot,
+  getEnvVar,
+  serializeResult,
+  setEnvVar,
+  toError,
+} from '../../lib';
+import type { Result } from '../../lib/result';
 import type { Credential, ModelProvider } from '../../schema';
 import { CredentialSchema } from '../../schema';
 import { validateAddCredentialOptions } from '../commands/add/validate';
 import { getErrorMessage } from '../errors';
-import type { RemovalPreview, RemovalResult, SchemaChange } from '../operations/remove/types';
+import type { RemovalPreview, SchemaChange } from '../operations/remove/types';
 import { runCliCommand } from '../telemetry/cli-command-run.js';
 import { CredentialType, standardize } from '../telemetry/schemas/common-shapes.js';
 import { requireTTY } from '../tui/guards/tty';
@@ -77,17 +86,17 @@ export class CredentialPrimitive extends BasePrimitive<AddCredentialOptions, Rem
       const credential = await this.createCredential(options);
       return { success: true, credentialName: credential.name };
     } catch (err) {
-      return { success: false, error: getErrorMessage(err) };
+      return { success: false, error: toError(err) };
     }
   }
 
-  async remove(credentialName: string, options?: { force?: boolean }): Promise<RemovalResult> {
+  async remove(credentialName: string, options?: { force?: boolean }): Promise<Result> {
     try {
       const project = await this.readProjectSpec();
 
       const credentialIndex = project.credentials.findIndex(c => c.name === credentialName);
       if (credentialIndex === -1) {
-        return { success: false, error: `Credential "${credentialName}" not found.` };
+        return { success: false, error: new ResourceNotFoundError(`Credential "${credentialName}" not found.`) };
       }
 
       const credential = project.credentials[credentialIndex]!;
@@ -96,7 +105,9 @@ export class CredentialPrimitive extends BasePrimitive<AddCredentialOptions, Rem
       if ('managed' in credential && credential.managed && !options?.force) {
         return {
           success: false,
-          error: `Credential "${credentialName}" is managed by the CLI and cannot be removed. Use force to override.`,
+          error: new ConflictError(
+            `Credential "${credentialName}" is managed by the CLI and cannot be removed. Use force to override.`
+          ),
         };
       }
 
@@ -106,7 +117,9 @@ export class CredentialPrimitive extends BasePrimitive<AddCredentialOptions, Rem
         const targetList = referencingTargets.map(t => t.name).join(', ');
         return {
           success: false,
-          error: `Credential "${credentialName}" is referenced by gateway target(s): ${targetList}. Use force to override.`,
+          error: new ConflictError(
+            `Credential "${credentialName}" is referenced by gateway target(s): ${targetList}. Use force to override.`
+          ),
         };
       }
 
@@ -115,8 +128,7 @@ export class CredentialPrimitive extends BasePrimitive<AddCredentialOptions, Rem
 
       return { success: true };
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Unknown error';
-      return { success: false, error: message };
+      return { success: false, error: toError(err) };
     }
   }
 
@@ -328,11 +340,11 @@ export class CredentialPrimitive extends BasePrimitive<AddCredentialOptions, Rem
               const result = await this.add(addOptions);
 
               if (!result.success) {
-                throw new Error(result.error);
+                throw result.error;
               }
 
               if (cliOptions.json) {
-                console.log(JSON.stringify(result));
+                console.log(JSON.stringify(serializeResult(result)));
               } else {
                 console.log(`Added credential '${result.credentialName}'`);
               }

--- a/src/cli/primitives/EvaluatorPrimitive.ts
+++ b/src/cli/primitives/EvaluatorPrimitive.ts
@@ -1,8 +1,9 @@
-import { findConfigRoot } from '../../lib';
+import { ConflictError, ResourceNotFoundError, findConfigRoot, serializeResult, toError } from '../../lib';
+import type { Result } from '../../lib/result';
 import type { EvaluationLevel, Evaluator, EvaluatorConfig } from '../../schema';
 import { EvaluationLevelSchema, EvaluatorSchema } from '../../schema';
 import { getErrorMessage } from '../errors';
-import type { RemovalPreview, RemovalResult, SchemaChange } from '../operations/remove/types';
+import type { RemovalPreview, SchemaChange } from '../operations/remove/types';
 import { runCliCommand } from '../telemetry/cli-command-run.js';
 import { EvaluatorType, Level, standardize } from '../telemetry/schemas/common-shapes.js';
 import { renderCodeBasedEvaluatorTemplate } from '../templates/EvaluatorRenderer';
@@ -57,17 +58,17 @@ export class EvaluatorPrimitive extends BasePrimitive<AddEvaluatorOptions, Remov
 
       return { success: true, evaluatorName: evaluator.name };
     } catch (err) {
-      return { success: false, error: getErrorMessage(err) };
+      return { success: false, error: toError(err) };
     }
   }
 
-  async remove(evaluatorName: string): Promise<RemovalResult> {
+  async remove(evaluatorName: string): Promise<Result> {
     try {
       const project = await this.readProjectSpec();
 
       const index = project.evaluators.findIndex(e => e.name === evaluatorName);
       if (index === -1) {
-        return { success: false, error: `Evaluator "${evaluatorName}" not found.` };
+        return { success: false, error: new ResourceNotFoundError(`Evaluator "${evaluatorName}" not found.`) };
       }
 
       // Warn if referenced by online eval configs
@@ -76,7 +77,9 @@ export class EvaluatorPrimitive extends BasePrimitive<AddEvaluatorOptions, Remov
         const configNames = referencingConfigs.map(c => c.name).join(', ');
         return {
           success: false,
-          error: `Evaluator "${evaluatorName}" is referenced by online eval config(s): ${configNames}. Remove those references first.`,
+          error: new ConflictError(
+            `Evaluator "${evaluatorName}" is referenced by online eval config(s): ${configNames}. Remove those references first.`
+          ),
         };
       }
 
@@ -96,7 +99,7 @@ export class EvaluatorPrimitive extends BasePrimitive<AddEvaluatorOptions, Remov
 
       return { success: true };
     } catch (err) {
-      return { success: false, error: getErrorMessage(err) };
+      return { success: false, error: toError(err) };
     }
   }
 
@@ -296,11 +299,11 @@ export class EvaluatorPrimitive extends BasePrimitive<AddEvaluatorOptions, Remov
               });
 
               if (!result.success) {
-                throw new Error(result.error);
+                throw result.error;
               }
 
               if (cliOptions.json) {
-                console.log(JSON.stringify(result));
+                console.log(JSON.stringify(serializeResult(result)));
               } else {
                 if (result.codePath) {
                   console.log(`Created evaluator '${result.evaluatorName}'`);

--- a/src/cli/primitives/GatewayPrimitive.ts
+++ b/src/cli/primitives/GatewayPrimitive.ts
@@ -1,4 +1,5 @@
-import { findConfigRoot } from '../../lib';
+import { ResourceNotFoundError, findConfigRoot, serializeResult, toError } from '../../lib';
+import type { Result } from '../../lib/result';
 import type {
   AgentCoreGateway,
   AgentCoreGatewayTarget,
@@ -11,7 +12,7 @@ import { AgentCoreGatewaySchema, PolicyEngineModeSchema } from '../../schema';
 import type { AddGatewayOptions as CLIAddGatewayOptions } from '../commands/add/types';
 import { validateAddGatewayOptions } from '../commands/add/validate';
 import { getErrorMessage } from '../errors';
-import type { RemovalPreview, RemovalResult, SchemaChange } from '../operations/remove/types';
+import type { RemovalPreview, SchemaChange } from '../operations/remove/types';
 import { runCliCommand, withCommandRunTelemetry } from '../telemetry/cli-command-run.js';
 import { AuthorizerType, PolicyEngineMode, standardize } from '../telemetry/schemas/common-shapes.js';
 import { requireTTY } from '../tui/guards/tty';
@@ -67,18 +68,18 @@ export class GatewayPrimitive extends BasePrimitive<AddGatewayOptions, Removable
       const result = await this.createGatewayFromWizard(config);
       return { success: true, gatewayName: result.name };
     } catch (err) {
-      return { success: false, error: getErrorMessage(err) };
+      return { success: false, error: toError(err) };
     }
   }
 
-  async remove(gatewayName: string): Promise<RemovalResult> {
+  async remove(gatewayName: string): Promise<Result> {
     try {
       const project = await this.readProjectSpec();
       const mcpSpec = extractMcpSpec(project);
 
       const gateway = mcpSpec.agentCoreGateways.find(g => g.name === gatewayName);
       if (!gateway) {
-        return { success: false, error: `Gateway "${gatewayName}" not found.` };
+        return { success: false, error: new ResourceNotFoundError(`Gateway "${gatewayName}" not found.`) };
       }
 
       const newMcpSpec = this.computeRemovedGatewayMcpSpec(mcpSpec, gatewayName);
@@ -86,8 +87,7 @@ export class GatewayPrimitive extends BasePrimitive<AddGatewayOptions, Removable
 
       return { success: true };
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Unknown error';
-      return { success: false, error: message };
+      return { success: false, error: toError(err) };
     }
   }
 
@@ -218,11 +218,11 @@ export class GatewayPrimitive extends BasePrimitive<AddGatewayOptions, Removable
           });
 
           if (!result.success) {
-            throw new Error(result.error);
+            throw result.error;
           }
 
           if (cliOptions.json) {
-            console.log(JSON.stringify(result));
+            console.log(JSON.stringify(serializeResult(result)));
           } else {
             console.log(`Added gateway '${result.gatewayName}'`);
           }
@@ -270,7 +270,7 @@ export class GatewayPrimitive extends BasePrimitive<AddGatewayOptions, Removable
                 resourceName: cliOptions.name,
                 message: result.success ? `Removed gateway '${cliOptions.name}'` : undefined,
                 note: result.success ? SOURCE_CODE_NOTE : undefined,
-                error: !result.success ? result.error : undefined,
+                error: !result.success ? result.error.message : undefined,
               })
             );
             process.exit(result.success ? 0 : 1);

--- a/src/cli/primitives/GatewayTargetPrimitive.ts
+++ b/src/cli/primitives/GatewayTargetPrimitive.ts
@@ -1,4 +1,13 @@
-import { APP_DIR, MCP_APP_SUBDIR, findConfigRoot, requireConfigRoot } from '../../lib';
+import {
+  APP_DIR,
+  MCP_APP_SUBDIR,
+  ResourceNotFoundError,
+  findConfigRoot,
+  requireConfigRoot,
+  serializeResult,
+  toError,
+} from '../../lib';
+import type { Result } from '../../lib/result';
 import type {
   AgentCoreCliMcpDefs,
   AgentCoreGatewayTarget,
@@ -13,7 +22,7 @@ import type { AddGatewayTargetOptions as CLIAddGatewayTargetOptions } from '../c
 import { validateAddGatewayTargetOptions } from '../commands/add/validate';
 import { getErrorMessage } from '../errors';
 import type { RemovableGatewayTarget } from '../operations/remove/remove-gateway-target';
-import type { RemovalPreview, RemovalResult, SchemaChange } from '../operations/remove/types';
+import type { RemovalPreview, SchemaChange } from '../operations/remove/types';
 import { runCliCommand, withCommandRunTelemetry } from '../telemetry/cli-command-run.js';
 import {
   GATEWAY_TARGET_TYPE_MAP,
@@ -76,16 +85,16 @@ export class GatewayTargetPrimitive extends BasePrimitive<AddGatewayTargetOption
       const result = await this.createToolFromWizard(config);
       return { success: true, toolName: result.toolName, sourcePath: result.projectPath };
     } catch (err) {
-      return { success: false, error: getErrorMessage(err) };
+      return { success: false, error: toError(err) };
     }
   }
 
-  async remove(name: string): Promise<RemovalResult> {
+  async remove(name: string): Promise<Result> {
     // Find the target by name to get its gateway info
     const tools = await this.getRemovable();
     const tool = tools.find(t => t.name === name);
     if (!tool) {
-      return { success: false, error: `Gateway target "${name}" not found.` };
+      return { success: false, error: new ResourceNotFoundError(`Gateway target "${name}" not found.`) };
     }
     return this.removeGatewayTarget(tool);
   }
@@ -183,7 +192,7 @@ export class GatewayTargetPrimitive extends BasePrimitive<AddGatewayTargetOption
   /**
    * Remove a gateway target (with full target info).
    */
-  async removeGatewayTarget(tool: RemovableGatewayTarget): Promise<RemovalResult> {
+  async removeGatewayTarget(tool: RemovableGatewayTarget): Promise<Result> {
     try {
       const project = await this.readProjectSpec();
       const mcpSpec = extractMcpSpec(project);
@@ -195,11 +204,14 @@ export class GatewayTargetPrimitive extends BasePrimitive<AddGatewayTargetOption
 
       const gateway = mcpSpec.agentCoreGateways.find(g => g.name === tool.gatewayName);
       if (!gateway) {
-        return { success: false, error: `Gateway "${tool.gatewayName}" not found.` };
+        return { success: false, error: new ResourceNotFoundError(`Gateway "${tool.gatewayName}" not found.`) };
       }
       const target = gateway.targets.find(t => t.name === tool.name);
       if (!target) {
-        return { success: false, error: `Target "${tool.name}" not found in gateway "${tool.gatewayName}".` };
+        return {
+          success: false,
+          error: new ResourceNotFoundError(`Target "${tool.name}" not found in gateway "${tool.gatewayName}".`),
+        };
       }
       if (target.compute?.implementation && 'path' in target.compute.implementation) {
         toolPath = target.compute.implementation.path;
@@ -223,8 +235,7 @@ export class GatewayTargetPrimitive extends BasePrimitive<AddGatewayTargetOption
 
       return { success: true };
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Unknown error';
-      return { success: false, error: message };
+      return { success: false, error: toError(err) };
     }
   }
 
@@ -475,11 +486,11 @@ export class GatewayTargetPrimitive extends BasePrimitive<AddGatewayTargetOption
           });
 
           if (!result.success) {
-            throw new Error(result.error);
+            throw result.error;
           }
 
           if (cliOptions.json) {
-            console.log(JSON.stringify(result));
+            console.log(JSON.stringify(serializeResult(result)));
           } else {
             console.log(`Added gateway target '${result.toolName}'`);
             if (result.sourcePath) {
@@ -520,7 +531,7 @@ export class GatewayTargetPrimitive extends BasePrimitive<AddGatewayTargetOption
                 resourceName: cliOptions.name,
                 message: result.success ? `Removed gateway target '${cliOptions.name}'` : undefined,
                 note: result.success ? SOURCE_CODE_NOTE : undefined,
-                error: !result.success ? result.error : undefined,
+                error: !result.success ? result.error.message : undefined,
               })
             );
             process.exit(result.success ? 0 : 1);

--- a/src/cli/primitives/MemoryPrimitive.tsx
+++ b/src/cli/primitives/MemoryPrimitive.tsx
@@ -1,4 +1,5 @@
-import { findConfigRoot } from '../../lib';
+import { ResourceNotFoundError, findConfigRoot, serializeResult, toError } from '../../lib';
+import type { Result } from '../../lib/result';
 import type {
   Memory,
   MemoryStrategy,
@@ -16,7 +17,7 @@ import {
 } from '../../schema';
 import { DEFAULT_DELIVERY_TYPE, validateAddMemoryOptions } from '../commands/add/validate';
 import { getErrorMessage } from '../errors';
-import type { RemovalPreview, RemovalResult, SchemaChange } from '../operations/remove/types';
+import type { RemovalPreview, SchemaChange } from '../operations/remove/types';
 import { runCliCommand } from '../telemetry/cli-command-run.js';
 import { requireTTY } from '../tui/guards/tty';
 import { DEFAULT_EVENT_EXPIRY } from '../tui/screens/memory/types';
@@ -83,17 +84,17 @@ export class MemoryPrimitive extends BasePrimitive<AddMemoryOptions, RemovableMe
 
       return { success: true, memoryName: memory.name };
     } catch (err) {
-      return { success: false, error: getErrorMessage(err) };
+      return { success: false, error: toError(err) };
     }
   }
 
-  async remove(memoryName: string): Promise<RemovalResult> {
+  async remove(memoryName: string): Promise<Result> {
     try {
       const project = await this.readProjectSpec();
 
       const memoryIndex = project.memories.findIndex(m => m.name === memoryName);
       if (memoryIndex === -1) {
-        return { success: false, error: `Memory "${memoryName}" not found.` };
+        return { success: false, error: new ResourceNotFoundError(`Memory "${memoryName}" not found.`) };
       }
 
       project.memories.splice(memoryIndex, 1);
@@ -101,8 +102,7 @@ export class MemoryPrimitive extends BasePrimitive<AddMemoryOptions, RemovableMe
 
       return { success: true };
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Unknown error';
-      return { success: false, error: message };
+      return { success: false, error: toError(err) };
     }
   }
 
@@ -218,11 +218,11 @@ export class MemoryPrimitive extends BasePrimitive<AddMemoryOptions, RemovableMe
               });
 
               if (!result.success) {
-                throw new Error(result.error);
+                throw result.error;
               }
 
               if (cliOptions.json) {
-                console.log(JSON.stringify(result));
+                console.log(JSON.stringify(serializeResult(result)));
               } else {
                 console.log(`Added memory '${result.memoryName}'`);
               }

--- a/src/cli/primitives/OnlineEvalConfigPrimitive.ts
+++ b/src/cli/primitives/OnlineEvalConfigPrimitive.ts
@@ -1,8 +1,9 @@
-import { findConfigRoot } from '../../lib';
+import { ResourceNotFoundError, findConfigRoot, serializeResult, toError } from '../../lib';
+import type { Result } from '../../lib/result';
 import type { OnlineEvalConfig } from '../../schema';
 import { OnlineEvalConfigSchema } from '../../schema';
 import { getErrorMessage } from '../errors';
-import type { RemovalPreview, RemovalResult, SchemaChange } from '../operations/remove/types';
+import type { RemovalPreview, SchemaChange } from '../operations/remove/types';
 import { runCliCommand } from '../telemetry/cli-command-run.js';
 import { requireTTY } from '../tui/guards/tty';
 import { BasePrimitive } from './BasePrimitive';
@@ -34,17 +35,17 @@ export class OnlineEvalConfigPrimitive extends BasePrimitive<AddOnlineEvalConfig
       const config = await this.createOnlineEvalConfig(options);
       return { success: true, configName: config.name };
     } catch (err) {
-      return { success: false, error: getErrorMessage(err) };
+      return { success: false, error: toError(err) };
     }
   }
 
-  async remove(configName: string): Promise<RemovalResult> {
+  async remove(configName: string): Promise<Result> {
     try {
       const project = await this.readProjectSpec();
 
       const index = project.onlineEvalConfigs.findIndex(c => c.name === configName);
       if (index === -1) {
-        return { success: false, error: `Online eval config "${configName}" not found.` };
+        return { success: false, error: new ResourceNotFoundError(`Online eval config "${configName}" not found.`) };
       }
 
       project.onlineEvalConfigs.splice(index, 1);
@@ -52,7 +53,7 @@ export class OnlineEvalConfigPrimitive extends BasePrimitive<AddOnlineEvalConfig
 
       return { success: true };
     } catch (err) {
-      return { success: false, error: getErrorMessage(err) };
+      return { success: false, error: toError(err) };
     }
   }
 
@@ -159,11 +160,11 @@ export class OnlineEvalConfigPrimitive extends BasePrimitive<AddOnlineEvalConfig
               });
 
               if (!result.success) {
-                throw new Error(result.error);
+                throw result.error;
               }
 
               if (cliOptions.json) {
-                console.log(JSON.stringify(result));
+                console.log(JSON.stringify(serializeResult(result)));
               } else {
                 console.log(`Added online eval config '${result.configName}'`);
               }

--- a/src/cli/primitives/PolicyEnginePrimitive.ts
+++ b/src/cli/primitives/PolicyEnginePrimitive.ts
@@ -1,8 +1,9 @@
-import { findConfigRoot } from '../../lib';
+import { ResourceNotFoundError, findConfigRoot, serializeResult, toError } from '../../lib';
+import type { Result } from '../../lib/result';
 import type { AgentCoreProjectSpec, PolicyEngine } from '../../schema';
 import { PolicyEngineModeSchema, PolicyEngineSchema } from '../../schema';
 import { getErrorMessage } from '../errors';
-import type { RemovalPreview, RemovalResult, SchemaChange } from '../operations/remove/types';
+import type { RemovalPreview, SchemaChange } from '../operations/remove/types';
 import { runCliCommand, withCommandRunTelemetry } from '../telemetry/cli-command-run.js';
 import { AttachMode, standardize } from '../telemetry/schemas/common-shapes.js';
 import { requireTTY } from '../tui/guards/tty';
@@ -40,17 +41,17 @@ export class PolicyEnginePrimitive extends BasePrimitive<AddPolicyEngineOptions,
 
       return { success: true, engineName: engine.name };
     } catch (err) {
-      return { success: false, error: getErrorMessage(err) };
+      return { success: false, error: toError(err) };
     }
   }
 
-  async remove(engineName: string): Promise<RemovalResult> {
+  async remove(engineName: string): Promise<Result> {
     try {
       const project = await this.readProjectSpec();
 
       const index = project.policyEngines.findIndex(e => e.name === engineName);
       if (index === -1) {
-        return { success: false, error: `Policy engine "${engineName}" not found.` };
+        return { success: false, error: new ResourceNotFoundError(`Policy engine "${engineName}" not found.`) };
       }
 
       project.policyEngines.splice(index, 1);
@@ -70,8 +71,7 @@ export class PolicyEnginePrimitive extends BasePrimitive<AddPolicyEngineOptions,
 
       return { success: true };
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Unknown error';
-      return { success: false, error: message };
+      return { success: false, error: toError(err) };
     }
   }
 
@@ -251,11 +251,11 @@ export class PolicyEnginePrimitive extends BasePrimitive<AddPolicyEngineOptions,
               }
 
               if (!result.success) {
-                throw new Error(result.error);
+                throw result.error;
               }
 
               if (cliOptions.json) {
-                console.log(JSON.stringify(result));
+                console.log(JSON.stringify(serializeResult(result)));
               } else {
                 console.log(`Added policy engine '${result.engineName}'`);
               }
@@ -327,13 +327,13 @@ export class PolicyEnginePrimitive extends BasePrimitive<AddPolicyEngineOptions,
                   resourceName: cliOptions.name,
                   message: result.success ? `Removed policy engine '${cliOptions.name}'` : undefined,
                   note: result.success ? SOURCE_CODE_NOTE : undefined,
-                  error: !result.success ? result.error : undefined,
+                  error: !result.success ? result.error.message : undefined,
                 })
               );
             } else if (result.success) {
               console.log(`Removed policy engine '${cliOptions.name}'`);
             } else {
-              console.error(result.error);
+              console.error(result.error.message);
             }
             process.exit(result.success ? 0 : 1);
           } else {

--- a/src/cli/primitives/PolicyPrimitive.ts
+++ b/src/cli/primitives/PolicyPrimitive.ts
@@ -1,10 +1,11 @@
-import { findConfigRoot } from '../../lib';
+import { ResourceNotFoundError, ValidationError, findConfigRoot, serializeResult, toError } from '../../lib';
+import type { Result } from '../../lib/result';
 import type { Policy } from '../../schema';
 import { PolicySchema, ValidationModeSchema } from '../../schema';
 import { detectRegion } from '../aws';
 import { getPolicyGeneration, startPolicyGeneration } from '../aws/policy-generation';
 import { getErrorMessage } from '../errors';
-import type { RemovalPreview, RemovalResult, SchemaChange } from '../operations/remove/types';
+import type { RemovalPreview, SchemaChange } from '../operations/remove/types';
 import { runCliCommand, withCommandRunTelemetry } from '../telemetry/cli-command-run.js';
 import { ValidationMode, standardize } from '../telemetry/schemas/common-shapes.js';
 import { requireTTY } from '../tui/guards/tty';
@@ -40,7 +41,7 @@ export class PolicyPrimitive extends BasePrimitive<AddPolicyOptions, RemovablePo
       if (sourceFlags.length > 1) {
         return {
           success: false,
-          error: 'Only one of --statement, --source, or --generate can be provided.',
+          error: new ValidationError('Only one of --statement, --source, or --generate can be provided.'),
         };
       }
 
@@ -48,7 +49,7 @@ export class PolicyPrimitive extends BasePrimitive<AddPolicyOptions, RemovablePo
 
       const engine = project.policyEngines.find(e => e.name === options.engine);
       if (!engine) {
-        return { success: false, error: `Policy engine "${options.engine}" not found.` };
+        return { success: false, error: new ResourceNotFoundError(`Policy engine "${options.engine}" not found.`) };
       }
 
       this.checkDuplicate(engine.policies, options.name, 'Policy');
@@ -57,11 +58,11 @@ export class PolicyPrimitive extends BasePrimitive<AddPolicyOptions, RemovablePo
 
       if (options.source && !statement) {
         if (!existsSync(options.source)) {
-          return { success: false, error: `Source file not found: ${options.source}` };
+          return { success: false, error: new ResourceNotFoundError(`Source file not found: ${options.source}`) };
         }
         statement = readFileSync(options.source, 'utf-8').trim();
         if (!statement) {
-          return { success: false, error: `Source file is empty: ${options.source}` };
+          return { success: false, error: new ValidationError(`Source file is empty: ${options.source}`) };
         }
       }
 
@@ -91,17 +92,23 @@ export class PolicyPrimitive extends BasePrimitive<AddPolicyOptions, RemovablePo
         if (!engineId) {
           return {
             success: false,
-            error: `Policy engine "${options.engine}" is not deployed. Run \`agentcore deploy\` first.`,
+            error: new ValidationError(
+              `Policy engine "${options.engine}" is not deployed. Run \`agentcore deploy\` first.`
+            ),
           };
         }
         if (options.gateway && !gatewayArn) {
-          return { success: false, error: `Gateway "${options.gateway}" not found in deployed state.` };
+          return {
+            success: false,
+            error: new ResourceNotFoundError(`Gateway "${options.gateway}" not found in deployed state.`),
+          };
         }
         if (!gatewayArn) {
           return {
             success: false,
-            error:
-              'No deployed gateway found. Policy generation requires a deployed gateway. Use --gateway <name> to specify one.',
+            error: new ResourceNotFoundError(
+              'No deployed gateway found. Policy generation requires a deployed gateway. Use --gateway <name> to specify one.'
+            ),
           };
         }
 
@@ -123,7 +130,10 @@ export class PolicyPrimitive extends BasePrimitive<AddPolicyOptions, RemovablePo
       }
 
       if (!statement) {
-        return { success: false, error: 'Either --statement, --source, or --generate is required.' };
+        return {
+          success: false,
+          error: new ValidationError('Either --statement, --source, or --generate is required.'),
+        };
       }
 
       const policy: Policy = {
@@ -139,7 +149,7 @@ export class PolicyPrimitive extends BasePrimitive<AddPolicyOptions, RemovablePo
 
       return { success: true, policyName: policy.name, engineName: options.engine };
     } catch (err) {
-      return { success: false, error: getErrorMessage(err) };
+      return { success: false, error: toError(err) };
     }
   }
 
@@ -148,7 +158,7 @@ export class PolicyPrimitive extends BasePrimitive<AddPolicyOptions, RemovablePo
    * The composite key format is used by getRemovable() and the generic TUI remove flow.
    * The separate arguments form is used by the CLI --name + --engine flags.
    */
-  async remove(nameOrCompositeKey: string, engineName?: string): Promise<RemovalResult> {
+  async remove(nameOrCompositeKey: string, engineName?: string): Promise<Result> {
     try {
       const project = await this.readProjectSpec();
 
@@ -167,7 +177,9 @@ export class PolicyPrimitive extends BasePrimitive<AddPolicyOptions, RemovablePo
         if (matchingEngines.length > 1) {
           return {
             success: false,
-            error: `Policy "${resolvedPolicy}" exists in multiple engines: ${matchingEngines.map(e => e.name).join(', ')}. Use --engine to specify which one.`,
+            error: new ValidationError(
+              `Policy "${resolvedPolicy}" exists in multiple engines: ${matchingEngines.map(e => e.name).join(', ')}. Use --engine to specify which one.`
+            ),
           };
         }
       }
@@ -185,10 +197,12 @@ export class PolicyPrimitive extends BasePrimitive<AddPolicyOptions, RemovablePo
 
       return {
         success: false,
-        error: `Policy "${resolvedPolicy}" not found${resolvedEngine ? ` in engine "${resolvedEngine}"` : ''}.`,
+        error: new ResourceNotFoundError(
+          `Policy "${resolvedPolicy}" not found${resolvedEngine ? ` in engine "${resolvedEngine}"` : ''}.`
+        ),
       };
     } catch (err) {
-      return { success: false, error: getErrorMessage(err) };
+      return { success: false, error: toError(err) };
     }
   }
 
@@ -328,11 +342,11 @@ export class PolicyPrimitive extends BasePrimitive<AddPolicyOptions, RemovablePo
               });
 
               if (!result.success) {
-                throw new Error(result.error);
+                throw result.error;
               }
 
               if (cliOptions.json) {
-                console.log(JSON.stringify(result));
+                console.log(JSON.stringify(serializeResult(result)));
               } else {
                 console.log(`Added policy '${result.policyName}' to engine '${result.engineName}'`);
               }
@@ -410,13 +424,13 @@ export class PolicyPrimitive extends BasePrimitive<AddPolicyOptions, RemovablePo
                   resourceName: cliOptions.name,
                   message: result.success ? `Removed policy '${cliOptions.name}'` : undefined,
                   note: result.success ? SOURCE_CODE_NOTE : undefined,
-                  error: !result.success ? result.error : undefined,
+                  error: !result.success ? result.error.message : undefined,
                 })
               );
             } else if (result.success) {
               console.log(`Removed policy '${cliOptions.name}'`);
             } else {
-              console.error(result.error);
+              console.error(result.error.message);
             }
             process.exit(result.success ? 0 : 1);
           } else {

--- a/src/cli/primitives/RuntimeEndpointPrimitive.ts
+++ b/src/cli/primitives/RuntimeEndpointPrimitive.ts
@@ -1,9 +1,17 @@
-import { findConfigRoot } from '../../lib';
+import {
+  ConflictError,
+  ResourceNotFoundError,
+  ValidationError,
+  findConfigRoot,
+  serializeResult,
+  toError,
+} from '../../lib';
+import type { Result } from '../../lib/result';
 import type { AgentCoreProjectSpec } from '../../schema';
 import { RuntimeEndpointSchema } from '../../schema';
 import type { ResourceType } from '../commands/remove/types';
 import { getErrorMessage } from '../errors';
-import type { RemovalPreview, RemovalResult, SchemaChange } from '../operations/remove/types';
+import type { RemovalPreview, SchemaChange } from '../operations/remove/types';
 import { runCliCommand, withCommandRunTelemetry } from '../telemetry/cli-command-run.js';
 import { BasePrimitive } from './BasePrimitive';
 import { SOURCE_CODE_NOTE } from './constants';
@@ -46,7 +54,7 @@ export class RuntimeEndpointPrimitive extends BasePrimitive<AddRuntimeEndpointOp
       // Find the parent runtime
       const runtime = project.runtimes.find(a => a.name === options.runtime);
       if (!runtime) {
-        return { success: false, error: `Runtime "${options.runtime}" not found.` };
+        return { success: false, error: new ResourceNotFoundError(`Runtime "${options.runtime}" not found.`) };
       }
 
       // Initialize endpoints dictionary if needed
@@ -56,14 +64,14 @@ export class RuntimeEndpointPrimitive extends BasePrimitive<AddRuntimeEndpointOp
       if (runtime.endpoints[options.endpoint]) {
         return {
           success: false,
-          error: `Endpoint "${options.endpoint}" already exists on runtime "${options.runtime}".`,
+          error: new ConflictError(`Endpoint "${options.endpoint}" already exists on runtime "${options.runtime}".`),
         };
       }
 
       // Validate version is a positive integer
       const version = options.version ?? 1;
       if (!Number.isInteger(version) || version < 1) {
-        return { success: false, error: `Version must be a positive integer (got ${version}).` };
+        return { success: false, error: new ValidationError(`Version must be a positive integer (got ${version}).`) };
       }
 
       // Check version against latest deployed version
@@ -75,7 +83,9 @@ export class RuntimeEndpointPrimitive extends BasePrimitive<AddRuntimeEndpointOp
             if (deployedRuntime?.runtimeVersion && version > deployedRuntime.runtimeVersion) {
               return {
                 success: false,
-                error: `Version ${version} exceeds latest deployed version ${deployedRuntime.runtimeVersion} for runtime "${options.runtime}".`,
+                error: new ValidationError(
+                  `Version ${version} exceeds latest deployed version ${deployedRuntime.runtimeVersion} for runtime "${options.runtime}".`
+                ),
               };
             }
           }
@@ -104,11 +114,11 @@ export class RuntimeEndpointPrimitive extends BasePrimitive<AddRuntimeEndpointOp
         version: config.version,
       };
     } catch (err) {
-      return { success: false, error: getErrorMessage(err) };
+      return { success: false, error: toError(err) };
     }
   }
 
-  async remove(name: string): Promise<RemovalResult> {
+  async remove(name: string): Promise<Result> {
     try {
       const project = await this.readProjectSpec();
 
@@ -119,7 +129,7 @@ export class RuntimeEndpointPrimitive extends BasePrimitive<AddRuntimeEndpointOp
         const endpointName = name.substring(slashIndex + 1);
         const runtime = project.runtimes.find(r => r.name === runtimeName);
         if (!runtime?.endpoints?.[endpointName]) {
-          return { success: false, error: `Runtime endpoint "${name}" not found.` };
+          return { success: false, error: new ResourceNotFoundError(`Runtime endpoint "${name}" not found.`) };
         }
         delete runtime.endpoints[endpointName];
         if (Object.keys(runtime.endpoints).length === 0) {
@@ -141,9 +151,9 @@ export class RuntimeEndpointPrimitive extends BasePrimitive<AddRuntimeEndpointOp
         }
       }
 
-      return { success: false, error: `Runtime endpoint "${name}" not found.` };
+      return { success: false, error: new ResourceNotFoundError(`Runtime endpoint "${name}" not found.`) };
     } catch (err) {
-      return { success: false, error: getErrorMessage(err) };
+      return { success: false, error: toError(err) };
     }
   }
 
@@ -263,11 +273,11 @@ export class RuntimeEndpointPrimitive extends BasePrimitive<AddRuntimeEndpointOp
             });
 
             if (!result.success) {
-              throw new Error(result.error);
+              throw result.error;
             }
 
             if (cliOptions.json) {
-              console.log(JSON.stringify(result));
+              console.log(JSON.stringify(serializeResult(result)));
             } else {
               console.log(`Added runtime endpoint '${cliOptions.endpoint}' to runtime '${cliOptions.runtime}'`);
             }
@@ -306,7 +316,7 @@ export class RuntimeEndpointPrimitive extends BasePrimitive<AddRuntimeEndpointOp
                 resourceName: cliOptions.name,
                 message: result.success ? `Removed runtime endpoint '${cliOptions.name}'` : undefined,
                 note: result.success ? SOURCE_CODE_NOTE : undefined,
-                error: !result.success ? result.error : undefined,
+                error: !result.success ? result.error.message : undefined,
               })
             );
             process.exit(result.success ? 0 : 1);

--- a/src/cli/primitives/__tests__/ABTestPrimitive.test.ts
+++ b/src/cli/primitives/__tests__/ABTestPrimitive.test.ts
@@ -11,6 +11,14 @@ vi.mock('../../../lib/index.js', () => ({
     writeProjectSpec = mockWriteProjectSpec;
   },
   findConfigRoot: () => '/fake/root',
+  toError: (err: unknown) => (err instanceof Error ? err : new Error(String(err))),
+  serializeResult: (r: unknown) => r,
+  ResourceNotFoundError: class extends Error {
+    constructor(m: string) {
+      super(m);
+      this.name = 'ResourceNotFoundError';
+    }
+  },
 }));
 
 function makeProject(abTests: { name: string; gatewayRef?: string }[] = []) {
@@ -121,7 +129,10 @@ describe('ABTestPrimitive', () => {
       const result = await primitive.add(validOptions);
 
       expect(result).toEqual(
-        expect.objectContaining({ success: false, error: expect.stringContaining('already exists') })
+        expect.objectContaining({
+          success: false,
+          error: expect.objectContaining({ message: expect.stringContaining('already exists') }),
+        })
       );
     });
 
@@ -130,7 +141,7 @@ describe('ABTestPrimitive', () => {
 
       const result = await primitive.add(validOptions);
 
-      expect(result).toEqual(expect.objectContaining({ success: false, error: 'disk read error' }));
+      expect(result).toEqual(expect.objectContaining({ success: false, error: new Error('disk read error') }));
     });
 
     it('returns error when writeProjectSpec fails', async () => {
@@ -139,7 +150,7 @@ describe('ABTestPrimitive', () => {
 
       const result = await primitive.add(validOptions);
 
-      expect(result).toEqual(expect.objectContaining({ success: false, error: 'disk write error' }));
+      expect(result).toEqual(expect.objectContaining({ success: false, error: new Error('disk write error') }));
     });
 
     it('returns error when variant weights do not sum to 100', async () => {
@@ -175,8 +186,8 @@ describe('ABTestPrimitive', () => {
 
       expect(result.success).toBe(false);
       if (!result.success) {
-        expect(result.error).toContain('NonExistent');
-        expect(result.error).toContain('not found');
+        expect(result.error.message).toContain('NonExistent');
+        expect(result.error.message).toContain('not found');
       }
     });
 
@@ -187,7 +198,7 @@ describe('ABTestPrimitive', () => {
 
       expect(result.success).toBe(false);
       if (!result.success) {
-        expect(result.error).toBe('io error');
+        expect(result.error.message).toBe('io error');
       }
     });
 

--- a/src/cli/primitives/__tests__/BasePrimitive.test.ts
+++ b/src/cli/primitives/__tests__/BasePrimitive.test.ts
@@ -1,5 +1,6 @@
+import type { Result } from '../../../lib/result';
 import { BasePrimitive } from '../BasePrimitive';
-import type { AddResult, AddScreenComponent, RemovableResource, RemovalPreview, RemovalResult } from '../types';
+import type { AddResult, AddScreenComponent, RemovableResource, RemovalPreview } from '../types';
 import type { Command } from '@commander-js/extra-typings';
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
@@ -14,7 +15,7 @@ class StubPrimitive extends BasePrimitive {
     return Promise.resolve({ success: true });
   }
 
-  remove(_name: string): Promise<RemovalResult> {
+  remove(_name: string): Promise<Result> {
     return Promise.resolve({ success: true });
   }
 

--- a/src/cli/primitives/__tests__/EvaluatorPrimitive.test.ts
+++ b/src/cli/primitives/__tests__/EvaluatorPrimitive.test.ts
@@ -11,6 +11,20 @@ vi.mock('../../../lib/index.js', () => ({
     writeProjectSpec = mockWriteProjectSpec;
   },
   findConfigRoot: () => '/fake/root',
+  toError: (err: unknown) => (err instanceof Error ? err : new Error(String(err))),
+  serializeResult: (r: unknown) => r,
+  ResourceNotFoundError: class extends Error {
+    constructor(m: string) {
+      super(m);
+      this.name = 'ResourceNotFoundError';
+    }
+  },
+  ConflictError: class extends Error {
+    constructor(m: string) {
+      super(m);
+      this.name = 'ConflictError';
+    }
+  },
 }));
 
 const validConfig: EvaluatorConfig = {
@@ -108,7 +122,10 @@ describe('EvaluatorPrimitive', () => {
       });
 
       expect(result).toEqual(
-        expect.objectContaining({ success: false, error: expect.stringContaining('already exists') })
+        expect.objectContaining({
+          success: false,
+          error: expect.objectContaining({ message: expect.stringContaining('already exists') }),
+        })
       );
     });
 
@@ -121,7 +138,7 @@ describe('EvaluatorPrimitive', () => {
         config: validConfig,
       });
 
-      expect(result).toEqual(expect.objectContaining({ success: false, error: 'disk read error' }));
+      expect(result).toEqual(expect.objectContaining({ success: false, error: new Error('disk read error') }));
     });
   });
 
@@ -145,8 +162,8 @@ describe('EvaluatorPrimitive', () => {
 
       expect(result.success).toBe(false);
       if (!result.success) {
-        expect(result.error).toContain('NonExistent');
-        expect(result.error).toContain('not found');
+        expect(result.error.message).toContain('NonExistent');
+        expect(result.error.message).toContain('not found');
       }
     });
 
@@ -159,8 +176,8 @@ describe('EvaluatorPrimitive', () => {
 
       expect(result.success).toBe(false);
       if (!result.success) {
-        expect(result.error).toContain('referenced by online eval config');
-        expect(result.error).toContain('MyOnlineConfig');
+        expect(result.error.message).toContain('referenced by online eval config');
+        expect(result.error.message).toContain('MyOnlineConfig');
       }
       expect(mockWriteProjectSpec).not.toHaveBeenCalled();
     });
@@ -172,7 +189,7 @@ describe('EvaluatorPrimitive', () => {
 
       expect(result.success).toBe(false);
       if (!result.success) {
-        expect(result.error).toBe('io error');
+        expect(result.error.message).toBe('io error');
       }
     });
   });

--- a/src/cli/primitives/__tests__/GatewayPrimitive.test.ts
+++ b/src/cli/primitives/__tests__/GatewayPrimitive.test.ts
@@ -34,6 +34,14 @@ vi.mock('../../../lib', () => {
     ConfigIO: MockConfigIO,
     findConfigRoot: vi.fn().mockReturnValue('/fake/root'),
     setEnvVar: vi.fn().mockResolvedValue(undefined),
+    toError: (err: unknown) => (err instanceof Error ? err : new Error(String(err))),
+    serializeResult: (r: unknown) => r,
+    ResourceNotFoundError: class extends Error {
+      constructor(m: string) {
+        super(m);
+        this.name = 'ResourceNotFoundError';
+      }
+    },
   };
 });
 

--- a/src/cli/primitives/__tests__/OnlineEvalConfigPrimitive.test.ts
+++ b/src/cli/primitives/__tests__/OnlineEvalConfigPrimitive.test.ts
@@ -10,6 +10,14 @@ vi.mock('../../../lib/index.js', () => ({
     writeProjectSpec = mockWriteProjectSpec;
   },
   findConfigRoot: () => '/fake/root',
+  toError: (err: unknown) => (err instanceof Error ? err : new Error(String(err))),
+  serializeResult: (r: unknown) => r,
+  ResourceNotFoundError: class extends Error {
+    constructor(m: string) {
+      super(m);
+      this.name = 'ResourceNotFoundError';
+    }
+  },
 }));
 
 function makeProject(
@@ -126,7 +134,10 @@ describe('OnlineEvalConfigPrimitive', () => {
       });
 
       expect(result).toEqual(
-        expect.objectContaining({ success: false, error: expect.stringContaining('already exists') })
+        expect.objectContaining({
+          success: false,
+          error: expect.objectContaining({ message: expect.stringContaining('already exists') }),
+        })
       );
     });
 
@@ -140,7 +151,7 @@ describe('OnlineEvalConfigPrimitive', () => {
         samplingRate: 10,
       });
 
-      expect(result).toEqual(expect.objectContaining({ success: false, error: 'no project' }));
+      expect(result).toEqual(expect.objectContaining({ success: false, error: new Error('no project') }));
     });
   });
 
@@ -169,8 +180,8 @@ describe('OnlineEvalConfigPrimitive', () => {
 
       expect(result.success).toBe(false);
       if (!result.success) {
-        expect(result.error).toContain('NonExistent');
-        expect(result.error).toContain('not found');
+        expect(result.error.message).toContain('NonExistent');
+        expect(result.error.message).toContain('not found');
       }
     });
 
@@ -181,7 +192,7 @@ describe('OnlineEvalConfigPrimitive', () => {
 
       expect(result.success).toBe(false);
       if (!result.success) {
-        expect(result.error).toBe('io error');
+        expect(result.error.message).toBe('io error');
       }
     });
   });

--- a/src/cli/primitives/__tests__/RuntimeEndpointPrimitive.test.ts
+++ b/src/cli/primitives/__tests__/RuntimeEndpointPrimitive.test.ts
@@ -14,6 +14,26 @@ vi.mock('../../../lib/index.js', () => ({
     readDeployedState = mockReadDeployedState;
   },
   findConfigRoot: () => '/fake/root',
+  toError: (err: unknown) => (err instanceof Error ? err : new Error(String(err))),
+  serializeResult: (r: unknown) => r,
+  ResourceNotFoundError: class extends Error {
+    constructor(m: string) {
+      super(m);
+      this.name = 'ResourceNotFoundError';
+    }
+  },
+  ConflictError: class extends Error {
+    constructor(m: string) {
+      super(m);
+      this.name = 'ConflictError';
+    }
+  },
+  ValidationError: class extends Error {
+    constructor(m: string) {
+      super(m);
+      this.name = 'ValidationError';
+    }
+  },
 }));
 
 function makeProject(
@@ -87,7 +107,12 @@ describe('RuntimeEndpointPrimitive', () => {
         endpoint: 'prod',
       });
 
-      expect(result).toEqual(expect.objectContaining({ success: false, error: expect.stringContaining('not found') }));
+      expect(result).toEqual(
+        expect.objectContaining({
+          success: false,
+          error: expect.objectContaining({ message: expect.stringContaining('not found') }),
+        })
+      );
     });
 
     it('returns error when endpoint already exists', async () => {
@@ -100,7 +125,10 @@ describe('RuntimeEndpointPrimitive', () => {
       });
 
       expect(result).toEqual(
-        expect.objectContaining({ success: false, error: expect.stringContaining('already exists') })
+        expect.objectContaining({
+          success: false,
+          error: expect.objectContaining({ message: expect.stringContaining('already exists') }),
+        })
       );
     });
 
@@ -134,7 +162,10 @@ describe('RuntimeEndpointPrimitive', () => {
       });
 
       expect(result).toEqual(
-        expect.objectContaining({ success: false, error: expect.stringContaining('positive integer') })
+        expect.objectContaining({
+          success: false,
+          error: expect.objectContaining({ message: expect.stringContaining('positive integer') }),
+        })
       );
     });
 
@@ -181,7 +212,10 @@ describe('RuntimeEndpointPrimitive', () => {
       });
 
       expect(result).toEqual(
-        expect.objectContaining({ success: false, error: expect.stringContaining('exceeds latest deployed version') })
+        expect.objectContaining({
+          success: false,
+          error: expect.objectContaining({ message: expect.stringContaining('exceeds latest deployed version') }),
+        })
       );
     });
   });
@@ -223,7 +257,12 @@ describe('RuntimeEndpointPrimitive', () => {
 
       const result = await primitive.remove('MyRuntime/nonexistent');
 
-      expect(result).toEqual(expect.objectContaining({ success: false, error: expect.stringContaining('not found') }));
+      expect(result).toEqual(
+        expect.objectContaining({
+          success: false,
+          error: expect.objectContaining({ message: expect.stringContaining('not found') }),
+        })
+      );
     });
 
     it('cleans up empty endpoints dict after removing last endpoint', async () => {

--- a/src/cli/primitives/index.ts
+++ b/src/cli/primitives/index.ts
@@ -24,4 +24,4 @@ export {
   getPrimitive,
 } from './registry';
 export { SOURCE_CODE_NOTE } from './constants';
-export type { AddResult, AddScreenComponent, RemovableResource, RemovalPreview, RemovalResult } from './types';
+export type { AddResult, AddScreenComponent, RemovableResource, RemovalPreview, Result } from './types';

--- a/src/cli/primitives/types.ts
+++ b/src/cli/primitives/types.ts
@@ -1,14 +1,11 @@
-import type { RemovalPreview, RemovalResult } from '../operations/remove/types';
+import type { Result } from '../../lib/result';
+import type { RemovalPreview } from '../operations/remove/types';
 import type { ComponentType } from 'react';
 
-/**
- * Result of an add operation.
- * Use the generic parameter to type extra fields on the success branch:
- *   AddResult<{ agentName: string }> → success branch has typed agentName
- */
-export type AddResult<T extends Record<string, unknown> = Record<string, unknown>> =
-  | ({ success: true; message?: string } & T)
-  | { success: false; error: string };
+export type { Result };
+
+/** @deprecated Use Result<T> directly */
+export type AddResult<T extends Record<string, unknown> = Record<string, unknown>> = Result<T>;
 
 /**
  * Represents a resource that can be removed.
@@ -21,7 +18,7 @@ export interface RemovableResource {
 /**
  * Re-export removal types from shared types.
  */
-export type { RemovalPreview, RemovalResult };
+export type { RemovalPreview };
 
 /**
  * Screen component type for TUI add flows.

--- a/src/cli/telemetry/README.md
+++ b/src/cli/telemetry/README.md
@@ -58,7 +58,7 @@ async function withCommandRunTelemetry<C extends Command, R extends OperationRes
 
 - `command` — the registered command key (e.g. `'add.widget'`)
 - `attrs` — attribute object matching the schema registered in Step 1
-- `fn` — async callback returning `{ success: true } | { success: false; error: string }`
+- `fn` — async callback returning `Result<T>` (from `src/lib/result.ts`)
 
 **Behavior:**
 

--- a/src/cli/telemetry/cli-command-run.ts
+++ b/src/cli/telemetry/cli-command-run.ts
@@ -1,9 +1,9 @@
+import type { Result } from '../../lib/result';
 import { getErrorMessage } from '../errors';
 import { TelemetryClientAccessor } from './client-accessor.js';
 import type { Command, CommandAttrs } from './schemas/command-run.js';
 
-// TODO: Replace with a generic Result<D, E> type that preserves the original error object.
-export type OperationResult = { success: true } | { success: false; error: string };
+export type OperationResult = Result;
 
 async function getTelemetryClient() {
   try {
@@ -33,7 +33,7 @@ export async function withCommandRunTelemetry<C extends Command, R extends Opera
   try {
     await client.withCommandRun(command, async () => {
       result = await fn();
-      if (!result.success) throw new Error(result.error);
+      if (!result.success) throw result.error;
       return attrs;
     });
   } catch (e) {
@@ -42,7 +42,7 @@ export async function withCommandRunTelemetry<C extends Command, R extends Opera
     // If not, fn() itself threw — convert to a failure result so callers
     // that don't wrap in try/catch (e.g. TUI hooks) don't leak unhandled rejections.
     if (!result) {
-      return { success: false, error: getErrorMessage(e) } as R;
+      return { success: false, error: e instanceof Error ? e : new Error(getErrorMessage(e)) } as R;
     }
   }
   return result!;

--- a/src/cli/telemetry/error-classification.ts
+++ b/src/cli/telemetry/error-classification.ts
@@ -9,6 +9,7 @@ const CONFIG_ERRORS = new Set([
   'ConfigReadError',
   'ConfigWriteError',
   'ConfigParseError',
+  'ValidationError',
 ]);
 const PACKAGING_ERRORS = new Set([
   'PackagingError',
@@ -16,11 +17,13 @@ const PACKAGING_ERRORS = new Set([
   'MissingProjectFileError',
   'UnsupportedLanguageError',
   'ArtifactSizeError',
+  'DependencyCheckError',
 ]);
 const CREDENTIAL_ERRORS = new Set([
   'AwsCredentialsError',
   'AccessDeniedException',
   'AccessDenied',
+  'AccessDeniedError',
   'ExpiredToken',
   'ExpiredTokenException',
   'TokenRefreshRequired',
@@ -36,6 +39,8 @@ const SERVICE_ERRORS = new Set([
   'ValidationException',
   'ConflictException',
   'ResourceAlreadyExistsException',
+  'ResourceNotFoundError',
+  'ConflictError',
 ]);
 
 const USER_CATEGORIES = new Set<ErrorCategoryValue>(['ConfigError', 'CredentialsError', 'ProjectError']);

--- a/src/cli/tui/hooks/__tests__/useRemove.test.tsx
+++ b/src/cli/tui/hooks/__tests__/useRemove.test.tsx
@@ -281,7 +281,7 @@ describe('useRemoveAgent', () => {
   });
 
   it('calls removeAgent and shows failure result', async () => {
-    mockAgentRemove.mockResolvedValue({ success: false, error: 'Not found' });
+    mockAgentRemove.mockResolvedValue({ success: false, error: new Error('Not found') });
     const { lastFrame } = render(<RemoveAgentHarness agentName="bad-agent" />);
 
     await delay();

--- a/src/cli/tui/hooks/useCreateABTest.ts
+++ b/src/cli/tui/hooks/useCreateABTest.ts
@@ -43,7 +43,7 @@ export function useCreateABTest() {
         enableOnCreate: config.enableOnCreate,
       });
       if (!addResult.success) {
-        throw new Error(addResult.error ?? 'Failed to create AB test');
+        throw new Error(addResult.error?.message ?? 'Failed to create AB test');
       }
       setStatus({ state: 'success' });
       return { ok: true as const, testName: config.name };
@@ -59,7 +59,7 @@ export function useCreateABTest() {
     try {
       const addResult = await abTestPrimitive.addTargetBased(config);
       if (!addResult.success) {
-        throw new Error(addResult.error ?? 'Failed to create target-based AB test');
+        throw new Error(addResult.error?.message ?? 'Failed to create target-based AB test');
       }
       setStatus({ state: 'success' });
       return { ok: true as const, testName: config.name };

--- a/src/cli/tui/hooks/useCreateConfigBundle.ts
+++ b/src/cli/tui/hooks/useCreateConfigBundle.ts
@@ -25,7 +25,7 @@ export function useCreateConfigBundle() {
         commitMessage: config.commitMessage,
       });
       if (!addResult.success) {
-        throw new Error(addResult.error ?? 'Failed to create configuration bundle');
+        throw new Error(addResult.error?.message ?? 'Failed to create configuration bundle');
       }
       setStatus({ state: 'success' });
       return { ok: true as const, bundleName: config.name };

--- a/src/cli/tui/hooks/useCreateEvaluator.ts
+++ b/src/cli/tui/hooks/useCreateEvaluator.ts
@@ -32,7 +32,7 @@ export function useCreateEvaluator() {
           })
       );
       if (!addResult.success) {
-        throw new Error(addResult.error ?? 'Failed to create evaluator');
+        throw new Error(addResult.error?.message ?? 'Failed to create evaluator');
       }
       setStatus({ state: 'success' });
       return { ok: true as const, evaluatorName: config.name, codePath: addResult.codePath };

--- a/src/cli/tui/hooks/useCreateMcp.ts
+++ b/src/cli/tui/hooks/useCreateMcp.ts
@@ -53,7 +53,7 @@ export function useCreateGateway() {
           })
       );
       if (!addResult.success) {
-        throw new Error(addResult.error ?? 'Failed to create gateway');
+        throw new Error(addResult.error?.message ?? 'Failed to create gateway');
       }
       const result: CreateGatewayResult = { name: config.name };
       setStatus({ state: 'success', result });

--- a/src/cli/tui/hooks/useCreateMemory.ts
+++ b/src/cli/tui/hooks/useCreateMemory.ts
@@ -45,7 +45,7 @@ export function useCreateMemory() {
           })
       );
       if (!addResult.success) {
-        throw new Error(addResult.error ?? 'Failed to create memory');
+        throw new Error(addResult.error?.message ?? 'Failed to create memory');
       }
       // Read back the memory object
       const configIO = new ConfigIO();

--- a/src/cli/tui/hooks/useCreateOnlineEval.ts
+++ b/src/cli/tui/hooks/useCreateOnlineEval.ts
@@ -38,7 +38,7 @@ export function useCreateOnlineEval() {
           })
       );
       if (!addResult.success) {
-        throw new Error(addResult.error ?? 'Failed to create online eval config');
+        throw new Error(addResult.error?.message ?? 'Failed to create online eval config');
       }
       setStatus({ state: 'success' });
       return { ok: true as const, configName: config.name };

--- a/src/cli/tui/hooks/useRemove.ts
+++ b/src/cli/tui/hooks/useRemove.ts
@@ -1,6 +1,7 @@
+import type { Result } from '../../../lib/result';
 import type { ResourceType } from '../../commands/remove/types';
 import { RemoveLogger } from '../../logging';
-import type { RemovableGatewayTarget, RemovalPreview, RemovalResult } from '../../operations/remove';
+import type { RemovableGatewayTarget, RemovalPreview } from '../../operations/remove';
 import type { RemovableCredential } from '../../primitives/CredentialPrimitive';
 import type { RemovableMemory } from '../../primitives/MemoryPrimitive';
 import type { RemovablePolicyResource } from '../../primitives/PolicyPrimitive';
@@ -62,7 +63,7 @@ function useRemovableResources<T>(loader: () => Promise<T[]>) {
  * All useRemove* hooks delegate to this.
  */
 function useRemoveResource<TIdentifier>(
-  removeFn: (id: TIdentifier) => Promise<RemovalResult>,
+  removeFn: (id: TIdentifier) => Promise<Result>,
   resourceType: ResourceType,
   getResourceName: (id: TIdentifier) => string
 ) {
@@ -76,7 +77,7 @@ function useRemoveResource<TIdentifier>(
 
   const remove = useCallback(async (id: TIdentifier, preview?: RemovalPreview): Promise<RemoveResult> => {
     setState({ isLoading: true, result: null });
-    const result = await withCommandRunTelemetry<SubCommand<'remove', ResourceType>, RemovalResult>(
+    const result = await withCommandRunTelemetry<SubCommand<'remove', ResourceType>, Result>(
       `remove.${resourceTypeRef.current}`,
       {},
       () => removeFnRef.current(id)
@@ -89,7 +90,7 @@ function useRemoveResource<TIdentifier>(
         resourceType: resourceTypeRef.current,
         resourceName: getNameRef.current(id),
       });
-      logger.logRemoval(preview, result.success, result.success ? undefined : result.error);
+      logger.logRemoval(preview, result.success, result.success ? undefined : result.error?.message);
       logPath = logger.getAbsoluteLogPath();
       setLogFilePath(logPath);
     }
@@ -297,10 +298,10 @@ export function useRemovalPreview() {
 
 interface RemovalState {
   isLoading: boolean;
-  result: RemovalResult | null;
+  result: Result | null;
 }
 
-type RemoveResult = RemovalResult & { logFilePath?: string };
+type RemoveResult = Result & { logFilePath?: string };
 
 export function useRemoveAgent() {
   return useRemoveResource(

--- a/src/cli/tui/screens/agent/useAddAgent.ts
+++ b/src/cli/tui/screens/agent/useAddAgent.ts
@@ -1,4 +1,12 @@
-import { APP_DIR, ConfigIO, NoProjectError, findConfigRoot, setEnvVar } from '../../../../lib';
+import {
+  APP_DIR,
+  AgentAlreadyExistsError,
+  ConfigIO,
+  NoProjectError,
+  type Result,
+  findConfigRoot,
+  setEnvVar,
+} from '../../../../lib';
 import type { AgentEnvSpec, DirectoryPath, FilePath } from '../../../../schema';
 import { type PythonSetupResult, setupPythonProject } from '../../../operations';
 import { createConfigBundleForAgent } from '../../../operations/agent/config-bundle-defaults';
@@ -165,7 +173,7 @@ export function useAddAgent() {
         () => addAgentInner(config)
       );
       if (!result.success) {
-        return { ok: false, error: result.error };
+        return { ok: false, error: result.error.message };
       }
       return result.outcome;
     } finally {
@@ -180,26 +188,24 @@ export function useAddAgent() {
   return { addAgent, isLoading, reset };
 }
 
-type AddAgentInnerResult =
-  | { success: true; outcome: AddAgentCreateResult | AddAgentByoResult }
-  | { success: false; error: string };
+type AddAgentInnerResult = Result<{ outcome: AddAgentCreateResult | AddAgentByoResult }>;
 
 async function addAgentInner(config: AddAgentConfig): Promise<AddAgentInnerResult> {
   const configBaseDir = findConfigRoot();
   if (!configBaseDir) {
-    return { success: false, error: new NoProjectError().message };
+    return { success: false, error: new NoProjectError() };
   }
 
   const configIO = new ConfigIO({ baseDir: configBaseDir });
 
   if (!configIO.configExists('project')) {
-    return { success: false, error: new NoProjectError().message };
+    return { success: false, error: new NoProjectError() };
   }
 
   const project = await configIO.readProjectSpec();
   const existingAgent = project.runtimes.find(agent => agent.name === config.name);
   if (existingAgent) {
-    return { success: false, error: `Agent "${config.name}" already exists in this project.` };
+    return { success: false, error: new AgentAlreadyExistsError(config.name) };
   }
 
   let outcome: AddAgentCreateResult | AddAgentByoResult | AddAgentError;
@@ -212,7 +218,7 @@ async function addAgentInner(config: AddAgentConfig): Promise<AddAgentInnerResul
   }
 
   if (!outcome.ok) {
-    return { success: false, error: outcome.error };
+    return { success: false, error: new Error(outcome.error) };
   }
   return { success: true, outcome };
 }
@@ -344,7 +350,7 @@ async function handleImportPath(
   });
 
   if (!result.success) {
-    return { ok: false, error: result.error ?? 'Unknown error' };
+    return { ok: false, error: result.error?.message ?? 'Unknown error' };
   }
 
   return {

--- a/src/cli/tui/screens/create/useCreateFlow.ts
+++ b/src/cli/tui/screens/create/useCreateFlow.ts
@@ -1,4 +1,12 @@
-import { APP_DIR, CONFIG_DIR, ConfigIO, findConfigRoot, setEnvVar, setSessionProjectRoot } from '../../../../lib';
+import {
+  APP_DIR,
+  CONFIG_DIR,
+  ConfigIO,
+  GitInitError,
+  findConfigRoot,
+  setEnvVar,
+  setSessionProjectRoot,
+} from '../../../../lib';
 import type { DeployedState } from '../../../../schema';
 import { getErrorMessage } from '../../../errors';
 import { CreateLogger } from '../../../logging';
@@ -205,7 +213,7 @@ export function useCreateFlow(cwd: string): CreateFlowState {
       has_agent: addAgentConfig !== null,
     };
 
-    const run = async (): Promise<{ success: true } | { success: false; error: string }> => {
+    const run = async (): Promise<{ success: true } | { success: false; error: Error }> => {
       // Project root is now cwd/projectName (creating a new directory)
       const projectRoot = join(cwd, projectName);
       const configBaseDir = join(projectRoot, CONFIG_DIR);
@@ -268,7 +276,7 @@ export function useCreateFlow(cwd: string): CreateFlowState {
           logger.endStep('error', errMsg);
           updateStep(stepIndex, { status: 'error', error: errMsg });
           logger.finalize(false);
-          return { success: false, error: errMsg };
+          return { success: false, error: new Error(errMsg) };
         }
 
         // Step: Add agent to project (if addAgentConfig is set)
@@ -387,7 +395,7 @@ export function useCreateFlow(cwd: string): CreateFlowState {
                   sessionStorageMountPath: addAgentConfig.sessionStorageMountPath,
                 });
                 if (!importResult.success) {
-                  throw new Error(importResult.error ?? 'Import failed');
+                  throw new Error(importResult.error?.message ?? 'Import failed');
                 }
               } else {
                 // BYO path: just write config to project (no file generation)
@@ -456,7 +464,7 @@ export function useCreateFlow(cwd: string): CreateFlowState {
             logger.endStep('error', errMsg);
             updateStep(stepIndex, { status: 'error', error: errMsg });
             logger.finalize(false);
-            return { success: false, error: errMsg };
+            return { success: false, error: new Error(errMsg) };
           }
 
           // Step: Set up Python environment (if Python and create path)
@@ -498,7 +506,7 @@ export function useCreateFlow(cwd: string): CreateFlowState {
           logger.endStep('error', errMsg);
           updateStep(stepIndex, { status: 'error', error: errMsg });
           logger.finalize(false);
-          return { success: false, error: errMsg };
+          return { success: false, error: new Error(errMsg) };
         }
 
         // Step: Initialize git repository
@@ -510,7 +518,7 @@ export function useCreateFlow(cwd: string): CreateFlowState {
           logger.endStep('error', gitResult.message);
           updateStep(stepIndex, { status: 'error', error: gitResult.message });
           logger.finalize(false);
-          return { success: false, error: gitResult.message ?? 'Git initialization failed' };
+          return { success: false, error: new GitInitError(gitResult.message ?? 'Git initialization failed') };
         } else if (gitResult.status === 'skipped') {
           logger.endStep('warn', gitResult.message);
           updateStep(stepIndex, { status: 'success', warn: gitResult.message });
@@ -534,7 +542,7 @@ export function useCreateFlow(cwd: string): CreateFlowState {
           }
           return prev;
         });
-        return { success: false, error: errMsg };
+        return { success: false, error: new Error(errMsg) };
       }
     };
 

--- a/src/cli/tui/screens/deploy/useDeployFlow.ts
+++ b/src/cli/tui/screens/deploy/useDeployFlow.ts
@@ -623,7 +623,7 @@ export function useDeployFlow(options: DeployFlowOptions = {}): DeployFlowState 
           if (targetName) {
             const teardown = await performStackTeardown(targetName);
             if (!teardown.success) {
-              throw new Error(`Stack teardown failed: ${teardown.error}`);
+              throw new Error(`Stack teardown failed: ${teardown.error.message}`);
             }
           }
         } else {
@@ -648,8 +648,8 @@ export function useDeployFlow(options: DeployFlowOptions = {}): DeployFlowState 
                 agentNames,
                 hasGateways,
               });
-              if (tsResult.error) {
-                logger.log(`Transaction search setup warning: ${tsResult.error}`, 'warn');
+              if (!tsResult.success) {
+                logger.log(`Transaction search setup warning: ${tsResult.error.message}`, 'warn');
               } else {
                 setDeployNotes(prev => [
                   ...prev,

--- a/src/cli/tui/screens/eval/EvalScreen.tsx
+++ b/src/cli/tui/screens/eval/EvalScreen.tsx
@@ -339,7 +339,7 @@ export function EvalScreen({ onExit }: EvalScreenProps) {
       }
       const result = handleListEvalRuns({});
       if (!result.success) {
-        setState({ phase: 'error', runs: [], error: result.error ?? 'Unknown error' });
+        setState({ phase: 'error', runs: [], error: result.error?.message ?? 'Unknown error' });
         return;
       }
       setState({ phase: 'loaded', runs: result.runs ?? [], error: null });

--- a/src/cli/tui/screens/identity/useCreateIdentity.ts
+++ b/src/cli/tui/screens/identity/useCreateIdentity.ts
@@ -25,7 +25,7 @@ export function useCreateIdentity() {
         () => credentialPrimitive.add(config)
       );
       if (!result.success) {
-        throw new Error(result.error ?? 'Failed to create credential');
+        throw new Error(result.error?.message ?? 'Failed to create credential');
       }
       // Read back the credential object
       const configIO = new ConfigIO();

--- a/src/cli/tui/screens/import/ImportFlow.tsx
+++ b/src/cli/tui/screens/import/ImportFlow.tsx
@@ -151,7 +151,7 @@ export function ImportFlow({ onBack, onNavigate }: ImportFlowProps) {
                   <Text dimColor>Name: </Text>
                   <Text>{result.resourceName}</Text>
                 </Text>
-                {result.resourceId && (
+                {'resourceId' in result && result.resourceId && (
                   <Text>
                     <Text dimColor>ID: </Text>
                     <Text>{result.resourceId}</Text>

--- a/src/cli/tui/screens/import/ImportProgressScreen.tsx
+++ b/src/cli/tui/screens/import/ImportProgressScreen.tsx
@@ -59,9 +59,9 @@ export function ImportProgressScreen({
           onSuccess(result);
         } else {
           setSteps(prev =>
-            prev.map(s => (s.status === 'running' ? { ...s, status: 'error', error: result.error } : s))
+            prev.map(s => (s.status === 'running' ? { ...s, status: 'error', error: result.error.message } : s))
           );
-          onError(result.error ?? 'Import failed');
+          onError(result.error.message ?? 'Import failed');
         }
       } else {
         // Starter toolkit
@@ -75,9 +75,9 @@ export function ImportProgressScreen({
           onSuccess(result);
         } else {
           setSteps(prev =>
-            prev.map(s => (s.status === 'running' ? { ...s, status: 'error', error: result.error } : s))
+            prev.map(s => (s.status === 'running' ? { ...s, status: 'error', error: result.error.message } : s))
           );
-          onError(result.error ?? 'Import failed');
+          onError(result.error.message ?? 'Import failed');
         }
       }
     };

--- a/src/cli/tui/screens/online-eval/OnlineEvalDashboard.tsx
+++ b/src/cli/tui/screens/online-eval/OnlineEvalDashboard.tsx
@@ -156,7 +156,7 @@ export function OnlineEvalDashboard({ onExit }: OnlineEvalDashboardProps) {
       setState(prev => ({ ...prev, phase: 'toggling' }));
       void handlePauseResume({ name: item.name }, action).then(result => {
         if (!result.success) {
-          setState(prev => ({ ...prev, phase: 'loaded', error: result.error ?? 'Toggle failed' }));
+          setState(prev => ({ ...prev, phase: 'loaded', error: result.error?.message ?? 'Toggle failed' }));
           return;
         }
         return fetchDashboardConfigs().then(configs => {

--- a/src/cli/tui/screens/policy/AddPolicyFlow.tsx
+++ b/src/cli/tui/screens/policy/AddPolicyFlow.tsx
@@ -139,7 +139,7 @@ export function AddPolicyFlow({ isInteractive = true, onExit, onBack, onDev, onD
       () => policyEnginePrimitive.add({ name: engineName })
     );
     if (!result.success) {
-      setFlow({ name: 'error', message: result.error });
+      setFlow({ name: 'error', message: result.error.message });
       return;
     }
     setEngineNames(prev => [...prev, engineName]);
@@ -184,7 +184,7 @@ export function AddPolicyFlow({ isInteractive = true, onExit, onBack, onDev, onD
       setPolicyNames(prev => [...prev, config.name]);
       setFlow({ name: 'policy-success', policyName: config.name, engineName: config.engine });
     } else {
-      setFlow({ name: 'error', message: result.error });
+      setFlow({ name: 'error', message: result.error.message });
     }
   }, []);
 

--- a/src/cli/tui/screens/recommendation/RecommendationFlow.tsx
+++ b/src/cli/tui/screens/recommendation/RecommendationFlow.tsx
@@ -33,7 +33,12 @@ type FlowState =
       recommendationId?: string;
       region?: string;
     }
-  | { name: 'results'; result: RunRecommendationCommandResult; config: RecommendationWizardConfig; filePath?: string }
+  | {
+      name: 'results';
+      result: Extract<RunRecommendationCommandResult, { success: true }>;
+      config: RecommendationWizardConfig;
+      filePath?: string;
+    }
   | { name: 'creds-error'; message: string }
   | { name: 'error'; message: string; logFilePath?: string };
 
@@ -194,13 +199,17 @@ export function RecommendationFlow({ onExit }: RecommendationFlowProps) {
           setFlow(prev => {
             if (prev.name !== 'running') return prev;
             const steps = prev.steps.map(s =>
-              s.status === 'running' ? { ...s, status: 'error' as const, error: result.error } : s
+              s.status === 'running' ? { ...s, status: 'error' as const, error: result.error.message } : s
             );
             return { ...prev, steps };
           });
           await new Promise(resolve => setTimeout(resolve, 2000));
           if (cancelled) return;
-          setFlow({ name: 'error', message: result.error ?? 'Recommendation failed', logFilePath: result.logFilePath });
+          setFlow({
+            name: 'error',
+            message: result.error?.message ?? 'Recommendation failed',
+            logFilePath: result.logFilePath,
+          });
           return;
         }
 
@@ -333,7 +342,7 @@ export function RecommendationFlow({ onExit }: RecommendationFlowProps) {
 // ─────────────────────────────────────────────────────────────────────────────
 
 interface ResultsViewProps {
-  result: RunRecommendationCommandResult;
+  result: Extract<RunRecommendationCommandResult, { success: true }>;
   config: RecommendationWizardConfig;
   filePath?: string;
   onRunAnother: () => void;
@@ -369,7 +378,7 @@ function ResultsView({ result, config, filePath, onRunAnother, onExit }: Results
           message: `New bundle version (${applyResult.newVersionId}) created with recommended changes. Local config updated.`,
         });
       } else {
-        setApplyStatus({ applied: false, message: applyResult.error ?? 'Unknown error' });
+        setApplyStatus({ applied: false, message: applyResult.error?.message ?? 'Unknown error' });
       }
     } catch (err) {
       setApplyStatus({ applied: false, message: getErrorMessage(err) });

--- a/src/cli/tui/screens/remove/RemoveFlow.tsx
+++ b/src/cli/tui/screens/remove/RemoveFlow.tsx
@@ -331,7 +331,7 @@ export function RemoveFlow({
           if (removeResult.success) {
             setFlow({ name: 'agent-success', agentName });
           } else {
-            setFlow({ name: 'error', message: removeResult.error });
+            setFlow({ name: 'error', message: removeResult.error.message });
           }
         } else {
           setFlow({ name: 'confirm-agent', agentName, preview: result.preview });
@@ -353,7 +353,7 @@ export function RemoveFlow({
           if (removeResult.success) {
             setFlow({ name: 'gateway-success', gatewayName });
           } else {
-            setFlow({ name: 'error', message: removeResult.error });
+            setFlow({ name: 'error', message: removeResult.error.message });
           }
         } else {
           setFlow({ name: 'confirm-gateway', gatewayName, preview: result.preview });
@@ -375,7 +375,7 @@ export function RemoveFlow({
           if (removeResult.success) {
             setFlow({ name: 'tool-success', toolName: tool.name });
           } else {
-            setFlow({ name: 'error', message: removeResult.error });
+            setFlow({ name: 'error', message: removeResult.error.message });
           }
         } else {
           setFlow({ name: 'confirm-gateway-target', tool, preview: result.preview });
@@ -397,7 +397,7 @@ export function RemoveFlow({
           if (removeResult.success) {
             setFlow({ name: 'memory-success', memoryName });
           } else {
-            setFlow({ name: 'error', message: removeResult.error });
+            setFlow({ name: 'error', message: removeResult.error.message });
           }
         } else {
           setFlow({ name: 'confirm-memory', memoryName, preview: result.preview });
@@ -419,7 +419,7 @@ export function RemoveFlow({
           if (removeResult.success) {
             setFlow({ name: 'identity-success', identityName });
           } else {
-            setFlow({ name: 'error', message: removeResult.error });
+            setFlow({ name: 'error', message: removeResult.error.message });
           }
         } else {
           setFlow({ name: 'confirm-identity', identityName, preview: result.preview });
@@ -441,7 +441,7 @@ export function RemoveFlow({
           if (removeResult.success) {
             setFlow({ name: 'evaluator-success', evaluatorName });
           } else {
-            setFlow({ name: 'error', message: removeResult.error });
+            setFlow({ name: 'error', message: removeResult.error.message });
           }
         } else {
           setFlow({ name: 'confirm-evaluator', evaluatorName, preview: result.preview });
@@ -463,7 +463,7 @@ export function RemoveFlow({
           if (removeResult.success) {
             setFlow({ name: 'online-eval-success', configName });
           } else {
-            setFlow({ name: 'error', message: removeResult.error });
+            setFlow({ name: 'error', message: removeResult.error.message });
           }
         } else {
           setFlow({ name: 'confirm-online-eval', configName, preview: result.preview });
@@ -485,7 +485,7 @@ export function RemoveFlow({
           if (removeResult.success) {
             setFlow({ name: 'policy-engine-success', engineName });
           } else {
-            setFlow({ name: 'error', message: removeResult.error });
+            setFlow({ name: 'error', message: removeResult.error.message });
           }
         } else {
           setFlow({ name: 'confirm-policy-engine', engineName, preview: result.preview });
@@ -510,7 +510,7 @@ export function RemoveFlow({
           if (removeResult.success) {
             setFlow({ name: 'policy-success', policyName });
           } else {
-            setFlow({ name: 'error', message: removeResult.error });
+            setFlow({ name: 'error', message: removeResult.error.message });
           }
         } else {
           setFlow({ name: 'confirm-policy', compositeKey, policyName, preview: result.preview });
@@ -532,7 +532,7 @@ export function RemoveFlow({
           if (removeResult.success) {
             setFlow({ name: 'config-bundle-success', bundleName });
           } else {
-            setFlow({ name: 'error', message: removeResult.error });
+            setFlow({ name: 'error', message: removeResult.error.message });
           }
         } else {
           setFlow({ name: 'confirm-config-bundle', bundleName, preview: result.preview });
@@ -554,7 +554,7 @@ export function RemoveFlow({
           if (removeResult.success) {
             setFlow({ name: 'ab-test-success', testName });
           } else {
-            setFlow({ name: 'error', message: removeResult.error });
+            setFlow({ name: 'error', message: removeResult.error.message });
           }
         } else {
           setFlow({ name: 'confirm-ab-test', testName, preview: result.preview });
@@ -576,7 +576,7 @@ export function RemoveFlow({
           if (removeResult.success) {
             setFlow({ name: 'runtime-endpoint-success', endpointName });
           } else {
-            setFlow({ name: 'error', message: removeResult.error });
+            setFlow({ name: 'error', message: removeResult.error.message });
           }
         } else {
           setFlow({ name: 'confirm-runtime-endpoint', endpointName, preview: result.preview });
@@ -662,7 +662,7 @@ export function RemoveFlow({
       if (result.success) {
         pendingResultRef.current = { name: 'agent-success', agentName, logFilePath: result.logFilePath };
       } else {
-        pendingResultRef.current = { name: 'error', message: result.error };
+        pendingResultRef.current = { name: 'error', message: result.error.message };
       }
       setResultReady(true);
     },
@@ -678,7 +678,7 @@ export function RemoveFlow({
       if (result.success) {
         pendingResultRef.current = { name: 'gateway-success', gatewayName, logFilePath: result.logFilePath };
       } else {
-        pendingResultRef.current = { name: 'error', message: result.error };
+        pendingResultRef.current = { name: 'error', message: result.error.message };
       }
       setResultReady(true);
     },
@@ -694,7 +694,7 @@ export function RemoveFlow({
       if (result.success) {
         pendingResultRef.current = { name: 'tool-success', toolName: tool.name, logFilePath: result.logFilePath };
       } else {
-        pendingResultRef.current = { name: 'error', message: result.error };
+        pendingResultRef.current = { name: 'error', message: result.error.message };
       }
       setResultReady(true);
     },
@@ -710,7 +710,7 @@ export function RemoveFlow({
       if (result.success) {
         pendingResultRef.current = { name: 'memory-success', memoryName, logFilePath: result.logFilePath };
       } else {
-        pendingResultRef.current = { name: 'error', message: result.error };
+        pendingResultRef.current = { name: 'error', message: result.error.message };
       }
       setResultReady(true);
     },
@@ -726,7 +726,7 @@ export function RemoveFlow({
       if (result.success) {
         pendingResultRef.current = { name: 'identity-success', identityName, logFilePath: result.logFilePath };
       } else {
-        pendingResultRef.current = { name: 'error', message: result.error };
+        pendingResultRef.current = { name: 'error', message: result.error.message };
       }
       setResultReady(true);
     },
@@ -742,7 +742,7 @@ export function RemoveFlow({
       if (result.success) {
         pendingResultRef.current = { name: 'evaluator-success', evaluatorName, logFilePath: result.logFilePath };
       } else {
-        pendingResultRef.current = { name: 'error', message: result.error };
+        pendingResultRef.current = { name: 'error', message: result.error.message };
       }
       setResultReady(true);
     },
@@ -758,7 +758,7 @@ export function RemoveFlow({
       if (result.success) {
         pendingResultRef.current = { name: 'online-eval-success', configName, logFilePath: result.logFilePath };
       } else {
-        pendingResultRef.current = { name: 'error', message: result.error };
+        pendingResultRef.current = { name: 'error', message: result.error.message };
       }
       setResultReady(true);
     },
@@ -774,7 +774,7 @@ export function RemoveFlow({
       if (result.success) {
         pendingResultRef.current = { name: 'policy-engine-success', engineName, logFilePath: result.logFilePath };
       } else {
-        pendingResultRef.current = { name: 'error', message: result.error };
+        pendingResultRef.current = { name: 'error', message: result.error.message };
       }
       setResultReady(true);
     },
@@ -790,7 +790,7 @@ export function RemoveFlow({
       if (result.success) {
         pendingResultRef.current = { name: 'policy-success', policyName, logFilePath: result.logFilePath };
       } else {
-        pendingResultRef.current = { name: 'error', message: result.error };
+        pendingResultRef.current = { name: 'error', message: result.error.message };
       }
       setResultReady(true);
     },
@@ -806,7 +806,7 @@ export function RemoveFlow({
       if (result.success) {
         pendingResultRef.current = { name: 'config-bundle-success', bundleName, logFilePath: result.logFilePath };
       } else {
-        pendingResultRef.current = { name: 'error', message: result.error };
+        pendingResultRef.current = { name: 'error', message: result.error.message };
       }
       setResultReady(true);
     },
@@ -822,7 +822,7 @@ export function RemoveFlow({
       if (result.success) {
         pendingResultRef.current = { name: 'ab-test-success', testName, logFilePath: result.logFilePath };
       } else {
-        pendingResultRef.current = { name: 'error', message: result.error };
+        pendingResultRef.current = { name: 'error', message: result.error.message };
       }
       setResultReady(true);
     },
@@ -838,7 +838,7 @@ export function RemoveFlow({
       if (result.success) {
         pendingResultRef.current = { name: 'runtime-endpoint-success', endpointName, logFilePath: result.logFilePath };
       } else {
-        pendingResultRef.current = { name: 'error', message: result.error };
+        pendingResultRef.current = { name: 'error', message: result.error.message };
       }
       setResultReady(true);
     },

--- a/src/cli/tui/screens/remove/useRemoveFlow.ts
+++ b/src/cli/tui/screens/remove/useRemoveFlow.ts
@@ -1,7 +1,7 @@
 import { ConfigIO, getWorkingDirectory } from '../../../../lib';
+import type { Result } from '../../../../lib/result';
 import { findStack } from '../../../cloudformation/stack-discovery';
 import { getErrorMessage } from '../../../errors';
-import type { RemovalResult } from '../../../operations/remove/types';
 import { createDefaultProjectSpec } from '../../../project';
 import { withCommandRunTelemetry } from '../../../telemetry/cli-command-run.js';
 import { type Step, areStepsComplete, hasStepError } from '../../components';
@@ -151,7 +151,7 @@ export function useRemoveFlow({ force, dryRun }: RemoveFlowOptions): RemoveFlowS
           const res = await withCommandRunTelemetry(
             'remove.all',
             {},
-            (): Promise<RemovalResult> =>
+            (): Promise<Result> =>
               withMinDuration(async () => {
                 const configIO = new ConfigIO();
 
@@ -164,7 +164,7 @@ export function useRemoveFlow({ force, dryRun }: RemoveFlowOptions): RemoveFlowS
                 return { success: true };
               })
           );
-          if (!res.success) throw new Error(res.error);
+          if (!res.success) throw res.error;
           updateStep(0, { status: 'success' });
         } catch (err) {
           updateStep(0, { status: 'error', error: getErrorMessage(err) });

--- a/src/cli/tui/screens/run-eval/RunBatchEvalFlow.tsx
+++ b/src/cli/tui/screens/run-eval/RunBatchEvalFlow.tsx
@@ -260,7 +260,7 @@ export function RunBatchEvalFlow({ onExit }: RunBatchEvalFlowProps) {
           setFlow(prev => {
             if (prev.name !== 'running') return prev;
             const steps = prev.steps.map(s =>
-              s.status === 'running' ? { ...s, status: 'error' as const, error: result.error } : s
+              s.status === 'running' ? { ...s, status: 'error' as const, error: result.error.message } : s
             );
             return { ...prev, steps };
           });
@@ -268,7 +268,7 @@ export function RunBatchEvalFlow({ onExit }: RunBatchEvalFlowProps) {
           if (cancelled) return;
           setFlow({
             name: 'error',
-            message: result.error ?? 'Batch evaluation failed',
+            message: result.error?.message ?? 'Batch evaluation failed',
             logFilePath: result.logFilePath,
           });
           return;

--- a/src/cli/tui/screens/run-eval/RunEvalFlow.tsx
+++ b/src/cli/tui/screens/run-eval/RunEvalFlow.tsx
@@ -20,7 +20,7 @@ type FlowState =
   | { name: 'loading' }
   | { name: 'wizard'; data: RunEvalFlowData }
   | { name: 'running'; config: RunEvalConfig }
-  | { name: 'results'; result: RunEvalResult; run: EvalRunResult }
+  | { name: 'results'; result: RunEvalResult; run: EvalRunResult; filePath: string }
   | { name: 'creds-error'; message: string }
   | { name: 'error'; message: string };
 
@@ -145,12 +145,12 @@ export function RunEvalFlow({ onExit, onViewRuns }: RunEvalFlowProps) {
 
         if (cancelled) return;
 
-        if (!result.success || !result.run) {
-          setFlow({ name: 'error', message: result.error ?? 'Evaluation failed' });
+        if (!result.success) {
+          setFlow({ name: 'error', message: result.error.message });
           return;
         }
 
-        setFlow({ name: 'results', result, run: result.run });
+        setFlow({ name: 'results', result, run: result.run, filePath: result.filePath });
       } catch (err) {
         if (!cancelled) setFlow({ name: 'error', message: getErrorMessage(err) });
       }
@@ -196,7 +196,7 @@ export function RunEvalFlow({ onExit, onViewRuns }: RunEvalFlowProps) {
     return (
       <ResultsView
         run={flow.run}
-        filePath={flow.result.filePath}
+        filePath={flow.filePath}
         onRunAnother={() => setFlow({ name: 'loading' })}
         onViewRuns={onViewRuns}
         onExit={onExit}

--- a/src/cli/tui/screens/runtime-endpoint/AddRuntimeEndpointFlow.tsx
+++ b/src/cli/tui/screens/runtime-endpoint/AddRuntimeEndpointFlow.tsx
@@ -95,7 +95,7 @@ export function AddRuntimeEndpointFlow({
         });
         return;
       }
-      setFlow({ name: 'error', message: result.error ?? 'Unknown error' });
+      setFlow({ name: 'error', message: result.error?.message ?? 'Unknown error' });
     });
   }, []);
 

--- a/src/cli/tui/screens/status/useStatusFlow.ts
+++ b/src/cli/tui/screens/status/useStatusFlow.ts
@@ -99,7 +99,7 @@ export function useStatusFlow() {
           ...prev,
           phase: 'ready',
           statusesLoaded: true,
-          statusesError: result.error,
+          statusesError: result.error?.message,
         }));
         return;
       }

--- a/src/lib/errors/index.ts
+++ b/src/lib/errors/index.ts
@@ -1,1 +1,2 @@
 export * from './config';
+export * from './types';

--- a/src/lib/errors/types.ts
+++ b/src/lib/errors/types.ts
@@ -1,0 +1,94 @@
+/**
+ * Error indicating no agentcore project was found in the working directory.
+ */
+export class NoProjectError extends Error {
+  constructor(message?: string) {
+    super(message ?? 'No agentcore project found. Run "agentcore create" first.');
+    this.name = 'NoProjectError';
+  }
+}
+
+/**
+ * Error thrown when an agent with the same name already exists.
+ */
+export class AgentAlreadyExistsError extends Error {
+  constructor(agentName: string) {
+    super(`An agent named "${agentName}" already exists in the schema.`);
+    this.name = 'AgentAlreadyExistsError';
+  }
+}
+
+/**
+ * Error indicating an AWS permissions failure (AccessDenied / AccessDeniedException).
+ */
+export class AccessDeniedError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'AccessDeniedError';
+  }
+}
+
+/**
+ * Error indicating missing system dependencies required for an operation.
+ */
+export class DependencyCheckError extends Error {
+  constructor(errors: string[]) {
+    super(errors.join('\n'));
+    this.name = 'DependencyCheckError';
+  }
+}
+
+/**
+ * Error indicating git repository initialization failed.
+ */
+export class GitInitError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'GitInitError';
+  }
+}
+
+/**
+ * Error indicating a referenced resource could not be found.
+ */
+export class ResourceNotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ResourceNotFoundError';
+  }
+}
+
+export class ValidationError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'ValidationError';
+  }
+}
+
+/**
+ * Converts an unknown thrown value to an Error instance.
+ * Use in catch blocks to ensure the error field is always an Error object.
+ */
+export function toError(err: unknown): Error {
+  return err instanceof Error ? err : new Error(String(err));
+}
+
+/**
+ * Error indicating a resource conflict (e.g., already exists).
+ */
+export class ConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ConflictError';
+  }
+}
+
+/**
+ * Error indicating an operation timed out or exceeded retry limits.
+ */
+export class TimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TimeoutError';
+  }
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -28,3 +28,5 @@ export * from './utils';
 // Schema I/O utilities
 export * from './schemas/io';
 export * from './time-constants';
+export { serializeResult } from './result';
+export type { Result } from './result';

--- a/src/lib/result.test.ts
+++ b/src/lib/result.test.ts
@@ -1,0 +1,19 @@
+import { serializeResult } from './result';
+import { describe, expect, it } from 'vitest';
+
+describe('serializeResult', () => {
+  it('passes through success results unchanged', () => {
+    const result = { success: true as const, name: 'test' };
+    expect(serializeResult(result)).toEqual({ success: true, name: 'test' });
+  });
+
+  it('converts error.message to string on failure', () => {
+    const result = { success: false as const, error: new Error('something broke') };
+    expect(serializeResult(result)).toEqual({ success: false, error: 'something broke' });
+  });
+
+  it('preserves extra fields on failure branch', () => {
+    const result = { success: false as const, error: new Error('fail'), logPath: '/tmp/log' };
+    expect(serializeResult(result)).toEqual({ success: false, error: 'fail', logPath: '/tmp/log' });
+  });
+});

--- a/src/lib/result.ts
+++ b/src/lib/result.ts
@@ -1,0 +1,30 @@
+/**
+ * Discriminated union for fallible operations, inspired by Rust's Result<T, E>.
+ *
+ * Success branch spreads T onto the result; failure branch carries an Error.
+ * E extends Error so callers always get stack traces, cause chains, and instanceof narrowing.
+ *
+ * @example
+ *   Result                                    // { success: true } | { success: false; error: Error }
+ *   Result<{ name: string }>                  // { success: true; name: string } | { success: false; error: Error }
+ *   Result<{ name: string }, ValidationError> // { success: true; name: string } | { success: false; error: ValidationError }
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export type Result<T extends Record<string, unknown> = {}, E extends Error = Error> =
+  | ({ success: true } & T)
+  | { success: false; error: E };
+
+/**
+ * Converts a Result object to a JSON-serializable form.
+ * Error objects have non-enumerable properties, so JSON.stringify produces `{}`.
+ * This replaces the `error` field with the error message string.
+ */
+export function serializeResult<T extends Record<string, unknown>>(
+  result: ({ success: true } & T) | ({ success: false; error: Error } & Record<string, unknown>)
+): Record<string, unknown> {
+  if (!result.success) {
+    const { error, ...rest } = result;
+    return { ...rest, error: error.message };
+  }
+  return result;
+}

--- a/src/lib/schemas/io/__tests__/config-io.test.ts
+++ b/src/lib/schemas/io/__tests__/config-io.test.ts
@@ -1,6 +1,6 @@
+import { NoProjectError } from '../../../errors';
 import { ConfigNotFoundError, ConfigParseError, ConfigValidationError } from '../../../errors/config.js';
 import { ConfigIO } from '../config-io.js';
-import { NoProjectError } from '../path-resolver.js';
 import { randomUUID } from 'node:crypto';
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { mkdir, rm, unlink, writeFile } from 'node:fs/promises';

--- a/src/lib/schemas/io/__tests__/path-resolver.test.ts
+++ b/src/lib/schemas/io/__tests__/path-resolver.test.ts
@@ -1,5 +1,5 @@
+import { NoProjectError } from '../../../errors';
 import {
-  NoProjectError,
   PathResolver,
   findConfigRoot,
   findProjectRoot,

--- a/src/lib/schemas/io/config-io.ts
+++ b/src/lib/schemas/io/config-io.ts
@@ -13,8 +13,9 @@ import {
   ConfigValidationError,
   ConfigWriteError,
 } from '../../errors';
+import { NoProjectError } from '../../errors';
 import { detectAwsAccount } from '../../utils';
-import { NoProjectError, type PathConfig, PathResolver, findConfigRoot } from './path-resolver';
+import { type PathConfig, PathResolver, findConfigRoot } from './path-resolver';
 import { loadSharedConfigFiles } from '@smithy/shared-ini-file-loader';
 import { existsSync } from 'fs';
 import { mkdir, readFile, writeFile } from 'fs/promises';

--- a/src/lib/schemas/io/index.ts
+++ b/src/lib/schemas/io/index.ts
@@ -7,7 +7,6 @@ export {
   getSessionProjectRoot,
   getWorkingDirectory,
   requireConfigRoot,
-  NoProjectError,
   type PathConfig,
 } from './path-resolver';
 export { ConfigIO, createConfigIO, getSchemaUrlForVersion } from './config-io';

--- a/src/lib/schemas/io/path-resolver.ts
+++ b/src/lib/schemas/io/path-resolver.ts
@@ -1,19 +1,9 @@
 import { CLI_LOGS_DIR, CLI_SYSTEM_DIR, CONFIG_DIR, CONFIG_FILES as _CONFIG_FILES } from '../../constants';
+import { NoProjectError } from '../../errors';
 import { existsSync } from 'fs';
 import { dirname, join } from 'path';
 
-// Re-export for backward compatibility
 export const CONFIG_FILES = _CONFIG_FILES;
-
-/**
- * Error thrown when no AgentCore project is found.
- */
-export class NoProjectError extends Error {
-  constructor(message?: string) {
-    super(message ?? 'No agentcore project found. Run "agentcore create" first.');
-    this.name = 'NoProjectError';
-  }
-}
 
 /**
  * Get the working directory where the user invoked the CLI.


### PR DESCRIPTION
## Description
### Problem 
The codebase uses an inconsistent result-like type that changes depending on the context. The implementations vary slightly, and are not explicit about (usually) sharing a common shape. This common shape also strips error types, and distills their information down to a string, which leads to brittle behavior when catching errors. 

As an example, systems that span modules (ex. telemetry) must handle each result type individually, resulting in excessive branching and complexity. Additionally, loss of error information, means loss of this information in telemetry, making it difficult to impossible to tell the type of error, and if it was user/application caused. 

### Solution
- unify result types behind a common flexible interface loosely based on Rust results. The main difference is that data is hoisted to the top level to be consistent with existing patterns. 
- store full error information on the result, allowing for `instanceof` checking and error name matching for stronger exception handling and telemetry. 

### Future Work
There are other result types that could be generalized with further work to support spread operators on the error as well. I left this OOS since the PR is already very large. Some other small patterns that this PR continues, but I think should change in the future:
- excessive mocking (Ex. some tests mock entire modules, rather than the underlying dependencies. We mock our own code in some places). 
- testing implementation rather than behavior (error messages are matches verbatim in many places, likely because thats all we had before. However, we should change these tests the verify error "shape" rather than exact content. 
- higher level utilities for working with results. There are common patterns that could be useful to abstract. As an example, a `mapResult` function that allows data transformations with clear error propagation. This could avoid some nesting of try/catches in a few places. 
- add more error types as we see fit. 
- avoid using console.log directly for more flexibility. 
## Related Issue

Closes #

## Documentation PR

N/A — internal refactor, no user-facing changes.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe): Internal refactor — unify result types

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.