### PR TITLE
fix(create): resolve user-supplied Dockerfile path from CLI invocation cwd, not project root

### DIFF
--- a/src/cli/tui/screens/agent/AddAgentScreen.tsx
+++ b/src/cli/tui/screens/agent/AddAgentScreen.tsx
@@ -45,7 +45,6 @@ import {
 } from './types';
 import { Box, Text, useInput } from 'ink';
 import Spinner from 'ink-spinner';
-import { basename, resolve } from 'path';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 // Helper to get provider display name and env var name from ModelProvider
@@ -1086,12 +1085,14 @@ export function AddAgentScreen({ existingAgentNames, onComplete, onExit }: AddAg
         {byoStep === 'dockerfile' && (
           <PathInput
             placeholder="Select a Dockerfile"
-            basePath={resolve(project?.projectRoot ?? process.cwd(), byoConfig.codeLocation)}
+            basePath={process.cwd()}
             pathType="file"
             allowEmpty
             emptyHelpText="Press Enter to use the default Dockerfile"
             onSubmit={value => {
-              setByoConfig(c => ({ ...c, dockerfile: value ? basename(value) : '' }));
+              // Preserve the user-entered path; resolution + copy into the
+              // agent code directory happens later in useAddAgent.handleByoPath.
+              setByoConfig(c => ({ ...c, dockerfile: value || '' }));
               goToNextByoStep('dockerfile');
             }}
             onCancel={handleByoBack}

--- a/src/cli/tui/screens/agent/__tests__/useAddAgent.test.ts
+++ b/src/cli/tui/screens/agent/__tests__/useAddAgent.test.ts
@@ -1,0 +1,107 @@
+import { resolveUserDockerfile } from '../useAddAgent';
+import { resolve } from 'path';
+import { describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// resolveUserDockerfile — regression tests for issue #1128
+//
+// The CLI must resolve a user-supplied Dockerfile path relative to the
+// directory the user invoked the CLI from (cwd), NOT relative to the
+// project root or codeLocation. Bare filenames are passed through
+// unchanged so the rendered template default keeps working.
+// ---------------------------------------------------------------------------
+
+describe('resolveUserDockerfile', () => {
+  it('returns copy:false for undefined', () => {
+    const result = resolveUserDockerfile(undefined, '/some/cwd');
+    expect(result).toEqual({ ok: true, copy: false, filename: undefined });
+  });
+
+  it('returns copy:false for empty string', () => {
+    const result = resolveUserDockerfile('', '/some/cwd');
+    expect(result).toEqual({ ok: true, copy: false, filename: undefined });
+  });
+
+  it('returns copy:false for a bare filename and preserves the name', () => {
+    // A bare filename is the schema-valid value persisted in the project spec.
+    // We must not try to copy it; we must keep it as-is.
+    const fileExists = vi.fn(() => false);
+    const result = resolveUserDockerfile('Dockerfile', '/some/cwd', fileExists);
+    expect(result).toEqual({ ok: true, copy: false, filename: 'Dockerfile' });
+    // Importantly: existsSync is NOT consulted for a bare filename, so a
+    // user-supplied "Dockerfile" never gets a misleading "not found" error.
+    expect(fileExists).not.toHaveBeenCalled();
+  });
+
+  it('resolves a relative path against cwd (not project root)', () => {
+    const fileExists = vi.fn(() => true);
+    const cwd = '/home/user/.github';
+    const result = resolveUserDockerfile('./Dockerfile.dev', cwd, fileExists);
+
+    expect(result).toEqual({
+      ok: true,
+      copy: true,
+      sourcePath: resolve(cwd, './Dockerfile.dev'),
+      filename: 'Dockerfile.dev',
+    });
+    expect(fileExists).toHaveBeenCalledWith(resolve(cwd, './Dockerfile.dev'));
+  });
+
+  it('resolves a nested relative path against cwd', () => {
+    const fileExists = vi.fn(() => true);
+    const cwd = '/home/user/.github';
+    const result = resolveUserDockerfile('subdir/Dockerfile.gpu', cwd, fileExists);
+
+    expect(result).toEqual({
+      ok: true,
+      copy: true,
+      sourcePath: resolve(cwd, 'subdir/Dockerfile.gpu'),
+      filename: 'Dockerfile.gpu',
+    });
+  });
+
+  it('honors absolute paths regardless of cwd', () => {
+    const fileExists = vi.fn(() => true);
+    const result = resolveUserDockerfile('/tmp/MyDockerfile', '/home/user', fileExists);
+
+    expect(result).toEqual({
+      ok: true,
+      copy: true,
+      sourcePath: resolve('/tmp/MyDockerfile'),
+      filename: 'MyDockerfile',
+    });
+  });
+
+  it('returns ok:false with a cwd-resolved path when source file is missing', () => {
+    const fileExists = vi.fn(() => false);
+    const cwd = '/home/user/.github';
+    const result = resolveUserDockerfile('./missing.Dockerfile', cwd, fileExists);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      // Error message must point at the cwd-resolved path so users can see
+      // the actual filesystem location that was checked.
+      expect(result.error).toContain(resolve(cwd, './missing.Dockerfile'));
+      expect(result.error).toMatch(/Dockerfile not found at/);
+    }
+  });
+
+  it('does not resolve relative to projectRoot/codeLocation (regression for #1128)', () => {
+    // The reporter's scenario: cwd is a sub-directory like ".github", but
+    // the project root and BYO codeLocation are different. The resolver
+    // must use cwd, not <projectRoot>/<codeLocation>.
+    const cwd = '/workspace/proj/.github';
+    const projectRoot = '/workspace/proj';
+    const codeLocation = 'harnesses/';
+
+    const fileExists = vi.fn((p: string) => p === resolve(cwd, './my.Dockerfile'));
+
+    const result = resolveUserDockerfile('./my.Dockerfile', cwd, fileExists);
+
+    expect(result.ok).toBe(true);
+    if (result.ok && result.copy) {
+      expect(result.sourcePath).toBe(resolve(cwd, './my.Dockerfile'));
+      expect(result.sourcePath).not.toBe(resolve(projectRoot, codeLocation, './my.Dockerfile'));
+    }
+  });
+});

--- a/src/cli/tui/screens/agent/useAddAgent.ts
+++ b/src/cli/tui/screens/agent/useAddAgent.ts
@@ -260,9 +260,13 @@ async function handleCreatePath(
   const renderer = createRenderer(renderConfig);
   await renderer.render({ outputDir: projectRoot });
 
-  // If dockerfile is a path (contains /), copy it into the agent directory (overwriting template default)
-  if (generateConfig.dockerfile?.includes('/')) {
-    const sourcePath = resolve(projectRoot, generateConfig.dockerfile);
+  // If dockerfile is a path (not a bare filename), resolve it relative to the
+  // directory the user invoked the CLI from (process.cwd()), copy it into the
+  // agent directory, and persist only the basename in the project spec
+  // (agent-env schema requires a filename, not a path).
+  const userDockerfile = generateConfig.dockerfile;
+  if (userDockerfile && userDockerfile !== basename(userDockerfile)) {
+    const sourcePath = resolve(process.cwd(), userDockerfile);
     if (!existsSync(sourcePath)) {
       return { ok: false, error: `Dockerfile not found at ${sourcePath}` };
     }
@@ -369,10 +373,12 @@ async function handleByoPath(
   const codeDir = join(projectRoot, config.codeLocation.replace(/\/$/, ''));
   mkdirSync(codeDir, { recursive: true });
 
-  // If dockerfile is a path (contains /), copy it into the code directory and use the filename
+  // If dockerfile is a path (not a bare filename), resolve it relative to the
+  // directory the user invoked the CLI from (process.cwd()), copy it into the
+  // BYO code directory, and use only the basename when persisting.
   let dockerfileName = config.dockerfile;
-  if (dockerfileName?.includes('/')) {
-    const sourcePath = resolve(projectRoot, dockerfileName);
+  if (dockerfileName && dockerfileName !== basename(dockerfileName)) {
+    const sourcePath = resolve(process.cwd(), dockerfileName);
     if (!existsSync(sourcePath)) {
       return { ok: false, error: `Dockerfile not found at ${sourcePath}` };
     }

--- a/src/cli/tui/screens/agent/useAddAgent.ts
+++ b/src/cli/tui/screens/agent/useAddAgent.ts
@@ -136,6 +136,62 @@ function mapAddAgentConfigToGenerateConfig(config: AddAgentConfig): GenerateConf
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Dockerfile path helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Result of resolving a user-supplied Dockerfile path.
+ *
+ * - `ok: true, copy: true`  → the user supplied a path; caller must copy
+ *   `sourcePath` into the destination dir under name `filename`.
+ * - `ok: true, copy: false` → user supplied a bare filename or nothing;
+ *   no copy is needed.
+ * - `ok: false`             → file does not exist at the resolved path.
+ */
+export type ResolveDockerfileResult =
+  | { ok: true; copy: false; filename: string | undefined }
+  | { ok: true; copy: true; sourcePath: string; filename: string }
+  | { ok: false; error: string };
+
+/**
+ * Resolve a user-supplied Dockerfile value relative to `cwd` (the directory
+ * the user invoked the CLI from).
+ *
+ * Behaviour:
+ *  - undefined / empty → no-op (`copy: false`, filename stays undefined).
+ *  - bare filename (e.g. `Dockerfile`) → no-op; the filename is preserved
+ *    as-is for the project spec.
+ *  - anything else (e.g. `./Dockerfile.dev`, `subdir/X`, `/abs/X`, `C:\X`) →
+ *    instruct the caller to copy from `resolve(cwd, value)` into the
+ *    destination directory, persisting only the basename.
+ *
+ * Validates that the resolved source file exists; returns `ok: false` with
+ * a descriptive error otherwise.
+ *
+ * Exported for unit testing — see issue #1128.
+ */
+export function resolveUserDockerfile(
+  value: string | undefined,
+  cwd: string,
+  fileExists: (p: string) => boolean = existsSync
+): ResolveDockerfileResult {
+  if (!value) {
+    return { ok: true, copy: false, filename: undefined };
+  }
+
+  // Bare filename → preserve as-is, no copy.
+  if (value === basename(value)) {
+    return { ok: true, copy: false, filename: value };
+  }
+
+  const sourcePath = resolve(cwd, value);
+  if (!fileExists(sourcePath)) {
+    return { ok: false, error: `Dockerfile not found at ${sourcePath}` };
+  }
+  return { ok: true, copy: true, sourcePath, filename: basename(sourcePath) };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Hook
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -264,15 +320,13 @@ async function handleCreatePath(
   // directory the user invoked the CLI from (process.cwd()), copy it into the
   // agent directory, and persist only the basename in the project spec
   // (agent-env schema requires a filename, not a path).
-  const userDockerfile = generateConfig.dockerfile;
-  if (userDockerfile && userDockerfile !== basename(userDockerfile)) {
-    const sourcePath = resolve(process.cwd(), userDockerfile);
-    if (!existsSync(sourcePath)) {
-      return { ok: false, error: `Dockerfile not found at ${sourcePath}` };
-    }
-    const filename = basename(sourcePath);
-    copyFileSync(sourcePath, join(agentPath, filename));
-    generateConfig.dockerfile = filename;
+  const dockerfileResolution = resolveUserDockerfile(generateConfig.dockerfile, process.cwd());
+  if (!dockerfileResolution.ok) {
+    return { ok: false, error: dockerfileResolution.error };
+  }
+  if (dockerfileResolution.copy) {
+    copyFileSync(dockerfileResolution.sourcePath, join(agentPath, dockerfileResolution.filename));
+    generateConfig.dockerfile = dockerfileResolution.filename;
   }
 
   // Write agent to project config
@@ -377,13 +431,13 @@ async function handleByoPath(
   // directory the user invoked the CLI from (process.cwd()), copy it into the
   // BYO code directory, and use only the basename when persisting.
   let dockerfileName = config.dockerfile;
-  if (dockerfileName && dockerfileName !== basename(dockerfileName)) {
-    const sourcePath = resolve(process.cwd(), dockerfileName);
-    if (!existsSync(sourcePath)) {
-      return { ok: false, error: `Dockerfile not found at ${sourcePath}` };
-    }
-    dockerfileName = basename(sourcePath);
-    copyFileSync(sourcePath, join(codeDir, dockerfileName));
+  const byoDockerfileResolution = resolveUserDockerfile(dockerfileName, process.cwd());
+  if (!byoDockerfileResolution.ok) {
+    return { ok: false, error: byoDockerfileResolution.error };
+  }
+  if (byoDockerfileResolution.copy) {
+    copyFileSync(byoDockerfileResolution.sourcePath, join(codeDir, byoDockerfileResolution.filename));
+    dockerfileName = byoDockerfileResolution.filename;
   }
 
   const project = await configIO.readProjectSpec();

--- a/src/cli/tui/screens/generate/GenerateWizardUI.tsx
+++ b/src/cli/tui/screens/generate/GenerateWizardUI.tsx
@@ -36,7 +36,6 @@ import {
 } from './types';
 import type { useGenerateWizard } from './useGenerateWizard';
 import { Box, Text, useInput } from 'ink';
-import { basename } from 'path';
 
 // Helper to get provider display name and env var name from ModelProvider
 function getProviderInfo(provider: ModelProvider): { name: string; envVarName: string } {
@@ -234,7 +233,11 @@ export function GenerateWizardUI({
           allowEmpty
           emptyHelpText="Press Enter to use the default Dockerfile"
           onSubmit={value => {
-            wizard.setDockerfile(value ? basename(value) : undefined);
+            // Pass the user-entered path through unchanged. Final basename
+            // resolution + copy into the agent directory happens in
+            // useAddAgent.handleCreatePath, so the directory component must
+            // survive this step.
+            wizard.setDockerfile(value || undefined);
           }}
           onCancel={onBack}
         />

--- a/src/cli/tui/screens/generate/__tests__/useGenerateWizard.test.tsx
+++ b/src/cli/tui/screens/generate/__tests__/useGenerateWizard.test.tsx
@@ -383,6 +383,28 @@ describe('useGenerateWizard — advanced config gate', () => {
       expect(ref.current!.wizard.step).toBe('confirm');
       vi.useRealTimers();
     });
+
+    it('setDockerfile preserves directory components (no basename stripping)', () => {
+      // Regression test for #1128: the wizard must keep the user-supplied
+      // path intact so useAddAgent.handleCreatePath can resolve it relative
+      // to process.cwd() and copy the file.
+      vi.useFakeTimers();
+      const { ref } = setup();
+      walkToAdvancedWithContainer(ref);
+
+      act(() => ref.current!.wizard.setAdvanced(['dockerfile']));
+      act(() => {
+        vi.runAllTimers();
+      });
+
+      act(() => ref.current!.wizard.setDockerfile('./subdir/Dockerfile.dev'));
+      act(() => {
+        vi.runAllTimers();
+      });
+
+      expect(ref.current!.wizard.config.dockerfile).toBe('./subdir/Dockerfile.dev');
+      vi.useRealTimers();
+    });
   });
 
   describe('filesystem advanced setting', () => {


### PR DESCRIPTION
## Description

Fixes a bug in the `agentcore create` wizard where a user-supplied Dockerfile path was resolved relative to the discovered **project root** (or `<projectRoot>/<codeLocation>` for BYO) instead of the directory the user invoked the CLI from. Per the issue reporter, this gave confusing "not found" errors like:

> path working dir is here  - `/workplace/.../.github/harnesses/`

…when the user expected the path to be resolved relative to their actual `cwd` (e.g. `/workplace/.../.github/`).

### Root cause

Two compounding problems in the TUI:

1. **`GenerateWizardUI.tsx`** and **`AddAgentScreen.tsx`** both called `basename(value)` inside the `PathInput.onSubmit` handler, which silently discarded the directory component of the path *before* it ever reached the resolution logic in `useAddAgent.ts`. As a result, the `if (dockerfile?.includes('/'))` branch in `handleCreatePath` was effectively dead code — no user-entered path was ever copied.
2. The BYO `PathInput` set its `basePath` to `resolve(project.projectRoot, byoConfig.codeLocation)`, so completion + validation operated relative to `<projectRoot>/<codeLocation>` (e.g. `…/.github/harnesses/`), which is exactly the bogus path the user saw in the error.
3. `useAddAgent.handleCreatePath` and `handleByoPath` resolved the source path with `resolve(projectRoot, dockerfile)`, ignoring the user's actual cwd.

### Fix

- Stop calling `basename()` in both wizard `onSubmit` handlers — pass the raw user input through.
- Set the BYO `PathInput` `basePath` to `process.cwd()` so completion + validation match where the user invoked the CLI (consistent with the `GenerateWizardUI` Dockerfile prompt and the existing policy `--source` flow).
- Extract a small, pure helper `resolveUserDockerfile(value, cwd, fileExists?)` in `useAddAgent.ts` that:
  - Returns no-op for `undefined`/empty.
  - Returns no-op for a bare filename (preserves the existing template-default semantics; the agent-env CDK schema also requires a filename, not a path).
  - Resolves anything else against `process.cwd()`, validates with `existsSync`, and instructs the caller to copy it into the agent / BYO code directory under just the basename.
- Refactor `handleCreatePath` and `handleByoPath` to call the new helper, eliminating duplication.

The detection condition `value !== basename(value)` also fixes a latent Windows bug where the previous `value.includes('/')` would miss `\` separators.

The persisted spec value remains a basename, so the CDK constructs and downstream renderers/packagers/config-bundle generation are unaffected.

## Related Issue

Closes #1128

## Documentation PR

N/A — purely a CLI bug fix; no public API or documented behavior changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ` <!-- targeted vitest runs of touched files; full suite delegated to CI -->
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots <!-- N/A: no asset changes -->

### Targeted test runs

- `src/cli/tui/screens/agent/__tests__/useAddAgent.test.ts` (new) — **8/8 pass**. Covers:
  - undefined / empty input → no-op
  - bare filename → preserved, never touches `fs`
  - relative path → resolved against `cwd`
  - nested relative path → basename extracted correctly
  - absolute path → honored as-is
  - missing file → `ok: false`, error mentions cwd-resolved path
  - **regression for #1128**: does NOT resolve under `projectRoot/codeLocation`
- `src/cli/tui/screens/generate/__tests__/useGenerateWizard.test.tsx` — **37/37 pass** (added a regression test that `setDockerfile('./subdir/Dockerfile.dev')` preserves the directory components).
- `src/cli/tui/screens/agent/__tests__/computeByoSteps.test.ts` — **4/4 pass** (sanity check, unaffected).

### Manual verification

1. From a sub-directory of a project (e.g. `<projectRoot>/.github/`), run `agentcore create`, choose a Container build, supply `./Dockerfile.dev` → file is copied into the agent directory and the spec records `dockerfile: "Dockerfile.dev"`.
2. Repeat for the BYO flow with `subdir/Dockerfile.gpu` and an absolute `/tmp/Dockerfile`.
3. Bare `Dockerfile` input still falls through to the template default (no copy), preserving existing UX.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly <!-- N/A — no doc changes needed -->
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings <!-- only 2 pre-existing ESLint warnings remain in AddAgentScreen.tsx -->
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
