### PR TITLE
fix: pin a2a-sdk below 1.0 to prevent breaking changes

### DIFF
--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -1164,7 +1164,7 @@ description = "AgentCore A2A Agent using Google ADK"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "a2a-sdk >= 0.2.0",
+    "a2a-sdk >= 0.2.0, < 1.0.0",
     "aws-opentelemetry-distro",
     "bedrock-agentcore[a2a] >= 1.0.3",
     "google-adk >= 1.0.0",
@@ -1525,7 +1525,7 @@ description = "AgentCore A2A Agent using LangChain + LangGraph"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "a2a-sdk >= 0.2.0",
+    "a2a-sdk >= 0.2.0, < 1.0.0",
     {{#if (eq modelProvider "Anthropic")}}"langchain-anthropic >= 0.3.0",
     {{/if}}{{#if (eq modelProvider "Bedrock")}}"langchain-aws >= 0.2.0",
     {{/if}}{{#if (eq modelProvider "Gemini")}}"langchain-google-genai >= 2.0.0",
@@ -1869,7 +1869,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     {{#if (eq modelProvider "Anthropic")}}"anthropic >= 0.30.0",
-    {{/if}}"a2a-sdk[all] >= 0.2.0",
+    {{/if}}"a2a-sdk[all] >= 0.2.0, < 1.0.0",
     "aws-opentelemetry-distro",
     "bedrock-agentcore[a2a] >= 1.0.3",
     "botocore[crt] >= 1.35.0",

--- a/src/assets/python/a2a/googleadk/base/pyproject.toml
+++ b/src/assets/python/a2a/googleadk/base/pyproject.toml
@@ -9,7 +9,7 @@ description = "AgentCore A2A Agent using Google ADK"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "a2a-sdk >= 0.2.0",
+    "a2a-sdk >= 0.2.0, < 1.0.0",
     "aws-opentelemetry-distro",
     "bedrock-agentcore[a2a] >= 1.0.3",
     "google-adk >= 1.0.0",

--- a/src/assets/python/a2a/langchain_langgraph/base/pyproject.toml
+++ b/src/assets/python/a2a/langchain_langgraph/base/pyproject.toml
@@ -9,7 +9,7 @@ description = "AgentCore A2A Agent using LangChain + LangGraph"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "a2a-sdk >= 0.2.0",
+    "a2a-sdk >= 0.2.0, < 1.0.0",
     {{#if (eq modelProvider "Anthropic")}}"langchain-anthropic >= 0.3.0",
     {{/if}}{{#if (eq modelProvider "Bedrock")}}"langchain-aws >= 0.2.0",
     {{/if}}{{#if (eq modelProvider "Gemini")}}"langchain-google-genai >= 2.0.0",

--- a/src/assets/python/a2a/strands/base/pyproject.toml
+++ b/src/assets/python/a2a/strands/base/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     {{#if (eq modelProvider "Anthropic")}}"anthropic >= 0.30.0",
-    {{/if}}"a2a-sdk[all] >= 0.2.0",
+    {{/if}}"a2a-sdk[all] >= 0.2.0, < 1.0.0",
     "aws-opentelemetry-distro",
     "bedrock-agentcore[a2a] >= 1.0.3",
     "botocore[crt] >= 1.35.0",


### PR DESCRIPTION
## Description

The [a2a-python SDK](https://github.com/a2aproject/a2a-python) recently released v1.0.0 which upgrades from the 0.3 protocol spec to the 1.0 protocol spec. This introduces breaking changes to module paths and APIs that our A2A templates depend on (e.g., `a2a.server.agent_execution`, `a2a.types`, `a2a.utils`).

Since our templates specify `a2a-sdk >= 0.2.0` with no upper bound, `pip install` now resolves to 1.0.x, breaking all `agentcore create --protocol A2A` projects.

This PR adds `< 1.0.0` upper bound to all three A2A template `pyproject.toml` files so pip resolves to 0.3.26 (latest compatible version).

### Files changed:
- `src/assets/python/a2a/googleadk/base/pyproject.toml`
- `src/assets/python/a2a/strands/base/pyproject.toml`
- `src/assets/python/a2a/langchain_langgraph/base/pyproject.toml`
- Snapshot updated accordingly

## Related Issue

<!-- Every PR must be associated with an issue. Link it below using #issue-number format. -->

Closes #1147 #1096

## Documentation PR

N/A — no documentation changes needed.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [x] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.