### PR TITLE
fix: skip schema-check and pr-title validation on release PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -102,6 +102,7 @@ jobs:
       - run: npm run typecheck
 
   schema-check:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'release') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -39,7 +39,8 @@ jobs:
             must start with a lowercase letter.
             Example: "feat: add deploy command"
           validateSingleCommit: false
-          # Skip validation for bot/dependency PRs
+          # Skip validation for bot/dependency/release PRs
           ignoreLabels: |
             bot
             dependencies
+            release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,6 +185,7 @@ jobs:
           gh pr create \
             --base "$BASE_BRANCH" \
             --head "$BRANCH_NAME" \
+            --label release \
             --title "Release v$NEW_VERSION" \
             --body "## Release v$NEW_VERSION
 


### PR DESCRIPTION
## Description

Skip the `schema-check` job and PR title validation on auto-created release PRs by using a `release` label.

- The release workflow now adds `--label release` to `gh pr create`
- `pr-title.yml` adds `release` to `ignoreLabels` so semantic title validation is skipped
- `lint.yml` adds an `if` condition to `schema-check` to skip when the `release` label is present

Ex. https://github.com/aws/agentcore-cli/pull/1271 has these checks failing, but its just noise since we don't care about these checks on release branches. 

## Related Issue

N/A — fixing CI failures on auto-created release PRs.

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [ ] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.