### PR TITLE
fix: restore requireProject() guard for --harness-arn

### DIFF
--- a/src/cli/commands/invoke/command.tsx
+++ b/src/cli/commands/invoke/command.tsx
@@ -226,7 +226,9 @@ export const registerInvoke = (program: Command) => {
         }
       ) => {
         try {
-          requireProject();
+          if (!cliOptions.harnessArn) {
+            requireProject();
+          }
 
           // Load config once for protocol resolution and to pass into handleInvokeCLI
           let invokeContext: InvokeContext | undefined;


### PR DESCRIPTION
## Description

The merge conflict resolution in `cac76c18` ("fix: resolve merge conflicts between main and preview") dropped the conditional guard around `requireProject()` in the invoke command, making it unconditional. This broke `agentcore invoke --harness-arn <arn>` outside a project directory, contradicting the documented behavior (`--harness-arn ... "no project required"`).

The fix restores the original guard: `requireProject()` is only called when `--harness-arn` is not provided.

## Related Issue

Regression introduced by #1256 (merge conflict resolution commit `cac76c18`).

## Documentation PR

N/A — restores previously documented behavior.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.