### PR TITLE
fix(deploy): pass stack selection to diff for --target filtering

### DIFF
--- a/src/cli/commands/deploy/__tests__/deploy.test.ts
+++ b/src/cli/commands/deploy/__tests__/deploy.test.ts
@@ -1,4 +1,6 @@
 import { runCLI } from '../../../../test-utils/index.js';
+import { runDeploy, runDiff } from '../actions.js';
+import { StackSelectionStrategy } from '@aws-cdk/toolkit-lib';
 import { randomUUID } from 'node:crypto';
 import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -54,5 +56,39 @@ describe('deploy without agents', () => {
     expect(json.success).toBe(false);
     expect(json.error).toBeDefined();
     expect(json.error.toLowerCase()).toContain('no resources defined');
+  });
+});
+
+describe('runDiff', () => {
+  it('passes stack selection pattern to toolkit wrapper diff', async () => {
+    let captured: unknown;
+    const fakeWrapper = {
+      diff: (opts?: unknown) => {
+        captured = opts;
+      },
+    };
+
+    await runDiff(fakeWrapper as any, 'AgentCore-myapp-prod');
+
+    expect(captured).toEqual({
+      stacks: { strategy: StackSelectionStrategy.PATTERN_MUST_MATCH, patterns: ['AgentCore-myapp-prod'] },
+    });
+  });
+});
+
+describe('runDeploy', () => {
+  it('passes stack selection pattern to toolkit wrapper deploy', async () => {
+    let captured: unknown;
+    const fakeWrapper = {
+      deploy: (opts?: unknown) => {
+        captured = opts;
+      },
+    };
+
+    await runDeploy(fakeWrapper as any, 'AgentCore-myapp-prod');
+
+    expect(captured).toEqual({
+      stacks: { strategy: StackSelectionStrategy.PATTERN_MUST_MATCH, patterns: ['AgentCore-myapp-prod'] },
+    });
   });
 });

--- a/src/cli/commands/deploy/actions.ts
+++ b/src/cli/commands/deploy/actions.ts
@@ -2,7 +2,8 @@ import { ConfigIO, SecureCredentials } from '../../../lib';
 import type { AgentCoreMcpSpec, DeployedState } from '../../../schema';
 import { applyTargetRegionToEnv } from '../../aws';
 import { validateAwsCredentials } from '../../aws/account';
-import { createSwitchableIoHost } from '../../cdk/toolkit-lib';
+import { CdkToolkitWrapper, createSwitchableIoHost } from '../../cdk/toolkit-lib';
+import type { SwitchableIoHost } from '../../cdk/toolkit-lib';
 import {
   buildDeployedState,
   getStackOutputs,
@@ -40,7 +41,9 @@ import {
 } from '../../operations/deploy/post-deploy-config-bundles';
 import { setupHttpGateways } from '../../operations/deploy/post-deploy-http-gateways';
 import { enableOnlineEvalConfigs } from '../../operations/deploy/post-deploy-online-evals';
+import { toStackName } from '../import/import-utils';
 import type { DeployResult } from './types';
+import { StackSelectionStrategy } from '@aws-cdk/toolkit-lib';
 
 export interface ValidatedDeployOptions {
   target: string;
@@ -54,6 +57,38 @@ export interface ValidatedDeployOptions {
 
 const AGENT_NEXT_STEPS = ['agentcore invoke', 'agentcore status'];
 const MEMORY_ONLY_NEXT_STEPS = ['agentcore add agent', 'agentcore status'];
+
+export async function runDiff(
+  toolkitWrapper: CdkToolkitWrapper,
+  stackName: string,
+  switchableIoHost?: SwitchableIoHost
+): Promise<void> {
+  const diffIoHost = switchableIoHost ?? createSwitchableIoHost();
+  let hasDiffContent = false;
+  diffIoHost.setOnRawMessage((code, _level, message) => {
+    if (!message) return;
+    // I4002: formatted diff per stack, I4001: overall diff summary
+    if (code === 'CDK_TOOLKIT_I4002' || code === 'CDK_TOOLKIT_I4001') {
+      hasDiffContent = true;
+      console.log(message);
+    }
+  });
+  diffIoHost.setVerbose(true);
+  await toolkitWrapper.diff({
+    stacks: { strategy: StackSelectionStrategy.PATTERN_MUST_MATCH, patterns: [stackName] },
+  });
+  if (!hasDiffContent) {
+    console.log('No stack differences detected.');
+  }
+  diffIoHost.setVerbose(false);
+  diffIoHost.setOnRawMessage(null);
+}
+
+export async function runDeploy(toolkitWrapper: CdkToolkitWrapper, stackName: string): Promise<void> {
+  await toolkitWrapper.deploy({
+    stacks: { strategy: StackSelectionStrategy.PATTERN_MUST_MATCH, patterns: [stackName] },
+  });
+}
 
 export async function handleDeploy(options: ValidatedDeployOptions): Promise<DeployResult> {
   let toolkitWrapper = null;
@@ -247,6 +282,8 @@ export async function handleDeploy(options: ValidatedDeployOptions): Promise<Dep
     const stackName = stackNames[0]!;
     endStep('success');
 
+    const targetStackName = toStackName(context.projectSpec.name, target.name);
+
     // Check if bootstrap needed
     startStep('Check bootstrap status');
     const bootstrapCheck = await checkBootstrapNeeded(context.awsTargets);
@@ -296,23 +333,7 @@ export async function handleDeploy(options: ValidatedDeployOptions): Promise<Dep
     // Diff mode: run cdk diff and exit without deploying
     if (options.diff) {
       startStep('Run CDK diff');
-      const diffIoHost = switchableIoHost ?? createSwitchableIoHost();
-      let hasDiffContent = false;
-      diffIoHost.setOnRawMessage((code, _level, message) => {
-        if (!message) return;
-        // I4002: formatted diff per stack, I4001: overall diff summary
-        if (code === 'CDK_TOOLKIT_I4002' || code === 'CDK_TOOLKIT_I4001') {
-          hasDiffContent = true;
-          console.log(message);
-        }
-      });
-      diffIoHost.setVerbose(true);
-      await toolkitWrapper.diff();
-      if (!hasDiffContent) {
-        console.log('No stack differences detected.');
-      }
-      diffIoHost.setVerbose(false);
-      diffIoHost.setOnRawMessage(null);
+      await runDiff(toolkitWrapper, targetStackName, switchableIoHost);
       endStep('success');
 
       logger.finalize(true);
@@ -339,7 +360,7 @@ export async function handleDeploy(options: ValidatedDeployOptions): Promise<Dep
       switchableIoHost.setVerbose(true);
     }
 
-    await toolkitWrapper.deploy();
+    await runDeploy(toolkitWrapper, targetStackName);
 
     // Disable verbose output
     if (switchableIoHost) {


### PR DESCRIPTION
## Description

When `--diff` or `--deploy` is used with `--target`, the CLI now passes a stack selection pattern (`*${targetName}*`) to the CDK toolkit so only the selected target's stack is operated on, not all stacks in the synthesized app.

Extracted `runDiff` and `runDeploy` functions for testability via dependency injection.

## Related Issue

Closes #980

## Type of Change

- [x] Bug fix

## Testing

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] My changes generate no new warnings