### PR TITLE
feat: expose ability to publish otel metrics to remote endpoint

### DIFF
--- a/src/cli/telemetry/client-accessor.ts
+++ b/src/cli/telemetry/client-accessor.ts
@@ -3,6 +3,7 @@ import { TelemetryClient } from './client.js';
 import { resolveAuditFilePath, resolveResourceAttributes } from './config.js';
 import { FileSystemSink } from './sinks/filesystem-sink.js';
 import { CompositeSink } from './sinks/metric-sink.js';
+import { OtelMetricSink } from './sinks/otel-metric-sink.js';
 import { join } from 'path';
 
 /**
@@ -35,6 +36,7 @@ async function createClient(entrypoint: string, mode: 'cli' | 'tui' = 'cli'): Pr
 
   const sinks = [];
   const audit = process.env.AGENTCORE_TELEMETRY_AUDIT === '1' || config.telemetry?.audit === true;
+  const endpoint = process.env.AGENTCORE_TELEMETRY_ENDPOINT ?? config.telemetry?.endpoint;
 
   if (audit) {
     const filePath = resolveAuditFilePath(
@@ -43,6 +45,10 @@ async function createClient(entrypoint: string, mode: 'cli' | 'tui' = 'cli'): Pr
       resource['agentcore-cli.session_id']
     );
     sinks.push(new FileSystemSink({ filePath, resource }));
+  }
+
+  if (endpoint) {
+    sinks.push(new OtelMetricSink({ endpoint, resource }));
   }
 
   return new TelemetryClient(new CompositeSink(sinks));

--- a/src/cli/telemetry/sinks/otel-metric-sink.ts
+++ b/src/cli/telemetry/sinks/otel-metric-sink.ts
@@ -22,6 +22,7 @@ export class OtelMetricSink implements MetricSink {
       headers: { 'X-Installation-Id': config.resource['agentcore-cli.installation_id'] },
       temporalityPreference: AggregationTemporality.DELTA,
     });
+
     this.meterProvider = new MeterProvider({
       resource,
       readers: [


### PR DESCRIPTION
## Description

Wire up the OtelMetricSink to the telemetry client when `AGENTCORE_TELEMETRY_ENDPOINT` is set (via env var or global config). This enables publishing CLI metrics to a remote OTLP-compatible endpoint. The endpoint can also be configured via `telemetry.endpoint` in the global config file.

Note: this is not enabling telemetry! The intent is to allow the team to manually add the endpoint to their config to start collecting some real data, users that do not explicitly edit their config with an endpoint will be unaffected. 

### Testing
verified metrics are making to to collector when injecting the endpoint. They are currently being dropped due to an issue in validation that has its own fix. 

## Related Issue

Closes #

## Documentation PR

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.