### PR TITLE
fix: align harness memory config with Smithy API model

### DIFF
--- a/src/cli/aws/agentcore-harness.ts
+++ b/src/cli/aws/agentcore-harness.ts
@@ -37,8 +37,15 @@ export interface HarnessSkill {
   path: string;
 }
 
+export interface HarnessAgentCoreMemoryConfiguration {
+  arn: string;
+  actorId?: string;
+  messagesCount?: number;
+  retrievalConfig?: Record<string, { topK?: number; relevanceScore?: number }>;
+}
+
 export interface HarnessMemoryConfiguration {
-  memoryArn?: string;
+  agentCoreMemoryConfiguration: HarnessAgentCoreMemoryConfiguration;
 }
 
 export interface HarnessTruncationConfiguration {

--- a/src/cli/aws/agentcore-harness.ts
+++ b/src/cli/aws/agentcore-harness.ts
@@ -41,7 +41,7 @@ export interface HarnessAgentCoreMemoryConfiguration {
   arn: string;
   actorId?: string;
   messagesCount?: number;
-  retrievalConfig?: Record<string, { topK?: number; relevanceScore?: number }>;
+  retrievalConfig?: Record<string, { topK?: number; relevanceScore?: number; strategyId?: string }>;
 }
 
 export interface HarnessMemoryConfiguration {

--- a/src/cli/operations/deploy/imperative/deployers/__tests__/harness-mapper.test.ts
+++ b/src/cli/operations/deploy/imperative/deployers/__tests__/harness-mapper.test.ts
@@ -380,7 +380,9 @@ describe('mapHarnessSpecToCreateOptions', () => {
       });
 
       expect(result.memory).toEqual({
-        memoryArn: 'arn:aws:bedrock-agentcore:us-east-1:123456789012:memory/mem-123',
+        agentCoreMemoryConfiguration: {
+          arn: 'arn:aws:bedrock-agentcore:us-east-1:123456789012:memory/mem-123',
+        },
       });
     });
 
@@ -391,7 +393,9 @@ describe('mapHarnessSpecToCreateOptions', () => {
       const result = await mapHarnessSpecToCreateOptions({ ...BASE_OPTIONS, harnessSpec: spec });
 
       expect(result.memory).toEqual({
-        memoryArn: 'arn:aws:bedrock-agentcore:us-east-1:123456789012:memory/custom-mem',
+        agentCoreMemoryConfiguration: {
+          arn: 'arn:aws:bedrock-agentcore:us-east-1:123456789012:memory/custom-mem',
+        },
       });
     });
 

--- a/src/cli/operations/deploy/imperative/deployers/harness-deployer.ts
+++ b/src/cli/operations/deploy/imperative/deployers/harness-deployer.ts
@@ -192,7 +192,7 @@ export class HarnessDeployer implements ImperativeDeployer<HarnessDeployedStateM
             roleArn: executionRoleArn,
             status: finalHarness.status,
             agentRuntimeArn: extractRuntimeArn(finalHarness),
-            memoryArn: createOptions.memory?.memoryArn,
+            memoryArn: createOptions.memory?.agentCoreMemoryConfiguration?.arn,
             configHash,
           };
           notes.push(`Updated harness "${entry.name}"`);
@@ -216,7 +216,7 @@ export class HarnessDeployer implements ImperativeDeployer<HarnessDeployedStateM
             roleArn: executionRoleArn,
             status: finalHarness.status,
             agentRuntimeArn: extractRuntimeArn(finalHarness),
-            memoryArn: createOptions.memory?.memoryArn,
+            memoryArn: createOptions.memory?.agentCoreMemoryConfiguration?.arn,
             configHash,
           };
           notes.push(`Created harness "${entry.name}"`);

--- a/src/cli/operations/deploy/imperative/deployers/harness-mapper.ts
+++ b/src/cli/operations/deploy/imperative/deployers/harness-mapper.ts
@@ -270,33 +270,37 @@ function mapMemory(
   deployedResources?: DeployedResourceState,
   cdkOutputs?: Record<string, string>
 ): HarnessMemoryConfiguration | undefined {
+  let arn: string | undefined;
+
   // Direct ARN takes precedence
   if (memory.arn) {
-    return { memoryArn: memory.arn };
-  }
-
-  // Resolve by name from deployed state or CDK outputs
-  if (memory.name) {
-    // Try deployed state first
+    arn = memory.arn;
+  } else if (memory.name) {
+    // Resolve by name from deployed state or CDK outputs
     const deployedMemory = deployedResources?.memories?.[memory.name];
     if (deployedMemory) {
-      return { memoryArn: deployedMemory.memoryArn };
+      arn = deployedMemory.memoryArn;
+    } else if (cdkOutputs) {
+      arn = resolveMemoryArnFromOutputs(memory.name, cdkOutputs);
     }
 
-    // Fall back to CDK outputs
-    if (cdkOutputs) {
-      const memoryArn = resolveMemoryArnFromOutputs(memory.name, cdkOutputs);
-      if (memoryArn) {
-        return { memoryArn };
-      }
+    if (!arn) {
+      throw new Error(
+        `Memory "${memory.name}" referenced by harness is not in deployed state. Ensure the memory is defined in agentcore.json and has been deployed.`
+      );
     }
-
-    throw new Error(
-      `Memory "${memory.name}" referenced by harness is not in deployed state. Ensure the memory is defined in agentcore.json and has been deployed.`
-    );
   }
 
-  return undefined;
+  if (!arn) {
+    return undefined;
+  }
+
+  return {
+    agentCoreMemoryConfiguration: {
+      arn,
+      ...(memory.actorId && { actorId: memory.actorId }),
+    },
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fixes harness memory not working when a memory ARN is configured in `harness.json`
- The Harness API expects memory as a Smithy union type `{ agentCoreMemoryConfiguration: { arn: "..." } }` but the CLI was sending `{ memoryArn: "..." }`
- The API silently accepted the wrong structure and stored `"memory": {}`, resulting in deployed harnesses having no memory capabilities

Closes #1291

## Changes

- `src/cli/aws/agentcore-harness.ts`: Updated `HarnessMemoryConfiguration` interface to match Smithy model with `agentCoreMemoryConfiguration` union wrapper
- `src/cli/operations/deploy/imperative/deployers/harness-mapper.ts`: Updated `mapMemory()` to return correct nested structure
- `src/cli/operations/deploy/imperative/deployers/harness-deployer.ts`: Updated ARN extraction from new structure

## Test plan

- [x] `npm test -- "harness-mapper"` — 38 tests pass
- [x] `npm test -- "harness-deployer"` — 22 tests pass
- [x] `npm test -- "agentcore-harness"` — 16 tests pass
- [x] `npx tsc --noEmit` — no type errors
- [x] E2E: deployed harness with memory, verified `GetHarness` returns `{ agentCoreMemoryConfiguration: { arn: "..." } }` instead of `{}`