### PR TITLE
chore: replace all github.token/GITHUB_TOKEN with GitHub App token

### DIFF
--- a/.github/workflows/cleanup-pr-tarballs.yml
+++ b/.github/workflows/cleanup-pr-tarballs.yml
@@ -14,10 +14,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: actions/checkout@v6
       - name: Delete PR tarball releases older than 7 days
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           CUTOFF=$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-7d +%Y-%m-%dT%H:%M:%SZ)
 

--- a/.github/workflows/pr-tarball.yml
+++ b/.github/workflows/pr-tarball.yml
@@ -50,10 +50,16 @@ jobs:
         run: |
           TARBALL_NAME=$(ls *.tgz | head -1 | xargs basename)
           echo "name=$TARBALL_NAME" >> $GITHUB_OUTPUT
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Create or update PR release
         id: release
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           TARBALL_NAME: ${{ steps.tarball.outputs.name }}
         run: |

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -14,9 +14,15 @@ jobs:
     permissions:
       pull-requests: read
     steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: amannn/action-semantic-pull-request@v6.1.1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           # Types aligned with this repo's commit conventions (see AGENTS.md)
           types: |

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -14,15 +14,9 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - name: Generate GitHub App Token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ vars.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: amannn/action-semantic-pull-request@v6.1.1
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           # Types aligned with this repo's commit conventions (see AGENTS.md)
           types: |

--- a/.github/workflows/release-main-and-preview.yml
+++ b/.github/workflows/release-main-and-preview.yml
@@ -135,9 +135,16 @@ jobs:
       - name: Update snapshots
         run: npm run test:update-snapshots
 
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Create release branch and PR
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           NEW_VERSION: ${{ steps.bump.outputs.version }}
         run: |
           BRANCH_NAME="release/v$NEW_VERSION"
@@ -219,9 +226,16 @@ jobs:
       - name: Update snapshots
         run: npm run test:update-snapshots
 
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Create release branch and PR
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           NEW_VERSION: ${{ steps.bump.outputs.version }}
         run: |
           BRANCH_NAME="release/v$NEW_VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,9 +160,16 @@ jobs:
             exit 1
           fi
 
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Create Pull Request
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           NEW_VERSION: ${{ steps.bump.outputs.version }}
           BASE_BRANCH: ${{ steps.release-meta.outputs.base_branch }}
           DIST_TAG: ${{ steps.release-meta.outputs.dist_tag }}

--- a/.github/workflows/strands-command.yml
+++ b/.github/workflows/strands-command.yml
@@ -94,6 +94,12 @@ jobs:
             };
             await processInputs(context, github, core, inputs);
 
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Run Strands Agent
         uses: ./.github/actions/strands-action
         with:
@@ -104,7 +110,7 @@ jobs:
           tools: 'strands_tools:shell,retrieve'
           aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
           aws_region: 'us-west-2'
-          pat_token: ${{ secrets.GITHUB_TOKEN }}
+          pat_token: ${{ steps.app-token.outputs.token }}
         env:
           SESSION_ID: ${{ steps.process-inputs.outputs.session_id }}
           S3_SESSION_BUCKET: ${{ secrets.AGENT_SESSIONS_BUCKET }}

--- a/.github/workflows/sync-from-public.yml
+++ b/.github/workflows/sync-from-public.yml
@@ -13,10 +13,17 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Configure Git
         run: |
@@ -101,15 +108,22 @@ jobs:
               --head "$conflict_branch" || echo "⚠️  Failed to create PR"
           fi
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
   sync-preview:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Configure Git
         run: |
@@ -194,4 +208,4 @@ jobs:
               --head "$conflict_branch" || echo "⚠️  Failed to create PR"
           fi
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/sync-preview.yml
+++ b/.github/workflows/sync-preview.yml
@@ -52,6 +52,14 @@ jobs:
             echo "status=conflict" >> $GITHUB_OUTPUT
           fi
 
+      - name: Generate GitHub App Token
+        if: steps.merge.outputs.status == 'conflict'
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Get original commit author
         if: steps.merge.outputs.status == 'conflict'
         id: author
@@ -65,12 +73,12 @@ jobs:
           echo "name=$AUTHOR" >> $GITHUB_OUTPUT
           echo "gh_user=$GH_USER" >> $GITHUB_OUTPUT
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Create PR for conflict resolution
         if: steps.merge.outputs.status == 'conflict'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           AUTHOR_NAME: ${{ steps.author.outputs.name }}
           AUTHOR_GH: ${{ steps.author.outputs.gh_user }}
         run: |


### PR DESCRIPTION
## Summary
Replace all remaining `github.token` and `secrets.GITHUB_TOKEN` usage with short-lived tokens from the `agentcore-devx-automation` GitHub App via `actions/create-github-app-token@v1`.

Updated workflows: sync-from-public, sync-preview, release-main-and-preview, release, pr-tarball, cleanup-pr-tarballs, pr-title, strands-command.

## Secrets to Delete After Verification
None — these were using the built-in token, not stored secrets.

## Test plan
- [ ] Verify APP_ID variable and APP_PRIVATE_KEY secret are set
- [ ] Merge and confirm workflows run successfully