### PR TITLE
fix: handle scoped conventional commits in changelog categorization

### DIFF
--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -218,11 +218,11 @@ function categorizeCommits(gitLog: string): CategorizedChanges {
 
     const msg = trimmed.slice(2).trim();
 
-    if (msg.startsWith('feat:') || msg.startsWith('feature:')) {
+    if (/^(feat|feature)(\(.*?\))?:/.test(msg)) {
       result.features.push(msg);
-    } else if (msg.startsWith('fix:') || msg.startsWith('bugfix:')) {
+    } else if (/^(fix|bugfix)(\(.*?\))?:/.test(msg)) {
       result.fixes.push(msg);
-    } else if (msg.startsWith('docs:') || msg.startsWith('doc:')) {
+    } else if (/^docs?(\(.*?\))?:/.test(msg)) {
       result.docs.push(msg);
     } else {
       result.other.push(msg);


### PR DESCRIPTION
## Description

The `categorizeCommits` function in `scripts/bump-version.ts` only handled non-scoped conventional commits (e.g., `fix: ...`, `feat: ...`). Scoped commits like `fix(ci): ...` or `feat(auth): ...` were incorrectly placed in the "Other Changes" section of the changelog.

Replaced `startsWith` checks with regex patterns that match an optional `(scope)` group.

See changelog for examples: https://github.com/aws/agentcore-cli/blob/main/CHANGELOG.md

## Related Issue

N/A

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

Verified locally by running `npx tsx scripts/bump-version.ts patch` and confirming scoped commits (e.g., `fix(ci): ...`) are categorized under "### Fixed" instead of "### Other Changes".

## Checklist

- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.