### PR TITLE
fix: add workflow_dispatch to sync-preview workflow

### DIFF
--- a/.github/workflows/sync-preview.yml
+++ b/.github/workflows/sync-preview.yml
@@ -1,6 +1,7 @@
 name: Sync Preview with Main
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
 


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to the sync-preview workflow so it can be manually run from the GitHub Actions UI
- Retains the existing automatic trigger on push to main

## Test plan
- [ ] Verify workflow appears with "Run workflow" button in GitHub Actions UI
- [ ] Verify automatic trigger on push to main still works