### PR TITLE
fix: emit ValidationError instead of UnknownError in create telemetry

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -48,6 +48,7 @@ await esbuild.build({
   platform: 'node',
   format: 'esm',
   minify: true,
+  keepNames: true,
   jsx: 'automatic',
   // Inject require shim for ESM compatibility with CommonJS dependencies
   banner: {

--- a/integ-tests/add-remove-resources.test.ts
+++ b/integ-tests/add-remove-resources.test.ts
@@ -197,6 +197,23 @@ describe('integration: add and remove resources', () => {
     });
   });
 
+  describe('add validation failure telemetry', () => {
+    it('emits ValidationError for add memory with missing --name', async () => {
+      telemetry.clearEntries();
+      const result = await runCLI(['add', 'memory', '--strategies', 'SEMANTIC', '--json'], project.projectPath, {
+        env: telemetry.env,
+      });
+
+      expect(result.exitCode).toBe(1);
+      telemetry.assertMetricEmitted({
+        command: 'add.memory',
+        exit_reason: 'failure',
+        error_name: 'ValidationError',
+        error_source: 'user',
+      });
+    });
+  });
+
   describe('remove all', () => {
     it('resets all schemas and emits telemetry', async () => {
       const result = await runCLI(['remove', 'all', '--yes', '--json'], project.projectPath, {

--- a/integ-tests/create-edge-cases.test.ts
+++ b/integ-tests/create-edge-cases.test.ts
@@ -38,6 +38,8 @@ describe.skipIf(!prereqs.npm || !prereqs.git)('integration: create edge cases', 
       telemetry.assertMetricEmitted({
         command: 'create',
         exit_reason: 'failure',
+        error_name: 'ValidationError',
+        error_source: 'user',
         agent_language: 'python',
         has_agent: 'true',
       });

--- a/src/cli/commands/create/command.tsx
+++ b/src/cli/commands/create/command.tsx
@@ -1,4 +1,4 @@
-import { getWorkingDirectory, serializeResult } from '../../../lib';
+import { ValidationError, getWorkingDirectory, serializeResult } from '../../../lib';
 import type {
   BuildType,
   ModelProvider,
@@ -132,7 +132,7 @@ async function handleCreateCLI(options: CreateOptions): Promise<void> {
     async () => {
       const validation = validateCreateOptions(options, cwd);
       if (!validation.valid) {
-        throw new Error(validation.error);
+        throw new ValidationError(validation.error!);
       }
       const green = '\x1b[32m';
       const reset = '\x1b[0m';

--- a/src/cli/primitives/AgentPrimitive.tsx
+++ b/src/cli/primitives/AgentPrimitive.tsx
@@ -4,6 +4,7 @@ import {
   ConflictError,
   NoProjectError,
   ResourceNotFoundError,
+  ValidationError,
   findConfigRoot,
   serializeResult,
   setEnvVar,
@@ -301,7 +302,7 @@ export class AgentPrimitive extends BasePrimitive<AddAgentOptions, RemovableReso
           await runCliCommand('add.agent', !!cliOptions.json, async () => {
             const validation = validateAddAgentOptions(cliOptions);
             if (!validation.valid) {
-              throw new Error(validation.error);
+              throw new ValidationError(validation.error!);
             }
 
             // Parse custom claims JSON if provided (already validated by validateAddAgentOptions)

--- a/src/cli/primitives/CredentialPrimitive.tsx
+++ b/src/cli/primitives/CredentialPrimitive.tsx
@@ -1,6 +1,7 @@
 import {
   ConflictError,
   ResourceNotFoundError,
+  ValidationError,
   findConfigRoot,
   getEnvVar,
   serializeResult,
@@ -315,7 +316,7 @@ export class CredentialPrimitive extends BasePrimitive<AddCredentialOptions, Rem
               });
 
               if (!validation.valid) {
-                throw new Error(validation.error);
+                throw new ValidationError(validation.error!);
               }
 
               const addOptions =

--- a/src/cli/primitives/GatewayPrimitive.ts
+++ b/src/cli/primitives/GatewayPrimitive.ts
@@ -1,4 +1,4 @@
-import { ResourceNotFoundError, findConfigRoot, serializeResult, toError } from '../../lib';
+import { ResourceNotFoundError, ValidationError, findConfigRoot, serializeResult, toError } from '../../lib';
 import type { Result } from '../../lib/result';
 import type {
   AgentCoreGateway,
@@ -191,7 +191,7 @@ export class GatewayPrimitive extends BasePrimitive<AddGatewayOptions, Removable
         await runCliCommand('add.gateway', !!cliOptions.json, async () => {
           const validation = validateAddGatewayOptions(cliOptions);
           if (!validation.valid) {
-            throw new Error(validation.error);
+            throw new ValidationError(validation.error!);
           }
 
           // Parse custom claims JSON if provided (already validated)

--- a/src/cli/primitives/GatewayTargetPrimitive.ts
+++ b/src/cli/primitives/GatewayTargetPrimitive.ts
@@ -2,6 +2,7 @@ import {
   APP_DIR,
   MCP_APP_SUBDIR,
   ResourceNotFoundError,
+  ValidationError,
   findConfigRoot,
   requireConfigRoot,
   serializeResult,
@@ -323,7 +324,7 @@ export class GatewayTargetPrimitive extends BasePrimitive<AddGatewayTargetOption
         await runCliCommand('add.gateway-target', !!cliOptions.json, async () => {
           const validation = await validateAddGatewayTargetOptions(cliOptions);
           if (!validation.valid) {
-            throw new Error(validation.error);
+            throw new ValidationError(validation.error!);
           }
 
           // Map CLI flag values to internal types

--- a/src/cli/primitives/MemoryPrimitive.tsx
+++ b/src/cli/primitives/MemoryPrimitive.tsx
@@ -1,4 +1,4 @@
-import { ResourceNotFoundError, findConfigRoot, serializeResult, toError } from '../../lib';
+import { ResourceNotFoundError, ValidationError, findConfigRoot, serializeResult, toError } from '../../lib';
 import type { Result } from '../../lib/result';
 import type {
   Memory,
@@ -204,7 +204,7 @@ export class MemoryPrimitive extends BasePrimitive<AddMemoryOptions, RemovableMe
               });
 
               if (!validation.valid) {
-                throw new Error(validation.error);
+                throw new ValidationError(validation.error!);
               }
 
               const result = await this.add({


### PR DESCRIPTION
## Description

When the `create` command fails validation (e.g. missing `--framework`, `--model-provider`, `--memory`), telemetry emits `error_name: "UnknownError"` instead of `error_name: "ValidationError"`.

Two root causes:

1. **Plain `Error` thrown instead of `ValidationError`** — `command.tsx` throws `new Error(validation.error)`. The `classifyError` function only recognizes `BaseError` subclasses via `instanceof`, so a plain `Error` gets `{ category: "UnknownError", source: "unknown" }`.

2. **`minify: true` without `keepNames` mangles class names** — `BaseError` sets `this.name = this.constructor.name`. With minification, constructor names are mangled (e.g. `"Gr"`), so `ErrorName.safeParse(err.name)` fails for *all* error subclasses. Per [esbuild docs](https://esbuild.github.io/api/#keep-names):

   > However, minification renames symbols to reduce code size [...] That changes value of the `name` property for many of these cases. [...] some frameworks rely on the `name` property for registration and binding purposes. If this is the case, you can enable this option to preserve the original `name` values even in minified code.

### Fix

- `src/cli/commands/create/command.tsx` — throw `new ValidationError(...)` instead of `new Error(...)`
- `esbuild.config.mjs` — add `keepNames: true` to preserve class names through minification
- `integ-tests/create-edge-cases.test.ts` — assert `error_name: "ValidationError"` and `error_source: "user"`

## Related Issue

Closes #

## Type of Change

- [x] Bug fix

## Testing

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [ ] I ran `npm run typecheck`
- [ ] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.