### PR TITLE
fix(cdk): conditionally pass harnesses prop for CDK construct compat

### DIFF
--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -356,10 +356,12 @@ export class AgentCoreStack extends Stack {
     const { spec, mcpSpec, credentials, harnesses } = props;
 
     // Create AgentCoreApplication with all agents and harness roles
-    this.application = new AgentCoreApplication(this, 'Application', {
-      spec,
-      harnesses: harnesses?.length ? harnesses : undefined,
-    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const appProps: Record<string, unknown> = { spec };
+    if (harnesses?.length) {
+      appProps.harnesses = harnesses;
+    }
+    this.application = new AgentCoreApplication(this, 'Application', appProps as any);
 
     // Create AgentCoreMcp if there are gateways configured
     if (mcpSpec?.agentCoreGateways && mcpSpec.agentCoreGateways.length > 0) {

--- a/src/assets/cdk/lib/cdk-stack.ts
+++ b/src/assets/cdk/lib/cdk-stack.ts
@@ -58,10 +58,12 @@ export class AgentCoreStack extends Stack {
     const { spec, mcpSpec, credentials, harnesses } = props;
 
     // Create AgentCoreApplication with all agents and harness roles
-    this.application = new AgentCoreApplication(this, 'Application', {
-      spec,
-      harnesses: harnesses?.length ? harnesses : undefined,
-    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const appProps: Record<string, unknown> = { spec };
+    if (harnesses?.length) {
+      appProps.harnesses = harnesses;
+    }
+    this.application = new AgentCoreApplication(this, 'Application', appProps as any);
 
     // Create AgentCoreMcp if there are gateways configured
     if (mcpSpec?.agentCoreGateways && mcpSpec.agentCoreGateways.length > 0) {


### PR DESCRIPTION
## Summary

Fixes e2e `http-gateway-targets.test.ts` failure on both `npm` and `main` CDK variants.

Preview's vended `cdk-stack.ts` passes `harnesses` to `AgentCoreApplication`, but the npm-published `@aws/agentcore-cdk` package doesn't have this prop in its TypeScript interface. With `strict: true`, the CDK app fails to compile during synth, producing no stack — then deploy errors with `NoStack: CloudFormationStack object does not hold a stack`.

Fix: build the `AgentCoreApplication` props dynamically and cast, so the `harnesses` property is only present when harnesses are actually configured.

## Test plan

- [ ] E2E `http-gateway-targets.test.ts` passes on both `npm` and `main` variants