### PR TITLE
fix(templates): pin google-adk < 2.0.0 to prevent runtime init timeout

### DIFF
--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -1181,7 +1181,7 @@ dependencies = [
     "a2a-sdk >= 0.2.0, < 1.0.0",
     "aws-opentelemetry-distro",
     "bedrock-agentcore[a2a] >= 1.0.3",
-    "google-adk >= 1.0.0",
+    "google-adk >= 1.0.0, < 2.0.0",
     "google-genai >= 1.0.0",
 ]
 
@@ -2129,7 +2129,7 @@ dependencies = [
     "ag-ui-protocol >= 0.1.10",
     "bedrock-agentcore >= 1.0.3",
     "fastapi >= 0.115.12",
-    "google-adk >= 1.16.0",
+    "google-adk >= 1.16.0, < 2.0.0",
     "google-genai >= 1.0.0",
     "opentelemetry-distro",
     "opentelemetry-exporter-otlp",
@@ -3613,7 +3613,7 @@ requires-python = ">=3.10"
 dependencies = [
     "opentelemetry-distro",
     "opentelemetry-exporter-otlp",
-    "google-adk >= 1.17.0",
+    "google-adk >= 1.17.0, < 2.0.0",
     "bedrock-agentcore >= 1.0.3",
     "botocore[crt] >= 1.35.0",
     {{#if hasGateway}}{{#if (includes gatewayAuthTypes "AWS_IAM")}}"mcp-proxy-for-aws >= 1.1.0",

--- a/src/assets/python/a2a/googleadk/base/pyproject.toml
+++ b/src/assets/python/a2a/googleadk/base/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "a2a-sdk >= 0.2.0, < 1.0.0",
     "aws-opentelemetry-distro",
     "bedrock-agentcore[a2a] >= 1.0.3",
-    "google-adk >= 1.0.0",
+    "google-adk >= 1.0.0, < 2.0.0",
     "google-genai >= 1.0.0",
 ]
 

--- a/src/assets/python/agui/googleadk/base/pyproject.toml
+++ b/src/assets/python/agui/googleadk/base/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "ag-ui-protocol >= 0.1.10",
     "bedrock-agentcore >= 1.0.3",
     "fastapi >= 0.115.12",
-    "google-adk >= 1.16.0",
+    "google-adk >= 1.16.0, < 2.0.0",
     "google-genai >= 1.0.0",
     "opentelemetry-distro",
     "opentelemetry-exporter-otlp",

--- a/src/assets/python/http/googleadk/base/pyproject.toml
+++ b/src/assets/python/http/googleadk/base/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 dependencies = [
     "opentelemetry-distro",
     "opentelemetry-exporter-otlp",
-    "google-adk >= 1.17.0",
+    "google-adk >= 1.17.0, < 2.0.0",
     "bedrock-agentcore >= 1.0.3",
     "botocore[crt] >= 1.35.0",
     {{#if hasGateway}}{{#if (includes gatewayAuthTypes "AWS_IAM")}}"mcp-proxy-for-aws >= 1.1.0",


### PR DESCRIPTION
## Summary
- Pins `google-adk` to `< 2.0.0` in all three GoogleADK template pyproject.toml files (http, a2a, agui)
- `google-adk 2.0.0` was released 2026-05-19T16:17 UTC and significantly increases cold-start import time (~2.5s locally for just `google.adk.agents`), pushing GoogleADK agents past the 30s runtime initialization limit in E2E
- The E2E failure in [run 26114689210](https://github.com/aws/agentcore-cli/actions/runs/26114689210/job/76800735222) was caused by pip resolving `>= 1.17.0` to the newly-published 2.0.0

## Test plan
- [x] Snapshot tests updated
- [x] Existing unit tests pass (typecheck passed in pre-commit)
- [ ] E2E re-run with this fix should resolve the `googleadk-gemini` init timeout