### PR TITLE
fix: resolve crash on all commands due to missing @aws-sdk/region-config-resolver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@aws-sdk/client-sts": "^3.893.0",
         "@aws-sdk/client-xray": "^3.1003.0",
         "@aws-sdk/credential-providers": "^3.893.0",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
         "@aws/agent-inspector": "0.4.1",
         "@commander-js/extra-typings": "^14.0.0",
         "@opentelemetry/api": "^1.9.1",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "@aws-sdk/client-resource-groups-tagging-api": "^3.893.0",
     "@aws-sdk/client-s3": "^3.1012.0",
     "@aws-sdk/client-sts": "^3.893.0",
+    "@aws-sdk/region-config-resolver": "^3.972.13",
     "@aws-sdk/client-xray": "^3.1003.0",
     "@aws-sdk/credential-providers": "^3.893.0",
     "@aws/agent-inspector": "0.4.1",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,15 +1,6 @@
 #!/usr/bin/env node
 import { main } from './cli.js';
 import { getErrorMessage } from './errors.js';
-import { createRequire } from 'module';
-
-// Handle --version early to avoid loading heavy dependencies
-if (process.argv.includes('--version') || process.argv.includes('-V')) {
-  const require = createRequire(import.meta.url);
-  const { version } = require('../../package.json') as { version: string };
-  console.log(version);
-  process.exit(0);
-}
 
 // Global safety net — prevent raw stack traces from reaching the user
 process.on('uncaughtException', err => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,6 +1,15 @@
 #!/usr/bin/env node
 import { main } from './cli.js';
 import { getErrorMessage } from './errors.js';
+import { createRequire } from 'module';
+
+// Handle --version early to avoid loading heavy dependencies
+if (process.argv.includes('--version') || process.argv.includes('-V')) {
+  const require = createRequire(import.meta.url);
+  const { version } = require('../../package.json') as { version: string };
+  console.log(version);
+  process.exit(0);
+}
 
 // Global safety net — prevent raw stack traces from reaching the user
 process.on('uncaughtException', err => {


### PR DESCRIPTION
## Summary

- `@aws-cdk/toolkit-lib@1.25.2` depends on `@aws-sdk/client-sts@^3`, which now resolves to `3.1048.0`. That version removed `@aws-sdk/region-config-resolver` from its dependencies, but `toolkit-lib`'s bundled CJS still requires it — causing every `agentcore` command to crash on fresh install.
- Adds `@aws-sdk/region-config-resolver` as a direct dependency so it's always available.
- Adds early `--version` interception in the entrypoint to avoid loading heavy deps for version checks.

## Test plan

- [x] `npm install -g .` then `agentcore --version` prints version without error
- [x] `agentcore status --help` loads without crash
- [x] `npm test` passes