### PR TITLE
ci: configure git credentials for prerelease CDK clone

### DIFF
--- a/.github/workflows/prerelease-tarball.yml
+++ b/.github/workflows/prerelease-tarball.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   prerelease-tarball:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -23,18 +24,27 @@ jobs:
           node-version: '20.x'
           cache: 'npm'
       - uses: astral-sh/setup-uv@v7
-      - run: npm run bundle
-      - name: Get tarball info
-        id: tarball
-        run: |
-          TARBALL_NAME=$(ls *.tgz | head -1 | xargs basename)
-          echo "name=$TARBALL_NAME" >> $GITHUB_OUTPUT
       - name: Generate GitHub App Token
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: aws
+      - name: Clone CDK repo
+        run: |
+          git clone --depth 1 "https://x-access-token:${CDK_REPO_TOKEN}@github.com/${CDK_REPO}.git" /tmp/cdk-repo
+        env:
+          CDK_REPO_TOKEN: ${{ steps.app-token.outputs.token }}
+          CDK_REPO: ${{ secrets.CDK_REPO_NAME }}
+      - run: npm run bundle
+        env:
+          AGENTCORE_CDK_PATH: /tmp/cdk-repo
+      - name: Get tarball info
+        id: tarball
+        run: |
+          TARBALL_NAME=$(ls *.tgz | head -1 | xargs basename)
+          echo "name=$TARBALL_NAME" >> $GITHUB_OUTPUT
       - name: Create or update prerelease
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Description

Move GitHub App token generation before `npm run bundle` and configure git credentials so the bundle script can clone the private `agentcore-l3-cdk-constructs` repo.

The bundle script runs `git clone https://github.com/aws/agentcore-l3-cdk-constructs.git` which fails without credentials since the repo is private. This uses the same `x-access-token` pattern as the e2e test workflows.

Failed run: https://github.com/aws/agentcore-cli/actions/runs/26293331790

## Related Issue

N/A

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:unit` and `npm run test:integ`
- [ ] I ran `npm run typecheck`
- [ ] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

Workflow-only change — validated YAML syntax. Same `x-access-token` pattern proven in e2e-tests.yml and e2e-tests-full.yml.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.