### PR TITLE
chore: replace PAT tokens with GitHub App token

### DIFF
--- a/.github/workflows/agent-restricted.yml
+++ b/.github/workflows/agent-restricted.yml
@@ -66,6 +66,13 @@ jobs:
 
       - uses: actions/checkout@v6
 
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Run Strands Agent
         uses: ./.github/actions/strands-action
         with:
@@ -78,6 +85,6 @@ jobs:
           agent_runner: ${{ inputs.agent_runner }}
           aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
           aws_region: 'us-west-2'
-          pat_token: ${{ secrets.PAT_TOKEN }}
+          pat_token: ${{ steps.app-token.outputs.token }}
         env:
           STRANDS_TOOLS_DIRECTORY: 'true'

--- a/.github/workflows/ci-failure-issue.yml
+++ b/.github/workflows/ci-failure-issue.yml
@@ -19,9 +19,16 @@ jobs:
     permissions:
       issues: write
     steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/github-script@v9
         with:
-          github-token: ${{ secrets.AUTOMATION_ACCOUNT_PAT_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             try {
               const workflowName = context.payload.workflow_run.name;


### PR DESCRIPTION
## Summary
- Replace `secrets.PAT_TOKEN` in `agent-restricted.yml` with a short-lived GitHub App token
- Replace `secrets.AUTOMATION_ACCOUNT_PAT_TOKEN` in `ci-failure-issue.yml` with a short-lived GitHub App token
- Uses `actions/create-github-app-token@v1` with the `agentcore-devx-automation` app (ID: 3637953)

## Setup Required
Before merging, add the following to this repo:
- **Variable** `APP_ID` = `3637953`
- **Secret** `APP_PRIVATE_KEY` = RSA private key from Secrets Manager

## Secrets to Delete After Verification
- `PAT_TOKEN`
- `AUTOMATION_ACCOUNT_PAT_TOKEN`

## Test plan
- [ ] Add APP_ID variable and APP_PRIVATE_KEY secret to repo
- [ ] Merge PR
- [ ] Trigger `agent-restricted` workflow manually and confirm it succeeds
- [ ] Wait for a CI failure (or simulate one) to confirm `ci-failure-issue` workflow works
- [ ] Delete old PAT secrets