### PR TITLE
fix: update PR tarball install instructions to use gh CLI

### DIFF
--- a/.github/workflows/pr-tarball.yml
+++ b/.github/workflows/pr-tarball.yml
@@ -90,5 +90,6 @@ jobs:
             ### How to install
 
             ```bash
-            npm install ${{ steps.release.outputs.url }}
+            gh release download pr-${{ github.event.pull_request.number }}-tarball --repo ${{ github.repository }} --pattern "*.tgz" --dir /tmp/pr-tarball
+            npm install -g /tmp/pr-tarball/${{ steps.tarball.outputs.name }}
             ```


### PR DESCRIPTION
## Summary
- PR tarball releases are created as drafts, which require authentication to download assets
- The old `npm install <url>` command in PR comments didn't work because npm can't auth to GitHub draft releases
- Updated instructions to use `gh release download` + `npm install -g` which handles auth via the gh CLI

## Test plan
- [ ] Merge and verify next PR tarball comment shows updated instructions
- [ ] Verify `gh release download` + `npm install -g` workflow works for an existing PR tarball