### PR TITLE
test(security-review): smoke-test inline comment posting (delete after verify)

### DIFF
--- a/scripts/__sec_review_smoketest.mjs
+++ b/scripts/__sec_review_smoketest.mjs
@@ -1,0 +1,36 @@
+// Deliberately vulnerable file used to smoke-test the Claude Security Review
+// workflow's inline-comment posting path. Will be reverted once we confirm
+// the bot files inline review comments correctly.
+import { exec } from 'node:child_process';
+import http from 'node:http';
+
+// FINDING 1 (hardcoded credential): AWS-shaped access key checked into source.
+const HARDCODED_AWS_ACCESS_KEY_ID = 'AKIAIOSFODNN7EXAMPLE';
+const HARDCODED_AWS_SECRET_ACCESS_KEY = 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY';
+
+function buildSignedRequest(payload) {
+  return {
+    payload,
+    auth: `AWS4-HMAC-SHA256 Credential=${HARDCODED_AWS_ACCESS_KEY_ID}`,
+    secret: HARDCODED_AWS_SECRET_ACCESS_KEY,
+  };
+}
+
+// FINDING 2 (command injection): builds a shell command from an HTTP query
+// string parameter and passes it to exec(). Concrete OS-command injection.
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, 'http://localhost');
+  const target = url.searchParams.get('host') ?? 'localhost';
+
+  exec(`ping -c 1 ${target}`, (err, stdout, stderr) => {
+    if (err) {
+      res.writeHead(500);
+      res.end(String(err));
+      return;
+    }
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end(stdout || stderr);
+  });
+});
+
+export { buildSignedRequest, server };


### PR DESCRIPTION
## Summary

Throwaway PR to verify the Claude Security Review workflow posts inline review comments on PR-context events. Adds `scripts/__sec_review_smoketest.mjs` with two deliberate findings the bot should flag:

- **Hardcoded AWS-shaped credentials** at lines 8-9
- **Command injection** via `child_process.exec` interpolating an HTTP query parameter at line 26

## Expected behavior

- `pull_request_target` fires the `Claude Security Review` workflow.
- The action's `mcp__github_inline_comment__create_inline_comment` MCP server registers (since this is now a PR-context event).
- Bot posts two inline review comments on `scripts/__sec_review_smoketest.mjs` plus a top-level summary comment via the workflow's summary step.

## Cleanup

Close without merging once verification is complete.