### PR TITLE
test(security-review): verify /security-review path against fix-fork-secrets

### DIFF
--- a/scripts/__sec_review_smoketest.mjs
+++ b/scripts/__sec_review_smoketest.mjs
@@ -1,0 +1,36 @@
+// Deliberately vulnerable file used to smoke-test the Claude Security Review
+// workflow. Two HIGH-severity findings the bundled /security-review skill
+// should flag and post as inline review comments. Will be deleted once the
+// posting path is verified.
+import { exec } from 'node:child_process';
+import http from 'node:http';
+
+// FINDING 1 — Hardcoded credential pattern.
+const HARDCODED_AWS_ACCESS_KEY_ID = 'AKIAIOSFODNN7EXAMPLE';
+const HARDCODED_AWS_SECRET_ACCESS_KEY = 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY';
+
+function buildSignedRequest(payload) {
+  return {
+    payload,
+    auth: `AWS4-HMAC-SHA256 Credential=${HARDCODED_AWS_ACCESS_KEY_ID}`,
+    secret: HARDCODED_AWS_SECRET_ACCESS_KEY,
+  };
+}
+
+// FINDING 2 — Command injection via exec() with unvalidated HTTP query parameter.
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, 'http://localhost');
+  const target = url.searchParams.get('host') ?? 'localhost';
+
+  exec(`ping -c 1 ${target}`, (err, stdout, stderr) => {
+    if (err) {
+      res.writeHead(500);
+      res.end(String(err));
+      return;
+    }
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end(stdout || stderr);
+  });
+});
+
+export { buildSignedRequest, server };


### PR DESCRIPTION
**Throwaway PR for testing — do not merge, do not review.**

Base = `fix-fork-secrets` (PR #1310's branch) so the security review workflow that runs on this PR is the *new* one with bundled-slash-command + honest summary + cancel-in-progress=false. Verifies the inline-comment posting path before #1310 merges.

The diff adds a single file with two deliberate findings the bundled `/security-review` skill should flag (hardcoded AWS creds + command injection via `exec`).

Will close once verified.