### PR TITLE
fix(import): guard interactive TUI with requireTTY() so non-TTY exits 1 cleanly (#982)

### DIFF
--- a/src/cli/commands/deploy/__tests__/deploy-non-tty.test.ts
+++ b/src/cli/commands/deploy/__tests__/deploy-non-tty.test.ts
@@ -1,0 +1,59 @@
+import { runCLI } from '../../../../test-utils/index.js';
+import { randomUUID } from 'node:crypto';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+/**
+ * Regression test for issue #982 (the command named in the bug title):
+ * `agentcore deploy` (and any TUI-mode invocation) in a non-TTY context
+ * must NOT crash with the Ink "Raw mode is not supported" error and must
+ * NOT exit 0. It must exit 1 with a clear interactive-terminal message so
+ * CI pipelines can detect the failure.
+ *
+ * The TUI path is reached when no flags are provided (and also for --diff).
+ * Flag-bearing modes (--yes, --json, --dry-run, --target, --verbose) route
+ * to the non-interactive CLI path which does not require a TTY and is not
+ * the subject of this regression.
+ */
+describe('deploy command non-TTY behavior (issue #982)', () => {
+  let testDir: string;
+  let projectDir: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `agentcore-deploy-tty-${randomUUID()}`);
+    projectDir = join(testDir, 'project');
+    const configDir = join(projectDir, 'agentcore');
+    await mkdir(configDir, { recursive: true });
+    // Minimal valid project marker so requireProject() passes — guard
+    // ordering means requireTTY() will fire first, but we keep a real
+    // project dir so an accidental ordering regression surfaces clearly.
+    await writeFile(join(configDir, 'agentcore.json'), JSON.stringify({ name: 'test', version: 1 }, null, 2), 'utf-8');
+  });
+
+  afterAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it('exits 1 with a clear message when run without flags in non-TTY (interactive path)', async () => {
+    // runCLI uses stdio: ['ignore', 'pipe', 'pipe'] — both stdin and stdout
+    // are non-TTY, exactly the scenario from the bug report.
+    const result = await runCLI(['deploy'], projectDir);
+
+    expect(result.exitCode).toBe(1);
+
+    const combined = `${result.stdout}\n${result.stderr}`;
+    expect(combined.toLowerCase()).toContain('requires an interactive terminal');
+    expect(combined).not.toContain('Raw mode is not supported');
+  });
+
+  it('exits 1 cleanly with --diff in non-TTY (TUI diff path)', async () => {
+    const result = await runCLI(['deploy', '--diff'], projectDir);
+
+    expect(result.exitCode).toBe(1);
+
+    const combined = `${result.stdout}\n${result.stderr}`;
+    expect(combined).not.toContain('Raw mode is not supported');
+  });
+});

--- a/src/cli/commands/import/__tests__/command.test.ts
+++ b/src/cli/commands/import/__tests__/command.test.ts
@@ -40,4 +40,19 @@ describe('import command non-TTY behavior (issue #982)', () => {
     expect(combined.toLowerCase()).toContain('requires an interactive terminal');
     expect(combined).not.toContain('Raw mode is not supported');
   });
+
+  it('does not apply the TTY guard to --source path (pins guard placement)', async () => {
+    // The requireTTY() guard must remain inside the no-source branch only.
+    // If it gets accidentally hoisted to the top of the action, this test
+    // will start failing with the interactive-terminal message instead of
+    // the source-file-validation message.
+    const bogusSource = join(projectDir, 'definitely-does-not-exist.yaml');
+    const result = await runCLI(['import', '--source', bogusSource], projectDir);
+
+    expect(result.exitCode).toBe(1);
+
+    const combined = `${result.stdout}\n${result.stderr}`;
+    expect(combined).toContain('Source file not found');
+    expect(combined.toLowerCase()).not.toContain('requires an interactive terminal');
+  });
 });

--- a/src/cli/commands/import/__tests__/command.test.ts
+++ b/src/cli/commands/import/__tests__/command.test.ts
@@ -1,0 +1,49 @@
+import { runCLI } from '../../../../test-utils/index.js';
+import { randomUUID } from 'node:crypto';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+/**
+ * Regression test for issue #982:
+ * Running `agentcore import` (interactive TUI path) with a non-TTY stdin/stdout
+ * must NOT crash with the Ink "Raw mode is not supported" error and must NOT
+ * exit 0. It must exit 1 with a clear interactive-terminal message so that
+ * CI pipelines can detect the failure.
+ */
+describe('import command non-TTY behavior (issue #982)', () => {
+  let testDir: string;
+  let projectDir: string;
+
+  beforeAll(async () => {
+    testDir = join(tmpdir(), `agentcore-import-tty-${randomUUID()}`);
+    projectDir = join(testDir, 'project');
+    const configDir = join(projectDir, 'agentcore');
+    await mkdir(configDir, { recursive: true });
+    // Minimal valid project marker so requireProject() passes.
+    await writeFile(join(configDir, 'agentcore.json'), JSON.stringify({ name: 'test', version: 1 }, null, 2), 'utf-8');
+  });
+
+  afterAll(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it('exits non-zero with a clear message when stdin is not a TTY', async () => {
+    // runCLI uses stdio: ['ignore', 'pipe', 'pipe'] — both stdin and stdout
+    // are non-TTY, exactly the scenario from the bug report.
+    const result = await runCLI(['import'], projectDir);
+
+    expect(result.exitCode).toBe(1);
+
+    const combined = `${result.stdout}\n${result.stderr}`;
+    expect(
+      combined.toLowerCase().includes('requires an interactive terminal'),
+      `Should print interactive-terminal message, got stdout=${result.stdout}, stderr=${result.stderr}`
+    ).toBeTruthy();
+    expect(
+      !combined.includes('Raw mode is not supported'),
+      `Must not surface the Ink raw-mode error, got: ${combined}`
+    ).toBeTruthy();
+  });
+});

--- a/src/cli/commands/import/__tests__/command.test.ts
+++ b/src/cli/commands/import/__tests__/command.test.ts
@@ -37,13 +37,7 @@ describe('import command non-TTY behavior (issue #982)', () => {
     expect(result.exitCode).toBe(1);
 
     const combined = `${result.stdout}\n${result.stderr}`;
-    expect(
-      combined.toLowerCase().includes('requires an interactive terminal'),
-      `Should print interactive-terminal message, got stdout=${result.stdout}, stderr=${result.stderr}`
-    ).toBeTruthy();
-    expect(
-      !combined.includes('Raw mode is not supported'),
-      `Must not surface the Ink raw-mode error, got: ${combined}`
-    ).toBeTruthy();
+    expect(combined.toLowerCase()).toContain('requires an interactive terminal');
+    expect(combined).not.toContain('Raw mode is not supported');
   });
 });

--- a/src/cli/commands/import/command.ts
+++ b/src/cli/commands/import/command.ts
@@ -1,3 +1,4 @@
+import { requireProject, requireTTY } from '../../tui/guards';
 import { handleImport } from './actions';
 import { ANSI } from './constants';
 import { registerImportEvaluator } from './import-evaluator';
@@ -22,11 +23,13 @@ export const registerImport = (program: Command) => {
     .option('-y, --yes', 'Auto-confirm prompts')
     .action(async (cliOptions: { source?: string; target?: string; yes?: boolean }) => {
       if (!cliOptions.source) {
-        // No --source and no subcommand — launch interactive TUI
-        const { requireProject } = await import('../../tui/guards/project');
-        const { requireTTY } = await import('../../tui/guards/tty');
-        requireProject();
+        // No --source and no subcommand — launch interactive TUI.
+        // Call requireTTY() before requireProject() so non-TTY contexts always
+        // exit with the plain-text message rather than going through any Ink
+        // rendering path (FatalError uses Ink, which can produce malformed
+        // output to a piped stream).
         requireTTY();
+        requireProject();
         const { render } = await import('ink');
         const React = await import('react');
         const { ImportFlow } = await import('../../tui/screens/import');

--- a/src/cli/commands/import/command.ts
+++ b/src/cli/commands/import/command.ts
@@ -24,7 +24,9 @@ export const registerImport = (program: Command) => {
       if (!cliOptions.source) {
         // No --source and no subcommand — launch interactive TUI
         const { requireProject } = await import('../../tui/guards/project');
+        const { requireTTY } = await import('../../tui/guards/tty');
         requireProject();
+        requireTTY();
         const { render } = await import('ink');
         const React = await import('react');
         const { ImportFlow } = await import('../../tui/screens/import');

--- a/src/cli/tui/guards/__tests__/tty.test.ts
+++ b/src/cli/tui/guards/__tests__/tty.test.ts
@@ -1,0 +1,65 @@
+import { requireTTY } from '../tty.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('requireTTY', () => {
+  const originalStdinIsTTY = process.stdin.isTTY;
+  const originalStdoutIsTTY = process.stdout.isTTY;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // Throw from process.exit so we can assert without actually exiting the test runner.
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__exit__:${code}`);
+    }) as never);
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {
+      /* swallow output during tests */
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: originalStdinIsTTY, configurable: true });
+    Object.defineProperty(process.stdout, 'isTTY', { value: originalStdoutIsTTY, configurable: true });
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('exits 1 with an interactive-terminal message when stdin is not a TTY', () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+
+    expect(() => requireTTY()).toThrow(/__exit__:1/);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const msg = String(errorSpy.mock.calls[0]?.[0] ?? '');
+    expect(msg).toMatch(/requires an interactive terminal/);
+  });
+
+  it('exits 1 with an interactive-terminal message when stdout is not a TTY', () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+    Object.defineProperty(process.stdout, 'isTTY', { value: false, configurable: true });
+
+    expect(() => requireTTY()).toThrow(/__exit__:1/);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const msg = String(errorSpy.mock.calls[0]?.[0] ?? '');
+    expect(msg).toMatch(/requires an interactive terminal/);
+  });
+
+  it('exits 1 when both stdin and stdout are non-TTY', () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+    Object.defineProperty(process.stdout, 'isTTY', { value: false, configurable: true });
+
+    expect(() => requireTTY()).toThrow(/__exit__:1/);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('is a no-op when both stdin and stdout are TTYs', () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+
+    expect(() => requireTTY()).not.toThrow();
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/tui/guards/__tests__/tty.test.ts
+++ b/src/cli/tui/guards/__tests__/tty.test.ts
@@ -2,12 +2,31 @@ import { requireTTY } from '../tty.js';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 describe('requireTTY', () => {
-  const originalStdinIsTTY = process.stdin.isTTY;
-  const originalStdoutIsTTY = process.stdout.isTTY;
+  let originalStdinIsTTY: boolean | undefined;
+  let originalStdoutIsTTY: boolean | undefined;
   let exitSpy: ReturnType<typeof vi.spyOn>;
   let errorSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
+    // Snapshot the live values inside beforeEach so a previous test file in
+    // the same worker that mutated process.stdin/stdout.isTTY without
+    // restoring cannot poison our restoration. Also re-define with
+    // configurable: true to make subsequent restoration deterministic
+    // across Node versions where the original descriptor for piped streams
+    // may not be configurable.
+    originalStdinIsTTY = process.stdin.isTTY;
+    originalStdoutIsTTY = process.stdout.isTTY;
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: originalStdinIsTTY,
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: originalStdoutIsTTY,
+      configurable: true,
+      writable: true,
+    });
+
     // Throw from process.exit so we can assert without actually exiting the test runner.
     exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
       throw new Error(`__exit__:${code}`);


### PR DESCRIPTION
## Description

Fix issue #982: non-TTY invocations of TUI-based commands could crash with the Ink "Raw mode is not supported on the current process.stdin" error and silently exit with code 0, hiding the failure from CI/CD pipelines and scripted usage.

### Root cause

The `requireTTY()` guard in `src/cli/tui/guards/tty.ts` already exists and is applied in `deploy`, `create`, `dev`, `add`, `remove`, and `invoke`. However, the `import` command's interactive TUI branch (`agentcore import` with no `--source` and no subcommand) called `render(<ImportFlow>)` **without** first calling `requireTTY()`. Verified reproducer:

```bash
echo "" | agentcore import      # before: Ink raw-mode error, exit 0
echo "" | agentcore import      # after:  exit 1, "requires an interactive terminal"
```

### Changes

- **`src/cli/commands/import/command.ts`** — Add `requireTTY()` (called *before* `requireProject()`, so the non-TTY exit path never goes through any Ink render) in the no-source branch. Hoisted to a static barrel import (`import { requireProject, requireTTY } from '../../tui/guards'`) for consistency with the other TUI commands.
- **`src/cli/tui/guards/__tests__/tty.test.ts`** *(new)* — Unit tests locking in the exit-1 + clear-message contract for `requireTTY()` across the four TTY combinations.
- **`src/cli/commands/import/__tests__/command.test.ts`** *(new)* — Integration test running `agentcore import` via `runCLI` (non-TTY stdin/stdout) asserting exit 1 with the interactive-terminal message and no Ink raw-mode text. Also pins guard placement: `import --source <bogus>` must take the source-file-validation path, not the TTY guard.
- **`src/cli/commands/deploy/__tests__/deploy-non-tty.test.ts`** *(new)* — Regression test for the command named in the bug title: `agentcore deploy` (no flags) and `agentcore deploy --diff` in non-TTY exit 1 cleanly without surfacing the Ink raw-mode error.

### Out of scope

- `deploy`, `create`, `dev`, `add`, `remove`, `invoke` already have `requireTTY()` (since PR #949) — verified working under the reproducer; no behavior change beyond adding the missing test coverage above.
- Non-interactive `render(<Text>)` usages in `status`, `fetch`, `package`, `traces`, `config-bundle` don't use Ink raw mode and don't trigger the bug.
- The global `uncaughtException` handler in `src/cli/index.ts` already exits 1; no change needed.

## Related Issue

Closes #982

## Documentation PR

N/A — bug fix, no user-facing surface area changes.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ` *(targeted: 8/8 tests across `tty.test.ts`, `import/__tests__/command.test.ts`, `deploy/__tests__/deploy-non-tty.test.ts` pass; full unit suite green in CI)*
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots *(N/A — no asset changes)*

Manual verification of the reproducer:

```bash
$ echo "" | agentcore import        # exit 1, "requires an interactive terminal"
$ echo "" | agentcore deploy        # exit 1, "requires an interactive terminal"
$ agentcore deploy < /dev/null      # exit 1, "requires an interactive terminal"
$ agentcore import --source bogus.yaml   # exit 1, "Source file not found" (guard correctly NOT applied)
```

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly *(no docs changes needed for this guard fix)*
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
