### PR TITLE
fix(ci): use npm-shrinkwrap.json for node_modules cache key

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: node_modules
-          key: node-modules-${{ hashFiles('package-lock.json') }}
+          key: node-modules-${{ hashFiles('npm-shrinkwrap.json') }}
 
   format:
     needs: setup
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/cache/restore@v5
         with:
           path: node_modules
-          key: node-modules-${{ hashFiles('package-lock.json') }}
+          key: node-modules-${{ hashFiles('npm-shrinkwrap.json') }}
       - run: npm run format:check
 
   lint:
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/cache/restore@v5
         with:
           path: node_modules
-          key: node-modules-${{ hashFiles('package-lock.json') }}
+          key: node-modules-${{ hashFiles('npm-shrinkwrap.json') }}
       - run: npm run lint
 
   security:
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/cache/restore@v5
         with:
           path: node_modules
-          key: node-modules-${{ hashFiles('package-lock.json') }}
+          key: node-modules-${{ hashFiles('npm-shrinkwrap.json') }}
       - run: npm run security:audit
 
   secrets:
@@ -84,7 +84,7 @@ jobs:
       - uses: actions/cache/restore@v5
         with:
           path: node_modules
-          key: node-modules-${{ hashFiles('package-lock.json') }}
+          key: node-modules-${{ hashFiles('npm-shrinkwrap.json') }}
       - run: npm run secrets:check
 
   typecheck:
@@ -98,7 +98,7 @@ jobs:
       - uses: actions/cache/restore@v5
         with:
           path: node_modules
-          key: node-modules-${{ hashFiles('package-lock.json') }}
+          key: node-modules-${{ hashFiles('npm-shrinkwrap.json') }}
       - run: npm run typecheck
 
   schema-check:


### PR DESCRIPTION
## Description

The `Quality and Safety Checks` workflow caches `node_modules` using `hashFiles('package-lock.json')` as the key, but `package-lock.json` is no longer tracked since it was replaced by `npm-shrinkwrap.json`. This causes `hashFiles` to return an empty string, so the cache key is always `node-modules-` (constant across all runs).

This means:
1. The `setup` job's cache save races with itself and often fails ("another job may be creating this cache")
2. Downstream jobs (lint, typecheck) restore a **stale** `node_modules` from a previous run with older SDK type definitions
3. eslint's type-checked rules fail with "type that could not be resolved" errors that cannot be reproduced locally

The fix changes all `hashFiles('package-lock.json')` references to `hashFiles('npm-shrinkwrap.json')`.

## Related Issue

Closes #

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

- [ ] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.