### PR TITLE
feat(harness): add verdict prefix to reviewer comments

### DIFF
--- a/.github/harness/prompts/review.md
+++ b/.github/harness/prompts/review.md
@@ -14,4 +14,4 @@ Review the PR. If there are any serious issues that require code changes before 
 each issue explaining the problem. If there are multiple ways to fix an issue, list the options so the author can
 choose. Skip style nits and minor suggestions — only flag things that actually need to change.
 
-When finished, submit a formal PR review (approve, request changes, or comment) — do not post a plain comment.
+When finished, submit a formal PR review (approve or request changes) with individual and inline comments in it. Be specific with line numbers.

--- a/.github/harness/prompts/review.md
+++ b/.github/harness/prompts/review.md
@@ -14,5 +14,4 @@ Review the PR. If there are any serious issues that require code changes before 
 each issue explaining the problem. If there are multiple ways to fix an issue, list the options so the author can
 choose. Skip style nits and minor suggestions — only flag things that actually need to change.
 
-If all serious issues have already been raised in existing comments, or if you found no new issues, post a single
-comment on the PR saying it looks good to merge (or that all issues have already been flagged).
+When finished, submit a formal PR review (approve, request changes, or comment) — do not post a plain comment.

--- a/.github/harness/prompts/system.md
+++ b/.github/harness/prompts/system.md
@@ -18,6 +18,16 @@ when users run `agentcore create`.
 
 `agentcore-cli` is the main product. It vends CDK projects using constructs from `agentcore-l3-cdk-constructs`.
 
+## Comment Format
+
+When posting your final review comment on a PR, you MUST begin the comment with one of these exact verdicts:
+
+- **APPROVED** — no issues found, safe to merge as-is.
+- **APPROVED WITH MINOR COMMENTS** — no blocking issues, but you have optional suggestions. The PR can merge without addressing them.
+- **REQUESTING CHANGES** — serious issues found that must be fixed before merging.
+
+The verdict must be the very first word(s) of the comment, on its own line, followed by your explanation.
+
 ## Testing with a bundled distribution
 
 Run `npm run bundle` in `agentcore-cli/` to create a tar distribution that includes the packaged

--- a/.github/harness/prompts/system.md
+++ b/.github/harness/prompts/system.md
@@ -18,15 +18,29 @@ when users run `agentcore create`.
 
 `agentcore-cli` is the main product. It vends CDK projects using constructs from `agentcore-l3-cdk-constructs`.
 
-## Comment Format
+## Submitting Your Review
 
-When posting your final review comment on a PR, you MUST begin the comment with one of these exact verdicts:
+When you have finished reviewing, submit a formal GitHub PR review using the `gh` CLI — do NOT post a plain comment.
 
-- **APPROVED** — no issues found, safe to merge as-is.
-- **APPROVED WITH MINOR COMMENTS** — no blocking issues, but you have optional suggestions. The PR can merge without addressing them.
-- **REQUESTING CHANGES** — serious issues found that must be fixed before merging.
+Use one of these commands depending on your verdict:
 
-The verdict must be the very first word(s) of the comment, on its own line, followed by your explanation.
+```bash
+# No issues — approve the PR
+gh pr review <pr-number> --approve --body "<your summary>"
+
+# Serious issues that must be fixed before merging
+gh pr review <pr-number> --request-changes --body "<your summary>"
+
+# No blocking issues, but you have optional suggestions
+gh pr review <pr-number> --comment --body "<your summary>"
+```
+
+Rules:
+- Always use `gh pr review`, never `gh pr comment`.
+- Use `--approve` when the PR is safe to merge as-is.
+- Use `--request-changes` when there are issues that must be fixed before merging.
+- Use `--comment` when you have minor, non-blocking suggestions the author can optionally address.
+- The body should summarize your findings. If you flagged individual lines earlier with inline comments, reference them in the summary.
 
 ## Testing with a bundled distribution
 

--- a/.github/harness/prompts/system.md
+++ b/.github/harness/prompts/system.md
@@ -18,30 +18,6 @@ when users run `agentcore create`.
 
 `agentcore-cli` is the main product. It vends CDK projects using constructs from `agentcore-l3-cdk-constructs`.
 
-## Submitting Your Review
-
-When you have finished reviewing, submit a formal GitHub PR review using the `gh` CLI — do NOT post a plain comment.
-
-Use one of these commands depending on your verdict:
-
-```bash
-# No issues — approve the PR
-gh pr review <pr-number> --approve --body "<your summary>"
-
-# Serious issues that must be fixed before merging
-gh pr review <pr-number> --request-changes --body "<your summary>"
-
-# No blocking issues, but you have optional suggestions
-gh pr review <pr-number> --comment --body "<your summary>"
-```
-
-Rules:
-- Always use `gh pr review`, never `gh pr comment`.
-- Use `--approve` when the PR is safe to merge as-is.
-- Use `--request-changes` when there are issues that must be fixed before merging.
-- Use `--comment` when you have minor, non-blocking suggestions the author can optionally address.
-- The body should summarize your findings. If you flagged individual lines earlier with inline comments, reference them in the summary.
-
 ## Testing with a bundled distribution
 
 Run `npm run bundle` in `agentcore-cli/` to create a tar distribution that includes the packaged


### PR DESCRIPTION
## Description

Adds a "Comment Format" section to the harness reviewer's system prompt requiring every PR comment to begin with one of three verdicts: `APPROVED`, `APPROVED WITH MINOR COMMENTS`, or `REQUESTING CHANGES`. This makes review outcomes immediately visible in the PR timeline and programmatically parseable.

## Related Issue

N/A — internal improvement to the AI reviewer harness.

## Documentation PR

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:unit` and `npm run test:integ`
- [ ] I ran `npm run typecheck`
- [ ] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

No code changes — prompt-only update to `.github/harness/prompts/system.md`.

## Checklist

- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.