### PR TITLE
fix: disambiguate sync-from-public branch checkout

### DIFF
--- a/.github/workflows/sync-from-public.yml
+++ b/.github/workflows/sync-from-public.yml
@@ -37,8 +37,7 @@ jobs:
 
       - name: Sync main with public/main
         run: |
-          git checkout main
-          git reset --hard origin/main
+          git checkout -B main origin/main
 
           # Check if public/main is already merged
           if git merge-base --is-ancestor public/main HEAD; then
@@ -137,8 +136,7 @@ jobs:
 
       - name: Sync preview with public/preview
         run: |
-          git checkout preview
-          git reset --hard origin/preview
+          git checkout -B preview origin/preview
 
           # Check if public/preview is already merged
           if git merge-base --is-ancestor public/preview HEAD; then


### PR DESCRIPTION
## Summary

The \`Sync from Public Repo\` workflow has been silently failing on every scheduled run (every 6h) since the public-origin branch collision started. This PR fixes the underlying \`git\` ambiguity.

### Root cause

Each job runs:

\`\`\`bash
git remote add public https://github.com/aws/agentcore-cli.git
git fetch public main      # or 'preview'
...
git checkout main          # ← ambiguous!
\`\`\`

After fetching, both \`origin\` and \`public\` have a branch named \`main\` (and \`preview\`), so the DWIM shortcut \`git checkout main\` fails:

\`\`\`
fatal: 'preview' matched multiple (2) remote tracking branches
##[error]Process completed with exit code 128.
\`\`\`

Recent failures (all caused by this):
- 2026-05-13 12:40 UTC — scheduled run on \`main\` HEAD ce00f570 — [run 25799666444](https://github.com/aws/agentcore-cli/actions/runs/25799666444)
- 2026-05-13 06:59 UTC — scheduled — [run 25783665408](https://github.com/aws/agentcore-cli/actions/runs/25783665408)
- 2026-05-13 00:30 UTC — scheduled — [run 25770480821](https://github.com/aws/agentcore-cli/actions/runs/25770480821)

### Fix

Replace \`git checkout <branch>\` + \`git reset --hard origin/<branch>\` with \`git checkout -B <branch> origin/<branch>\` in both jobs. \`-B\` creates or resets the local branch from an explicit ref, sidestepping the DWIM ambiguity entirely and consolidating two steps into one.

### Why now

Before the App-token rollout (5767d93e), the same workflow already had this latent bug — but at that time the public mirror was lagging behind, so the \`merge-base --is-ancestor\` short-circuit kept hiding it. Once the repos drifted, every run started hitting the failed \`checkout\`.

## Test plan

- [ ] Merge and watch the next 6-hour scheduled run succeed (or fail with a different, real error)
- [ ] If it now succeeds and main+public are already in sync, expect the \`merge-base --is-ancestor\` early-exit path to fire and the job to no-op