### PR TITLE
fix: add -g flag to bundle install instructions

### DIFF
--- a/scripts/bundle.mjs
+++ b/scripts/bundle.mjs
@@ -158,7 +158,7 @@ const cliTarballPath = path.join(cliRoot, cliTarballName);
 
 if (fs.existsSync(cliTarballPath)) {
   log(`Done! Tarball: ${cliTarballPath}`);
-  log(`Install with: npm install ${cliTarballPath}`);
+  log(`Install with: npm install -g ${cliTarballPath}`);
   log('When you run agentcore create, the bundled CDK constructs will be installed automatically.');
 } else {
   log(`Done! Check ${cliRoot} for the .tgz file.`);


### PR DESCRIPTION
## Description

The bundle script outputs an `npm install <tarball>` instruction after building, but without `-g` the CLI binary is not linked globally and the `agentcore` command is not available. This adds the `-g` flag to the install instruction.

## Related Issue

N/A

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.