### PR TITLE
ci(security-review): fix origin/HEAD missing so /security-review's git diff works

### DIFF
--- a/.github/workflows/pr-security-review.yml
+++ b/.github/workflows/pr-security-review.yml
@@ -167,6 +167,19 @@ jobs:
           # the base branch locally too. fetch-depth: 0 grabs the full history.
           fetch-depth: 0
 
+      - name: Set origin/HEAD for /security-review skill
+        env:
+          BASE_REF: ${{ steps.pr.outputs.base_ref }}
+        run: |
+          set -euo pipefail
+          # actions/checkout doesn't set up the remote's symbolic HEAD ref, so
+          # `git diff origin/HEAD...` (the first command the bundled
+          # /security-review skill runs) fails with "ambiguous argument
+          # 'origin/HEAD...': unknown revision". Point origin/HEAD at the PR's
+          # base branch so the skill resolves the diff against the right ref.
+          git remote set-head origin "$BASE_REF"
+          git symbolic-ref refs/remotes/origin/HEAD
+
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v6
         with:


### PR DESCRIPTION
## Why

Run [#26186045056](https://github.com/aws/agentcore-cli/actions/runs/26186045056) on PR #1321 failed with `Reached maximum number of turns (30)` because the very first thing the bundled `/security-review` skill does is `git diff origin/HEAD...`, and that resolves to:

```
fatal: ambiguous argument 'origin/HEAD...': unknown revision or path not in the working tree
```

`actions/checkout` clones the remote and sets `origin/<head-ref>` but does **not** set the remote's symbolic `HEAD` ref. So `origin/HEAD` is undefined, the skill's git command crashes, Claude tries 30 turns of recovery variants, then the action exits 1.

This affects every PR run after [#1310](https://github.com/aws/agentcore-cli/pull/1310) merged (we switched from inlining the prompt + custom git context to letting the bundled skill drive its own git commands).

## What changes

One step inserted right after `Checkout PR head`:

```yaml
- name: Set origin/HEAD for /security-review skill
  env:
    BASE_REF: ${{ steps.pr.outputs.base_ref }}
  run: |
    set -euo pipefail
    git remote set-head origin "$BASE_REF"
    git symbolic-ref refs/remotes/origin/HEAD
```

`git remote set-head origin <base-ref>` makes `origin/HEAD` resolve to the PR's base branch. The follow-up `git symbolic-ref` line is a sanity print that fails the step early if the head still isn't set.

## Test plan

- [ ] Merge.
- [ ] Open a small PR (or wait for the next community PR + `safe-to-review`); confirm the security review run no longer hits `error_max_turns`, that the skill's `git diff origin/HEAD...` resolves correctly, and that inline findings (or a "no findings" summary) post as expected.