### PR TITLE
ci: add workflow to create issues on CI failure

### DIFF
--- a/.github/workflows/ci-failure-issue.yml
+++ b/.github/workflows/ci-failure-issue.yml
@@ -1,0 +1,60 @@
+name: CI Failure Issue
+
+on:
+  workflow_run:
+    # These names must match the `name:` field in each workflow file exactly
+    workflows:
+      - "Build and Test"
+      - "Quality and Safety Checks"
+      - "E2E Tests (Full Suite)"
+      - "CodeQL"
+    types: [completed]
+
+jobs:
+  create-issue:
+    concurrency: ci-failure-issue-${{ github.event.workflow_run.name }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.head_branch == 'main' }}
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v9
+        with:
+          script: |
+            try {
+              const workflowName = context.payload.workflow_run.name;
+
+              if (!/^[A-Za-z0-9 _()\-]+$/.test(workflowName)) {
+                core.setFailed(`Unexpected characters in workflow name: ${workflowName}`);
+                return;
+              }
+
+              const sha = context.payload.workflow_run.head_sha;
+              const runUrl = context.payload.workflow_run.html_url;
+              const branch = context.payload.workflow_run.head_branch;
+              const title = `CI Failure: ${workflowName}`;
+
+              const { data: issues } = await github.rest.issues.listForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels: 'high-severity,ci',
+                state: 'open',
+                per_page: 100
+              });
+
+              if (issues.some(i => i.title === title)) {
+                core.info(`Issue already exists for "${title}"`);
+                return;
+              }
+
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                labels: ['high-severity', 'ci'],
+                body: `## CI Failure\n\n- **Workflow:** ${workflowName}\n- **Branch:** ${branch}\n- **Commit:** ${sha}\n- **Run:** ${runUrl}\n\nPlease investigate this failure.`
+              });
+            } catch (error) {
+              core.setFailed(`Failed to create CI failure issue: ${error.message || error}`);
+            }

--- a/.github/workflows/ci-failure-issue.yml
+++ b/.github/workflows/ci-failure-issue.yml
@@ -4,10 +4,10 @@ on:
   workflow_run:
     # These names must match the `name:` field in each workflow file exactly
     workflows:
-      - "Build and Test"
-      - "Quality and Safety Checks"
-      - "E2E Tests (Full Suite)"
-      - "CodeQL"
+      - 'Build and Test'
+      - 'Quality and Safety Checks'
+      - 'E2E Tests (Full Suite)'
+      - 'CodeQL'
     types: [completed]
 
 jobs:


### PR DESCRIPTION
## Description

Adds a new workflow `.github/workflows/ci-failure-issue.yml` that automatically creates a GitHub issue (labeled `high-severity` + `ci`) when any CI check fails on the most recent commit to `main`.

Key details:
- Triggers via `workflow_run` on: Build and Test, Quality and Safety Checks, E2E Tests (Full Suite), CodeQL
- Creates one issue per failing workflow
- Deduplicates by checking open issues with matching title/labels using the Issues API (not Search API)
- Includes concurrency control, input validation, error handling, and timeout

## Related Issue

## Documentation PR

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:unit` and `npm run test:integ`
- [ ] I ran `npm run typecheck`
- [ ] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

Can be verified by intentionally failing a CI check on main after merge, or by temporarily changing the branch filter to trigger on a feature branch.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.