### PR TITLE
fix: scope summaries retrieval to actor for cross-session memory recall

### DIFF
--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -1915,7 +1915,7 @@ def get_memory_session_manager(session_id: Optional[str], actor_id: str) -> Opti
         f"/users/{actor_id}/preferences": RetrievalConfig(top_k=3, relevance_score=0.5),
 {{/if}}
 {{#if (includes memoryProviders.[0].strategies "SUMMARIZATION")}}
-        f"/summaries/{actor_id}/{session_id}": RetrievalConfig(top_k=3, relevance_score=0.5),
+        f"/summaries/{actor_id}": RetrievalConfig(top_k=3, relevance_score=0.5),
 {{/if}}
     }
 {{/if}}
@@ -2755,7 +2755,7 @@ def get_memory_session_manager(session_id: Optional[str], actor_id: str) -> Opti
         f"/users/{actor_id}/preferences": RetrievalConfig(top_k=3, relevance_score=0.5),
 {{/if}}
 {{#if (includes memoryProviders.[0].strategies "SUMMARIZATION")}}
-        f"/summaries/{actor_id}/{session_id}": RetrievalConfig(top_k=3, relevance_score=0.5),
+        f"/summaries/{actor_id}": RetrievalConfig(top_k=3, relevance_score=0.5),
 {{/if}}
     }
 {{/if}}
@@ -5029,7 +5029,7 @@ def get_memory_session_manager(session_id: Optional[str], actor_id: str) -> Opti
         f"/users/{actor_id}/preferences": RetrievalConfig(top_k=3, relevance_score=0.5),
 {{/if}}
 {{#if (includes memoryProviders.[0].strategies "SUMMARIZATION")}}
-        f"/summaries/{actor_id}/{session_id}": RetrievalConfig(top_k=3, relevance_score=0.5),
+        f"/summaries/{actor_id}": RetrievalConfig(top_k=3, relevance_score=0.5),
 {{/if}}
     }
 {{/if}}

--- a/src/assets/python/a2a/strands/capabilities/memory/session.py
+++ b/src/assets/python/a2a/strands/capabilities/memory/session.py
@@ -25,7 +25,7 @@ def get_memory_session_manager(session_id: Optional[str], actor_id: str) -> Opti
         f"/users/{actor_id}/preferences": RetrievalConfig(top_k=3, relevance_score=0.5),
 {{/if}}
 {{#if (includes memoryProviders.[0].strategies "SUMMARIZATION")}}
-        f"/summaries/{actor_id}/{session_id}": RetrievalConfig(top_k=3, relevance_score=0.5),
+        f"/summaries/{actor_id}": RetrievalConfig(top_k=3, relevance_score=0.5),
 {{/if}}
     }
 {{/if}}

--- a/src/assets/python/agui/strands/capabilities/memory/session.py
+++ b/src/assets/python/agui/strands/capabilities/memory/session.py
@@ -25,7 +25,7 @@ def get_memory_session_manager(session_id: Optional[str], actor_id: str) -> Opti
         f"/users/{actor_id}/preferences": RetrievalConfig(top_k=3, relevance_score=0.5),
 {{/if}}
 {{#if (includes memoryProviders.[0].strategies "SUMMARIZATION")}}
-        f"/summaries/{actor_id}/{session_id}": RetrievalConfig(top_k=3, relevance_score=0.5),
+        f"/summaries/{actor_id}": RetrievalConfig(top_k=3, relevance_score=0.5),
 {{/if}}
     }
 {{/if}}

--- a/src/assets/python/http/strands/capabilities/memory/session.py
+++ b/src/assets/python/http/strands/capabilities/memory/session.py
@@ -25,7 +25,7 @@ def get_memory_session_manager(session_id: Optional[str], actor_id: str) -> Opti
         f"/users/{actor_id}/preferences": RetrievalConfig(top_k=3, relevance_score=0.5),
 {{/if}}
 {{#if (includes memoryProviders.[0].strategies "SUMMARIZATION")}}
-        f"/summaries/{actor_id}/{session_id}": RetrievalConfig(top_k=3, relevance_score=0.5),
+        f"/summaries/{actor_id}": RetrievalConfig(top_k=3, relevance_score=0.5),
 {{/if}}
     }
 {{/if}}


### PR DESCRIPTION
## Summary

- Remove `/{session_id}` from the summaries namespace path in the generated `memory/session.py` template
- Fixes all three protocol variants (HTTP, A2A, AGUI) so agents with `--memory longAndShortTerm` can retrieve conversation summaries across sessions via hierarchical prefix matching
- Updates asset snapshots to reflect the template change

## Problem

The generated retrieval config scoped summaries to `/summaries/{actor_id}/{session_id}`, meaning the agent could only recall summaries from the **current** session. This completely defeated the purpose of long-term memory for returning users.

## Fix

Change the retrieval path from `/summaries/{actor_id}/{session_id}` to `/summaries/{actor_id}`. The SDK's `retrieve_memories()` uses hierarchical prefix matching, so this now finds summaries stored under any session for the actor.

Writes still store under `/summaries/{actor_id}/{session_id}` (SDK behavior), so session-level organization is preserved — only the read scope is widened.

## Test plan

- [x] `npm run test:update-snapshots` — snapshots regenerated
- [x] Asset snapshot tests pass (109/109)
- [x] Pre-commit hooks pass (typecheck, lint, secretlint)
- [ ] Manual verification: create agent with `--memory longAndShortTerm`, invoke across two sessions, confirm second session retrieves first session's summaries

Closes #1279