### PR TITLE
fix(dev): skip deploy for plain agents without harnesses

### DIFF
--- a/src/cli/commands/dev/browser-mode.ts
+++ b/src/cli/commands/dev/browser-mode.ts
@@ -129,7 +129,9 @@ export async function launchBrowserDev(): Promise<void> {
     process.exit(1);
   }
 
-  await runCliDeploy();
+  if (hasHarnesses) {
+    await runCliDeploy();
+  }
 
   const configRoot = findConfigRoot(workingDir);
   const persistTracesDir = path.join(configRoot ?? workingDir, '.cli', 'traces');

--- a/src/cli/commands/dev/command.tsx
+++ b/src/cli/commands/dev/command.tsx
@@ -389,8 +389,8 @@ export const registerDev = (program: Command) => {
           // Get provider info from agent config
           const providerInfo = '(see agent code)';
 
-          // Deploy resources before starting dev server
-          if (!opts.skipDeploy) {
+          // Deploy resources before starting dev server (only when harnesses need it)
+          if (!opts.skipDeploy && hasHarnesses) {
             await runCliDeploy();
           }
 

--- a/src/cli/tui/hooks/useDevDeploy.ts
+++ b/src/cli/tui/hooks/useDevDeploy.ts
@@ -49,6 +49,19 @@ export function useDevDeploy({ skip, ready = true }: UseDevDeployOptions = {}): 
       try {
         const configIO = new ConfigIO();
 
+        // Only deploy if the project has harnesses (cloud-dependent resources).
+        // Plain agents (Strands, LangGraph, etc.) run locally and don't need deployment.
+        try {
+          const projectSpec = await configIO.readProjectSpec();
+          const hasHarnesses = (projectSpec.harnesses ?? []).length > 0;
+          if (!hasHarnesses) {
+            onProgress('Local agent — no deploy needed', 'success');
+            return;
+          }
+        } catch {
+          // If we can't read project spec, proceed with deploy as a safe default
+        }
+
         // Auto-populate aws-targets.json if empty
         try {
           const targets = await configIO.readAWSDeploymentTargets();


### PR DESCRIPTION
## Summary

- `agentcore dev` was triggering a full CDK deploy even for plain agents (Strands, LangGraph, etc.) that only need a local dev server. This is a bug, it should only deploy when the project has a harness.

## Changes

- `browser-mode.ts`: Guard `runCliDeploy()` with `if (hasHarnesses)` in `launchBrowserDev()`
- `command.tsx`: Guard the `--logs` path deploy with `&& hasHarnesses`
- `useDevDeploy.ts`: Early-return in the TUI hook when project has no harnesses

## Test plan

- [x] All 132 existing dev/hook tests pass
- [x] `agentcore dev` with a plain Strands agent (no harness) starts local server without deploying
- [x] `agentcore dev` with a harness project still triggers deploy as before
- [x] `agentcore dev --logs` with plain agent skips deploy
- [x] TUI dev mode with plain agent shows "Local agent — no deploy needed"

Closes #1189