### PR TITLE
fix(e2e): add max_turns to SIMULATED_V1 dataset examples

### DIFF
--- a/e2e-tests/dataset-lifecycle.test.ts
+++ b/e2e-tests/dataset-lifecycle.test.ts
@@ -373,8 +373,8 @@ describe.sequential('e2e: dataset lifecycle', () => {
       // Write simulated examples to the dataset file (must match SIMULATED_V1 schema)
       const datasetFile = join(projectPath, 'agentcore/datasets', `${simulatedDatasetName}.jsonl`);
       const examples = [
-        '{"scenario_id": "sim_booking", "input": "Book a flight", "actor_profile": {"traits": {"personality": "impatient"}, "context": "frequent flyer", "goal": "book cheapest flight"}}',
-        '{"scenario_id": "sim_cancel", "input": "Cancel reservation", "actor_profile": {"traits": {"personality": "polite"}, "context": "first time user", "goal": "get full refund"}}',
+        '{"scenario_id": "sim_booking", "input": "Book a flight", "max_turns": 5, "actor_profile": {"traits": {"personality": "impatient"}, "context": "frequent flyer", "goal": "book cheapest flight"}}',
+        '{"scenario_id": "sim_cancel", "input": "Cancel reservation", "max_turns": 5, "actor_profile": {"traits": {"personality": "polite"}, "context": "first time user", "goal": "get full refund"}}',
       ];
       await writeFile(datasetFile, examples.join('\n') + '\n', 'utf-8');
 


### PR DESCRIPTION
## Summary

The `e2e: dataset lifecycle > deploys a SIMULATED_V1 schema type dataset` test has been failing on `main` because the inline example fixtures omit the required `max_turns` field. CloudFormation rejects the `AWS::BedrockAgentCore::Dataset` resource with:

```
Resource handler returned message:
"Example at index 0 failed schema validation: 'max_turns' must be an integer"
```

This adds `max_turns: 5` to both SIMULATED_V1 examples in `e2e-tests/dataset-lifecycle.test.ts` so the resource passes schema validation and the deploy completes.

Note: `5` is an arbitrary positive integer chosen to satisfy the schema — the failure surfaced no bound information, so any sane integer works.

## Test plan

- [ ] CI E2E suite passes the SIMULATED_V1 case
- [ ] No other dataset-lifecycle tests regress