### PR TITLE
fix(templates): make Strands TypeScript template strict-typecheck clean

### DIFF
--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -5693,38 +5693,33 @@ Thumbs.db
 
 exports[`Assets Directory Snapshots > TypeScript assets > typescript/typescript/http/strands/base/main.ts should match snapshot 1`] = `
 "import { BedrockAgentCoreApp } from 'bedrock-agentcore/runtime';
-import { Agent, tool } from '@strands-agents/sdk';
+import { Agent, McpClient, tool, type ToolList } from '@strands-agents/sdk';
+import { z } from 'zod';
 import { loadModel } from './model/load.js';
 import { getStreamableHttpMcpClient } from './mcp_client/client.js';
 
-// Define a collection of MCP clients
-const mcpClients = [getStreamableHttpMcpClient()].filter(Boolean);
+// Define a collection of MCP clients (filter out anything that failed to initialize)
+const mcpClients: McpClient[] = [getStreamableHttpMcpClient()].filter(
+  (client): client is McpClient => Boolean(client)
+);
 
 // Define a collection of tools used by the model
-const tools: unknown[] = [];
+const tools: ToolList = [];
 
-// Define a simple function tool
+// Define a simple function tool — the Zod schema gives us type inference and runtime validation for free
 const addNumbers = tool({
   name: 'add_numbers',
   description: 'Return the sum of two numbers',
-  inputSchema: {
-    type: 'object',
-    properties: {
-      a: { type: 'number' },
-      b: { type: 'number' },
-    },
-    required: ['a', 'b'],
-  },
-  callback: async ({ a, b }: { a: number; b: number }) => a + b,
+  inputSchema: z.object({
+    a: z.number(),
+    b: z.number(),
+  }),
+  callback: async ({ a, b }) => a + b,
 });
 tools.push(addNumbers);
 
-// Add MCP clients to tools if available
-for (const mcpClient of mcpClients) {
-  if (mcpClient) {
-    tools.push(mcpClient);
-  }
-}
+// Add MCP clients to tools
+tools.push(...mcpClients);
 
 const SYSTEM_PROMPT = \`
 You are a helpful assistant. Use tools when appropriate.
@@ -5912,7 +5907,8 @@ exports[`Assets Directory Snapshots > TypeScript assets > typescript/typescript/
     "@modelcontextprotocol/sdk": "^1.25.2",
     "@strands-agents/sdk": "1.0.0-rc.4",
     "bedrock-agentcore": "^0.2.4",
-    "tsx": "^4.19.0"
+    "tsx": "^4.19.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/src/assets/typescript/http/strands/base/main.ts
+++ b/src/assets/typescript/http/strands/base/main.ts
@@ -1,36 +1,31 @@
 import { BedrockAgentCoreApp } from 'bedrock-agentcore/runtime';
-import { Agent, tool } from '@strands-agents/sdk';
+import { Agent, McpClient, tool, type ToolList } from '@strands-agents/sdk';
+import { z } from 'zod';
 import { loadModel } from './model/load.js';
 import { getStreamableHttpMcpClient } from './mcp_client/client.js';
 
-// Define a collection of MCP clients
-const mcpClients = [getStreamableHttpMcpClient()].filter(Boolean);
+// Define a collection of MCP clients (filter out anything that failed to initialize)
+const mcpClients: McpClient[] = [getStreamableHttpMcpClient()].filter(
+  (client): client is McpClient => Boolean(client)
+);
 
 // Define a collection of tools used by the model
-const tools: unknown[] = [];
+const tools: ToolList = [];
 
-// Define a simple function tool
+// Define a simple function tool — the Zod schema gives us type inference and runtime validation for free
 const addNumbers = tool({
   name: 'add_numbers',
   description: 'Return the sum of two numbers',
-  inputSchema: {
-    type: 'object',
-    properties: {
-      a: { type: 'number' },
-      b: { type: 'number' },
-    },
-    required: ['a', 'b'],
-  },
-  callback: async ({ a, b }: { a: number; b: number }) => a + b,
+  inputSchema: z.object({
+    a: z.number(),
+    b: z.number(),
+  }),
+  callback: async ({ a, b }) => a + b,
 });
 tools.push(addNumbers);
 
-// Add MCP clients to tools if available
-for (const mcpClient of mcpClients) {
-  if (mcpClient) {
-    tools.push(mcpClient);
-  }
-}
+// Add MCP clients to tools
+tools.push(...mcpClients);
 
 const SYSTEM_PROMPT = `
 You are a helpful assistant. Use tools when appropriate.

--- a/src/assets/typescript/http/strands/base/package.json
+++ b/src/assets/typescript/http/strands/base/package.json
@@ -22,7 +22,8 @@
     "@modelcontextprotocol/sdk": "^1.25.2",
     "@strands-agents/sdk": "1.0.0-rc.4",
     "bedrock-agentcore": "^0.2.4",
-    "tsx": "^4.19.0"
+    "tsx": "^4.19.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",


### PR DESCRIPTION
## Description

The generated Strands TypeScript template (`src/assets/typescript/http/strands/base/`) does not pass `tsc --noEmit` with the very `tsconfig.json` it ships with (`strict: true`). Two errors:

```
main.ts(24,3): error TS2769: No overload matches this call.
  Overload 2 of 2, '(config: FunctionToolConfig): InvokableTool<unknown, JSONValue>', gave the following error.
    Type '({ a, b }: { a: number; b: number; }) => Promise<number>' is not assignable to type 'FunctionToolCallback'.
      Types of parameters '__0' and 'input' are incompatible.
        Type 'unknown' is not assignable to type '{ a: number; b: number; }'.

main.ts(47,7): error TS2322: Type 'unknown[]' is not assignable to type '(McpClient | Agent | ToolList | Tool)[]'.
  Type 'unknown' is not assignable to type 'McpClient | Agent | ToolList | Tool'.
```

This means a brand-new TypeScript project created via `agentcore create --language TypeScript --framework Strands` fails its own `npm run build` immediately, before the user has touched anything.

### Root cause

1. The template uses the JSON-Schema overload of `tool()`, whose callback type is `FunctionToolCallback = (input: unknown, ...) => ...`. But the example callback was declared with a concretely-typed parameter `({ a, b }: { a: number; b: number })`, which is the opposite direction of subtype assignability and `strict` mode rejects it.
2. The `tools` array was declared as `unknown[]`, but `Agent` expects `ToolList = (Tool | McpClient | Agent | ToolList)[]`.

### Fix

- Switch the example tool to the **Zod schema overload** of `tool()`. This is the SDK's idiomatic type-safe API (`zod` is already a `peerDependency` of `@strands-agents/sdk` `^4.1.12`), so we get type inference on the callback and runtime input validation for free, with no casts.
- Type the `tools` array as `ToolList` and the `mcpClients` array as `McpClient[]` (with a proper type guard in the `.filter()` call instead of `Boolean`).
- Add `zod ^4.4.3` as a direct dependency in the template's `package.json` (cleanly satisfies the SDK's peer dependency constraint, resolves to the latest 4.x at install time).

### Files changed

- `src/assets/typescript/http/strands/base/main.ts` — fixed types, switched to Zod schema
- `src/assets/typescript/http/strands/base/package.json` — added `zod ^4.4.3`
- `src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap` — snapshot regenerated via `npm run test:update-snapshots`

The Vercel AI TS template was checked and does **not** have this issue (it doesn't use `tool()` or a `tools` array), so no changes there.

### Verification (done locally on a freshly generated project)

- `npx tsc --noEmit` in the generated project → **exit 0** (was 2 errors before)
- `agentcore dev` → server starts and accepts `POST /invocations` exactly as before
- `npm run test:update-snapshots` → 1 snapshot updated (the strands-base TS template diff), committed
- All CLI checks (`typecheck`, `lint`, `format:check`) pass on this branch

## Related Issue

Closes #

## Documentation PR

N/A — the docs update for the broader CLI command surface is being tracked separately in #1296. This PR is template-code only.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ` *(unit: 3912/3916 — the 4 failures (`DeployStatus`, `LogPanel`, `SecretInput`) are preexisting on `main` and verified to fail identically on `upstream/main` without my changes; root cause is Ink 6.8.0 emitting ANSI codes that the strict `.toBe()` assertions don't expect, unrelated to this PR)*
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint` *(0 errors; 29 preexisting warnings, none in files touched by this PR)*
- [x] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works *(verified via `tsc --noEmit` on a freshly generated project from the updated template, plus the existing snapshot tests)*
- [x] I have updated the documentation accordingly *(no doc changes needed; the README in the template still describes the same behavior)*
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed *(the runnable example tool in `main.ts` is itself the example, and now it actually compiles)*
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
