### PR TITLE
fix(test): strip ANSI codes from Ink TUI test assertions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,7 @@
         "node-pty": "^1.1.0",
         "prettier": "^3.7.4",
         "secretlint": "^12.2.0",
+        "strip-ansi": "^7.2.0",
         "tsx": "^4.21.0",
         "typescript": "^5",
         "typescript-eslint": "^8.50.1",

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "node-pty": "^1.1.0",
     "prettier": "^3.7.4",
     "secretlint": "^12.2.0",
+    "strip-ansi": "^7.2.0",
     "tsx": "^4.21.0",
     "typescript": "^5",
     "typescript-eslint": "^8.50.1",

--- a/src/cli/tui/components/__tests__/DeployStatus.test.tsx
+++ b/src/cli/tui/components/__tests__/DeployStatus.test.tsx
@@ -2,6 +2,7 @@ import type { DeployMessage } from '../../../cdk/toolkit-lib/index.js';
 import { DeployStatus } from '../DeployStatus.js';
 import { render } from 'ink-testing-library';
 import React from 'react';
+import stripAnsi from 'strip-ansi';
 import { describe, expect, it } from 'vitest';
 
 function makeMsg(
@@ -28,7 +29,7 @@ describe('DeployStatus', () => {
     it('shows "Deploying to AWS" when not complete', () => {
       const { lastFrame } = render(<DeployStatus messages={[]} isComplete={false} hasError={false} />);
 
-      expect(lastFrame()).toContain('Deploying to AWS');
+      expect(stripAnsi(lastFrame()!)).toContain('Deploying to AWS');
     });
 
     it('shows success message when complete without error', () => {
@@ -90,7 +91,7 @@ describe('DeployStatus', () => {
       const { lastFrame } = render(<DeployStatus messages={messages} isComplete={false} hasError={false} />);
 
       // Should show deploying text but no resource lines
-      expect(lastFrame()).toContain('Deploying to AWS');
+      expect(stripAnsi(lastFrame()!)).toContain('Deploying to AWS');
       expect(lastFrame()).not.toContain('Some general info');
     });
 

--- a/src/cli/tui/components/__tests__/LogPanel.test.tsx
+++ b/src/cli/tui/components/__tests__/LogPanel.test.tsx
@@ -2,6 +2,7 @@ import type { LogEntry } from '../LogPanel.js';
 import { LogPanel } from '../LogPanel.js';
 import { render } from 'ink-testing-library';
 import React from 'react';
+import stripAnsi from 'strip-ansi';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const UP_ARROW = '\x1B[A';
@@ -19,7 +20,7 @@ describe('LogPanel', () => {
   describe('empty state', () => {
     it('renders "No output yet" with no other content', () => {
       const { lastFrame } = render(<LogPanel logs={[]} />);
-      expect(lastFrame()).toBe('No output yet');
+      expect(stripAnsi(lastFrame()!)).toBe('No output yet');
     });
   });
 

--- a/src/cli/tui/components/__tests__/SecretInput.test.tsx
+++ b/src/cli/tui/components/__tests__/SecretInput.test.tsx
@@ -1,6 +1,7 @@
 import { ApiKeySecretInput, SecretInput } from '../SecretInput.js';
 import { render } from 'ink-testing-library';
 import React from 'react';
+import stripAnsi from 'strip-ansi';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 
@@ -34,7 +35,7 @@ describe('SecretInput', () => {
       <SecretInput prompt="Key" placeholder="sk-..." onSubmit={vi.fn()} onCancel={vi.fn()} />
     );
 
-    expect(lastFrame()).toContain('sk-...');
+    expect(stripAnsi(lastFrame()!)).toContain('sk-...');
   });
 
   it('masks input with default * character', async () => {


### PR DESCRIPTION
## Description

Three TUI component test files have failing assertions on `main` because Ink 6.8.0 emits ANSI escape codes from styled `<Text>` and gradient components even when the renderer is not attached to a TTY. The assertions compare `lastFrame()` against plain strings, so the ANSI bytes inside the frame cause them to fail.

### What's failing on `main`

```
src/cli/tui/components/__tests__/DeployStatus.test.tsx
  ✗ shows "Deploying to AWS" when not complete
  ✗ ignores non-resource-event messages (non-I5502 codes)
    → frame contains `\u001b[90m╭...` from <GradientText> + bordered <Box>

src/cli/tui/components/__tests__/LogPanel.test.tsx
  ✗ renders "No output yet" with no other content
    → frame is `\u001b[2mNo output yet\u001b[22m` (from <Text dimColor>)

src/cli/tui/components/__tests__/SecretInput.test.tsx
  ✗ renders placeholder when value is empty
    → placeholder is split into <Cursor> + <Text dimColor>, so the literal
      substring 'sk-...' has ANSI codes between 's' and 'k-...'
```

### Fix

Import `strip-ansi` (already a transitive dep, now declared as a top-level `devDependency`) and apply it to `lastFrame()` in the four affected assertions only. Other assertions in the same files were left untouched because they pass through plain log lines / system messages that are already ANSI-free in their substrings.

### Why `strip-ansi` rather than rewriting the components

The components (`<Text dimColor>`, `<GradientText>`, `<Cursor>`) are intentionally styled — that styling is part of the actual UX. The bug is in the test assertions assuming `lastFrame()` is plain text, which is fragile any time Ink's rendering behavior changes. Stripping ANSI in the assertion is the minimal, low-risk change and matches the standard pattern used by other Ink-based projects.

### Files changed

- `package.json` — `strip-ansi ^7.2.0` added under `devDependencies` (was already pulled in transitively via Vitest / ESLint)
- `package-lock.json` — regenerated
- `src/cli/tui/components/__tests__/DeployStatus.test.tsx` — 2 assertions
- `src/cli/tui/components/__tests__/LogPanel.test.tsx` — 1 assertion
- `src/cli/tui/components/__tests__/SecretInput.test.tsx` — 1 assertion

5 files, **+9 / -4 lines** total.

### Before / After

```
Before: Test Files 3 failed | 270 passed (273) | Tests 4 failed | 3912 passed (3916)
After:  Test Files 273 passed (273)            | Tests 3916 passed (3916)
```

## Related Issue

Closes #

## Documentation PR

N/A — test-only change.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ` *(unit: 3916/3916 — was 3912/3916 before this PR)*
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint` *(0 errors; 29 preexisting warnings, none in files touched by this PR)*
- [x] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots *(N/A — no asset changes)*

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works *(no new tests; this fixes broken existing tests)*
- [x] I have updated the documentation accordingly *(no doc changes needed)*
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
