### PR TITLE
fix: build CLI before running integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "test": "vitest run --project unit",
     "test:all": "vitest run",
     "test:watch": "vitest --project unit",
-    "test:integ": "vitest run --project integ",
+    "test:integ": "npm run build && vitest run --project integ",
     "test:unit": "vitest run --project unit --coverage",
     "test:e2e": "vitest run --project e2e",
     "test:update-snapshots": "vitest run --project unit --update",

--- a/scripts/run-e2e-dev.sh
+++ b/scripts/run-e2e-dev.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Run E2E tests against your dev account using local credentials.
+#
+# Usage:
+#   ./scripts/run-e2e-dev.sh                          # runs strands-bedrock.test.ts
+#   ./scripts/run-e2e-dev.sh --all                    # runs the full e2e suite
+#   ./scripts/run-e2e-dev.sh e2e-tests/foo.test.ts    # runs a specific test file
+
+set -euo pipefail
+
+REGION="${AWS_REGION:-us-east-1}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# ── Parse arguments ────────────────────────────────────────────────────────────
+RUN_ALL=false
+TEST_FILES=()
+for arg in "$@"; do
+  if [[ "$arg" == "--all" ]]; then
+    RUN_ALL=true
+  else
+    TEST_FILES+=("$arg")
+  fi
+done
+
+# ── Build & install CLI from source ────────────────────────────────────────────
+cd "$REPO_ROOT"
+npm run build
+TARBALL=$(npm pack | tail -1)
+npm install -g "$TARBALL"
+echo "=== Installed: $(agentcore --version) ==="
+
+# ── Set env vars for tests ─────────────────────────────────────────────────────
+export AWS_REGION="$REGION"
+export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+
+# ── Run tests ──────────────────────────────────────────────────────────────────
+cd "$REPO_ROOT"
+
+EXCLUDE_API_KEY_TESTS=(
+  --exclude 'e2e-tests/*-anthropic*'
+  --exclude 'e2e-tests/*-openai*'
+  --exclude 'e2e-tests/*-gemini*'
+)
+
+if [[ "$RUN_ALL" == "true" ]]; then
+  echo "=== Running full e2e suite ==="
+  npx vitest run --project e2e
+elif [[ ${#TEST_FILES[@]} -gt 0 ]]; then
+  echo "=== Running: ${TEST_FILES[*]} ==="
+  npx vitest run --project e2e "${TEST_FILES[@]}"
+else
+  echo "=== Running all Bedrock/IAM tests (excluding API-key-dependent tests) ==="
+  npx vitest run --project e2e "${EXCLUDE_API_KEY_TESTS[@]}"
+fi

--- a/scripts/run-e2e-local.sh
+++ b/scripts/run-e2e-local.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Run E2E tests locally, replicating the GitHub Actions e2e-tests.yml workflow.
+# Run E2E tests locally in the CI account, replicating the GitHub Actions e2e-tests.yml workflow.
 #
 # Required env vars:
 #   E2E_ROLE_ARN    — IAM role ARN to assume (grants access to the test account)


### PR DESCRIPTION
## Description

### Problem
PR fixes two issues:
- integ tests don't run on fresh build: https://github.com/aws/agentcore-cli/issues/1283
- e2e tests command doesn't work.

### Solution
- run build before integ tests. 
- add a script for running e2e tests in dev account. Note: this is separate from `run-e2e-local.sh`, which attempts to simulate CI locally. `run-e2e-dev.sh` runs the tests in a dev account, not CI. 

### Testing 
- `npm run test:e2e` no longer errors. 
- `npm run test:integ` runs the integ tests. 
## Related Issue

N/A

## Documentation PR

N/A

## Type of Change

- [x] New feature
- [x] Other (please describe): Developer workflow improvement — new script for local E2E testing

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.