### PR TITLE
fix: emit telemetry eagerly in dev --logs to avoid SIGINT race

### DIFF
--- a/src/cli/commands/dev/command.tsx
+++ b/src/cli/commands/dev/command.tsx
@@ -381,51 +381,57 @@ export const registerDev = (program: Command) => {
           console.log(`Log: ${logger.getRelativeLogPath()}`);
           console.log(`Press Ctrl+C to stop\n`);
 
-          const devResult = await withCommandRunTelemetry(
-            'dev',
-            {
-              dev_action: 'server' as const,
-              ui_mode: 'terminal' as const,
-              has_stream: false,
-              agent_protocol: standardize(AgentProtocol, (config.protocol ?? 'http').toLowerCase()),
-              invoke_count: 0,
-            },
-            async (): Promise<Result> => {
-              await new Promise<void>((resolve, reject) => {
-                const devCallbacks = {
-                  onLog: (level: string, msg: string) => {
-                    const prefix = level === 'error' ? '❌' : level === 'warn' ? '⚠️' : '→';
-                    console.log(`${prefix} ${msg}`);
-                    logger.log(msg, level === 'error' ? 'error' : 'info');
-                  },
-                  onExit: (code: number | null) => {
-                    console.log(`\nServer exited with code ${code ?? 0}`);
-                    logger.finalize(code === 0);
-                    if (code !== 0 && code !== null) {
-                      reject(new Error(`Server exited with code ${code}`));
-                    } else {
-                      resolve();
-                    }
-                  },
-                };
-
-                const server = createDevServer(config, {
-                  port: actualPort,
-                  envVars: mergedEnvVars,
-                  callbacks: devCallbacks,
-                });
-                server.start().catch(reject);
-
-                process.once('SIGINT', () => {
-                  console.log('\nStopping server...');
-                  collector?.stop();
-                  server.kill();
-                });
+          // Emit telemetry eagerly before the blocking server loop.
+          // The global SIGINT handler calls process.exit(0) synchronously,
+          // which would prevent withCommandRunTelemetry from ever flushing.
+          {
+            const client = await TelemetryClientAccessor.get().catch(() => undefined);
+            if (client) {
+              client.emit('cli.command_run', 0, {
+                command_group: 'dev',
+                command: 'dev',
+                exit_reason: 'success',
+                dev_action: 'server',
+                ui_mode: 'terminal',
+                has_stream: false,
+                agent_protocol: standardize(AgentProtocol, (config.protocol ?? 'http').toLowerCase()),
+                invoke_count: 0,
               });
-              return { success: true as const };
+              await client.flush();
             }
-          );
-          if (!devResult.success) throw devResult.error;
+          }
+
+          await new Promise<void>((resolve, reject) => {
+            const devCallbacks = {
+              onLog: (level: string, msg: string) => {
+                const prefix = level === 'error' ? '❌' : level === 'warn' ? '⚠️' : '→';
+                console.log(`${prefix} ${msg}`);
+                logger.log(msg, level === 'error' ? 'error' : 'info');
+              },
+              onExit: (code: number | null) => {
+                console.log(`\nServer exited with code ${code ?? 0}`);
+                logger.finalize(code === 0);
+                if (code !== 0 && code !== null) {
+                  reject(new Error(`Server exited with code ${code}`));
+                } else {
+                  resolve();
+                }
+              },
+            };
+
+            const server = createDevServer(config, {
+              port: actualPort,
+              envVars: mergedEnvVars,
+              callbacks: devCallbacks,
+            });
+            server.start().catch(reject);
+
+            process.once('SIGINT', () => {
+              console.log('\nStopping server...');
+              collector?.stop();
+              server.kill();
+            });
+          });
           process.exit(0);
         }
 


### PR DESCRIPTION
## Description

`dev --logs` never emits telemetry because the global SIGINT handler in `cli.ts` (`setupGlobalCleanup`) calls `process.exit(0)` synchronously, terminating the process before `withCommandRunTelemetry` can flush. The dev command's own SIGINT handler (registered later) never runs.

This change emits telemetry eagerly before the blocking server loop, matching the existing browser-mode pattern which has the same constraint.

## Related Issue

Closes #

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.