### PR TITLE
fix: remove session storage from TypeScript agent config

### DIFF
--- a/src/cli/commands/add/__tests__/validate.test.ts
+++ b/src/cli/commands/add/__tests__/validate.test.ts
@@ -1583,4 +1583,15 @@ describe('validateAddAgentOptions - session storage mount path', () => {
     const result = validateAddAgentOptions({ ...baseOptions });
     expect(result.valid).toBe(true);
   });
+
+  it('rejects session storage for TypeScript agents', () => {
+    const result = validateAddAgentOptions({
+      ...baseOptions,
+      language: 'TypeScript',
+      framework: 'Strands',
+      sessionStorageMountPath: '/mnt/data',
+    });
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe('--session-storage-mount-path is not supported for TypeScript agents');
+  });
 });

--- a/src/cli/commands/add/validate.ts
+++ b/src/cli/commands/add/validate.ts
@@ -91,6 +91,11 @@ export function validateAddAgentOptions(options: AddAgentOptions): ValidationRes
       (matchEnumValue(TargetLanguageSchema, options.language) as typeof options.language) ?? options.language;
   if (options.build) options.build = matchEnumValue(BuildTypeSchema, options.build) ?? options.build;
 
+  // Session storage is not supported for TypeScript agents — reject early before any path-specific returns
+  if (options.sessionStorageMountPath && options.language === 'TypeScript') {
+    return { valid: false, error: '--session-storage-mount-path is not supported for TypeScript agents' };
+  }
+
   if (!options.name) {
     return { valid: false, error: '--name is required' };
   }
@@ -285,11 +290,8 @@ export function validateAddAgentOptions(options: AddAgentOptions): ValidationRes
   if (lifecycleResult.idleTimeout !== undefined) options.idleTimeout = lifecycleResult.idleTimeout;
   if (lifecycleResult.maxLifetime !== undefined) options.maxLifetime = lifecycleResult.maxLifetime;
 
-  // Validate session storage mount path
+  // Validate session storage mount path format (TypeScript rejection is handled at the top)
   if (options.sessionStorageMountPath) {
-    if (options.language === 'TypeScript') {
-      return { valid: false, error: '--session-storage-mount-path is not supported for TypeScript agents' };
-    }
     const mountPathResult = SessionStorageSchema.shape.mountPath.safeParse(options.sessionStorageMountPath);
     if (!mountPathResult.success) {
       return { valid: false, error: `--session-storage-mount-path: ${mountPathResult.error.issues[0]?.message}` };

--- a/src/cli/commands/add/validate.ts
+++ b/src/cli/commands/add/validate.ts
@@ -287,6 +287,9 @@ export function validateAddAgentOptions(options: AddAgentOptions): ValidationRes
 
   // Validate session storage mount path
   if (options.sessionStorageMountPath) {
+    if (options.language === 'TypeScript') {
+      return { valid: false, error: '--session-storage-mount-path is not supported for TypeScript agents' };
+    }
     const mountPathResult = SessionStorageSchema.shape.mountPath.safeParse(options.sessionStorageMountPath);
     if (!mountPathResult.success) {
       return { valid: false, error: `--session-storage-mount-path: ${mountPathResult.error.issues[0]?.message}` };

--- a/src/cli/tui/screens/generate/GenerateWizardUI.tsx
+++ b/src/cli/tui/screens/generate/GenerateWizardUI.tsx
@@ -126,9 +126,11 @@ export function GenerateWizardUI({
   const isSessionStorageMountPathStep = wizard.step === 'sessionStorageMountPath';
   const isConfirmStep = wizard.step === 'confirm';
 
-  // Advanced multi-select items — filter out dockerfile when not a Container build
+  // Advanced multi-select items — filter out options not applicable to current config
   const advancedItems: SelectableItem[] = ADVANCED_SETTING_OPTIONS.filter(
-    o => o.id !== 'dockerfile' || wizard.config.buildType === 'Container'
+    o =>
+      (o.id !== 'dockerfile' || wizard.config.buildType === 'Container') &&
+      (o.id !== 'filesystem' || wizard.config.language !== 'TypeScript')
   ).map(o => ({ id: o.id, title: o.title, description: o.description }));
 
   const handleSelect = (item: SelectableItem) => {


### PR DESCRIPTION
## Summary
- Hides the "Session filesystem storage" advanced setting in the TUI wizard when the selected language is TypeScript (not supported for TS agents)
- Adds validation that rejects `--session-storage-mount-path` with a clear error for TypeScript agents in non-interactive mode

## Test plan
- [x] Existing unit tests pass (219 validate tests, 36 generate wizard tests)
- [ ] Verify TUI does not show "Session filesystem storage" option when creating a TypeScript agent
- [ ] Verify TUI still shows the option for Python agents
- [ ] Verify `agentcore add agent --language TypeScript --session-storage-mount-path /mnt/data` returns an error