### PR TITLE
fix: replace third-party base image with AWS public ECR image (CVE-2026-31789)

### DIFF
--- a/docs/container-builds.md
+++ b/docs/container-builds.md
@@ -40,7 +40,7 @@ app/MyAgent/
 ## Generated Dockerfile
 
 The template uses `public.ecr.aws/docker/library/python:3.12-slim` as the base image (with `uv` installed via
-`pip install uv==0.11.14`) with these design choices:
+`pip install uv`) with these design choices:
 
 - **Layer caching**: Dependencies (`pyproject.toml`) are installed before copying application code
 - **Non-root**: Runs as `bedrock_agentcore` (UID 1000)

--- a/docs/container-builds.md
+++ b/docs/container-builds.md
@@ -39,7 +39,8 @@ app/MyAgent/
 
 ## Generated Dockerfile
 
-The template uses `ghcr.io/astral-sh/uv:python3.12-bookworm-slim` as the base image with these design choices:
+The template uses `public.ecr.aws/docker/library/python:3.12-slim` as the base image (with `uv` installed via
+`pip install uv==0.11.14`) with these design choices:
 
 - **Layer caching**: Dependencies (`pyproject.toml`) are installed before copying application code
 - **Non-root**: Runs as `bedrock_agentcore` (UID 1000)

--- a/src/assets/__tests__/__snapshots__/dockerfile-render.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/dockerfile-render.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Dockerfile enableOtel rendering > renders opentelemetry-instrument CMD when enableOtel is true > Dockerfile-enableOtel-true 1`] = `
-"FROM public.ecr.aws/docker/library/python:3.12-slim
+"FROM public.ecr.aws/docker/library/python:3.12-slim-bookworm
 
 RUN pip install --no-cache-dir uv==0.11.14
 
@@ -41,7 +41,7 @@ CMD ["opentelemetry-instrument", "python", "-m", "main"]
 `;
 
 exports[`Dockerfile enableOtel rendering > renders plain python CMD when enableOtel is false > Dockerfile-enableOtel-false 1`] = `
-"FROM public.ecr.aws/docker/library/python:3.12-slim
+"FROM public.ecr.aws/docker/library/python:3.12-slim-bookworm
 
 RUN pip install --no-cache-dir uv==0.11.14
 

--- a/src/assets/__tests__/__snapshots__/dockerfile-render.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/dockerfile-render.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Dockerfile enableOtel rendering > renders opentelemetry-instrument CMD when enableOtel is true > Dockerfile-enableOtel-true 1`] = `
 "FROM public.ecr.aws/docker/library/python:3.12-slim-bookworm
 
-RUN pip install --no-cache-dir uv==0.11.14
+RUN pip install --no-cache-dir uv
 
 ARG UV_DEFAULT_INDEX
 ARG UV_INDEX
@@ -43,7 +43,7 @@ CMD ["opentelemetry-instrument", "python", "-m", "main"]
 exports[`Dockerfile enableOtel rendering > renders plain python CMD when enableOtel is false > Dockerfile-enableOtel-false 1`] = `
 "FROM public.ecr.aws/docker/library/python:3.12-slim-bookworm
 
-RUN pip install --no-cache-dir uv==0.11.14
+RUN pip install --no-cache-dir uv
 
 ARG UV_DEFAULT_INDEX
 ARG UV_INDEX

--- a/src/assets/__tests__/__snapshots__/dockerfile-render.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/dockerfile-render.test.ts.snap
@@ -1,7 +1,9 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Dockerfile enableOtel rendering > renders opentelemetry-instrument CMD when enableOtel is true > Dockerfile-enableOtel-true 1`] = `
-"FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+"FROM public.ecr.aws/docker/library/python:3.12-slim
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
 ARG UV_DEFAULT_INDEX
 ARG UV_INDEX
@@ -39,7 +41,9 @@ CMD ["opentelemetry-instrument", "python", "-m", "main"]
 `;
 
 exports[`Dockerfile enableOtel rendering > renders plain python CMD when enableOtel is false > Dockerfile-enableOtel-false 1`] = `
-"FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+"FROM public.ecr.aws/docker/library/python:3.12-slim
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
 ARG UV_DEFAULT_INDEX
 ARG UV_INDEX

--- a/src/assets/__tests__/__snapshots__/dockerfile-render.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/dockerfile-render.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Dockerfile enableOtel rendering > renders opentelemetry-instrument CMD when enableOtel is true > Dockerfile-enableOtel-true 1`] = `
 "FROM public.ecr.aws/docker/library/python:3.12-slim
 
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+RUN pip install --no-cache-dir uv==0.11.14
 
 ARG UV_DEFAULT_INDEX
 ARG UV_INDEX
@@ -43,7 +43,7 @@ CMD ["opentelemetry-instrument", "python", "-m", "main"]
 exports[`Dockerfile enableOtel rendering > renders plain python CMD when enableOtel is false > Dockerfile-enableOtel-false 1`] = `
 "FROM public.ecr.aws/docker/library/python:3.12-slim
 
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+RUN pip install --no-cache-dir uv==0.11.14
 
 ARG UV_DEFAULT_INDEX
 ARG UV_INDEX

--- a/src/assets/container/python/Dockerfile
+++ b/src/assets/container/python/Dockerfile
@@ -1,6 +1,6 @@
 FROM public.ecr.aws/docker/library/python:3.12-slim-bookworm
 
-RUN pip install --no-cache-dir uv==0.11.14
+RUN pip install --no-cache-dir uv
 
 ARG UV_DEFAULT_INDEX
 ARG UV_INDEX

--- a/src/assets/container/python/Dockerfile
+++ b/src/assets/container/python/Dockerfile
@@ -1,4 +1,6 @@
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+FROM public.ecr.aws/docker/library/python:3.12-slim
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
 ARG UV_DEFAULT_INDEX
 ARG UV_INDEX

--- a/src/assets/container/python/Dockerfile
+++ b/src/assets/container/python/Dockerfile
@@ -1,6 +1,6 @@
 FROM public.ecr.aws/docker/library/python:3.12-slim
 
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+RUN pip install --no-cache-dir uv==0.11.14
 
 ARG UV_DEFAULT_INDEX
 ARG UV_INDEX

--- a/src/assets/container/python/Dockerfile
+++ b/src/assets/container/python/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/python:3.12-slim
+FROM public.ecr.aws/docker/library/python:3.12-slim-bookworm
 
 RUN pip install --no-cache-dir uv==0.11.14
 

--- a/src/cli/commands/import/actions.ts
+++ b/src/cli/commands/import/actions.ts
@@ -383,7 +383,8 @@ export async function handleImport(options: ImportOptions): Promise<ImportResult
               fs.writeFileSync(
                 destDockerfile,
                 [
-                  'FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim',
+                  'FROM public.ecr.aws/docker/library/python:3.12-slim',
+                  'RUN pip install --no-cache-dir uv==0.11.14',
                   'WORKDIR /app',
                   '',
                   'ENV UV_SYSTEM_PYTHON=1 \\',

--- a/src/cli/commands/import/actions.ts
+++ b/src/cli/commands/import/actions.ts
@@ -383,7 +383,7 @@ export async function handleImport(options: ImportOptions): Promise<ImportResult
               fs.writeFileSync(
                 destDockerfile,
                 [
-                  'FROM public.ecr.aws/docker/library/python:3.12-slim',
+                  'FROM public.ecr.aws/docker/library/python:3.12-slim-bookworm',
                   'RUN pip install --no-cache-dir uv==0.11.14',
                   'WORKDIR /app',
                   '',

--- a/src/cli/commands/import/actions.ts
+++ b/src/cli/commands/import/actions.ts
@@ -384,7 +384,7 @@ export async function handleImport(options: ImportOptions): Promise<ImportResult
                 destDockerfile,
                 [
                   'FROM public.ecr.aws/docker/library/python:3.12-slim-bookworm',
-                  'RUN pip install --no-cache-dir uv==0.11.14',
+                  'RUN pip install --no-cache-dir uv',
                   'WORKDIR /app',
                   '',
                   'ENV UV_SYSTEM_PYTHON=1 \\',


### PR DESCRIPTION
## Summary

- Replaces `ghcr.io/astral-sh/uv:python3.12-bookworm-slim` with `public.ecr.aws/docker/library/python:3.12-slim` in the Python container Dockerfile to remediate CVE-2026-31789 (OpenSSL)
- Copies `uv` binary via multi-stage `COPY --from` to preserve existing dependency management workflow
- Aligns with the fix already applied to `agentcore-samples` (PR #1461)

## Context

Ticket: https://t.corp.amazon.com/D448133494

Customer reported CVE-2026-31789 in the third-party base image used by `agentcore create` for Python projects. The `agentcore-samples` repo was patched but this repo still used the vulnerable image.

## Test plan

- [x] Snapshot tests updated
- [ ] Verify `agentcore create` + `agentcore dev` works with the new base image
- [ ] Verify container builds successfully with `agentcore package`