### PR TITLE
fix: apply prettier formatting to review.md

### DIFF
--- a/.github/harness/prompts/review.md
+++ b/.github/harness/prompts/review.md
@@ -14,4 +14,5 @@ Review the PR. If there are any serious issues that require code changes before 
 each issue explaining the problem. If there are multiple ways to fix an issue, list the options so the author can
 choose. Skip style nits and minor suggestions — only flag things that actually need to change.
 
-When finished, submit a formal PR review (approve or request changes) with individual and inline comments in it. Be specific with line numbers.
+When finished, submit a formal PR review (approve or request changes) with individual and inline comments in it. Be
+specific with line numbers.


### PR DESCRIPTION
## Description

Fixes a prose wrapping issue in `.github/harness/prompts/review.md` where a line exceeded the configured `printWidth: 120` setting. Prettier with `proseWrap: always` now wraps it correctly.

## Related Issue

Closes #1164

## Documentation PR

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe): Code style fix (prettier formatting)

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.