### PR TITLE
docs: add bedrock:CountTokens to IAM policy examples

### DIFF
--- a/docs/policies/iam-policy-boundary.json
+++ b/docs/policies/iam-policy-boundary.json
@@ -4,7 +4,7 @@
     {
       "Sid": "BedrockModelAccess",
       "Effect": "Allow",
-      "Action": ["bedrock:InvokeModel", "bedrock:InvokeModelWithResponseStream"],
+      "Action": ["bedrock:InvokeModel", "bedrock:InvokeModelWithResponseStream", "bedrock:CountTokens"],
       "Resource": ["arn:aws:bedrock:*::foundation-model/*", "arn:aws:bedrock:*:ACCOUNT_ID:*"]
     },
     {

--- a/docs/policies/iam-policy-user.json
+++ b/docs/policies/iam-policy-user.json
@@ -116,7 +116,7 @@
     {
       "Sid": "BedrockModelInvocation",
       "Effect": "Allow",
-      "Action": ["bedrock:InvokeModel", "bedrock:InvokeModelWithResponseStream"],
+      "Action": ["bedrock:InvokeModel", "bedrock:InvokeModelWithResponseStream", "bedrock:CountTokens"],
       "Resource": "*"
     },
     {


### PR DESCRIPTION
## Summary

- Adds `bedrock:CountTokens` to both `docs/policies/iam-policy-boundary.json` and `docs/policies/iam-policy-user.json`

## Why

The Strands SDK calls `bedrock:CountTokens` to estimate token usage before model calls, enabling proactive context window management. Users running Strands-based agents need this permission included in their IAM policies. Without it, token estimation fails silently.

## Related

Companion L3 constructs PR: https://github.com/aws/agentcore-l3-cdk-constructs/pull/213

## Test plan
- [ ] Verify policy JSON is valid
- [ ] No automated tests needed (docs only)