### PR TITLE
feat(tui): add dedicated Logs screen for streaming runtime logs

### DIFF
--- a/src/cli/tui/App.tsx
+++ b/src/cli/tui/App.tsx
@@ -15,6 +15,7 @@ import { FetchAccessScreen } from './screens/fetch-access';
 import { HelpScreen, HomeScreen } from './screens/home';
 import { ImportFlow } from './screens/import';
 import { InvokeScreen } from './screens/invoke';
+import { LogsScreen } from './screens/logs';
 import { OnlineEvalDashboard } from './screens/online-eval';
 import { PackageScreen } from './screens/package';
 import { RecommendationFlow, RecommendationHistoryScreen, RecommendationsHubScreen } from './screens/recommendation';
@@ -35,6 +36,7 @@ type Route =
   | { name: 'help'; initialQuery?: string }
   | { name: 'deploy' }
   | { name: 'invoke' }
+  | { name: 'logs' }
   | { name: 'create' }
   | { name: 'add' }
   | { name: 'status' }
@@ -103,6 +105,8 @@ function AppContent() {
       setRoute({ name: 'deploy' });
     } else if (id === 'invoke') {
       setRoute({ name: 'invoke' });
+    } else if (id === 'logs') {
+      setRoute({ name: 'logs' });
     } else if (id === 'status') {
       setRoute({ name: 'status' });
     } else if (id === 'create') {
@@ -181,6 +185,10 @@ function AppContent() {
 
   if (route.name === 'invoke') {
     return <InvokeScreen isInteractive={true} onExit={() => setRoute({ name: 'help' })} />;
+  }
+
+  if (route.name === 'logs') {
+    return <LogsScreen isInteractive={true} onExit={() => setRoute({ name: 'help' })} />;
   }
 
   if (route.name === 'status') {

--- a/src/cli/tui/copy.ts
+++ b/src/cli/tui/copy.ts
@@ -62,15 +62,6 @@ export const COMMAND_DESCRIPTIONS = {
  * These commands must run in the terminal, not in the TUI.
  */
 export const CLI_ONLY_EXAMPLES: Record<string, { description: string; examples: string[] }> = {
-  logs: {
-    description: 'Stream or search agent runtime logs. This command runs in the terminal.',
-    examples: [
-      'agentcore logs',
-      'agentcore logs --since 30m --level error',
-      'agentcore logs --runtime MyAgent --query "timeout"',
-      'agentcore logs evals --since 1h',
-    ],
-  },
   traces: {
     description: 'View and download agent traces. This command runs in the terminal.',
     examples: [

--- a/src/cli/tui/hooks/__tests__/useLogsStream.test.tsx
+++ b/src/cli/tui/hooks/__tests__/useLogsStream.test.tsx
@@ -1,0 +1,165 @@
+import type { AgentContext } from '../../../commands/logs/action.js';
+import { useLogsStream } from '../useLogsStream.js';
+import { Text } from 'ink';
+import { render } from 'ink-testing-library';
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { mockStreamLogs } = vi.hoisted(() => ({
+  mockStreamLogs: vi.fn(),
+}));
+
+vi.mock('../../../aws/cloudwatch.js', () => ({
+  streamLogs: mockStreamLogs,
+}));
+
+const AGENT_CONTEXT: AgentContext = {
+  agentId: 'test-runtime-id',
+  agentName: 'TestAgent',
+  accountId: '123456789012',
+  region: 'us-east-1',
+  endpointName: 'default',
+  logGroupName: '/aws/bedrock-agentcore/runtimes/test-runtime-id-default',
+};
+
+function Harness({ agentContext }: { agentContext: AgentContext | undefined }) {
+  const { logs, isStreaming, error } = useLogsStream(agentContext);
+  return (
+    <Text>
+      streaming:{String(isStreaming)} logs:{logs.length} error:{error ?? 'null'}
+    </Text>
+  );
+}
+
+describe('useLogsStream', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('stays idle when agentContext is undefined', () => {
+    // eslint-disable-next-line require-yield
+    mockStreamLogs.mockImplementation(async function* () {
+      await Promise.resolve();
+    });
+
+    const { lastFrame } = render(<Harness agentContext={undefined} />);
+
+    expect(lastFrame()).toContain('streaming:false');
+    expect(lastFrame()).toContain('logs:0');
+    expect(lastFrame()).toContain('error:null');
+    expect(mockStreamLogs).not.toHaveBeenCalled();
+  });
+
+  it('transitions to streaming and appends log entries', async () => {
+    let resolve: () => void;
+    const done = new Promise<void>(r => {
+      resolve = r;
+    });
+
+    mockStreamLogs.mockImplementation(async function* () {
+      await Promise.resolve();
+      yield { timestamp: 1000, message: 'hello world' };
+      yield { timestamp: 2000, message: '[ERROR] something broke' };
+      resolve!();
+    });
+
+    const { lastFrame } = render(<Harness agentContext={AGENT_CONTEXT} />);
+
+    await done;
+    await new Promise(r => setTimeout(r, 50));
+
+    const frame = lastFrame();
+    expect(frame).toContain('logs:2');
+  });
+
+  it('detects error level from message content', async () => {
+    let resolve: () => void;
+    const done = new Promise<void>(r => {
+      resolve = r;
+    });
+
+    mockStreamLogs.mockImplementation(async function* () {
+      await Promise.resolve();
+      yield { timestamp: 1000, message: '[error] bad thing' };
+      resolve!();
+    });
+
+    const { lastFrame } = render(<Harness agentContext={AGENT_CONTEXT} />);
+    await done;
+    await new Promise(r => setTimeout(r, 50));
+
+    expect(lastFrame()).toContain('logs:1');
+  });
+
+  it('shows friendly message for ResourceNotFoundException', async () => {
+    // eslint-disable-next-line require-yield
+    mockStreamLogs.mockImplementation(async function* () {
+      await Promise.resolve();
+      const err = new Error('Not found');
+      err.name = 'ResourceNotFoundException';
+      throw err;
+    });
+
+    const { lastFrame } = render(<Harness agentContext={AGENT_CONTEXT} />);
+    await new Promise(r => setTimeout(r, 50));
+
+    const frame = lastFrame();
+    expect(frame).toContain('error:No logs found');
+    expect(frame).toContain('Has the agent been invoked?');
+    expect(frame).toContain('streaming:false');
+  });
+
+  it('shows generic error message for other errors', async () => {
+    // eslint-disable-next-line require-yield
+    mockStreamLogs.mockImplementation(async function* () {
+      await Promise.resolve();
+      throw new Error('Connection refused');
+    });
+
+    const { lastFrame } = render(<Harness agentContext={AGENT_CONTEXT} />);
+    await new Promise(r => setTimeout(r, 50));
+
+    const frame = lastFrame();
+    expect(frame).toContain('error:Connection refused');
+    expect(frame).toContain('streaming:false');
+  });
+
+  it('does not surface abort errors when unmounted', async () => {
+    // eslint-disable-next-line require-yield
+    mockStreamLogs.mockImplementation(async function* ({ abortSignal }: { abortSignal: AbortSignal }) {
+      await new Promise((_, reject) => {
+        abortSignal.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')));
+      });
+    });
+
+    const { lastFrame, unmount } = render(<Harness agentContext={AGENT_CONTEXT} />);
+    await new Promise(r => setTimeout(r, 50));
+
+    expect(lastFrame()).toContain('streaming:true');
+
+    unmount();
+    await new Promise(r => setTimeout(r, 50));
+  });
+
+  it('caps log buffer at 1000 entries', async () => {
+    let resolve: () => void;
+    const done = new Promise<void>(r => {
+      resolve = r;
+    });
+
+    mockStreamLogs.mockImplementation(async function* () {
+      await Promise.resolve();
+      for (let i = 0; i < 1050; i++) {
+        yield { timestamp: i, message: `log ${i}` };
+      }
+      resolve!();
+    });
+
+    const { lastFrame } = render(<Harness agentContext={AGENT_CONTEXT} />);
+    await done;
+    await new Promise(r => setTimeout(r, 100));
+
+    const frame = lastFrame();
+    expect(frame).toContain('logs:1000');
+  });
+});

--- a/src/cli/tui/hooks/index.ts
+++ b/src/cli/tui/hooks/index.ts
@@ -8,6 +8,7 @@ export { useMultiSelectNavigation } from './useMultiSelectNavigation';
 export { useResponsive } from './useResponsive';
 export { useAvailableAgents, useCreateGateway, useExistingGateways } from './useCreateMcp';
 export { useDevServer } from './useDevServer';
+export { useLogsStream } from './useLogsStream';
 export { useProject } from './useProject';
 export type { UseProjectResult, ProjectContext } from './useProject';
 export { useTextInput } from './useTextInput';

--- a/src/cli/tui/hooks/useLogsStream.ts
+++ b/src/cli/tui/hooks/useLogsStream.ts
@@ -1,0 +1,83 @@
+import { streamLogs } from '../../aws/cloudwatch';
+import type { AgentContext } from '../../commands/logs/action';
+import type { LogEntry } from '../components/LogPanel';
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+const MAX_LOG_ENTRIES = 1000;
+
+interface UseLogsStreamResult {
+  logs: LogEntry[];
+  isStreaming: boolean;
+  error?: string;
+}
+
+function detectLevel(message: string): LogEntry['level'] {
+  const lower = message.toLowerCase();
+  if (lower.includes('"level":"error"') || lower.includes('[error]') || lower.startsWith('error')) {
+    return 'error';
+  }
+  if (lower.includes('"level":"warn"') || lower.includes('[warn]') || lower.startsWith('warn')) {
+    return 'warn';
+  }
+  return 'info';
+}
+
+export function useLogsStream(agentContext: AgentContext | undefined): UseLogsStreamResult {
+  const [logs, setLogs] = useState<LogEntry[]>([]);
+  const [streamState, setStreamState] = useState<'idle' | 'streaming' | 'done'>('idle');
+  const [error, setError] = useState<string | undefined>();
+  const abortRef = useRef<AbortController | null>(null);
+
+  const isStreaming = useMemo(() => streamState === 'streaming', [streamState]);
+
+  useEffect(() => {
+    if (!agentContext) return;
+
+    const ac = new AbortController();
+    abortRef.current = ac;
+
+    const run = async () => {
+      setStreamState('streaming');
+      setError(undefined);
+      setLogs([]);
+
+      try {
+        for await (const event of streamLogs({
+          logGroupName: agentContext.logGroupName,
+          region: agentContext.region,
+          accountId: agentContext.accountId,
+          abortSignal: ac.signal,
+        })) {
+          if (ac.signal.aborted) break;
+          const entry: LogEntry = {
+            level: detectLevel(event.message),
+            message: `${new Date(event.timestamp).toISOString()}  ${event.message}`,
+          };
+          setLogs(prev => {
+            const next = [...prev, entry];
+            return next.length > MAX_LOG_ENTRIES ? next.slice(-MAX_LOG_ENTRIES) : next;
+          });
+        }
+      } catch (err: unknown) {
+        if (ac.signal.aborted) return;
+        const errorName = (err as { name?: string })?.name;
+        if (errorName === 'ResourceNotFoundException') {
+          setError(`No logs found for agent '${agentContext.agentName}'. Has the agent been invoked?`);
+        } else {
+          setError((err as Error).message ?? 'Failed to stream logs');
+        }
+      } finally {
+        setStreamState('done');
+      }
+    };
+
+    void run();
+
+    return () => {
+      ac.abort();
+      abortRef.current = null;
+    };
+  }, [agentContext]);
+
+  return { logs, isStreaming, error };
+}

--- a/src/cli/tui/hooks/useLogsStream.ts
+++ b/src/cli/tui/hooks/useLogsStream.ts
@@ -19,7 +19,10 @@ function detectLevel(message: string): LogEntry['level'] {
   if (lower.includes('"level":"warn"') || lower.includes('[warn]') || lower.startsWith('warn')) {
     return 'warn';
   }
-  return 'info';
+  if (lower.includes('"level":"info"') || lower.includes('[info]') || lower.startsWith('info')) {
+    return 'info';
+  }
+  return 'system';
 }
 
 export function useLogsStream(agentContext: AgentContext | undefined): UseLogsStreamResult {

--- a/src/cli/tui/screens/logs/LogsScreen.tsx
+++ b/src/cli/tui/screens/logs/LogsScreen.tsx
@@ -13,13 +13,12 @@ interface LogsScreenProps {
 }
 
 type Phase = 'loading' | 'select-agent' | 'streaming' | 'error';
-type LevelFilter = 'all' | 'error' | 'warn' | 'info';
+type LevelFilter = 'all' | 'error' | 'warn';
 
 const FILTER_LABELS: Record<LevelFilter, string> = {
   all: 'All',
   error: 'Errors',
-  warn: 'Warnings+',
-  info: 'Info+',
+  warn: 'Warn+Errors',
 };
 
 function filterLogs(logs: LogEntry[], filter: LevelFilter): LogEntry[] {
@@ -119,9 +118,6 @@ export function LogsScreen({ onExit }: LogsScreenProps) {
         if (input === '3') {
           setLevelFilter('warn');
         }
-        if (input === '4') {
-          setLevelFilter('info');
-        }
       }
     },
     { isActive: !showFullScreen }
@@ -166,7 +162,7 @@ export function LogsScreen({ onExit }: LogsScreenProps) {
     );
   }
 
-  const helpText = '↑↓ scroll · f full-screen · 1 all · 2 errors · 3 warn+ · 4 info+ · Esc back';
+  const helpText = '↑↓ scroll · f full-screen · 1 all · 2 errors · 3 warn+ · Esc back';
 
   return (
     <Screen
@@ -202,7 +198,7 @@ export function LogsScreen({ onExit }: LogsScreenProps) {
         </Box>
       }
     >
-      <Box flexDirection="column" flexGrow={1}>
+      <Box flexDirection="column" height={maxLines + 2}>
         <LogPanel logs={filteredLogs} maxLines={maxLines} minimal={false} isActive={phase === 'streaming'} />
       </Box>
     </Screen>

--- a/src/cli/tui/screens/logs/LogsScreen.tsx
+++ b/src/cli/tui/screens/logs/LogsScreen.tsx
@@ -1,10 +1,11 @@
 import type { AgentContext } from '../../../commands/logs/action';
 import { resolveAgentContext } from '../../../commands/logs/action';
 import { loadDeployedProjectConfig } from '../../../operations/resolve-agent';
-import { FullScreenLogView, Screen, SelectList } from '../../components';
+import { FullScreenLogView, LogPanel, Screen, SelectList } from '../../components';
+import type { LogEntry } from '../../components/LogPanel';
 import { useLogsStream } from '../../hooks/useLogsStream';
-import { Box, Text, useInput } from 'ink';
-import React, { useEffect, useState } from 'react';
+import { Box, Text, useInput, useStdout } from 'ink';
+import React, { useEffect, useMemo, useState } from 'react';
 
 interface LogsScreenProps {
   isInteractive: boolean;
@@ -12,6 +13,21 @@ interface LogsScreenProps {
 }
 
 type Phase = 'loading' | 'select-agent' | 'streaming' | 'error';
+type LevelFilter = 'all' | 'error' | 'warn' | 'info';
+
+const FILTER_LABELS: Record<LevelFilter, string> = {
+  all: 'All',
+  error: 'Errors',
+  warn: 'Warnings+',
+  info: 'Info+',
+};
+
+function filterLogs(logs: LogEntry[], filter: LevelFilter): LogEntry[] {
+  if (filter === 'all') return logs;
+  if (filter === 'error') return logs.filter(l => l.level === 'error');
+  if (filter === 'warn') return logs.filter(l => l.level === 'error' || l.level === 'warn');
+  return logs;
+}
 
 export function LogsScreen({ onExit }: LogsScreenProps) {
   const [phase, setPhase] = useState<Phase>('loading');
@@ -20,8 +36,14 @@ export function LogsScreen({ onExit }: LogsScreenProps) {
   const [selectedAgent, setSelectedAgent] = useState<AgentContext | undefined>();
   const [loadError, setLoadError] = useState<string | undefined>();
   const [showFullScreen, setShowFullScreen] = useState(false);
+  const [levelFilter, setLevelFilter] = useState<LevelFilter>('all');
+  const { stdout } = useStdout();
+  const terminalHeight = stdout?.rows ?? 24;
+  const maxLines = Math.max(5, terminalHeight - 14);
 
   const { logs, isStreaming, error: streamError } = useLogsStream(selectedAgent);
+
+  const filteredLogs = useMemo(() => filterLogs(logs, levelFilter), [logs, levelFilter]);
 
   useEffect(() => {
     const load = async () => {
@@ -85,8 +107,20 @@ export function LogsScreen({ onExit }: LogsScreenProps) {
       }
 
       if (phase === 'streaming' && !showFullScreen) {
-        if (input === 'l') {
+        if (input === 'f') {
           setShowFullScreen(true);
+        }
+        if (input === '1') {
+          setLevelFilter('all');
+        }
+        if (input === '2') {
+          setLevelFilter('error');
+        }
+        if (input === '3') {
+          setLevelFilter('warn');
+        }
+        if (input === '4') {
+          setLevelFilter('info');
         }
       }
     },
@@ -94,7 +128,7 @@ export function LogsScreen({ onExit }: LogsScreenProps) {
   );
 
   if (showFullScreen) {
-    return <FullScreenLogView logs={logs} onExit={() => setShowFullScreen(false)} />;
+    return <FullScreenLogView logs={filteredLogs} onExit={() => setShowFullScreen(false)} />;
   }
 
   if (phase === 'loading') {
@@ -132,22 +166,27 @@ export function LogsScreen({ onExit }: LogsScreenProps) {
     );
   }
 
-  const helpText = isStreaming ? 'l full-screen · Esc back' : streamError ? 'Esc back' : 'l full-screen · Esc back';
+  const helpText = '↑↓ scroll · f full-screen · 1 all · 2 errors · 3 warn+ · 4 info+ · Esc back';
 
   return (
     <Screen
       title="Logs"
       onExit={onExit}
       helpText={helpText}
+      exitEnabled={!showFullScreen}
       headerContent={
         <Box flexDirection="column">
           <Box>
             <Text>Agent: </Text>
             <Text color="green">{selectedAgent?.agentName}</Text>
-          </Box>
-          <Box>
-            <Text>Region: </Text>
+            <Text> Region: </Text>
             <Text color="cyan">{selectedAgent?.region}</Text>
+            <Text> Filter: </Text>
+            <Text bold>{FILTER_LABELS[levelFilter]}</Text>
+            <Text dimColor>
+              {' '}
+              ({filteredLogs.length}/{logs.length})
+            </Text>
           </Box>
           <Box>
             <Text>Status: </Text>
@@ -159,28 +198,12 @@ export function LogsScreen({ onExit }: LogsScreenProps) {
               <Text color="yellow">Disconnected</Text>
             )}
           </Box>
-          {streamError && (
-            <Box marginTop={1}>
-              <Text color="red">{streamError}</Text>
-            </Box>
-          )}
+          {streamError && <Text color="red">{streamError}</Text>}
         </Box>
       }
     >
       <Box flexDirection="column" flexGrow={1}>
-        {logs.length === 0 && isStreaming && <Text dimColor>Waiting for logs...</Text>}
-        {logs.length > 0 && (
-          <Box flexDirection="column">
-            {logs.slice(-20).map((log, idx) => (
-              <Text key={idx} color={log.level === 'error' ? 'red' : log.level === 'warn' ? 'yellow' : undefined}>
-                {log.message}
-              </Text>
-            ))}
-            {logs.length > 20 && (
-              <Text dimColor>Showing last 20 of {logs.length} entries. Press l for full-screen view.</Text>
-            )}
-          </Box>
-        )}
+        <LogPanel logs={filteredLogs} maxLines={maxLines} minimal={false} isActive={phase === 'streaming'} />
       </Box>
     </Screen>
   );

--- a/src/cli/tui/screens/logs/LogsScreen.tsx
+++ b/src/cli/tui/screens/logs/LogsScreen.tsx
@@ -198,7 +198,7 @@ export function LogsScreen({ onExit }: LogsScreenProps) {
         </Box>
       }
     >
-      <Box flexDirection="column" height={maxLines + 2}>
+      <Box flexDirection="column" height={maxLines + 2} overflow="hidden">
         <LogPanel logs={filteredLogs} maxLines={maxLines} minimal={false} isActive={phase === 'streaming'} />
       </Box>
     </Screen>

--- a/src/cli/tui/screens/logs/LogsScreen.tsx
+++ b/src/cli/tui/screens/logs/LogsScreen.tsx
@@ -1,0 +1,191 @@
+import type { AgentContext } from '../../../commands/logs/action';
+import { resolveAgentContext } from '../../../commands/logs/action';
+import { loadDeployedProjectConfig } from '../../../operations/resolve-agent';
+import { FullScreenLogView, Screen, SelectList } from '../../components';
+import { useLogsStream } from '../../hooks/useLogsStream';
+import { Box, Text, useInput } from 'ink';
+import React, { useEffect, useState } from 'react';
+
+interface LogsScreenProps {
+  isInteractive: boolean;
+  onExit: () => void;
+}
+
+type Phase = 'loading' | 'select-agent' | 'streaming' | 'error';
+
+export function LogsScreen({ onExit }: LogsScreenProps) {
+  const [phase, setPhase] = useState<Phase>('loading');
+  const [agents, setAgents] = useState<AgentContext[]>([]);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [selectedAgent, setSelectedAgent] = useState<AgentContext | undefined>();
+  const [loadError, setLoadError] = useState<string | undefined>();
+  const [showFullScreen, setShowFullScreen] = useState(false);
+
+  const { logs, isStreaming, error: streamError } = useLogsStream(selectedAgent);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const context = await loadDeployedProjectConfig();
+        const runtimeNames = context.project.runtimes.map(r => r.name);
+
+        if (runtimeNames.length === 0) {
+          setLoadError('No runtimes defined in agentcore.json');
+          setPhase('error');
+          return;
+        }
+
+        const resolved: AgentContext[] = [];
+        for (const name of runtimeNames) {
+          const result = resolveAgentContext(context, { runtime: name });
+          if (result.success) {
+            resolved.push(result.agentContext);
+          }
+        }
+
+        if (resolved.length === 0) {
+          setLoadError('No deployed agents found. Run `agentcore deploy` first.');
+          setPhase('error');
+          return;
+        }
+
+        setAgents(resolved);
+
+        if (resolved.length === 1) {
+          setSelectedAgent(resolved[0]);
+          setPhase('streaming');
+        } else {
+          setPhase('select-agent');
+        }
+      } catch (err) {
+        setLoadError((err as Error).message ?? 'Failed to load project config');
+        setPhase('error');
+      }
+    };
+
+    void load();
+  }, []);
+
+  useInput(
+    (input, key) => {
+      if (phase === 'select-agent') {
+        if (key.upArrow || input === 'k') {
+          setSelectedIndex(prev => (prev - 1 + agents.length) % agents.length);
+        }
+        if (key.downArrow || input === 'j') {
+          setSelectedIndex(prev => (prev + 1) % agents.length);
+        }
+        if (key.return) {
+          const agent = agents[selectedIndex];
+          if (agent) {
+            setSelectedAgent(agent);
+            setPhase('streaming');
+          }
+        }
+      }
+
+      if (phase === 'streaming' && !showFullScreen) {
+        if (input === 'l') {
+          setShowFullScreen(true);
+        }
+      }
+    },
+    { isActive: !showFullScreen }
+  );
+
+  if (showFullScreen) {
+    return <FullScreenLogView logs={logs} onExit={() => setShowFullScreen(false)} />;
+  }
+
+  if (phase === 'loading') {
+    return (
+      <Screen title="Logs" onExit={onExit} helpText="Loading...">
+        <Text>Loading deployed agents...</Text>
+      </Screen>
+    );
+  }
+
+  if (phase === 'error') {
+    return (
+      <Screen title="Logs" onExit={onExit} helpText="Esc back">
+        <Text color="red">{loadError}</Text>
+      </Screen>
+    );
+  }
+
+  if (phase === 'select-agent') {
+    const items = agents.map(a => ({
+      id: a.agentId,
+      title: a.agentName,
+      description: `${a.region}`,
+    }));
+
+    return (
+      <Screen title="Logs" onExit={onExit} helpText="↑↓ select · Enter confirm · Esc back">
+        <Box flexDirection="column">
+          <Text bold>Select an agent to stream logs:</Text>
+          <Box marginTop={1}>
+            <SelectList items={items} selectedIndex={selectedIndex} />
+          </Box>
+        </Box>
+      </Screen>
+    );
+  }
+
+  const helpText = isStreaming
+    ? '↑↓ scroll · l full-screen · Esc back'
+    : streamError
+      ? 'Esc back'
+      : '↑↓ scroll · l full-screen · Esc back';
+
+  return (
+    <Screen
+      title="Logs"
+      onExit={onExit}
+      helpText={helpText}
+      headerContent={
+        <Box flexDirection="column">
+          <Box>
+            <Text>Agent: </Text>
+            <Text color="green">{selectedAgent?.agentName}</Text>
+          </Box>
+          <Box>
+            <Text>Region: </Text>
+            <Text color="cyan">{selectedAgent?.region}</Text>
+          </Box>
+          <Box>
+            <Text>Status: </Text>
+            {isStreaming ? (
+              <Text color="green">Streaming...</Text>
+            ) : streamError ? (
+              <Text color="red">Error</Text>
+            ) : (
+              <Text color="yellow">Disconnected</Text>
+            )}
+          </Box>
+          {streamError && (
+            <Box marginTop={1}>
+              <Text color="red">{streamError}</Text>
+            </Box>
+          )}
+        </Box>
+      }
+    >
+      <Box flexDirection="column" flexGrow={1}>
+        {logs.length === 0 && isStreaming && <Text dimColor>Waiting for logs...</Text>}
+        {logs.length > 0 && (
+          <Box flexDirection="column">
+            {logs.slice(-20).map((log, idx) => (
+              <Text key={idx} color={log.level === 'error' ? 'red' : log.level === 'warn' ? 'yellow' : undefined}>
+                {log.message}
+              </Text>
+            ))}
+            {logs.length > 20 && (
+              <Text dimColor>Showing last 20 of {logs.length} entries. Press l for full-screen view.</Text>
+            )}
+          </Box>
+        )}
+      </Box>
+    </Screen>
+  );
+}

--- a/src/cli/tui/screens/logs/LogsScreen.tsx
+++ b/src/cli/tui/screens/logs/LogsScreen.tsx
@@ -1,18 +1,16 @@
-import type { AgentContext } from '../../../commands/logs/action';
-import { resolveAgentContext } from '../../../commands/logs/action';
-import { loadDeployedProjectConfig } from '../../../operations/resolve-agent';
 import { FullScreenLogView, LogPanel, Screen, SelectList } from '../../components';
 import type { LogEntry } from '../../components/LogPanel';
-import { useLogsStream } from '../../hooks/useLogsStream';
+import { HELP_TEXT } from '../../constants';
+import { useListNavigation } from '../../hooks/useListNavigation';
+import { useLogsFlow } from './useLogsFlow';
 import { Box, Text, useInput, useStdout } from 'ink';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 
 interface LogsScreenProps {
   isInteractive: boolean;
   onExit: () => void;
 }
 
-type Phase = 'loading' | 'select-agent' | 'streaming' | 'error';
 type LevelFilter = 'all' | 'error' | 'warn';
 
 const FILTER_LABELS: Record<LevelFilter, string> = {
@@ -29,82 +27,24 @@ function filterLogs(logs: LogEntry[], filter: LevelFilter): LogEntry[] {
 }
 
 export function LogsScreen({ onExit }: LogsScreenProps) {
-  const [phase, setPhase] = useState<Phase>('loading');
-  const [agents, setAgents] = useState<AgentContext[]>([]);
-  const [selectedIndex, setSelectedIndex] = useState(0);
-  const [selectedAgent, setSelectedAgent] = useState<AgentContext | undefined>();
-  const [loadError, setLoadError] = useState<string | undefined>();
+  const { phase, agents, selectedAgent, loadError, selectAgent, logs, isStreaming, streamError } = useLogsFlow();
   const [showFullScreen, setShowFullScreen] = useState(false);
   const [levelFilter, setLevelFilter] = useState<LevelFilter>('all');
   const { stdout } = useStdout();
   const terminalHeight = stdout?.rows ?? 24;
   const maxLines = Math.max(5, terminalHeight - 14);
 
-  const { logs, isStreaming, error: streamError } = useLogsStream(selectedAgent);
-
   const filteredLogs = useMemo(() => filterLogs(logs, levelFilter), [logs, levelFilter]);
 
-  useEffect(() => {
-    const load = async () => {
-      try {
-        const context = await loadDeployedProjectConfig();
-        const runtimeNames = context.project.runtimes.map(r => r.name);
-
-        if (runtimeNames.length === 0) {
-          setLoadError('No runtimes defined in agentcore.json');
-          setPhase('error');
-          return;
-        }
-
-        const resolved: AgentContext[] = [];
-        for (const name of runtimeNames) {
-          const result = resolveAgentContext(context, { runtime: name });
-          if (result.success) {
-            resolved.push(result.agentContext);
-          }
-        }
-
-        if (resolved.length === 0) {
-          setLoadError('No deployed agents found. Run `agentcore deploy` first.');
-          setPhase('error');
-          return;
-        }
-
-        setAgents(resolved);
-
-        if (resolved.length === 1) {
-          setSelectedAgent(resolved[0]);
-          setPhase('streaming');
-        } else {
-          setPhase('select-agent');
-        }
-      } catch (err) {
-        setLoadError((err as Error).message ?? 'Failed to load project config');
-        setPhase('error');
-      }
-    };
-
-    void load();
-  }, []);
+  const { selectedIndex } = useListNavigation({
+    items: agents,
+    onSelect: agent => selectAgent(agent),
+    onExit,
+    isActive: phase === 'select-agent' && !showFullScreen,
+  });
 
   useInput(
-    (input, key) => {
-      if (phase === 'select-agent') {
-        if (key.upArrow || input === 'k') {
-          setSelectedIndex(prev => (prev - 1 + agents.length) % agents.length);
-        }
-        if (key.downArrow || input === 'j') {
-          setSelectedIndex(prev => (prev + 1) % agents.length);
-        }
-        if (key.return) {
-          const agent = agents[selectedIndex];
-          if (agent) {
-            setSelectedAgent(agent);
-            setPhase('streaming');
-          }
-        }
-      }
-
+    (input, _key) => {
       if (phase === 'streaming' && !showFullScreen) {
         if (input === 'f') {
           setShowFullScreen(true);
@@ -120,7 +60,7 @@ export function LogsScreen({ onExit }: LogsScreenProps) {
         }
       }
     },
-    { isActive: !showFullScreen }
+    { isActive: phase === 'streaming' && !showFullScreen }
   );
 
   if (showFullScreen) {
@@ -137,7 +77,7 @@ export function LogsScreen({ onExit }: LogsScreenProps) {
 
   if (phase === 'error') {
     return (
-      <Screen title="Logs" onExit={onExit} helpText="Esc back">
+      <Screen title="Logs" onExit={onExit} helpText={HELP_TEXT.BACK}>
         <Text color="red">{loadError}</Text>
       </Screen>
     );
@@ -151,7 +91,7 @@ export function LogsScreen({ onExit }: LogsScreenProps) {
     }));
 
     return (
-      <Screen title="Logs" onExit={onExit} helpText="↑↓ select · Enter confirm · Esc back">
+      <Screen title="Logs" onExit={onExit} helpText={HELP_TEXT.NAVIGATE_SELECT}>
         <Box flexDirection="column">
           <Text bold>Select an agent to stream logs:</Text>
           <Box marginTop={1}>
@@ -162,13 +102,11 @@ export function LogsScreen({ onExit }: LogsScreenProps) {
     );
   }
 
-  const helpText = '↑↓ scroll · f full-screen · 1 all · 2 errors · 3 warn+ · Esc back';
-
   return (
     <Screen
       title="Logs"
       onExit={onExit}
-      helpText={helpText}
+      helpText="f full-screen · 1 all · 2 errors · 3 warn+ · Esc back"
       exitEnabled={!showFullScreen}
       headerContent={
         <Box flexDirection="column">

--- a/src/cli/tui/screens/logs/LogsScreen.tsx
+++ b/src/cli/tui/screens/logs/LogsScreen.tsx
@@ -132,11 +132,7 @@ export function LogsScreen({ onExit }: LogsScreenProps) {
     );
   }
 
-  const helpText = isStreaming
-    ? '↑↓ scroll · l full-screen · Esc back'
-    : streamError
-      ? 'Esc back'
-      : '↑↓ scroll · l full-screen · Esc back';
+  const helpText = isStreaming ? 'l full-screen · Esc back' : streamError ? 'Esc back' : 'l full-screen · Esc back';
 
   return (
     <Screen

--- a/src/cli/tui/screens/logs/__tests__/LogsScreen.test.tsx
+++ b/src/cli/tui/screens/logs/__tests__/LogsScreen.test.tsx
@@ -1,0 +1,134 @@
+import { LogsScreen } from '../LogsScreen.js';
+import { render } from 'ink-testing-library';
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { mockLoadDeployedProjectConfig, mockResolveAgentContext } = vi.hoisted(() => ({
+  mockLoadDeployedProjectConfig: vi.fn(),
+  mockResolveAgentContext: vi.fn(),
+}));
+
+vi.mock('../../../../commands/logs/action.js', () => ({
+  resolveAgentContext: mockResolveAgentContext,
+}));
+
+vi.mock('../../../../operations/resolve-agent.js', () => ({
+  loadDeployedProjectConfig: mockLoadDeployedProjectConfig,
+}));
+
+vi.mock('../../../../aws/cloudwatch.js', () => ({
+  // eslint-disable-next-line require-yield
+  async *streamLogs() {
+    await new Promise(() => {
+      /* never resolves */
+    });
+  },
+}));
+
+const noop = () => undefined;
+
+describe('LogsScreen', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('shows error when no runtimes are defined', async () => {
+    mockLoadDeployedProjectConfig.mockResolvedValue({
+      project: { runtimes: [] },
+      deployedState: { targets: {} },
+      awsTargets: [],
+    });
+
+    const { lastFrame } = render(<LogsScreen isInteractive={true} onExit={noop} />);
+    await new Promise(r => setTimeout(r, 50));
+
+    expect(lastFrame()).toContain('No runtimes defined');
+  });
+
+  it('shows error when no agents are deployed', async () => {
+    mockLoadDeployedProjectConfig.mockResolvedValue({
+      project: { runtimes: [{ name: 'Agent1' }] },
+      deployedState: { targets: {} },
+      awsTargets: [],
+    });
+    mockResolveAgentContext.mockReturnValue({ success: false, error: 'Not deployed' });
+
+    const { lastFrame } = render(<LogsScreen isInteractive={true} onExit={noop} />);
+    await new Promise(r => setTimeout(r, 50));
+
+    expect(lastFrame()).toContain('No deployed agents found');
+  });
+
+  it('auto-selects single agent and shows streaming view', async () => {
+    mockLoadDeployedProjectConfig.mockResolvedValue({
+      project: { runtimes: [{ name: 'MyAgent' }] },
+      deployedState: { targets: { default: { resources: { runtimes: {} } } } },
+      awsTargets: [{ name: 'default', region: 'us-east-1', account: '123' }],
+    });
+    mockResolveAgentContext.mockReturnValue({
+      success: true,
+      agentContext: {
+        agentId: 'rt-123',
+        agentName: 'MyAgent',
+        accountId: '123',
+        region: 'us-east-1',
+        endpointName: 'default',
+        logGroupName: '/aws/logs/test',
+      },
+    });
+
+    const { lastFrame } = render(<LogsScreen isInteractive={true} onExit={noop} />);
+    await new Promise(r => setTimeout(r, 50));
+
+    const frame = lastFrame();
+    expect(frame).toContain('Agent:');
+    expect(frame).toContain('MyAgent');
+    expect(frame).toContain('us-east-1');
+  });
+
+  it('shows agent selection when multiple agents exist', async () => {
+    mockLoadDeployedProjectConfig.mockResolvedValue({
+      project: { runtimes: [{ name: 'Agent1' }, { name: 'Agent2' }] },
+      deployedState: { targets: { default: { resources: { runtimes: {} } } } },
+      awsTargets: [{ name: 'default', region: 'us-west-2', account: '456' }],
+    });
+    mockResolveAgentContext
+      .mockReturnValueOnce({
+        success: true,
+        agentContext: {
+          agentId: 'rt-1',
+          agentName: 'Agent1',
+          accountId: '456',
+          region: 'us-west-2',
+          endpointName: 'default',
+          logGroupName: '/aws/logs/1',
+        },
+      })
+      .mockReturnValueOnce({
+        success: true,
+        agentContext: {
+          agentId: 'rt-2',
+          agentName: 'Agent2',
+          accountId: '456',
+          region: 'us-west-2',
+          endpointName: 'default',
+          logGroupName: '/aws/logs/2',
+        },
+      });
+
+    const { lastFrame } = render(<LogsScreen isInteractive={true} onExit={noop} />);
+    await new Promise(r => setTimeout(r, 50));
+
+    const frame = lastFrame();
+    expect(frame).toContain('Select an agent');
+    expect(frame).toContain('Agent1');
+    expect(frame).toContain('Agent2');
+  });
+
+  it('shows error when config loading throws', async () => {
+    mockLoadDeployedProjectConfig.mockRejectedValue(new Error('File not found'));
+
+    const { lastFrame } = render(<LogsScreen isInteractive={true} onExit={noop} />);
+    await new Promise(r => setTimeout(r, 50));
+
+    expect(lastFrame()).toContain('File not found');
+  });
+});

--- a/src/cli/tui/screens/logs/index.ts
+++ b/src/cli/tui/screens/logs/index.ts
@@ -1,0 +1,1 @@
+export { LogsScreen } from './LogsScreen';

--- a/src/cli/tui/screens/logs/useLogsFlow.ts
+++ b/src/cli/tui/screens/logs/useLogsFlow.ts
@@ -1,0 +1,84 @@
+import type { AgentContext } from '../../../commands/logs/action';
+import { resolveAgentContext } from '../../../commands/logs/action';
+import { loadDeployedProjectConfig } from '../../../operations/resolve-agent';
+import { withCommandRunTelemetry } from '../../../telemetry/cli-command-run.js';
+import type { LogEntry } from '../../components/LogPanel';
+import { useLogsStream } from '../../hooks/useLogsStream';
+import { useEffect, useState } from 'react';
+
+type Phase = 'loading' | 'select-agent' | 'streaming' | 'error';
+
+interface UseLogsFlowResult {
+  phase: Phase;
+  agents: AgentContext[];
+  selectedAgent: AgentContext | undefined;
+  loadError: string | undefined;
+  selectAgent: (agent: AgentContext) => void;
+  logs: LogEntry[];
+  isStreaming: boolean;
+  streamError: string | undefined;
+}
+
+export function useLogsFlow(): UseLogsFlowResult {
+  const [phase, setPhase] = useState<Phase>('loading');
+  const [agents, setAgents] = useState<AgentContext[]>([]);
+  const [selectedAgent, setSelectedAgent] = useState<AgentContext | undefined>();
+  const [loadError, setLoadError] = useState<string | undefined>();
+
+  const { logs, isStreaming, error: streamError } = useLogsStream(selectedAgent);
+
+  useEffect(() => {
+    const load = async () => {
+      const result = await withCommandRunTelemetry('logs', { has_query: false, has_level_filter: false }, async () => {
+        const context = await loadDeployedProjectConfig();
+        const runtimeNames = context.project.runtimes.map(r => r.name);
+
+        if (runtimeNames.length === 0) {
+          return { success: false as const, error: new Error('No runtimes defined in agentcore.json') };
+        }
+
+        const resolved: AgentContext[] = [];
+        for (const name of runtimeNames) {
+          const res = resolveAgentContext(context, { runtime: name });
+          if (res.success) {
+            resolved.push(res.agentContext);
+          }
+        }
+
+        if (resolved.length === 0) {
+          return {
+            success: false as const,
+            error: new Error('No deployed agents found. Run `agentcore deploy` first.'),
+          };
+        }
+
+        return { success: true as const, agents: resolved };
+      });
+
+      if (!result.success) {
+        setLoadError(result.error.message);
+        setPhase('error');
+        return;
+      }
+
+      const resolved = (result as { success: true; agents: AgentContext[] }).agents;
+      setAgents(resolved);
+
+      if (resolved.length === 1) {
+        setSelectedAgent(resolved[0]);
+        setPhase('streaming');
+      } else {
+        setPhase('select-agent');
+      }
+    };
+
+    void load();
+  }, []);
+
+  const selectAgent = (agent: AgentContext) => {
+    setSelectedAgent(agent);
+    setPhase('streaming');
+  };
+
+  return { phase, agents, selectedAgent, loadError, selectAgent, logs, isStreaming, streamError };
+}

--- a/src/cli/tui/utils/__tests__/commands.test.ts
+++ b/src/cli/tui/utils/__tests__/commands.test.ts
@@ -49,9 +49,9 @@ describe('getCommandsForUI', () => {
     expect(pkg!.cliOnly).toBe(false);
   });
 
-  it('marks logs, traces, pause, resume as cliOnly', () => {
+  it('marks traces, pause, resume as cliOnly', () => {
     const cmds = getCommandsForUI(program);
-    for (const name of ['logs', 'traces', 'pause', 'resume']) {
+    for (const name of ['traces', 'pause', 'resume']) {
       const cmd = cmds.find(c => c.id === name);
       expect(cmd, `${name} should be in results`).toBeDefined();
       expect(cmd!.cliOnly, `${name} should be cliOnly`).toBe(true);

--- a/src/cli/tui/utils/commands.ts
+++ b/src/cli/tui/utils/commands.ts
@@ -17,7 +17,7 @@ const HIDDEN_FROM_TUI = ['help', 'telemetry', 'promote'] as const;
 /**
  * Commands that are CLI-only (shown but marked as requiring CLI invocation).
  */
-const CLI_ONLY_COMMANDS = ['logs', 'traces', 'pause', 'resume', 'stop', 'archive'] as const;
+const CLI_ONLY_COMMANDS = ['traces', 'pause', 'resume', 'stop', 'archive'] as const;
 
 /**
  * Commands hidden from TUI when inside an existing project.


### PR DESCRIPTION
## Summary

- Adds a new TUI screen for streaming deployed agent CloudWatch runtime logs in real-time
- Removes `logs` from the CLI-only command list so it's now accessible directly from the TUI menu
- Users can select a deployed agent and stream logs with full-screen view support (press `l`)

## Implementation

- `useLogsStream` hook: manages CloudWatch `streamLogs` lifecycle with abort/cleanup, auto-detects log levels, caps buffer at 1000 entries
- `LogsScreen` component: phases through loading → agent selection (if multiple) → streaming view with error handling
- Reuses existing `FullScreenLogView` for scrollable full-screen log viewing

## Test plan

- [x] Typecheck passes (`tsc --noEmit`)
- [x] Lint passes (`eslint`)
- [x] All 663 TUI unit tests pass
- [x] TUI harness e2e: logs command appears in menu (not CLI-only)
- [x] TUI harness e2e: selecting logs navigates to Logs screen
- [x] TUI harness e2e: error states render correctly (no deploy, no runtimes)
- [x] TUI harness e2e: streaming phase shows agent name, region, status
- [x] TUI harness e2e: Esc navigates back to command list

Closes #565