### PR TITLE
ci: add preview tarball workflow

### DIFF
--- a/.github/workflows/prerelease-tarball.yml
+++ b/.github/workflows/prerelease-tarball.yml
@@ -1,4 +1,4 @@
-name: Preview Tarball
+name: Prerelease Tarball
 
 on:
   push:
@@ -10,11 +10,11 @@ permissions:
   contents: write
 
 concurrency:
-  group: preview-tarball
+  group: prerelease-tarball
   cancel-in-progress: true
 
 jobs:
-  preview-tarball:
+  prerelease-tarball:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -42,7 +42,7 @@ jobs:
           # Create a new pre-release with the tarball
           gh release create "$TAG" \
             "${TARBALL_NAME}" \
-            --title "Preview (prerelease)" \
+            --title "Prerelease" \
             --notes "Auto-generated tarball from the latest commit on main." \
             --prerelease \
             --target "${{ github.sha }}"

--- a/.github/workflows/preview-tarball.yml
+++ b/.github/workflows/preview-tarball.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '22.x'
+          node-version: '20.x'
           cache: 'npm'
       - uses: astral-sh/setup-uv@v7
       - run: npm run bundle

--- a/.github/workflows/preview-tarball.yml
+++ b/.github/workflows/preview-tarball.yml
@@ -29,15 +29,9 @@ jobs:
         run: |
           TARBALL_NAME=$(ls *.tgz | head -1 | xargs basename)
           echo "name=$TARBALL_NAME" >> $GITHUB_OUTPUT
-      - name: Generate GitHub App Token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ vars.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Create or update prerelease
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TARBALL_NAME: ${{ steps.tarball.outputs.name }}
         run: |
           TAG="prerelease"

--- a/.github/workflows/preview-tarball.yml
+++ b/.github/workflows/preview-tarball.yml
@@ -1,0 +1,54 @@
+name: Preview Tarball
+
+on:
+  push:
+    branches: [main]
+  # Manually trigger to pull in the latest CDK constructs changes
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: preview-tarball
+  cancel-in-progress: true
+
+jobs:
+  preview-tarball:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22.x'
+          cache: 'npm'
+      - uses: astral-sh/setup-uv@v7
+      - run: npm run bundle
+      - name: Get tarball info
+        id: tarball
+        run: |
+          TARBALL_NAME=$(ls *.tgz | head -1 | xargs basename)
+          echo "name=$TARBALL_NAME" >> $GITHUB_OUTPUT
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      - name: Create or update prerelease
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TARBALL_NAME: ${{ steps.tarball.outputs.name }}
+        run: |
+          TAG="prerelease"
+
+          # Delete existing release if it exists (to update the tarball)
+          gh release delete "$TAG" --yes --cleanup-tag 2>/dev/null || true
+
+          # Create a new pre-release with the tarball
+          gh release create "$TAG" \
+            "${TARBALL_NAME}" \
+            --title "Preview (prerelease)" \
+            --notes "Auto-generated tarball from the latest commit on main." \
+            --prerelease \
+            --target "${{ github.sha }}"


### PR DESCRIPTION
## Description

Add a GitHub Actions workflow that builds and publishes a prerelease tarball (with bundled CDK constructs) on every push to main. The release is tagged `prerelease` and updated in-place. Also supports `workflow_dispatch` for manually pulling in latest CDK changes.

## Related Issue

N/A

## Documentation PR

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

Workflow-only change — validated YAML syntax locally.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.