### PR TITLE
fix(deploy): respect TUI target selection in deploy flow

### DIFF
--- a/src/cli/tui/hooks/useCdkPreflight.ts
+++ b/src/cli/tui/hooks/useCdkPreflight.ts
@@ -1,6 +1,6 @@
 import { ConfigIO, SecureCredentials } from '../../../lib';
 import { AwsCredentialsError } from '../../../lib/errors/types';
-import type { DeployedState } from '../../../schema';
+import type { AwsDeploymentTarget, DeployedState } from '../../../schema';
 import { applyTargetRegionToEnv } from '../../aws';
 import { validateAwsCredentials } from '../../aws/account';
 import { type CdkToolkitWrapper, type SwitchableIoHost, createSwitchableIoHost } from '../../cdk/toolkit-lib';
@@ -52,6 +52,14 @@ export interface PreflightOptions {
   isInteractive?: boolean;
   /** Skip identity provider check (for plan command which only synthesizes) */
   skipIdentityCheck?: boolean;
+  /**
+   * Subset of targets the user picked in the TUI target selector. When provided,
+   * the preflight context's awsTargets is filtered to only these targets, so
+   * downstream deploy steps and the displayed Target header reflect what was
+   * actually selected. When omitted, all configured targets are used (CLI mode
+   * already filters via --target before reaching here).
+   */
+  selectedTargets?: AwsDeploymentTarget[];
 }
 
 export interface PreflightResult {
@@ -113,7 +121,7 @@ const IDENTITY_STEP: Step = { label: LABEL_API_KEY, status: 'pending' };
 const BOOTSTRAP_STEP: Step = { label: 'Bootstrap AWS environment', status: 'pending' };
 
 export function useCdkPreflight(options: PreflightOptions): PreflightResult {
-  const { logger, isInteractive = false, skipIdentityCheck = false } = options;
+  const { logger, isInteractive = false, skipIdentityCheck = false, selectedTargets } = options;
 
   // Create switchable ioHost - starts silent, can be flipped to verbose for deploy
   const switchableIoHost = useMemo(() => createSwitchableIoHost(), []);
@@ -301,6 +309,17 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
         let preflightContext: PreflightContext;
         try {
           preflightContext = await validateProject();
+          // Filter to only the targets the user picked in the TUI selector,
+          // if provided. Without this, the deploy header shows every target
+          // in aws-targets.json and downstream `awsTargets[0]` reads can
+          // resolve to a target the user did not select. See issue #1267.
+          if (selectedTargets && selectedTargets.length > 0) {
+            const selectedNames = new Set(selectedTargets.map(t => t.name));
+            preflightContext = {
+              ...preflightContext,
+              awsTargets: preflightContext.awsTargets.filter(t => selectedNames.has(t.name)),
+            };
+          }
           setContext(preflightContext);
           // Make aws-targets.json region authoritative for downstream SDK / CDK
           // toolkit-lib clients that bypass explicit region options. Restored on
@@ -530,7 +549,16 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
     return () => {
       process.off('unhandledRejection', handleUnhandledRejection);
     };
-  }, [phase, logger, switchableIoHost, isInteractive, skipIdentityCheck, teardownConfirmed, restoreRegionEnv]);
+  }, [
+    phase,
+    logger,
+    switchableIoHost,
+    isInteractive,
+    skipIdentityCheck,
+    teardownConfirmed,
+    restoreRegionEnv,
+    selectedTargets,
+  ]);
 
   // Handle identity-setup phase (after user provides credentials)
   useEffect(() => {

--- a/src/cli/tui/screens/deploy/DeployScreen.tsx
+++ b/src/cli/tui/screens/deploy/DeployScreen.tsx
@@ -67,6 +67,19 @@ export function DeployScreen({
   // Load MCP spec for ResourceGraph
   const configIO = useMemo(() => new ConfigIO(), []);
 
+  // Resolve which targets the user picked in the AWS target selector. When the
+  // project has a single target, the selector skips the picker phase and pre-
+  // selects index 0; with multiple targets the user explicitly selects one (or
+  // several) and we pass that filter down so the deploy actually targets the
+  // right environments. See issue #1267.
+  const selectedTargets = useMemo(
+    () =>
+      awsConfig.selectedTargetIndices
+        .map(i => awsConfig.availableTargets[i])
+        .filter((t): t is NonNullable<typeof t> => t !== undefined),
+    [awsConfig.selectedTargetIndices, awsConfig.availableTargets]
+  );
+
   const {
     phase,
     steps,
@@ -97,7 +110,7 @@ export function DeployScreen({
     useEnvLocalCredentials,
     useManualCredentials,
     skipCredentials,
-  } = useDeployFlow({ preSynthesized, isInteractive, diffMode });
+  } = useDeployFlow({ preSynthesized, isInteractive, diffMode, selectedTargets });
   const allSuccess = !hasError && isComplete;
   const skipPreflight = !!preSynthesized;
 

--- a/src/cli/tui/screens/deploy/useDeployFlow.ts
+++ b/src/cli/tui/screens/deploy/useDeployFlow.ts
@@ -1,4 +1,5 @@
 import { ConfigIO } from '../../../../lib';
+import type { AwsDeploymentTarget } from '../../../../schema';
 import type { CdkToolkitWrapper, DeployMessage, SwitchableIoHost } from '../../../cdk/toolkit-lib';
 import {
   buildDeployedState,
@@ -65,6 +66,12 @@ interface DeployFlowOptions {
   isInteractive?: boolean;
   /** Run CDK diff instead of deploy */
   diffMode?: boolean;
+  /**
+   * Subset of targets the user picked in the TUI target selector. When set,
+   * the preflight context's awsTargets is filtered to only these targets.
+   * See issue #1267.
+   */
+  selectedTargets?: AwsDeploymentTarget[];
 }
 
 interface DeployFlowState {
@@ -118,14 +125,14 @@ interface DeployFlowState {
 }
 
 export function useDeployFlow(options: DeployFlowOptions = {}): DeployFlowState {
-  const { preSynthesized, isInteractive = false, diffMode = false } = options;
+  const { preSynthesized, isInteractive = false, diffMode = false, selectedTargets } = options;
   const skipPreflight = !!preSynthesized;
 
   // Create logger once for the entire deploy flow
   const [logger] = useState(() => new ExecLogger({ command: 'deploy' }));
 
   // Always call the hook (React rules), but we won't use it when preSynthesized is provided
-  const preflight = useCdkPreflight({ logger, isInteractive });
+  const preflight = useCdkPreflight({ logger, isInteractive, selectedTargets });
 
   // Use pre-synthesized values when provided, otherwise use preflight values
   const cdkToolkitWrapper = preSynthesized?.cdkToolkitWrapper ?? preflight.cdkToolkitWrapper;


### PR DESCRIPTION
## Description

Fixes the bug reported in #1267 where the TUI shows every target from `aws-targets.json` on the deploy screen, even when the user selected just one in the picker.

While investigating, I found this is actually a **double bug**, both rooted in the same missing wire-up:

### Bug 1 (the visible one — what #1267 reports)

`DeployScreen.tsx` renders the header from the full target list:

```tsx
const targetDisplay = context?.awsTargets.map(t => `${t.region}:${t.account}`).join(', ');
```

So with `[us, eu]` in `aws-targets.json` the header always says `Target: us-east-1:..., eu-west-1:...`, regardless of what the user picked.

### Bug 2 (silent and worse)

The deploy flow doesn't iterate `awsTargets` — it reads `awsTargets[0]` in several places:

- `src/cli/tui/screens/deploy/useDeployFlow.ts:221`, `:626`, `:644`, `:645`
- `src/cli/operations/deploy/preflight.ts:265` (`checkBootstrapNeeded`)

So with `[us, eu]` the deploy always ran against `us` even when the user selected `eu` in the picker. **The wrong target was being deployed silently.**

### Root cause

The TUI target selector lives in `useAwsTargetConfig`. It tracks the user's choice in `awsConfig.selectedTargetIndices` and exposes it as a return value — but **nobody downstream consumed it**. `useCdkPreflight` called `validateProject()`, which unconditionally loads every target via `configIO.resolveAWSDeploymentTargets()`, and that array flowed straight into `context.awsTargets`. The user's selection was effectively dropped on the floor between the picker and the preflight context.

CLI mode (`agentcore deploy --target X`) is unaffected because it filters by name in `src/cli/commands/deploy/actions.ts` *before* the preflight runs.

## Fix

Three small, additive changes — no refactor, no new dependencies:

1. **`useCdkPreflight`** — added `selectedTargets?: AwsDeploymentTarget[]` to `PreflightOptions`. After `validateProject()`, when `selectedTargets` is provided, filter `preflightContext.awsTargets` to those names only:

   ```ts
   if (selectedTargets && selectedTargets.length > 0) {
     const selectedNames = new Set(selectedTargets.map(t => t.name));
     preflightContext = {
       ...preflightContext,
       awsTargets: preflightContext.awsTargets.filter(t => selectedNames.has(t.name)),
     };
   }
   ```

2. **`useDeployFlow`** — added the same `selectedTargets` field to `DeployFlowOptions` and passed it through to `useCdkPreflight`.

3. **`DeployScreen`** — derived `selectedTargets` from `awsConfig` (mapping `selectedTargetIndices` over `availableTargets`) and passed it into `useDeployFlow`. When the project has a single target, `useAwsTargetConfig` already pre-selects index `0`, so this also works for the single-target case.

When `selectedTargets` is omitted (or empty), the existing behavior is preserved — important for any non-TUI callers of `useCdkPreflight`.

## Files changed

```
 src/cli/tui/hooks/useCdkPreflight.ts        | +25 / -3
 src/cli/tui/screens/deploy/DeployScreen.tsx | +14 / -1
 src/cli/tui/screens/deploy/useDeployFlow.ts |  +9 / -2
```

3 files, **+48 / -6 lines** total.

## Verification

### Manual reproduction (with this branch built and pointed at a freshly generated project)

`agentcore/aws-targets.json`:

```json
[
  { "name": "us", "account": "123456789012", "region": "us-east-1" },
  { "name": "eu", "account": "123456789012", "region": "eu-west-1" }
]
```

- **Before this PR**, picking `us` in the selector → deploy header shows `Target: us-east-1:..., eu-west-1:...` (both).
- **After this PR**, picking `us` in the selector → deploy header shows `Target: us-east-1:...` (only the picked one). Picking `eu` shows only `eu-west-1`.

### Static checks

- `npm run typecheck` ✅
- `npm run lint` ✅ — 0 errors, 29 warnings (identical to `upstream/main` baseline; **no new warnings introduced**)
- `npm run format:check` ✅
- `npm run test:unit` — 3912/3916 passing. The 4 failures (`DeployStatus`, `LogPanel`, `SecretInput`) are preexisting on `main` and unrelated to this PR (they fail identically on `upstream/main` without my changes; they're caused by Ink 6.8.0 emitting ANSI codes that strict `.toBe()` assertions don't expect, and are tracked in #1301).

## Note on the related issue #1263

While investigating, I cross-checked whether this fix also resolves #1263 ("Deploying the same agent in different target regions for the same account fails"). **It does not.** That is a separate bug in the `@aws/agentcore-cdk` package: the IAM role created by the L3 construct uses a fixed name like `HarnessTest_MyHarness` with no per-target/region disambiguation, so a second deploy of the same agent in a different region of the same account collides on IAM (which is global per account). Even with this PR applied, the user could correctly *select* the second target via the TUI but the deploy would still fail at CFN time on `AlreadyExists`. That fix has to land in `@aws/agentcore-cdk`, not here.

## Related Issue

Closes #1267

## Documentation PR

N/A.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [x] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots *(N/A — no asset changes)*

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works *(verified manually as described above; happy to add a unit test for `useCdkPreflight` with `selectedTargets` if requested)*
- [x] I have updated the documentation accordingly *(no doc changes needed)*
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
