### PR TITLE
fix(templates): remove global agent singleton that leaks history across sessions

### DIFF
--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -4894,17 +4894,12 @@ def create_agent():
         hooks=[ConfigBundleHook()],
     )
 {{else}}
-_agent = None
-
-def get_or_create_agent():
-    global _agent
-    if _agent is None:
-        _agent = Agent(
-            model=load_model(),
-            system_prompt=DEFAULT_SYSTEM_PROMPT,
-            tools=tools
-        )
-    return _agent
+def create_agent():
+    return Agent(
+        model=load_model(),
+        system_prompt=DEFAULT_SYSTEM_PROMPT,
+        tools=tools
+    )
 {{/if}}
 {{/if}}
 
@@ -4918,11 +4913,7 @@ async def invoke(payload, context):
     user_id = getattr(context, 'user_id', 'default-user')
     agent = get_or_create_agent(session_id, user_id)
 {{else}}
-{{#if hasConfigBundle}}
     agent = create_agent()
-{{else}}
-    agent = get_or_create_agent()
-{{/if}}
 {{/if}}
 
     # Execute and format response

--- a/src/assets/python/http/strands/base/main.py
+++ b/src/assets/python/http/strands/base/main.py
@@ -173,17 +173,12 @@ def create_agent():
         hooks=[ConfigBundleHook()],
     )
 {{else}}
-_agent = None
-
-def get_or_create_agent():
-    global _agent
-    if _agent is None:
-        _agent = Agent(
-            model=load_model(),
-            system_prompt=DEFAULT_SYSTEM_PROMPT,
-            tools=tools
-        )
-    return _agent
+def create_agent():
+    return Agent(
+        model=load_model(),
+        system_prompt=DEFAULT_SYSTEM_PROMPT,
+        tools=tools
+    )
 {{/if}}
 {{/if}}
 
@@ -197,11 +192,7 @@ async def invoke(payload, context):
     user_id = getattr(context, 'user_id', 'default-user')
     agent = get_or_create_agent(session_id, user_id)
 {{else}}
-{{#if hasConfigBundle}}
     agent = create_agent()
-{{else}}
-    agent = get_or_create_agent()
-{{/if}}
 {{/if}}
 
     # Execute and format response


### PR DESCRIPTION
## Summary

- The Strands HTTP template (non-memory path) used a global `_agent` singleton shared across all invocations
- Strands `Agent` accumulates conversation history on the instance, so User A's messages leaked to User B
- **Security issue**: any user hitting the same runtime instance could see prior users' conversation content
- Fix: replace singleton with per-invocation `create_agent()` factory (same pattern the configBundle path already used)

## Changes

- `src/assets/python/http/strands/base/main.py`: Replace `global _agent` singleton with `create_agent()` factory
- Updated snapshot

## Test plan

- [x] Asset snapshot tests pass (124/124)
- [x] Typecheck passes
- [ ] Deploy a Strands HTTP agent (no memory), invoke with two different sessions, verify no history leakage

Closes #809