### PR TITLE
feat: relax requestHeaderAllowlist to broader X-Amzn-Bedrock-AgentCore- namespace (#1151)

### DIFF
--- a/src/cli/commands/shared/__tests__/header-utils.test.ts
+++ b/src/cli/commands/shared/__tests__/header-utils.test.ts
@@ -39,6 +39,21 @@ describe('normalizeHeaderName', () => {
   it('auto-prefixes suffix with hyphens like "My-Custom-Header"', () => {
     expect(normalizeHeaderName('My-Custom-Header')).toBe('X-Amzn-Bedrock-AgentCore-Runtime-Custom-My-Custom-Header');
   });
+
+  it('preserves a header already under the broader namespace prefix without re-prefixing', () => {
+    expect(normalizeHeaderName('X-Amzn-Bedrock-AgentCore-Runtime-User-Id')).toBe(
+      'X-Amzn-Bedrock-AgentCore-Runtime-User-Id'
+    );
+    expect(normalizeHeaderName('X-Amzn-Bedrock-AgentCore-Runtime-Session-Id')).toBe(
+      'X-Amzn-Bedrock-AgentCore-Runtime-Session-Id'
+    );
+  });
+
+  it('canonicalizes the namespace prefix casing for non-Custom headers', () => {
+    expect(normalizeHeaderName('x-amzn-bedrock-agentcore-Runtime-User-Id')).toBe(
+      'X-Amzn-Bedrock-AgentCore-Runtime-User-Id'
+    );
+  });
 });
 
 describe('parseAndNormalizeHeaders', () => {
@@ -126,6 +141,16 @@ describe('validateHeaderAllowlist', () => {
     const result = validateHeaderAllowlist('My@Header');
     expect(result.success).toBe(false);
     expect(result.error).toContain('Invalid header name');
+  });
+
+  it('accepts headers under the broader X-Amzn-Bedrock-AgentCore- namespace', () => {
+    expect(validateHeaderAllowlist('X-Amzn-Bedrock-AgentCore-Runtime-User-Id')).toEqual({ success: true });
+    expect(validateHeaderAllowlist('X-Amzn-Bedrock-AgentCore-Runtime-Session-Id')).toEqual({ success: true });
+    expect(
+      validateHeaderAllowlist(
+        'Authorization, X-Amzn-Bedrock-AgentCore-Runtime-User-Id, X-Amzn-Bedrock-AgentCore-Runtime-Custom-Foo'
+      )
+    ).toEqual({ success: true });
   });
 });
 

--- a/src/cli/commands/shared/header-utils.ts
+++ b/src/cli/commands/shared/header-utils.ts
@@ -1,9 +1,12 @@
 import {
+  HEADER_ALLOWLIST_NAMESPACE_PREFIX as HEADER_ALLOWLIST_NAMESPACE_PREFIX_FROM_SCHEMA,
   HEADER_ALLOWLIST_PREFIX as HEADER_ALLOWLIST_PREFIX_FROM_SCHEMA,
   MAX_HEADER_ALLOWLIST_SIZE as MAX_HEADER_ALLOWLIST_SIZE_FROM_SCHEMA,
+  isAllowedRequestHeader,
 } from '../../../schema/schemas/agent-env';
 
 export const HEADER_ALLOWLIST_PREFIX = HEADER_ALLOWLIST_PREFIX_FROM_SCHEMA;
+export const HEADER_ALLOWLIST_NAMESPACE_PREFIX = HEADER_ALLOWLIST_NAMESPACE_PREFIX_FROM_SCHEMA;
 export const MAX_HEADER_ALLOWLIST_SIZE = MAX_HEADER_ALLOWLIST_SIZE_FROM_SCHEMA;
 
 const HEADER_NAME_PATTERN = /^[A-Za-z0-9-]+$/;
@@ -11,8 +14,12 @@ const HEADER_NAME_PATTERN = /^[A-Za-z0-9-]+$/;
 /**
  * Normalize a header name according to AgentCore Runtime rules:
  * - "Authorization" (case-insensitive) -> "Authorization"
- * - Headers already starting with the prefix (case-insensitive) -> canonical prefix + original suffix
- * - Other headers -> prepend the prefix
+ * - Headers already starting with the canonical custom prefix
+ *   (case-insensitive) -> canonical prefix + original suffix
+ * - Headers already under the broader 'X-Amzn-Bedrock-AgentCore-' namespace
+ *   (case-insensitive) -> canonical namespace prefix + original suffix
+ *   (i.e. these are accepted as-is and NOT re-prefixed with the Custom- prefix)
+ * - Other (bare) header names -> prepend the Custom- prefix
  */
 export function normalizeHeaderName(input: string): string {
   if (input.toLowerCase() === 'authorization') {
@@ -20,6 +27,9 @@ export function normalizeHeaderName(input: string): string {
   }
   if (input.toLowerCase().startsWith(HEADER_ALLOWLIST_PREFIX.toLowerCase())) {
     return `${HEADER_ALLOWLIST_PREFIX}${input.slice(HEADER_ALLOWLIST_PREFIX.length)}`;
+  }
+  if (input.toLowerCase().startsWith(HEADER_ALLOWLIST_NAMESPACE_PREFIX.toLowerCase())) {
+    return `${HEADER_ALLOWLIST_NAMESPACE_PREFIX}${input.slice(HEADER_ALLOWLIST_NAMESPACE_PREFIX.length)}`;
   }
   return `${HEADER_ALLOWLIST_PREFIX}${input}`;
 }
@@ -67,6 +77,15 @@ export function validateHeaderAllowlist(value: string): { success: boolean; erro
       success: false,
       error: `Header allowlist cannot exceed ${MAX_HEADER_ALLOWLIST_SIZE} headers. Provided: ${headers.length}`,
     };
+  }
+
+  for (const header of headers) {
+    if (!isAllowedRequestHeader(header)) {
+      return {
+        success: false,
+        error: `Invalid header "${header}". Must be "Authorization" or start with "${HEADER_ALLOWLIST_NAMESPACE_PREFIX}". See https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-header-allowlist.html`,
+      };
+    }
   }
 
   return { success: true };

--- a/src/cli/primitives/AgentPrimitive.tsx
+++ b/src/cli/primitives/AgentPrimitive.tsx
@@ -254,7 +254,7 @@ export class AgentPrimitive extends BasePrimitive<AddAgentOptions, RemovableReso
       .option('--client-secret <secret>', 'OAuth client secret [non-interactive]')
       .option(
         '--request-header-allowlist <headers>',
-        'Comma-separated list of custom header names to allow (auto-prefixed with X-Amzn-Bedrock-AgentCore-Runtime-Custom-) [non-interactive]'
+        'Comma-separated list of allowed request header names. Bare names are auto-prefixed with X-Amzn-Bedrock-AgentCore-Runtime-Custom-; "Authorization" and any header under the X-Amzn-Bedrock-AgentCore- namespace are also accepted. See https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-header-allowlist.html [non-interactive]'
       )
       .option(
         '--idle-timeout <seconds>',

--- a/src/cli/tui/screens/agent/AddAgentScreen.tsx
+++ b/src/cli/tui/screens/agent/AddAgentScreen.tsx
@@ -1181,8 +1181,9 @@ export function AddAgentScreen({ existingAgentNames, onComplete, onExit }: AddAg
             />
             <Box marginTop={1}>
               <Text dimColor>
-                Enter header suffixes or full names. We auto-prefix with X-Amzn-Bedrock-AgentCore-Runtime-Custom- if
-                needed. &apos;Authorization&apos; is also accepted.
+                Enter header suffixes or full names. Bare names are auto-prefixed with
+                X-Amzn-Bedrock-AgentCore-Runtime-Custom-. &apos;Authorization&apos; and any header under the
+                X-Amzn-Bedrock-AgentCore- namespace are also accepted.
               </Text>
             </Box>
           </Box>

--- a/src/schema/schemas/__tests__/agent-env.test.ts
+++ b/src/schema/schemas/__tests__/agent-env.test.ts
@@ -6,11 +6,17 @@ import {
   EnvVarNameSchema,
   EnvVarSchema,
   GatewayNameSchema,
+  HEADER_ALLOWLIST_NAMESPACE_PREFIX,
+  HEADER_ALLOWLIST_PREFIX,
   InstrumentationSchema,
   LifecycleConfigurationSchema,
+  MAX_HEADER_ALLOWLIST_SIZE,
   NetworkConfigSchema,
+  REQUEST_HEADER_ALLOWLIST_PATTERN,
+  RequestHeaderAllowlistSchema,
   RuntimeEndpointNameSchema,
   RuntimeEndpointSchema,
+  isAllowedRequestHeader,
 } from '../agent-env.js';
 import { describe, expect, it } from 'vitest';
 
@@ -621,6 +627,61 @@ describe('AgentEnvSpecSchema - endpoints', () => {
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.data.endpoints!.prod).toEqual({ version: 5 });
+    }
+  });
+});
+
+describe('REQUEST_HEADER_ALLOWLIST_PATTERN / isAllowedRequestHeader', () => {
+  it('matches Authorization (case-insensitive)', () => {
+    expect(REQUEST_HEADER_ALLOWLIST_PATTERN.test('Authorization')).toBe(true);
+    expect(isAllowedRequestHeader('authorization')).toBe(true);
+  });
+
+  it('matches headers under the AgentCore namespace prefix', () => {
+    expect(isAllowedRequestHeader('X-Amzn-Bedrock-AgentCore-Runtime-Custom-Foo')).toBe(true);
+    expect(isAllowedRequestHeader('X-Amzn-Bedrock-AgentCore-Runtime-User-Id')).toBe(true);
+    expect(isAllowedRequestHeader('X-Amzn-Bedrock-AgentCore-Runtime-Session-Id')).toBe(true);
+  });
+
+  it('rejects non-matching names and the bare namespace prefix', () => {
+    expect(isAllowedRequestHeader('Foo')).toBe(false);
+    expect(isAllowedRequestHeader('X-Custom-Foo')).toBe(false);
+    expect(isAllowedRequestHeader(HEADER_ALLOWLIST_NAMESPACE_PREFIX)).toBe(false);
+    expect(isAllowedRequestHeader('')).toBe(false);
+  });
+});
+
+describe('RequestHeaderAllowlistSchema', () => {
+  it('accepts Authorization and Custom- prefixed headers', () => {
+    const result = RequestHeaderAllowlistSchema.safeParse(['Authorization', `${HEADER_ALLOWLIST_PREFIX}Foo`]);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts the broader namespace prefix', () => {
+    const result = RequestHeaderAllowlistSchema.safeParse([
+      'X-Amzn-Bedrock-AgentCore-Runtime-User-Id',
+      'X-Amzn-Bedrock-AgentCore-Runtime-Session-Id',
+    ]);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects bare names without the namespace prefix', () => {
+    const result = RequestHeaderAllowlistSchema.safeParse(['Foo-Bar']);
+    expect(result.success).toBe(false);
+  });
+
+  it(`rejects more than ${MAX_HEADER_ALLOWLIST_SIZE} headers`, () => {
+    const headers = Array.from({ length: MAX_HEADER_ALLOWLIST_SIZE + 1 }, (_, i) => `${HEADER_ALLOWLIST_PREFIX}H${i}`);
+    const result = RequestHeaderAllowlistSchema.safeParse(headers);
+    expect(result.success).toBe(false);
+  });
+
+  it('error message references the AWS doc URL', () => {
+    const result = RequestHeaderAllowlistSchema.safeParse(['Foo']);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const allMessages = result.error.issues.map(i => i.message).join(' | ');
+      expect(allMessages).toContain('runtime-header-allowlist.html');
     }
   });
 });

--- a/src/schema/schemas/agent-env.ts
+++ b/src/schema/schemas/agent-env.ts
@@ -125,19 +125,51 @@ export type NetworkConfig = z.infer<typeof NetworkConfigSchema>;
 
 /**
  * Allowed request headers for the runtime.
- * Each header must be 'Authorization' or start with 'X-Amzn-Bedrock-AgentCore-Runtime-Custom-'.
+ *
+ * Per AWS Bedrock AgentCore runtime header allowlist documentation
+ * (https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-header-allowlist.html),
+ * each header must be either:
+ *  - 'Authorization' (case-sensitive canonical form), or
+ *  - any header beginning with the AgentCore runtime namespace prefix
+ *    'X-Amzn-Bedrock-AgentCore-' (case-insensitive), e.g.
+ *      * 'X-Amzn-Bedrock-AgentCore-Runtime-Custom-<Suffix>'
+ *      * 'X-Amzn-Bedrock-AgentCore-Runtime-User-Id'
+ *      * 'X-Amzn-Bedrock-AgentCore-Runtime-Session-Id'
+ *      * other documented headers under the same namespace
+ *
  * Maximum 20 headers.
+ *
+ * NOTE: This file is duplicated in agentcore-l3-cdk-constructs/src/schema/schemas/agent-env.ts.
+ * Keep both copies in sync.
  */
 export const HEADER_ALLOWLIST_PREFIX = 'X-Amzn-Bedrock-AgentCore-Runtime-Custom-';
+export const HEADER_ALLOWLIST_NAMESPACE_PREFIX = 'X-Amzn-Bedrock-AgentCore-';
 export const MAX_HEADER_ALLOWLIST_SIZE = 20;
+
+/**
+ * Pattern matching any header name that is an acceptable entry in the
+ * request header allowlist. Matches case-insensitively for the namespace
+ * prefix to accommodate user-supplied casing variations; the runtime
+ * itself is HTTP-header-case-insensitive.
+ */
+export const REQUEST_HEADER_ALLOWLIST_PATTERN = /^(Authorization|X-Amzn-Bedrock-AgentCore-[A-Za-z0-9-]+)$/i;
+
+/**
+ * Returns true when the given header name is allowed in the runtime
+ * request header allowlist (Authorization or any header under the
+ * AgentCore runtime namespace prefix).
+ */
+export function isAllowedRequestHeader(name: string): boolean {
+  return REQUEST_HEADER_ALLOWLIST_PATTERN.test(name);
+}
 
 export const RequestHeaderAllowlistSchema = z
   .array(
     z
       .string()
       .refine(
-        val => val === 'Authorization' || val.startsWith(HEADER_ALLOWLIST_PREFIX),
-        `Must be "Authorization" or start with "${HEADER_ALLOWLIST_PREFIX}"`
+        isAllowedRequestHeader,
+        `Must be "Authorization" or start with "${HEADER_ALLOWLIST_NAMESPACE_PREFIX}". See https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-header-allowlist.html`
       )
   )
   .max(MAX_HEADER_ALLOWLIST_SIZE, `Maximum ${MAX_HEADER_ALLOWLIST_SIZE} headers allowed`);


### PR DESCRIPTION
## Description

Relaxes the runtime `requestHeaderAllowlist` validation to accept the broader
`X-Amzn-Bedrock-AgentCore-` namespace, in addition to the existing
`Authorization` and legacy `X-Amzn-Bedrock-AgentCore-Runtime-Custom-` prefixed
headers. This brings the CLI in line with the published AWS Bedrock AgentCore
runtime header allowlist:

https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-header-allowlist.html

Previously, the schema only accepted exactly `Authorization` or names starting
with `X-Amzn-Bedrock-AgentCore-Runtime-Custom-`. Documented runtime headers
such as `X-Amzn-Bedrock-AgentCore-Runtime-User-Id` and
`X-Amzn-Bedrock-AgentCore-Runtime-Session-Id` were therefore rejected by the
CLI before deployment, even though the service accepts them.

### Changes

**Schema** (`src/schema/schemas/agent-env.ts`)
- New exports: `HEADER_ALLOWLIST_NAMESPACE_PREFIX` (`'X-Amzn-Bedrock-AgentCore-'`),
  `REQUEST_HEADER_ALLOWLIST_PATTERN`
  (`/^(Authorization|X-Amzn-Bedrock-AgentCore-[A-Za-z0-9-]+)$/i`),
  and `isAllowedRequestHeader()` helper.
- `RequestHeaderAllowlistSchema.refine()` now uses `isAllowedRequestHeader`
  with an updated error message that links to the AWS doc.
- Existing `HEADER_ALLOWLIST_PREFIX` export is preserved (still used for
  auto-prefixing bare names) — no breaking change for consumers.
- Added a "duplicated — keep in sync with `agentcore-l3-cdk-constructs`" doc
  note above the constants.

**Header utilities** (`src/cli/commands/shared/header-utils.ts`)
- Re-exports `HEADER_ALLOWLIST_NAMESPACE_PREFIX` and `isAllowedRequestHeader`.
- `normalizeHeaderName` now recognizes inputs already under the broader
  namespace and canonicalizes their casing **without** re-wrapping them in the
  `Custom-` prefix (preventing nonsense names like
  `…Runtime-Custom-X-Amzn-Bedrock-AgentCore-Runtime-User-Id`). Bare names
  continue to be auto-prefixed with the legacy `Custom-` prefix for backward
  compatibility.
- `validateHeaderAllowlist` now runs each parsed header through
  `isAllowedRequestHeader` and returns a structured error (with doc URL) when
  a name does not match, providing earlier and clearer feedback than relying
  on the Zod refine alone.

**Help text**
- `src/cli/primitives/AgentPrimitive.tsx`: updated the
  `--request-header-allowlist` Commander option description to mention the
  broader namespace and link to the AWS doc.
- `src/cli/tui/screens/agent/AddAgentScreen.tsx`: updated the dim helper text
  beneath the input field accordingly.

**Tests**
- `src/cli/commands/shared/__tests__/header-utils.test.ts`: added cases
  covering `normalizeHeaderName` for namespace-prefixed inputs (no
  double-prefix; canonical casing) and `validateHeaderAllowlist` accepting
  the broader namespace.
- `src/schema/schemas/__tests__/agent-env.test.ts`: new schema-level tests
  for `REQUEST_HEADER_ALLOWLIST_PATTERN`, `isAllowedRequestHeader`, and
  `RequestHeaderAllowlistSchema` (accept/reject cases, max-20 boundary, doc
  URL in error message).

### Companion PR

The schema duplicate in `aws/agentcore-l3-cdk-constructs` has been updated in
lockstep on branch `fix/1151-6ed1535c` (commit `080c327`).

## Related Issue

Closes #1151

## Documentation PR

N/A — the documented behavior already matches the AWS public docs at
https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-header-allowlist.html;
this PR brings the CLI's runtime validation in line with that doc. The CLI
help text and TUI hints have been updated in this PR.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

Targeted test runs (executed locally):

- `npx vitest run --project unit src/cli/commands/shared/__tests__/header-utils.test.ts src/schema/schemas/__tests__/agent-env.test.ts`
  → **128 / 128 passing** across both files.
- `npm run typecheck` → clean (no errors).
- Pre-commit hooks (prettier, eslint, secretlint) → all green.

CI will exercise the full unit + integ suites on this PR.

## Code review

Round 1: 10 findings, all approved.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
