### PR TITLE
fix(status): exit non-zero when --type/--state filter value is invalid

### DIFF
--- a/src/cli/commands/status/__tests__/action.test.ts
+++ b/src/cli/commands/status/__tests__/action.test.ts
@@ -805,3 +805,59 @@ describe('handleProjectStatus — invocation URL enrichment', () => {
     expect(agentEntry!.invocationUrl).toBeUndefined();
   });
 });
+
+describe('registerStatus --type / --state validation exit code', () => {
+  const renderMock = vi.fn();
+  vi.doMock('ink', () => ({
+    Box: ({ children }: { children?: unknown }) => children,
+    Text: ({ children }: { children?: unknown }) => children,
+    render: (...args: unknown[]) => renderMock(...args),
+  }));
+  vi.doMock('../../../tui/guards', () => ({
+    requireProject: vi.fn(),
+  }));
+
+  beforeEach(() => {
+    renderMock.mockReset();
+  });
+
+  it('exits with non-zero code when --type is invalid', async () => {
+    const { Command } = await import('@commander-js/extra-typings');
+    const { registerStatus } = await import('../command.js');
+
+    const program = new Command();
+    program.exitOverride();
+    registerStatus(program as unknown as Parameters<typeof registerStatus>[0]);
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__exit:${code ?? 0}`);
+    }) as never);
+
+    try {
+      await expect(program.parseAsync(['node', 'agentcore', 'status', '--type', 'bogus'])).rejects.toThrow(/__exit:1/);
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
+  it('exits with non-zero code when --state is invalid', async () => {
+    const { Command } = await import('@commander-js/extra-typings');
+    const { registerStatus } = await import('../command.js');
+
+    const program = new Command();
+    program.exitOverride();
+    registerStatus(program as unknown as Parameters<typeof registerStatus>[0]);
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__exit:${code ?? 0}`);
+    }) as never);
+
+    try {
+      await expect(program.parseAsync(['node', 'agentcore', 'status', '--state', 'bogus'])).rejects.toThrow(/__exit:1/);
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+});

--- a/src/cli/commands/status/command.tsx
+++ b/src/cli/commands/status/command.tsx
@@ -76,7 +76,7 @@ export const registerStatus = (program: Command) => {
             Invalid resource type &apos;{cliOptions.type}&apos;. Valid types: {VALID_RESOURCE_TYPES.join(', ')}
           </Text>
         );
-        return;
+        process.exit(1);
       }
 
       // Validate --state
@@ -86,7 +86,7 @@ export const registerStatus = (program: Command) => {
             Invalid state &apos;{cliOptions.state}&apos;. Valid states: {VALID_STATES.join(', ')}
           </Text>
         );
-        return;
+        process.exit(1);
       }
 
       try {


### PR DESCRIPTION
## Description

`agentcore status --type <invalid>` (and `--state <invalid>`) printed an error message but returned exit code 0. Non-interactive callers — scripts, CI pipelines, automation — had no way to detect the rejection and would happily continue as if nothing was wrong.

The fix is minimal: in `src/cli/commands/status/command.tsx`, after rendering the validation error for an invalid `--type` or `--state`, replace the bare `return;` with `process.exit(1);`. This matches the convention already used in this same file's catch handler (line 297). Two lines changed in production code.

Reviewer findings round 1: 1 finding, all approved.

### Before
```
$ agentcore status --type bogus
Invalid resource type 'bogus'. Valid types: agent, runtime-endpoint, memory, credential, gateway, evaluator, online-eval, policy-engine, policy
$ echo $?
0
```

### After
```
$ agentcore status --type bogus
Invalid resource type 'bogus'. Valid types: agent, runtime-endpoint, memory, credential, gateway, evaluator, online-eval, policy-engine, policy, config-bundle, ab-test
$ echo $?
1
```

## Related Issue

Closes #984

## Documentation PR

N/A — no user-facing documentation changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

Added two unit tests in `src/cli/commands/status/__tests__/action.test.ts` that register the `status` command on a Commander program, parse it with `--type bogus` / `--state bogus`, and assert `process.exit` is called with `1`. All 36 tests in this file pass; full CI (format, lint, typecheck, unit-test 1/3 + 2/3 + 3/3, build, CodeQL, security, secrets, ai-review) is green.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.