### PR TITLE
ci: use GitHub App token for prerelease workflow

### DIFF
--- a/.github/workflows/prerelease-tarball.yml
+++ b/.github/workflows/prerelease-tarball.yml
@@ -29,9 +29,15 @@ jobs:
         run: |
           TARBALL_NAME=$(ls *.tgz | head -1 | xargs basename)
           echo "name=$TARBALL_NAME" >> $GITHUB_OUTPUT
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Create or update prerelease
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TARBALL_NAME: ${{ steps.tarball.outputs.name }}
         run: |
           TAG="prerelease"


### PR DESCRIPTION
## Description

Switch the prerelease-tarball workflow from `secrets.GITHUB_TOKEN` to a GitHub App token, consistent with all other workflows in the repo.

The default workflow token was insufficient because we need access to the private repo, see: https://github.com/aws/agentcore-cli/actions/runs/26293331790

## Related Issue

N/A

## Documentation PR

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe): CI fix

## Testing

How have you tested the change?

- [ ] I ran `npm run test:unit` and `npm run test:integ`
- [ ] I ran `npm run typecheck`
- [ ] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

Workflow-only change — validated YAML syntax locally.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.