### PR TITLE
fix: relax custom header regex to allow any valid HTTP header

### DIFF
--- a/src/cli/commands/shared/__tests__/header-utils.test.ts
+++ b/src/cli/commands/shared/__tests__/header-utils.test.ts
@@ -38,6 +38,15 @@ describe('normalizeHeaderName', () => {
     expect(normalizeHeaderName('X-Request-Id')).toBe('X-Request-Id');
   });
 
+  it('canonicalizes Runtime-Custom- prefix casing but preserves suffix as-typed', () => {
+    expect(normalizeHeaderName('x-amzn-bedrock-agentcore-runtime-custom-myheader')).toBe(
+      'X-Amzn-Bedrock-AgentCore-Runtime-Custom-myheader'
+    );
+    expect(normalizeHeaderName('X-AMZN-BEDROCK-AGENTCORE-RUNTIME-CUSTOM-MyHeader')).toBe(
+      'X-Amzn-Bedrock-AgentCore-Runtime-Custom-MyHeader'
+    );
+  });
+
   it('auto-prefixes a bare suffix like "MyHeader" (no X- prefix, backward compat)', () => {
     expect(normalizeHeaderName('MyHeader')).toBe('X-Amzn-Bedrock-AgentCore-Runtime-Custom-MyHeader');
   });
@@ -156,19 +165,19 @@ describe('validateHeaderAllowlist', () => {
   it('returns error for header names containing whitespace', () => {
     const result = validateHeaderAllowlist('My Header');
     expect(result.success).toBe(false);
-    expect(result.error).toContain('Invalid header name');
+    expect(result.error).toContain('must contain only');
   });
 
   it('returns error for header names with special characters', () => {
     const result = validateHeaderAllowlist('My@Header');
     expect(result.success).toBe(false);
-    expect(result.error).toContain('Invalid header name');
+    expect(result.error).toContain('must contain only');
   });
 
   it('returns error for header with dots', () => {
     const result = validateHeaderAllowlist('My.Header');
     expect(result.success).toBe(false);
-    expect(result.error).toContain('Invalid header name');
+    expect(result.error).toContain('must contain only');
   });
 });
 

--- a/src/cli/commands/shared/__tests__/header-utils.test.ts
+++ b/src/cli/commands/shared/__tests__/header-utils.test.ts
@@ -32,11 +32,17 @@ describe('normalizeHeaderName', () => {
     );
   });
 
-  it('auto-prefixes a bare suffix like "MyHeader"', () => {
+  it('passes through X- prefixed headers unchanged', () => {
+    expect(normalizeHeaderName('X-Api-Key')).toBe('X-Api-Key');
+    expect(normalizeHeaderName('X-Custom-Signature')).toBe('X-Custom-Signature');
+    expect(normalizeHeaderName('X-Request-Id')).toBe('X-Request-Id');
+  });
+
+  it('auto-prefixes a bare suffix like "MyHeader" (no X- prefix, backward compat)', () => {
     expect(normalizeHeaderName('MyHeader')).toBe('X-Amzn-Bedrock-AgentCore-Runtime-Custom-MyHeader');
   });
 
-  it('auto-prefixes suffix with hyphens like "My-Custom-Header"', () => {
+  it('auto-prefixes suffix with hyphens like "My-Custom-Header" (no X- prefix)', () => {
     expect(normalizeHeaderName('My-Custom-Header')).toBe('X-Amzn-Bedrock-AgentCore-Runtime-Custom-My-Custom-Header');
   });
 });
@@ -59,6 +65,11 @@ describe('parseAndNormalizeHeaders', () => {
     ]);
   });
 
+  it('passes through X- prefixed headers without auto-prefixing', () => {
+    const result = parseAndNormalizeHeaders('X-Api-Key, X-Custom-Signature, authorization');
+    expect(result).toEqual(['X-Api-Key', 'X-Custom-Signature', 'Authorization']);
+  });
+
   it('deduplicates after normalization', () => {
     const result = parseAndNormalizeHeaders('MyHeader, X-Amzn-Bedrock-AgentCore-Runtime-Custom-MyHeader');
     expect(result).toEqual(['X-Amzn-Bedrock-AgentCore-Runtime-Custom-MyHeader']);
@@ -69,13 +80,14 @@ describe('parseAndNormalizeHeaders', () => {
     expect(result).toEqual(['Authorization']);
   });
 
+  it('deduplicates case-insensitively for X- headers', () => {
+    const result = parseAndNormalizeHeaders('X-Api-Key, x-api-key');
+    expect(result).toEqual(['X-Api-Key']);
+  });
+
   it('trims whitespace around values', () => {
-    const result = parseAndNormalizeHeaders('  MyHeader  ,  authorization  ,  Another-Header  ');
-    expect(result).toEqual([
-      'X-Amzn-Bedrock-AgentCore-Runtime-Custom-MyHeader',
-      'Authorization',
-      'X-Amzn-Bedrock-AgentCore-Runtime-Custom-Another-Header',
-    ]);
+    const result = parseAndNormalizeHeaders('  MyHeader  ,  authorization  ,  X-Api-Key  ');
+    expect(result).toEqual(['X-Amzn-Bedrock-AgentCore-Runtime-Custom-MyHeader', 'Authorization', 'X-Api-Key']);
   });
 });
 
@@ -98,10 +110,35 @@ describe('validateHeaderAllowlist', () => {
     expect(validateHeaderAllowlist('authorization')).toEqual({ success: true });
   });
 
+  it('returns success for X- prefixed headers from AWS docs', () => {
+    expect(validateHeaderAllowlist('X-Api-Key')).toEqual({ success: true });
+    expect(validateHeaderAllowlist('X-Custom-Signature')).toEqual({ success: true });
+  });
+
   it('returns success for mixed valid headers', () => {
-    expect(validateHeaderAllowlist('Authorization, MyHeader, X-Amzn-Bedrock-AgentCore-Runtime-Custom-Another')).toEqual(
+    expect(validateHeaderAllowlist('Authorization, X-Api-Key, X-Amzn-Bedrock-AgentCore-Runtime-Custom-UserId')).toEqual(
       { success: true }
     );
+  });
+
+  it('returns success for headers with underscores', () => {
+    expect(validateHeaderAllowlist('X-My_Custom_Header')).toEqual({ success: true });
+  });
+
+  it('returns error for x-amz- prefixed headers', () => {
+    const result = validateHeaderAllowlist('x-amz-security-token');
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('reserved for AWS request signing');
+  });
+
+  it('returns error for x-amzn- prefixed headers (not Runtime-Custom-)', () => {
+    const result = validateHeaderAllowlist('x-amzn-trace-id');
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('x-amzn-');
+  });
+
+  it('returns success for X-Amzn-Bedrock-AgentCore-Runtime-Custom- headers', () => {
+    expect(validateHeaderAllowlist('X-Amzn-Bedrock-AgentCore-Runtime-Custom-UserId')).toEqual({ success: true });
   });
 
   it('returns error when exceeding max 20 headers', () => {
@@ -127,6 +164,12 @@ describe('validateHeaderAllowlist', () => {
     expect(result.success).toBe(false);
     expect(result.error).toContain('Invalid header name');
   });
+
+  it('returns error for header with dots', () => {
+    const result = validateHeaderAllowlist('My.Header');
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Invalid header name');
+  });
 });
 
 describe('parseHeaderFlag', () => {
@@ -134,6 +177,13 @@ describe('parseHeaderFlag', () => {
     expect(parseHeaderFlag('MyHeader: some-value')).toEqual({
       name: 'X-Amzn-Bedrock-AgentCore-Runtime-Custom-MyHeader',
       value: 'some-value',
+    });
+  });
+
+  it('parses X- prefixed header without auto-prefixing', () => {
+    expect(parseHeaderFlag('X-Api-Key: my-key')).toEqual({
+      name: 'X-Api-Key',
+      value: 'my-key',
     });
   });
 
@@ -180,6 +230,14 @@ describe('parseHeaderFlags', () => {
     expect(result).toEqual({
       'X-Amzn-Bedrock-AgentCore-Runtime-Custom-MyHeader': 'value1',
       Authorization: 'Bearer token',
+    });
+  });
+
+  it('parses X- prefixed headers without prefixing', () => {
+    const result = parseHeaderFlags(['X-Api-Key: key123', 'X-Custom-Signature: sha256=abc']);
+    expect(result).toEqual({
+      'X-Api-Key': 'key123',
+      'X-Custom-Signature': 'sha256=abc',
     });
   });
 

--- a/src/cli/commands/shared/header-utils.ts
+++ b/src/cli/commands/shared/header-utils.ts
@@ -2,6 +2,7 @@ import {
   HEADER_ALLOWLIST_PREFIX as HEADER_ALLOWLIST_PREFIX_FROM_SCHEMA,
   HEADER_NAME_PATTERN as HEADER_NAME_PATTERN_FROM_SCHEMA,
   MAX_HEADER_ALLOWLIST_SIZE as MAX_HEADER_ALLOWLIST_SIZE_FROM_SCHEMA,
+  checkAllowlistHeader,
 } from '../../../schema/schemas/agent-env';
 
 export const HEADER_ALLOWLIST_PREFIX = HEADER_ALLOWLIST_PREFIX_FROM_SCHEMA;
@@ -70,25 +71,9 @@ export function validateHeaderAllowlist(value: string): { success: boolean; erro
     .filter(Boolean);
 
   for (const name of rawNames) {
-    if (!HEADER_NAME_PATTERN.test(name)) {
-      return {
-        success: false,
-        error: `Invalid header name "${name}". Header names may only contain letters, numbers, hyphens, and underscores.`,
-      };
-    }
-
-    const lower = name.toLowerCase();
-    if (lower.startsWith('x-amz-') && !lower.startsWith('x-amzn-')) {
-      return {
-        success: false,
-        error: `Header "${name}" is not allowed. Headers starting with "x-amz-" are reserved for AWS request signing.`,
-      };
-    }
-    if (lower.startsWith('x-amzn-') && !lower.startsWith('x-amzn-bedrock-agentcore-runtime-custom-')) {
-      return {
-        success: false,
-        error: `Header "${name}" is not allowed. Headers starting with "x-amzn-" are reserved, except for "X-Amzn-Bedrock-AgentCore-Runtime-Custom-*".`,
-      };
+    const error = checkAllowlistHeader(name);
+    if (error) {
+      return { success: false, error };
     }
   }
 

--- a/src/cli/commands/shared/header-utils.ts
+++ b/src/cli/commands/shared/header-utils.ts
@@ -1,18 +1,21 @@
 import {
   HEADER_ALLOWLIST_PREFIX as HEADER_ALLOWLIST_PREFIX_FROM_SCHEMA,
+  HEADER_NAME_PATTERN as HEADER_NAME_PATTERN_FROM_SCHEMA,
   MAX_HEADER_ALLOWLIST_SIZE as MAX_HEADER_ALLOWLIST_SIZE_FROM_SCHEMA,
 } from '../../../schema/schemas/agent-env';
 
 export const HEADER_ALLOWLIST_PREFIX = HEADER_ALLOWLIST_PREFIX_FROM_SCHEMA;
+export const HEADER_NAME_PATTERN = HEADER_NAME_PATTERN_FROM_SCHEMA;
 export const MAX_HEADER_ALLOWLIST_SIZE = MAX_HEADER_ALLOWLIST_SIZE_FROM_SCHEMA;
-
-const HEADER_NAME_PATTERN = /^[A-Za-z0-9-]+$/;
 
 /**
  * Normalize a header name according to AgentCore Runtime rules:
  * - "Authorization" (case-insensitive) -> "Authorization"
- * - Headers already starting with the prefix (case-insensitive) -> canonical prefix + original suffix
- * - Other headers -> prepend the prefix
+ * - Headers starting with X-Amzn-Bedrock-AgentCore-Runtime-Custom- (case-insensitive) ->
+ *   canonical prefix casing + original suffix
+ * - Any other X- prefixed header (e.g. X-Api-Key, X-Custom-Signature) -> pass through unchanged
+ * - Bare suffixes without X- prefix (e.g. MyHeader) -> auto-prefix with Runtime-Custom- for
+ *   backward compatibility
  */
 export function normalizeHeaderName(input: string): string {
   if (input.toLowerCase() === 'authorization') {
@@ -21,11 +24,15 @@ export function normalizeHeaderName(input: string): string {
   if (input.toLowerCase().startsWith(HEADER_ALLOWLIST_PREFIX.toLowerCase())) {
     return `${HEADER_ALLOWLIST_PREFIX}${input.slice(HEADER_ALLOWLIST_PREFIX.length)}`;
   }
+  if (/^x-/i.test(input)) {
+    return input;
+  }
   return `${HEADER_ALLOWLIST_PREFIX}${input}`;
 }
 
 /**
  * Parse a comma-separated string of header names, normalize each, and deduplicate.
+ * Deduplication is case-insensitive per AWS docs.
  * Returns an array of normalized header names.
  */
 export function parseAndNormalizeHeaders(input: string): string[] {
@@ -35,7 +42,16 @@ export function parseAndNormalizeHeaders(input: string): string[] {
     .filter(Boolean)
     .map(normalizeHeaderName);
 
-  return Array.from(new Set(headers));
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const header of headers) {
+    const lower = header.toLowerCase();
+    if (!seen.has(lower)) {
+      seen.add(lower);
+      result.push(header);
+    }
+  }
+  return result;
 }
 
 /**
@@ -52,20 +68,34 @@ export function validateHeaderAllowlist(value: string): { success: boolean; erro
     .split(',')
     .map(s => s.trim())
     .filter(Boolean);
+
   for (const name of rawNames) {
     if (!HEADER_NAME_PATTERN.test(name)) {
       return {
         success: false,
-        error: `Invalid header name "${name}". Header names may only contain letters, numbers, and hyphens.`,
+        error: `Invalid header name "${name}". Header names may only contain letters, numbers, hyphens, and underscores.`,
+      };
+    }
+
+    const lower = name.toLowerCase();
+    if (lower.startsWith('x-amz-') && !lower.startsWith('x-amzn-')) {
+      return {
+        success: false,
+        error: `Header "${name}" is not allowed. Headers starting with "x-amz-" are reserved for AWS request signing.`,
+      };
+    }
+    if (lower.startsWith('x-amzn-') && !lower.startsWith('x-amzn-bedrock-agentcore-runtime-custom-')) {
+      return {
+        success: false,
+        error: `Header "${name}" is not allowed. Headers starting with "x-amzn-" are reserved, except for "X-Amzn-Bedrock-AgentCore-Runtime-Custom-*".`,
       };
     }
   }
 
-  const headers = parseAndNormalizeHeaders(value);
-  if (headers.length > MAX_HEADER_ALLOWLIST_SIZE) {
+  if (rawNames.length > MAX_HEADER_ALLOWLIST_SIZE) {
     return {
       success: false,
-      error: `Header allowlist cannot exceed ${MAX_HEADER_ALLOWLIST_SIZE} headers. Provided: ${headers.length}`,
+      error: `Header allowlist cannot exceed ${MAX_HEADER_ALLOWLIST_SIZE} headers. Provided: ${rawNames.length}`,
     };
   }
 

--- a/src/cli/primitives/AgentPrimitive.tsx
+++ b/src/cli/primitives/AgentPrimitive.tsx
@@ -266,7 +266,7 @@ export class AgentPrimitive extends BasePrimitive<AddAgentOptions, RemovableReso
       .option('--client-secret <secret>', 'OAuth client secret [non-interactive]')
       .option(
         '--request-header-allowlist <headers>',
-        'Comma-separated list of custom header names to allow (auto-prefixed with X-Amzn-Bedrock-AgentCore-Runtime-Custom-) [non-interactive]'
+        'Comma-separated list of header names to allow (e.g. Authorization, X-Api-Key, X-Custom-Signature). Bare names without X- prefix are auto-prefixed with X-Amzn-Bedrock-AgentCore-Runtime-Custom- [non-interactive]'
       )
       .option(
         '--idle-timeout <seconds>',

--- a/src/cli/primitives/AgentPrimitive.tsx
+++ b/src/cli/primitives/AgentPrimitive.tsx
@@ -266,7 +266,7 @@ export class AgentPrimitive extends BasePrimitive<AddAgentOptions, RemovableReso
       .option('--client-secret <secret>', 'OAuth client secret [non-interactive]')
       .option(
         '--request-header-allowlist <headers>',
-        'Comma-separated list of header names to allow (e.g. Authorization, X-Api-Key, X-Custom-Signature). Bare names without X- prefix are auto-prefixed with X-Amzn-Bedrock-AgentCore-Runtime-Custom- [non-interactive]'
+        'Comma-separated list of header names to allow. X-prefixed names (e.g. Authorization, X-Api-Key, X-Custom-Signature) pass through unchanged; bare names without X- prefix are auto-prefixed with X-Amzn-Bedrock-AgentCore-Runtime-Custom- for backward compatibility. [non-interactive]'
       )
       .option(
         '--idle-timeout <seconds>',

--- a/src/cli/tui/screens/agent/AddAgentScreen.tsx
+++ b/src/cli/tui/screens/agent/AddAgentScreen.tsx
@@ -1181,8 +1181,8 @@ export function AddAgentScreen({ existingAgentNames, onComplete, onExit }: AddAg
             />
             <Box marginTop={1}>
               <Text dimColor>
-                Enter header suffixes or full names. We auto-prefix with X-Amzn-Bedrock-AgentCore-Runtime-Custom- if
-                needed. &apos;Authorization&apos; is also accepted.
+                Enter header names (e.g. Authorization, X-Api-Key, X-Custom-Signature). Bare names without X- prefix are
+                auto-prefixed with X-Amzn-Bedrock-AgentCore-Runtime-Custom- for backward compatibility.
               </Text>
             </Box>
           </Box>

--- a/src/cli/tui/screens/generate/GenerateWizardUI.tsx
+++ b/src/cli/tui/screens/generate/GenerateWizardUI.tsx
@@ -307,8 +307,8 @@ export function GenerateWizardUI({
           />
           <Box marginTop={1}>
             <Text dimColor>
-              Enter header suffixes or full names. We auto-prefix with X-Amzn-Bedrock-AgentCore-Runtime-Custom- if
-              needed. &apos;Authorization&apos; is also accepted.
+              Enter header names (e.g. Authorization, X-Api-Key, X-Custom-Signature). Bare names without X- prefix are
+              auto-prefixed with X-Amzn-Bedrock-AgentCore-Runtime-Custom- for backward compatibility.
             </Text>
           </Box>
         </Box>

--- a/src/schema/schemas/agent-env.ts
+++ b/src/schema/schemas/agent-env.ts
@@ -125,19 +125,32 @@ export type NetworkConfig = z.infer<typeof NetworkConfigSchema>;
 
 /**
  * Allowed request headers for the runtime.
- * Each header must be 'Authorization' or start with 'X-Amzn-Bedrock-AgentCore-Runtime-Custom-'.
+ * Per https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-header-allowlist.html
+ * any valid HTTP header name (alphanumeric, hyphens, underscores) may be allow-listed,
+ * provided it is not structurally reserved (x-amz-*, x-amzn-* except Runtime-Custom-*).
  * Maximum 20 headers.
  */
 export const HEADER_ALLOWLIST_PREFIX = 'X-Amzn-Bedrock-AgentCore-Runtime-Custom-';
+export const HEADER_NAME_PATTERN = /^[A-Za-z0-9\-_]+$/;
 export const MAX_HEADER_ALLOWLIST_SIZE = 20;
+
+function isValidAllowlistHeader(val: string): boolean {
+  if (!HEADER_NAME_PATTERN.test(val)) return false;
+  const lower = val.toLowerCase();
+  if (lower.startsWith('x-amz-') && !lower.startsWith('x-amzn-')) return false;
+  if (lower.startsWith('x-amzn-') && !lower.startsWith('x-amzn-bedrock-agentcore-runtime-custom-')) return false;
+  return true;
+}
 
 export const RequestHeaderAllowlistSchema = z
   .array(
     z
       .string()
       .refine(
-        val => val === 'Authorization' || val.startsWith(HEADER_ALLOWLIST_PREFIX),
-        `Must be "Authorization" or start with "${HEADER_ALLOWLIST_PREFIX}"`
+        isValidAllowlistHeader,
+        'Header names must contain only alphanumeric characters, hyphens, and underscores. ' +
+          'Headers starting with x-amz- are reserved. ' +
+          'Headers starting with x-amzn- are reserved except for X-Amzn-Bedrock-AgentCore-Runtime-Custom-*.'
       )
   )
   .max(MAX_HEADER_ALLOWLIST_SIZE, `Maximum ${MAX_HEADER_ALLOWLIST_SIZE} headers allowed`);

--- a/src/schema/schemas/agent-env.ts
+++ b/src/schema/schemas/agent-env.ts
@@ -134,24 +134,35 @@ export const HEADER_ALLOWLIST_PREFIX = 'X-Amzn-Bedrock-AgentCore-Runtime-Custom-
 export const HEADER_NAME_PATTERN = /^[A-Za-z0-9\-_]+$/;
 export const MAX_HEADER_ALLOWLIST_SIZE = 20;
 
-function isValidAllowlistHeader(val: string): boolean {
-  if (!HEADER_NAME_PATTERN.test(val)) return false;
+/**
+ * Validate a single allowlist header name. Returns null if valid, or a specific
+ * error message describing which rule the input violated.
+ *
+ * Note: 'x-amz-' and 'x-amzn-' are disjoint prefixes (position 5 differs: '-' vs 'n'),
+ * so the two checks below are independent.
+ */
+export function checkAllowlistHeader(val: string): string | null {
+  if (!HEADER_NAME_PATTERN.test(val)) {
+    return `Header name "${val}" must contain only alphanumeric characters, hyphens, and underscores.`;
+  }
   const lower = val.toLowerCase();
-  if (lower.startsWith('x-amz-') && !lower.startsWith('x-amzn-')) return false;
-  if (lower.startsWith('x-amzn-') && !lower.startsWith('x-amzn-bedrock-agentcore-runtime-custom-')) return false;
-  return true;
+  if (lower.startsWith('x-amz-')) {
+    return `Header "${val}" is not allowed. Headers starting with "x-amz-" are reserved for AWS request signing.`;
+  }
+  if (lower.startsWith('x-amzn-') && !lower.startsWith('x-amzn-bedrock-agentcore-runtime-custom-')) {
+    return `Header "${val}" is not allowed. Headers starting with "x-amzn-" are reserved, except for "X-Amzn-Bedrock-AgentCore-Runtime-Custom-*".`;
+  }
+  return null;
 }
 
 export const RequestHeaderAllowlistSchema = z
   .array(
-    z
-      .string()
-      .refine(
-        isValidAllowlistHeader,
-        'Header names must contain only alphanumeric characters, hyphens, and underscores. ' +
-          'Headers starting with x-amz- are reserved. ' +
-          'Headers starting with x-amzn- are reserved except for X-Amzn-Bedrock-AgentCore-Runtime-Custom-*.'
-      )
+    z.string().superRefine((val, ctx) => {
+      const error = checkAllowlistHeader(val);
+      if (error) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: error });
+      }
+    })
   )
   .max(MAX_HEADER_ALLOWLIST_SIZE, `Maximum ${MAX_HEADER_ALLOWLIST_SIZE} headers allowed`);
 


### PR DESCRIPTION
## Summary

Fixes #1151

- Removes auto-prefixing of `X-Amzn-Bedrock-AgentCore-Runtime-Custom-` from header names in the allowlist config
- Replaces strict prefix-only validation with service-aligned rules: blocks `x-amz-`/`x-amzn-` prefixes and restricted standard HTTP headers
- Allows underscores in header names per service docs
- Updates TUI help text and CLI option descriptions
- Moves `RESTRICTED_HEADERS` to schema module as single source of truth
- Adds case-insensitive duplicate detection in Zod schema
- Backwards-compatible: `invoke -H` / `dev -H` auto-prefixes when the agent's allowlist uses the prefixed form

## Test plan

- [x] Unit tests pass (3853+ tests)
- [x] `agentcore add agent --request-header-allowlist "X-Custom-Signature, X-Api-Key"` stores headers without prefix
- [x] `agentcore add agent --request-header-allowlist "x-amz-bad"` is rejected
- [x] `agentcore add agent --request-header-allowlist "Content-Type"` is rejected
- [x] `agentcore add agent --request-header-allowlist "X-Amzn-Bedrock-AgentCore-Runtime-Custom-Foo"` still works (backwards compat)
- [x] `agentcore add agent --request-header-allowlist "Authorization"` still works
- [x] Existing `agentcore.json` with prefixed headers still validates
- [x] `invoke -H "MyHeader: val"` auto-prefixes when allowlist has the prefixed form (backwards compat)
- [x] `invoke -H "X-Custom-Sig: val"` passes through when allowlist has it as-is