### PR TITLE
fix(cdk): replace async entry point with synchronous reads

### DIFF
--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -45,10 +45,14 @@ agentcore status    # checks deployment status
 exports[`Assets Directory Snapshots > CDK assets > cdk/cdk/bin/cdk.ts should match snapshot 1`] = `
 "#!/usr/bin/env node
 import { AgentCoreStack } from '../lib/cdk-stack';
-import { ConfigIO, type AwsDeploymentTarget } from '@aws/agentcore-cdk';
+import type { AgentCoreProjectSpec, AwsDeploymentTarget } from '@aws/agentcore-cdk';
 import { App, type Environment } from 'aws-cdk-lib';
 import * as path from 'path';
 import * as fs from 'fs';
+
+// CDK CLI's autoSynth uses process.on('beforeExit') which fires before async
+// functions resolve. All reads must be synchronous to ensure stacks are
+// registered on the App before the CDK CLI reads the cloud assembly.
 
 function toEnvironment(target: AwsDeploymentTarget): Environment {
   return {
@@ -65,115 +69,111 @@ function toStackName(projectName: string, targetName: string): string {
   return \`AgentCore-\${sanitize(projectName)}-\${sanitize(targetName)}\`;
 }
 
-async function main() {
-  // Config root is parent of cdk/ directory. The CLI sets process.cwd() to agentcore/cdk/.
-  const configRoot = path.resolve(process.cwd(), '..');
-  const configIO = new ConfigIO({ baseDir: configRoot });
+// Config root is parent of cdk/ directory. The CLI sets process.cwd() to agentcore/cdk/.
+const configRoot = path.resolve(process.cwd(), '..');
+const projectRoot = path.resolve(configRoot, '..');
 
-  const spec = await configIO.readProjectSpec();
-  const targets = await configIO.readAWSDeploymentTargets();
+const spec: AgentCoreProjectSpec = JSON.parse(
+  fs.readFileSync(path.join(configRoot, 'agentcore.json'), 'utf-8')
+);
+const targets: AwsDeploymentTarget[] = JSON.parse(
+  fs.readFileSync(path.join(configRoot, 'aws-targets.json'), 'utf-8')
+);
 
-  // Extract MCP configuration from project spec.
-  // Gateway fields are stored in agentcore.json but may not yet be on the
-  // AgentCoreProjectSpec type from @aws/agentcore-cdk, so we read them
-  // dynamically and cast the resulting object.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const specAny = spec as any;
-  const mcpSpec = specAny.agentCoreGateways?.length
-    ? {
-        agentCoreGateways: specAny.agentCoreGateways,
-        mcpRuntimeTools: specAny.mcpRuntimeTools,
-        unassignedTargets: specAny.unassignedTargets,
-      }
-    : undefined;
-
-  // Read deployed state for credential ARNs (populated by pre-deploy identity setup)
-  let deployedState: Record<string, unknown> | undefined;
-  try {
-    deployedState = JSON.parse(fs.readFileSync(path.join(configRoot, '.cli', 'deployed-state.json'), 'utf8'));
-  } catch {
-    // Deployed state may not exist on first deploy
-  }
-
-  if (targets.length === 0) {
-    throw new Error('No deployment targets configured. Please define targets in agentcore/aws-targets.json');
-  }
-
-  // Read harness configs for role creation.
-  // Harness fields may not yet be on the AgentCoreProjectSpec type from @aws/agentcore-cdk,
-  // so we read them dynamically via specAny (same pattern as gateways above).
-  // Harness paths in agentcore.json are relative to the project root (parent of agentcore/).
-  const projectRoot = path.resolve(configRoot, '..');
-  const harnessConfigs: {
-    name: string;
-    executionRoleArn?: string;
-    memoryName?: string;
-    containerUri?: string;
-    hasDockerfile?: boolean;
-    dockerfile?: string;
-    codeLocation?: string;
-    tools?: { type: string; name: string }[];
-    apiKeyArn?: string;
-  }[] = [];
-  for (const entry of specAny.harnesses ?? []) {
-    const harnessDir = path.resolve(projectRoot, entry.path);
-    const harnessPath = path.resolve(harnessDir, 'harness.json');
-    try {
-      const harnessSpec = JSON.parse(fs.readFileSync(harnessPath, 'utf-8'));
-      harnessConfigs.push({
-        name: entry.name,
-        executionRoleArn: harnessSpec.executionRoleArn,
-        memoryName: harnessSpec.memory?.name,
-        containerUri: harnessSpec.containerUri,
-        hasDockerfile: !!harnessSpec.dockerfile,
-        dockerfile: harnessSpec.dockerfile,
-        codeLocation: harnessSpec.dockerfile ? harnessDir : undefined,
-        tools: harnessSpec.tools,
-        apiKeyArn: harnessSpec.model?.apiKeyArn,
-      });
-    } catch (err) {
-      throw new Error(
-        \`Could not read harness.json for "\${entry.name}" at \${harnessPath}: \${err instanceof Error ? err.message : err}\`
-      );
+// Extract MCP configuration from project spec.
+// Gateway fields are stored in agentcore.json but may not yet be on the
+// AgentCoreProjectSpec type from @aws/agentcore-cdk, so we read them
+// dynamically and cast the resulting object.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const specAny = spec as any;
+const mcpSpec = specAny.agentCoreGateways?.length
+  ? {
+      agentCoreGateways: specAny.agentCoreGateways,
+      mcpRuntimeTools: specAny.mcpRuntimeTools,
+      unassignedTargets: specAny.unassignedTargets,
     }
-  }
+  : undefined;
 
-  const app = new App();
-
-  for (const target of targets) {
-    const env = toEnvironment(target);
-    const stackName = toStackName(spec.name, target.name);
-
-    // Extract credentials from deployed state for this target
-    const targetState = (deployedState as Record<string, unknown>)?.targets as
-      | Record<string, Record<string, unknown>>
-      | undefined;
-    const targetResources = targetState?.[target.name]?.resources as Record<string, unknown> | undefined;
-    const credentials = targetResources?.credentials as
-      | Record<string, { credentialProviderArn: string; clientSecretArn?: string }>
-      | undefined;
-
-    new AgentCoreStack(app, stackName, {
-      spec,
-      mcpSpec,
-      credentials,
-      harnesses: harnessConfigs.length > 0 ? harnessConfigs : undefined,
-      env,
-      description: \`AgentCore stack for \${spec.name} deployed to \${target.name} (\${target.region})\`,
-      tags: {
-        'agentcore:project-name': spec.name,
-        'agentcore:target-name': target.name,
-      },
-    });
-  }
-
-  app.synth();
+// Read deployed state for credential ARNs (populated by pre-deploy identity setup)
+let deployedState: Record<string, unknown> | undefined;
+try {
+  deployedState = JSON.parse(fs.readFileSync(path.join(configRoot, '.cli', 'deployed-state.json'), 'utf8'));
+} catch {
+  // Deployed state may not exist on first deploy
 }
 
-main().catch((error: unknown) => {
-  console.error('AgentCore CDK synthesis failed:', error instanceof Error ? error.message : error);
-  process.exitCode = 1;
-});
+if (targets.length === 0) {
+  throw new Error('No deployment targets configured. Please define targets in agentcore/aws-targets.json');
+}
+
+// Read harness configs for role creation.
+// Harness fields may not yet be on the AgentCoreProjectSpec type from @aws/agentcore-cdk,
+// so we read them dynamically via specAny (same pattern as gateways above).
+// Harness paths in agentcore.json are relative to the project root (parent of agentcore/).
+const harnessConfigs: {
+  name: string;
+  executionRoleArn?: string;
+  memoryName?: string;
+  containerUri?: string;
+  hasDockerfile?: boolean;
+  dockerfile?: string;
+  codeLocation?: string;
+  tools?: { type: string; name: string }[];
+  apiKeyArn?: string;
+}[] = [];
+for (const entry of specAny.harnesses ?? []) {
+  const harnessDir = path.resolve(projectRoot, entry.path);
+  const harnessPath = path.resolve(harnessDir, 'harness.json');
+  try {
+    const harnessSpec = JSON.parse(fs.readFileSync(harnessPath, 'utf-8'));
+    harnessConfigs.push({
+      name: entry.name,
+      executionRoleArn: harnessSpec.executionRoleArn,
+      memoryName: harnessSpec.memory?.name,
+      containerUri: harnessSpec.containerUri,
+      hasDockerfile: !!harnessSpec.dockerfile,
+      dockerfile: harnessSpec.dockerfile,
+      codeLocation: harnessSpec.dockerfile ? harnessDir : undefined,
+      tools: harnessSpec.tools,
+      apiKeyArn: harnessSpec.model?.apiKeyArn,
+    });
+  } catch (err) {
+    throw new Error(
+      \`Could not read harness.json for "\${entry.name}" at \${harnessPath}: \${err instanceof Error ? err.message : err}\`
+    );
+  }
+}
+
+const app = new App();
+
+for (const target of targets) {
+  const env = toEnvironment(target);
+  const stackName = toStackName(spec.name, target.name);
+
+  // Extract credentials from deployed state for this target
+  const targetState = (deployedState as Record<string, unknown>)?.targets as
+    | Record<string, Record<string, unknown>>
+    | undefined;
+  const targetResources = targetState?.[target.name]?.resources as Record<string, unknown> | undefined;
+  const credentials = targetResources?.credentials as
+    | Record<string, { credentialProviderArn: string; clientSecretArn?: string }>
+    | undefined;
+
+  new AgentCoreStack(app, stackName, {
+    spec,
+    mcpSpec,
+    credentials,
+    harnesses: harnessConfigs.length > 0 ? harnessConfigs : undefined,
+    env,
+    description: \`AgentCore stack for \${spec.name} deployed to \${target.name} (\${target.region})\`,
+    tags: {
+      'agentcore:project-name': spec.name,
+      'agentcore:target-name': target.name,
+    },
+  });
+}
+
+app.synth();
 "
 `;
 

--- a/src/assets/cdk/bin/cdk.ts
+++ b/src/assets/cdk/bin/cdk.ts
@@ -1,9 +1,13 @@
 #!/usr/bin/env node
 import { AgentCoreStack } from '../lib/cdk-stack';
-import { ConfigIO, type AwsDeploymentTarget } from '@aws/agentcore-cdk';
+import type { AgentCoreProjectSpec, AwsDeploymentTarget } from '@aws/agentcore-cdk';
 import { App, type Environment } from 'aws-cdk-lib';
 import * as path from 'path';
 import * as fs from 'fs';
+
+// CDK CLI's autoSynth uses process.on('beforeExit') which fires before async
+// functions resolve. All reads must be synchronous to ensure stacks are
+// registered on the App before the CDK CLI reads the cloud assembly.
 
 function toEnvironment(target: AwsDeploymentTarget): Environment {
   return {
@@ -20,112 +24,108 @@ function toStackName(projectName: string, targetName: string): string {
   return `AgentCore-${sanitize(projectName)}-${sanitize(targetName)}`;
 }
 
-async function main() {
-  // Config root is parent of cdk/ directory. The CLI sets process.cwd() to agentcore/cdk/.
-  const configRoot = path.resolve(process.cwd(), '..');
-  const configIO = new ConfigIO({ baseDir: configRoot });
+// Config root is parent of cdk/ directory. The CLI sets process.cwd() to agentcore/cdk/.
+const configRoot = path.resolve(process.cwd(), '..');
+const projectRoot = path.resolve(configRoot, '..');
 
-  const spec = await configIO.readProjectSpec();
-  const targets = await configIO.readAWSDeploymentTargets();
+const spec: AgentCoreProjectSpec = JSON.parse(
+  fs.readFileSync(path.join(configRoot, 'agentcore.json'), 'utf-8')
+);
+const targets: AwsDeploymentTarget[] = JSON.parse(
+  fs.readFileSync(path.join(configRoot, 'aws-targets.json'), 'utf-8')
+);
 
-  // Extract MCP configuration from project spec.
-  // Gateway fields are stored in agentcore.json but may not yet be on the
-  // AgentCoreProjectSpec type from @aws/agentcore-cdk, so we read them
-  // dynamically and cast the resulting object.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const specAny = spec as any;
-  const mcpSpec = specAny.agentCoreGateways?.length
-    ? {
-        agentCoreGateways: specAny.agentCoreGateways,
-        mcpRuntimeTools: specAny.mcpRuntimeTools,
-        unassignedTargets: specAny.unassignedTargets,
-      }
-    : undefined;
-
-  // Read deployed state for credential ARNs (populated by pre-deploy identity setup)
-  let deployedState: Record<string, unknown> | undefined;
-  try {
-    deployedState = JSON.parse(fs.readFileSync(path.join(configRoot, '.cli', 'deployed-state.json'), 'utf8'));
-  } catch {
-    // Deployed state may not exist on first deploy
-  }
-
-  if (targets.length === 0) {
-    throw new Error('No deployment targets configured. Please define targets in agentcore/aws-targets.json');
-  }
-
-  // Read harness configs for role creation.
-  // Harness fields may not yet be on the AgentCoreProjectSpec type from @aws/agentcore-cdk,
-  // so we read them dynamically via specAny (same pattern as gateways above).
-  // Harness paths in agentcore.json are relative to the project root (parent of agentcore/).
-  const projectRoot = path.resolve(configRoot, '..');
-  const harnessConfigs: {
-    name: string;
-    executionRoleArn?: string;
-    memoryName?: string;
-    containerUri?: string;
-    hasDockerfile?: boolean;
-    dockerfile?: string;
-    codeLocation?: string;
-    tools?: { type: string; name: string }[];
-    apiKeyArn?: string;
-  }[] = [];
-  for (const entry of specAny.harnesses ?? []) {
-    const harnessDir = path.resolve(projectRoot, entry.path);
-    const harnessPath = path.resolve(harnessDir, 'harness.json');
-    try {
-      const harnessSpec = JSON.parse(fs.readFileSync(harnessPath, 'utf-8'));
-      harnessConfigs.push({
-        name: entry.name,
-        executionRoleArn: harnessSpec.executionRoleArn,
-        memoryName: harnessSpec.memory?.name,
-        containerUri: harnessSpec.containerUri,
-        hasDockerfile: !!harnessSpec.dockerfile,
-        dockerfile: harnessSpec.dockerfile,
-        codeLocation: harnessSpec.dockerfile ? harnessDir : undefined,
-        tools: harnessSpec.tools,
-        apiKeyArn: harnessSpec.model?.apiKeyArn,
-      });
-    } catch (err) {
-      throw new Error(
-        `Could not read harness.json for "${entry.name}" at ${harnessPath}: ${err instanceof Error ? err.message : err}`
-      );
+// Extract MCP configuration from project spec.
+// Gateway fields are stored in agentcore.json but may not yet be on the
+// AgentCoreProjectSpec type from @aws/agentcore-cdk, so we read them
+// dynamically and cast the resulting object.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const specAny = spec as any;
+const mcpSpec = specAny.agentCoreGateways?.length
+  ? {
+      agentCoreGateways: specAny.agentCoreGateways,
+      mcpRuntimeTools: specAny.mcpRuntimeTools,
+      unassignedTargets: specAny.unassignedTargets,
     }
-  }
+  : undefined;
 
-  const app = new App();
-
-  for (const target of targets) {
-    const env = toEnvironment(target);
-    const stackName = toStackName(spec.name, target.name);
-
-    // Extract credentials from deployed state for this target
-    const targetState = (deployedState as Record<string, unknown>)?.targets as
-      | Record<string, Record<string, unknown>>
-      | undefined;
-    const targetResources = targetState?.[target.name]?.resources as Record<string, unknown> | undefined;
-    const credentials = targetResources?.credentials as
-      | Record<string, { credentialProviderArn: string; clientSecretArn?: string }>
-      | undefined;
-
-    new AgentCoreStack(app, stackName, {
-      spec,
-      mcpSpec,
-      credentials,
-      harnesses: harnessConfigs.length > 0 ? harnessConfigs : undefined,
-      env,
-      description: `AgentCore stack for ${spec.name} deployed to ${target.name} (${target.region})`,
-      tags: {
-        'agentcore:project-name': spec.name,
-        'agentcore:target-name': target.name,
-      },
-    });
-  }
-
-  app.synth();
+// Read deployed state for credential ARNs (populated by pre-deploy identity setup)
+let deployedState: Record<string, unknown> | undefined;
+try {
+  deployedState = JSON.parse(fs.readFileSync(path.join(configRoot, '.cli', 'deployed-state.json'), 'utf8'));
+} catch {
+  // Deployed state may not exist on first deploy
 }
 
-main().catch((error: unknown) => {
-  console.error('AgentCore CDK synthesis failed:', error instanceof Error ? error.message : error);
-  process.exitCode = 1;
-});
+if (targets.length === 0) {
+  throw new Error('No deployment targets configured. Please define targets in agentcore/aws-targets.json');
+}
+
+// Read harness configs for role creation.
+// Harness fields may not yet be on the AgentCoreProjectSpec type from @aws/agentcore-cdk,
+// so we read them dynamically via specAny (same pattern as gateways above).
+// Harness paths in agentcore.json are relative to the project root (parent of agentcore/).
+const harnessConfigs: {
+  name: string;
+  executionRoleArn?: string;
+  memoryName?: string;
+  containerUri?: string;
+  hasDockerfile?: boolean;
+  dockerfile?: string;
+  codeLocation?: string;
+  tools?: { type: string; name: string }[];
+  apiKeyArn?: string;
+}[] = [];
+for (const entry of specAny.harnesses ?? []) {
+  const harnessDir = path.resolve(projectRoot, entry.path);
+  const harnessPath = path.resolve(harnessDir, 'harness.json');
+  try {
+    const harnessSpec = JSON.parse(fs.readFileSync(harnessPath, 'utf-8'));
+    harnessConfigs.push({
+      name: entry.name,
+      executionRoleArn: harnessSpec.executionRoleArn,
+      memoryName: harnessSpec.memory?.name,
+      containerUri: harnessSpec.containerUri,
+      hasDockerfile: !!harnessSpec.dockerfile,
+      dockerfile: harnessSpec.dockerfile,
+      codeLocation: harnessSpec.dockerfile ? harnessDir : undefined,
+      tools: harnessSpec.tools,
+      apiKeyArn: harnessSpec.model?.apiKeyArn,
+    });
+  } catch (err) {
+    throw new Error(
+      `Could not read harness.json for "${entry.name}" at ${harnessPath}: ${err instanceof Error ? err.message : err}`
+    );
+  }
+}
+
+const app = new App();
+
+for (const target of targets) {
+  const env = toEnvironment(target);
+  const stackName = toStackName(spec.name, target.name);
+
+  // Extract credentials from deployed state for this target
+  const targetState = (deployedState as Record<string, unknown>)?.targets as
+    | Record<string, Record<string, unknown>>
+    | undefined;
+  const targetResources = targetState?.[target.name]?.resources as Record<string, unknown> | undefined;
+  const credentials = targetResources?.credentials as
+    | Record<string, { credentialProviderArn: string; clientSecretArn?: string }>
+    | undefined;
+
+  new AgentCoreStack(app, stackName, {
+    spec,
+    mcpSpec,
+    credentials,
+    harnesses: harnessConfigs.length > 0 ? harnessConfigs : undefined,
+    env,
+    description: `AgentCore stack for ${spec.name} deployed to ${target.name} (${target.region})`,
+    tags: {
+      'agentcore:project-name': spec.name,
+      'agentcore:target-name': target.name,
+    },
+  });
+}
+
+app.synth();


### PR DESCRIPTION
## Summary

- `cdk ls`, `cdk synth`, and `cdk deploy` silently produce zero stacks (exit code 0) because CDK CLI's `autoSynth` fires on `beforeExit` before the async `main()` resolves
- Replace `async main()` + `await ConfigIO` with synchronous `fs.readFileSync` + `JSON.parse` so stacks are registered on the App before CDK reads the cloud assembly
- Same pattern already used for `deployed-state.json` in the same file

## Root Cause

CDK's `autoSynth` uses `process.on('beforeExit')` which fires when the synchronous event loop drains — before any pending async work completes. The `async main()` wrapper meant the App was still empty when CDK read it.

## Changes

- `src/assets/cdk/bin/cdk.ts`: Remove `async main()` wrapper, replace `ConfigIO` calls with direct `fs.readFileSync`, make all code top-level synchronous

## Test plan

- [x] Asset snapshot tests pass (124/124)
- [x] Typecheck passes
- [x] Lint passes
- [ ] `agentcore create --defaults` → `cd agentcore/cdk && npx tsc && npx cdk ls` outputs stack name
- [ ] `agentcore deploy` still works end-to-end (uses same template via toolkit)

Closes #821