### PR TITLE
feat: instrument telemetry for dev command

### DIFF
--- a/integ-tests/dev-server.test.ts
+++ b/integ-tests/dev-server.test.ts
@@ -1,4 +1,4 @@
-import { runCLI } from '../src/test-utils/index.js';
+import { createTelemetryHelper, runCLI } from '../src/test-utils/index.js';
 import { type ChildProcess, execSync, spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { mkdir, rm } from 'node:fs/promises';
@@ -37,6 +37,8 @@ describe('integration: dev server', () => {
   let testDir: string;
   let projectPath: string;
   let devProcess: ChildProcess | null = null;
+
+  const telemetry = createTelemetryHelper();
 
   beforeAll(async () => {
     testDir = join(tmpdir(), `agentcore-integ-dev-${randomUUID()}`);
@@ -81,6 +83,7 @@ describe('integration: dev server', () => {
     if (devProcess) {
       devProcess.kill('SIGKILL');
     }
+    telemetry.destroy();
     await rm(testDir, { recursive: true, force: true });
   });
 
@@ -100,6 +103,31 @@ describe('integration: dev server', () => {
 
       const serverReady = await waitForServer(port, 20000);
       expect(serverReady, 'Dev server should respond to ping within 20s').toBeTruthy();
+
+      // Invoke the running server and verify telemetry
+      const invokeResult = await runCLI(['dev', 'hello', '--port', String(port)], projectPath, {
+        env: telemetry.env,
+      });
+      expect(invokeResult.exitCode).toBe(0);
+
+      telemetry.assertMetricEmitted({
+        command: 'dev',
+        action: 'invoke',
+        ui_mode: 'terminal',
+        exit_reason: 'success',
+        protocol: 'http',
+      });
+
+      // Verify failure telemetry when invoking a non-running port
+      telemetry.clearEntries();
+      const failResult = await runCLI(['dev', 'hello', '--port', '19999'], projectPath, { env: telemetry.env });
+      expect(failResult.exitCode).toBe(1);
+
+      telemetry.assertMetricEmitted({
+        command: 'dev',
+        action: 'invoke',
+        exit_reason: 'failure',
+      });
 
       // Clean shutdown
       devProcess.kill('SIGTERM');

--- a/src/cli/commands/dev/command.tsx
+++ b/src/cli/commands/dev/command.tsx
@@ -1,4 +1,11 @@
-import { type Result, findConfigRoot, getWorkingDirectory } from '../../../lib';
+import {
+  ConnectionError,
+  ResourceNotFoundError,
+  type Result,
+  ValidationError,
+  findConfigRoot,
+  getWorkingDirectory,
+} from '../../../lib';
 import { getErrorMessage } from '../../errors';
 import { detectContainerRuntime } from '../../external-requirements';
 import { ExecLogger } from '../../logging';
@@ -19,6 +26,7 @@ import {
 } from '../../operations/dev';
 import { OtelCollector, startOtelCollector } from '../../operations/dev/otel';
 import { withCommandRunTelemetry } from '../../telemetry/cli-command-run.js';
+import { TelemetryClientAccessor } from '../../telemetry/client-accessor.js';
 import { Protocol, standardize } from '../../telemetry/schemas/common-shapes.js';
 import { FatalError } from '../../tui/components';
 import { LayoutProvider } from '../../tui/context';
@@ -55,7 +63,9 @@ async function invokeDevServer(
     }
   } catch (err) {
     throw isConnectionRefused(err)
-      ? new Error(`Dev server not running on port ${port}. Start it with: agentcore dev --logs`, { cause: err })
+      ? new ConnectionError(`Dev server not running on port ${port}. Start it with: agentcore dev --logs`, {
+          cause: err,
+        })
       : err;
   }
 }
@@ -68,7 +78,9 @@ async function invokeA2ADevServer(port: number, prompt: string, headers?: Record
     process.stdout.write('\n');
   } catch (err) {
     throw isConnectionRefused(err)
-      ? new Error(`Dev server not running on port ${port}. Start it with: agentcore dev --logs`, { cause: err })
+      ? new ConnectionError(`Dev server not running on port ${port}. Start it with: agentcore dev --logs`, {
+          cause: err,
+        })
       : err;
   }
 }
@@ -102,7 +114,7 @@ async function handleMcpInvoke(
       }
     } else if (invokeValue === 'call-tool') {
       if (!toolName) {
-        throw new Error(
+        throw new ValidationError(
           '--tool is required with call-tool. Usage: agentcore dev call-tool --tool <name> --input \'{"arg": "value"}\''
         );
       }
@@ -112,19 +124,21 @@ async function handleMcpInvoke(
         try {
           args = JSON.parse(input) as Record<string, unknown>;
         } catch {
-          throw new Error(`Invalid JSON for --input: ${input}. Expected format: --input '{"key": "value"}'`);
+          throw new ValidationError(`Invalid JSON for --input: ${input}. Expected format: --input '{"key": "value"}'`);
         }
       }
       const result = await callMcpTool(port, toolName, args, sessionId, undefined, headers);
       console.log(result);
     } else {
-      throw new Error(
+      throw new ValidationError(
         `Unknown MCP invoke command "${invokeValue}". Usage: agentcore dev list-tools | agentcore dev call-tool --tool <name>`
       );
     }
   } catch (err) {
     throw isConnectionRefused(err)
-      ? new Error(`Dev server not running on port ${port}. Start it with: agentcore dev --logs`, { cause: err })
+      ? new ConnectionError(`Dev server not running on port ${port}. Start it with: agentcore dev --logs`, {
+          cause: err,
+        })
       : err;
   }
 }
@@ -132,7 +146,7 @@ async function handleMcpInvoke(
 async function execInContainer(command: string, containerName: string): Promise<void> {
   const detection = await detectContainerRuntime();
   if (!detection.runtime) {
-    throw new Error('No container runtime found (docker, podman, or finch required)');
+    throw new ResourceNotFoundError('No container runtime found (docker, podman, or finch required)');
   }
   return new Promise((resolve, reject) => {
     const child = spawn(detection.runtime!.binary, ['exec', containerName, 'bash', '-c', command], {
@@ -465,32 +479,32 @@ export const registerDev = (program: Command) => {
         }
 
         // Default: launch web UI in browser
-        // runBrowserMode blocks forever (internal await new Promise(() => {})).
-        // On SIGINT, its internal handler stops the server and the process exits.
-        // Telemetry only emits here on startup failure; normal shutdown telemetry
-        // requires refactoring runWebUI to return a shutdown promise (follow-up).
-        const browserResult = await withCommandRunTelemetry(
-          'dev',
-          {
+        // NOTE: Do not copy this pattern. runBrowserMode blocks forever (internal
+        // await new Promise(() => {})) so we cannot use withCommandRunTelemetry here.
+        // We emit telemetry eagerly before the blocking call. If startup fails, the
+        // error propagates to the outer catch. Prefer withCommandRunTelemetry for
+        // commands that return.
+        {
+          const client = await TelemetryClientAccessor.get().catch(() => undefined);
+          const devAttrs = {
             action: 'server' as const,
             ui_mode: 'browser' as const,
             has_stream: false,
             protocol: standardize(Protocol, (targetDevAgent?.protocol ?? 'http').toLowerCase()),
             invoke_count: 0,
-          },
-          async (): Promise<Result> => {
-            await runBrowserMode({
-              workingDir,
-              project,
-              port,
-              agentName: opts.runtime,
-              otelEnvVars,
-              collector,
-            });
-            return { success: true };
+          };
+          if (client) {
+            await client.withCommandRun('dev', () => devAttrs);
           }
-        );
-        if (!browserResult.success) throw browserResult.error;
+          await runBrowserMode({
+            workingDir,
+            project,
+            port,
+            agentName: opts.runtime,
+            otelEnvVars,
+            collector,
+          });
+        }
       } catch (error) {
         console.error(`Error: ${getErrorMessage(error)}`);
         process.exit(1);

--- a/src/cli/commands/dev/command.tsx
+++ b/src/cli/commands/dev/command.tsx
@@ -1,4 +1,4 @@
-import { findConfigRoot, getWorkingDirectory } from '../../../lib';
+import { type Result, findConfigRoot, getWorkingDirectory } from '../../../lib';
 import { getErrorMessage } from '../../errors';
 import { detectContainerRuntime } from '../../external-requirements';
 import { ExecLogger } from '../../logging';
@@ -18,6 +18,8 @@ import {
   loadProjectConfig,
 } from '../../operations/dev';
 import { OtelCollector, startOtelCollector } from '../../operations/dev/otel';
+import { withCommandRunTelemetry } from '../../telemetry/cli-command-run.js';
+import { Protocol, standardize } from '../../telemetry/schemas/common-shapes.js';
 import { FatalError } from '../../tui/components';
 import { LayoutProvider } from '../../tui/context';
 import { COMMAND_DESCRIPTIONS } from '../../tui/copy';
@@ -26,7 +28,7 @@ import { parseHeaderFlags } from '../shared/header-utils';
 import { runBrowserMode } from './browser-mode';
 import type { Command } from '@commander-js/extra-typings';
 import { spawn } from 'child_process';
-import { Text, render } from 'ink';
+import { render } from 'ink';
 import path from 'node:path';
 import React from 'react';
 
@@ -43,7 +45,6 @@ async function invokeDevServer(
 ): Promise<void> {
   try {
     if (stream) {
-      // Stream response to stdout
       for await (const chunk of invokeAgentStreaming({ port, message: prompt, headers })) {
         process.stdout.write(chunk);
       }
@@ -53,13 +54,9 @@ async function invokeDevServer(
       console.log(response);
     }
   } catch (err) {
-    if (isConnectionRefused(err)) {
-      console.error(`Error: Dev server not running on port ${port}`);
-      console.error('Start it with: agentcore dev --logs');
-    } else {
-      console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
-    }
-    process.exit(1);
+    throw isConnectionRefused(err)
+      ? new Error(`Dev server not running on port ${port}. Start it with: agentcore dev --logs`, { cause: err })
+      : err;
   }
 }
 
@@ -70,13 +67,9 @@ async function invokeA2ADevServer(port: number, prompt: string, headers?: Record
     }
     process.stdout.write('\n');
   } catch (err) {
-    if (isConnectionRefused(err)) {
-      console.error(`Error: Dev server not running on port ${port}`);
-      console.error('Start it with: agentcore dev --logs');
-    } else {
-      console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
-    }
-    process.exit(1);
+    throw isConnectionRefused(err)
+      ? new Error(`Dev server not running on port ${port}. Start it with: agentcore dev --logs`, { cause: err })
+      : err;
   }
 }
 
@@ -109,47 +102,37 @@ async function handleMcpInvoke(
       }
     } else if (invokeValue === 'call-tool') {
       if (!toolName) {
-        console.error('Error: --tool is required with call-tool');
-        console.error('Usage: agentcore dev call-tool --tool <name> --input \'{"arg": "value"}\'');
-        process.exit(1);
+        throw new Error(
+          '--tool is required with call-tool. Usage: agentcore dev call-tool --tool <name> --input \'{"arg": "value"}\''
+        );
       }
-      // Initialize session first, then call tool with the session ID
       const { sessionId } = await listMcpTools(port, undefined, headers);
       let args: Record<string, unknown> = {};
       if (input) {
         try {
           args = JSON.parse(input) as Record<string, unknown>;
         } catch {
-          console.error(`Error: Invalid JSON for --input: ${input}`);
-          console.error('Expected format: --input \'{"key": "value"}\'');
-          process.exit(1);
+          throw new Error(`Invalid JSON for --input: ${input}. Expected format: --input '{"key": "value"}'`);
         }
       }
       const result = await callMcpTool(port, toolName, args, sessionId, undefined, headers);
       console.log(result);
     } else {
-      console.error(`Error: Unknown MCP invoke command "${invokeValue}"`);
-      console.error('Usage:');
-      console.error('  agentcore dev list-tools');
-      console.error('  agentcore dev call-tool --tool <name> --input \'{"arg": "value"}\'');
-      process.exit(1);
+      throw new Error(
+        `Unknown MCP invoke command "${invokeValue}". Usage: agentcore dev list-tools | agentcore dev call-tool --tool <name>`
+      );
     }
   } catch (err) {
-    if (isConnectionRefused(err)) {
-      console.error(`Error: Dev server not running on port ${port}`);
-      console.error('Start it with: agentcore dev --logs');
-    } else {
-      console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
-    }
-    process.exit(1);
+    throw isConnectionRefused(err)
+      ? new Error(`Dev server not running on port ${port}. Start it with: agentcore dev --logs`, { cause: err })
+      : err;
   }
 }
 
 async function execInContainer(command: string, containerName: string): Promise<void> {
   const detection = await detectContainerRuntime();
   if (!detection.runtime) {
-    console.error('Error: No container runtime found (docker, podman, or finch required)');
-    process.exit(1);
+    throw new Error('No container runtime found (docker, podman, or finch required)');
   }
   return new Promise((resolve, reject) => {
     const child = spawn(detection.runtime!.binary, ['exec', containerName, 'bash', '-c', command], {
@@ -158,9 +141,10 @@ async function execInContainer(command: string, containerName: string): Promise<
     child.on('error', reject);
     child.on('close', code => {
       if (code !== 0 && code !== null) {
-        process.exit(code);
+        reject(new Error(`Container exec exited with code ${code}`));
+      } else {
+        resolve();
       }
-      resolve();
     });
   });
 }
@@ -213,7 +197,21 @@ export const registerDev = (program: Command) => {
             process.exit(1);
           }
           const containerName = `agentcore-dev-${agentName}`.toLowerCase();
-          await execInContainer(positionalPrompt, containerName);
+          const execResult = await withCommandRunTelemetry(
+            'dev',
+            {
+              action: 'exec' as const,
+              ui_mode: 'terminal' as const,
+              has_stream: false,
+              protocol: standardize(Protocol, (targetAgent?.protocol ?? 'http').toLowerCase()),
+              invoke_count: 0,
+            },
+            async (): Promise<Result> => {
+              await execInContainer(positionalPrompt, containerName);
+              return { success: true };
+            }
+          );
+          if (!execResult.success) throw execResult.error;
           return;
         }
 
@@ -242,19 +240,37 @@ export const registerDev = (program: Command) => {
           if (protocol === 'A2A') invokePort = 9000;
           else if (protocol === 'MCP') invokePort = 8000;
 
-          // Protocol-aware dispatch
-          if (protocol === 'MCP') {
-            await handleMcpInvoke(invokePort, invokePrompt, opts.tool, opts.input, headers);
-          } else if (protocol === 'A2A') {
-            await invokeA2ADevServer(invokePort, invokePrompt, headers);
-          } else if (protocol === 'AGUI') {
-            for await (const chunk of invokeForProtocol('AGUI', { port: invokePort, message: invokePrompt, headers })) {
-              process.stdout.write(chunk);
+          const invokeResult = await withCommandRunTelemetry(
+            'dev',
+            {
+              action: 'invoke' as const,
+              ui_mode: 'terminal' as const,
+              has_stream: opts.stream ?? false,
+              protocol: standardize(Protocol, protocol.toLowerCase()),
+              invoke_count: 1,
+            },
+            async (): Promise<Result> => {
+              // Protocol-aware dispatch
+              if (protocol === 'MCP') {
+                await handleMcpInvoke(invokePort, invokePrompt, opts.tool, opts.input, headers);
+              } else if (protocol === 'A2A') {
+                await invokeA2ADevServer(invokePort, invokePrompt, headers);
+              } else if (protocol === 'AGUI') {
+                for await (const chunk of invokeForProtocol('AGUI', {
+                  port: invokePort,
+                  message: invokePrompt,
+                  headers,
+                })) {
+                  process.stdout.write(chunk);
+                }
+                process.stdout.write('\n');
+              } else {
+                await invokeDevServer(invokePort, invokePrompt, opts.stream ?? false, headers);
+              }
+              return { success: true };
             }
-            process.stdout.write('\n');
-          } else {
-            await invokeDevServer(invokePort, invokePrompt, opts.stream ?? false, headers);
-          }
+          );
+          if (!invokeResult.success) throw invokeResult.error;
           return;
         }
 
@@ -353,32 +369,52 @@ export const registerDev = (program: Command) => {
           console.log(`Log: ${logger.getRelativeLogPath()}`);
           console.log(`Press Ctrl+C to stop\n`);
 
-          const devCallbacks = {
-            onLog: (level: string, msg: string) => {
-              const prefix = level === 'error' ? '❌' : level === 'warn' ? '⚠️' : '→';
-              console.log(`${prefix} ${msg}`);
-              logger.log(msg, level === 'error' ? 'error' : 'info');
+          const devResult = await withCommandRunTelemetry(
+            'dev',
+            {
+              action: 'server' as const,
+              ui_mode: 'terminal' as const,
+              has_stream: false,
+              protocol: standardize(Protocol, (config.protocol ?? 'http').toLowerCase()),
+              invoke_count: 0,
             },
-            onExit: (code: number | null) => {
-              console.log(`\nServer exited with code ${code ?? 0}`);
-              logger.finalize(code === 0);
-              process.exit(code ?? 0);
-            },
-          };
+            async (): Promise<Result> => {
+              await new Promise<void>((resolve, reject) => {
+                const devCallbacks = {
+                  onLog: (level: string, msg: string) => {
+                    const prefix = level === 'error' ? '❌' : level === 'warn' ? '⚠️' : '→';
+                    console.log(`${prefix} ${msg}`);
+                    logger.log(msg, level === 'error' ? 'error' : 'info');
+                  },
+                  onExit: (code: number | null) => {
+                    console.log(`\nServer exited with code ${code ?? 0}`);
+                    logger.finalize(code === 0);
+                    if (code !== 0 && code !== null) {
+                      reject(new Error(`Server exited with code ${code}`));
+                    } else {
+                      resolve();
+                    }
+                  },
+                };
 
-          const server = createDevServer(config, { port: actualPort, envVars: mergedEnvVars, callbacks: devCallbacks });
-          await server.start();
+                const server = createDevServer(config, {
+                  port: actualPort,
+                  envVars: mergedEnvVars,
+                  callbacks: devCallbacks,
+                });
+                server.start().catch(reject);
 
-          // Handle Ctrl+C — use server.kill() for proper container cleanup
-          process.on('SIGINT', () => {
-            console.log('\nStopping server...');
-            collector?.stop();
-            server.kill();
-          });
-
-          // Keep process alive
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
-          await new Promise(() => {});
+                process.once('SIGINT', () => {
+                  console.log('\nStopping server...');
+                  collector?.stop();
+                  server.kill();
+                });
+              });
+              return { success: true as const };
+            }
+          );
+          if (!devResult.success) throw devResult.error;
+          process.exit(0);
         }
 
         // If --no-browser provided, launch terminal TUI mode
@@ -392,39 +428,71 @@ export const registerDev = (program: Command) => {
             process.stdout.write(SHOW_CURSOR);
           };
 
-          const { DevScreen } = await import('../../tui/screens/dev/DevScreen');
-          const { unmount, waitUntilExit } = render(
-            <LayoutProvider>
-              <DevScreen
-                onBack={() => {
-                  exitAltScreen();
-                  unmount();
-                  process.exit(0);
-                }}
-                workingDir={workingDir}
-                port={port}
-                agentName={opts.runtime}
-                headers={headers}
-              />
-            </LayoutProvider>
-          );
+          const tuiResult = await withCommandRunTelemetry(
+            'dev',
+            {
+              action: 'server' as const,
+              ui_mode: 'terminal' as const,
+              has_stream: false,
+              protocol: standardize(Protocol, (targetDevAgent?.protocol ?? 'http').toLowerCase()),
+              invoke_count: 0,
+            },
+            async (): Promise<Result> => {
+              const { DevScreen } = await import('../../tui/screens/dev/DevScreen');
+              const { unmount, waitUntilExit } = render(
+                <LayoutProvider>
+                  <DevScreen
+                    onBack={() => {
+                      exitAltScreen();
+                      unmount();
+                    }}
+                    workingDir={workingDir}
+                    port={port}
+                    agentName={opts.runtime}
+                    headers={headers}
+                  />
+                </LayoutProvider>
+              );
 
-          await waitUntilExit();
-          exitAltScreen();
-          return;
+              await waitUntilExit();
+              exitAltScreen();
+              return { success: true };
+            }
+          );
+          if (!tuiResult.success) throw tuiResult.error;
+          collector?.stop();
+          process.exit(0);
         }
 
         // Default: launch web UI in browser
-        await runBrowserMode({
-          workingDir,
-          project,
-          port,
-          agentName: opts.runtime,
-          otelEnvVars,
-          collector,
-        });
+        // runBrowserMode blocks forever (internal await new Promise(() => {})).
+        // On SIGINT, its internal handler stops the server and the process exits.
+        // Telemetry only emits here on startup failure; normal shutdown telemetry
+        // requires refactoring runWebUI to return a shutdown promise (follow-up).
+        const browserResult = await withCommandRunTelemetry(
+          'dev',
+          {
+            action: 'server' as const,
+            ui_mode: 'browser' as const,
+            has_stream: false,
+            protocol: standardize(Protocol, (targetDevAgent?.protocol ?? 'http').toLowerCase()),
+            invoke_count: 0,
+          },
+          async (): Promise<Result> => {
+            await runBrowserMode({
+              workingDir,
+              project,
+              port,
+              agentName: opts.runtime,
+              otelEnvVars,
+              collector,
+            });
+            return { success: true };
+          }
+        );
+        if (!browserResult.success) throw browserResult.error;
       } catch (error) {
-        render(<Text color="red">Error: {getErrorMessage(error)}</Text>);
+        console.error(`Error: ${getErrorMessage(error)}`);
         process.exit(1);
       }
     });

--- a/src/cli/telemetry/schemas/__tests__/command-run.test.ts
+++ b/src/cli/telemetry/schemas/__tests__/command-run.test.ts
@@ -120,6 +120,63 @@ describe('COMMAND_SCHEMAS', () => {
   it('no-attrs commands accept empty object', () => {
     expect(COMMAND_SCHEMAS['telemetry.disable'].parse({})).toEqual({});
   });
+
+  it('accepts valid dev invoke attrs', () => {
+    const attrs = {
+      action: 'invoke',
+      ui_mode: 'terminal',
+      has_stream: true,
+      protocol: 'http',
+      invoke_count: 1,
+    };
+    expect(COMMAND_SCHEMAS.dev.parse(attrs)).toEqual(attrs);
+  });
+
+  it('accepts valid dev server browser attrs', () => {
+    const attrs = {
+      action: 'server',
+      ui_mode: 'browser',
+      has_stream: false,
+      protocol: 'mcp',
+      invoke_count: 12,
+    };
+    expect(COMMAND_SCHEMAS.dev.parse(attrs)).toEqual(attrs);
+  });
+
+  it('accepts dev exec attrs', () => {
+    const attrs = {
+      action: 'exec',
+      ui_mode: 'terminal',
+      has_stream: false,
+      protocol: 'http',
+      invoke_count: 1,
+    };
+    expect(COMMAND_SCHEMAS.dev.parse(attrs)).toEqual(attrs);
+  });
+
+  it('rejects dev attrs with invalid action', () => {
+    expect(() =>
+      COMMAND_SCHEMAS.dev.parse({
+        action: 'unknown',
+        ui_mode: 'terminal',
+        has_stream: false,
+        protocol: 'http',
+        invoke_count: 0,
+      })
+    ).toThrow();
+  });
+
+  it('rejects dev attrs with invalid ui_mode', () => {
+    expect(() =>
+      COMMAND_SCHEMAS.dev.parse({
+        action: 'server',
+        ui_mode: 'headless',
+        has_stream: false,
+        protocol: 'http',
+        invoke_count: 0,
+      })
+    ).toThrow();
+  });
 });
 
 describe('deriveCommandGroup', () => {

--- a/src/cli/telemetry/schemas/command-run.ts
+++ b/src/cli/telemetry/schemas/command-run.ts
@@ -24,6 +24,7 @@ import {
   RefType,
   ResourceType,
   SourceType,
+  UiMode,
   ValidationMode,
   safeSchema,
 } from './common-shapes.js';
@@ -105,6 +106,7 @@ const DeployAttrs = safeSchema({
 
 const DevAttrs = safeSchema({
   action: Action,
+  ui_mode: UiMode,
   has_stream: z.boolean(),
   protocol: Protocol,
   invoke_count: Count,

--- a/src/cli/telemetry/schemas/common-shapes.ts
+++ b/src/cli/telemetry/schemas/common-shapes.ts
@@ -46,7 +46,8 @@ export function standardize<T extends z.ZodEnum<any>>(schema: T, value: string |
 export const Count = z.number().int().nonnegative();
 
 // Shared enums — alphabetical, one per attribute name from the metric shape spec
-export const Action = z.enum(['server', 'invoke']);
+export const Action = z.enum(['server', 'invoke', 'exec']);
+export const UiMode = z.enum(['browser', 'terminal']);
 export const AgentType = z.enum(['create', 'byo', 'import']);
 export const AttachMode = z.enum(['log_only', 'enforce']);
 export const AuthType = z.enum(['sigv4', 'bearer_token']);
@@ -94,7 +95,7 @@ export const ModelProvider = z.enum(['bedrock', 'anthropic', 'openai', 'gemini']
 export const NetworkMode = z.enum(['public', 'vpc']);
 export const OutboundAuth = z.enum(['oauth', 'api-key', 'none']);
 export const PolicyEngineMode = z.enum(['log_only', 'enforce']);
-export const Protocol = z.enum(['http', 'mcp', 'a2a']);
+export const Protocol = z.enum(['http', 'mcp', 'a2a', 'agui']);
 export const RefType = z.enum(['arn', 'name']);
 export const ResourceType = z.enum(['gateway', 'agent']);
 export const SourceType = z.enum(['file', 'statement', 'generate']);

--- a/src/lib/errors/types.ts
+++ b/src/lib/errors/types.ts
@@ -66,6 +66,16 @@ export class ValidationError extends Error {
 }
 
 /**
+ * Error indicating a network connection failure (e.g., server not reachable).
+ */
+export class ConnectionError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'ConnectionError';
+  }
+}
+
+/**
  * Converts an unknown thrown value to an Error instance.
  * Use in catch blocks to ensure the error field is always an Error object.
  */


### PR DESCRIPTION
## Description

Add telemetry instrumentation to the `dev` command for all execution paths (invoke, exec, server modes).

**Schema changes:**
- Expanded `Action` enum: `'exec'`
- Added `UiMode` enum: `'browser' | 'terminal'`
- Added `'agui'` to `Protocol` enum
- Added `ui_mode` field to `DevAttrs`

**Attributes emitted:** action, ui_mode, has_stream, protocol, invoke_count

Note: because the dev server runs indefinitely, we emit telemetry eagerly before the server starts. The alternative is to refactor how runWebUI works to return a result that allows us to determine if the error was a cancellation (ctrl + c) which would count as a success, or a crash, which would count as a failure. However, this is a large refactor and is therefore left out of scope. 

The effect is that dev success metrics with browser correspond to "was the user able to launch the browser" rather than, "did the browser launch successfully". 

## Related Issue

Closes #

## Documentation PR

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

**Additional testing:**
- E2E verified with tarball: telemetry JSONL correctly emitted for both success and failure paths
- Verified user-facing error messages preserved ("Dev server not running on port X")

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.