### PR TITLE
ci: cap E2E full suite to 6 parallel jobs to reduce runner starvation

### DIFF
--- a/.github/workflows/e2e-tests-full.yml
+++ b/.github/workflows/e2e-tests-full.yml
@@ -25,6 +25,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       fail-fast: false
+      max-parallel: 6
       matrix:
         cdk-source: [npm, main]
         shard: ['1/6', '2/6', '3/6', '4/6', '5/6', '6/6']


### PR DESCRIPTION
## Description

Adds `max-parallel: 6` to the E2E Tests (Full Suite) matrix strategy to reduce peak runner consumption from 13 simultaneous jobs to 6.

During merge storms (multiple PRs merging to main in quick succession), the 12-shard matrix (6 shards × 2 cdk-source variants) plus browser-tests consumes 13 runners simultaneously. This starves all other workflows — PR checks, Build and Test, Quality and Safety — of available runners, causing 45–70 minute queues.

With `max-parallel: 6`, the full suite runs in two waves instead of one. Duration increases moderately (~30 min vs ~15 min) but leaves half the runner pool free for PR workflows.

## Related Issue

N/A — operational issue discovered during CI queue investigation on 2026-05-12.

## Documentation PR

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe): CI performance — reduce runner starvation during merge storms

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

No source code changes — workflow-only. Validated YAML syntax is correct.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.