### PR TITLE
ci: use PAT for CI failure issue creation

### DIFF
--- a/.github/workflows/ci-failure-issue.yml
+++ b/.github/workflows/ci-failure-issue.yml
@@ -21,6 +21,7 @@ jobs:
     steps:
       - uses: actions/github-script@v9
         with:
+          github-token: ${{ secrets.AUTOMATION_ACCOUNT_PAT_TOKEN }}
           script: |
             try {
               const workflowName = context.payload.workflow_run.name;


### PR DESCRIPTION
## Description

Switch the CI failure issue workflow to use `AUTOMATION_ACCOUNT_PAT_TOKEN` instead of the default `GITHUB_TOKEN`.

Issues created with `GITHUB_TOKEN` do not trigger other workflows (documented GitHub limitation), so the Slack notification workflow (`slack-issue-notification.yml`) was not firing on CI failure issues. Using a PAT allows the created issue to trigger the `issues: opened` event that the Slack workflow listens on.

## Related Issue

Depends on #1174 being merged first.

## Documentation PR

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

- [ ] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

Verify that after merge, a CI failure creates an issue AND the Slack notification fires.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.