### PR TITLE
fix(telemetry): emit dev command telemetry before blocking

### DIFF
--- a/integ-tests/dev-server.test.ts
+++ b/integ-tests/dev-server.test.ts
@@ -88,7 +88,7 @@ describe('integration: dev server', () => {
   });
 
   it.skipIf(!hasNpm || !hasGit || !hasUv)(
-    'starts dev server and responds to health check',
+    'starts dev server, responds to health check, and emits telemetry',
     async () => {
       expect(projectPath, 'Project should have been created').toBeTruthy();
 
@@ -98,11 +98,20 @@ describe('integration: dev server', () => {
       devProcess = spawn('node', [cliPath, 'dev', '--port', String(port), '--logs'], {
         cwd: projectPath,
         stdio: 'pipe',
-        env: { ...process.env, INIT_CWD: undefined },
+        env: { ...process.env, INIT_CWD: undefined, ...telemetry.env },
       });
 
       const serverReady = await waitForServer(port, 20000);
       expect(serverReady, 'Dev server should respond to ping within 20s').toBeTruthy();
+
+      // Verify telemetry was emitted for the server startup (before blocking)
+      telemetry.assertMetricEmitted({
+        command: 'dev',
+        dev_action: 'server',
+        ui_mode: 'terminal',
+        exit_reason: 'success',
+      });
+      telemetry.clearEntries();
 
       // Invoke the running server and verify telemetry
       const invokeResult = await runCLI(['dev', 'hello', '--port', String(port)], projectPath, {
@@ -134,5 +143,28 @@ describe('integration: dev server', () => {
       devProcess = null;
     },
     30000
+  );
+
+  it.skipIf(!hasNpm || !hasGit || !hasUv)(
+    'exits with error when runtime not found and emits failure telemetry',
+    async () => {
+      expect(projectPath, 'Project should have been created').toBeTruthy();
+
+      telemetry.clearEntries();
+      const result = await runCLI(['dev', '--logs', '--runtime', 'nonexistent-agent'], projectPath, {
+        env: telemetry.env,
+      });
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('nonexistent-agent');
+      expect(result.stderr).toContain('not found');
+
+      telemetry.assertMetricEmitted({
+        command: 'dev',
+        dev_action: 'server',
+        exit_reason: 'failure',
+      });
+    },
+    15000
   );
 });

--- a/src/cli/commands/dev/command.tsx
+++ b/src/cli/commands/dev/command.tsx
@@ -201,7 +201,7 @@ export const registerDev = (program: Command) => {
               dev_action: 'exec' as const,
               ui_mode: 'terminal' as const,
               has_stream: false,
-              agent_protocol: 'http' as const,
+              agent_protocol: standardize(AgentProtocol, 'unknown'),
               invoke_count: 0,
             },
             async () => {
@@ -245,7 +245,7 @@ export const registerDev = (program: Command) => {
               dev_action: 'invoke' as const,
               ui_mode: 'terminal' as const,
               has_stream: opts.stream ?? false,
-              agent_protocol: 'http' as const,
+              agent_protocol: standardize(AgentProtocol, 'unknown'),
               invoke_count: 1,
             },
             async () => {
@@ -311,7 +311,7 @@ export const registerDev = (program: Command) => {
             dev_action: 'server' as const,
             ui_mode: 'terminal' as const,
             has_stream: false,
-            agent_protocol: 'http' as const,
+            agent_protocol: standardize(AgentProtocol, 'unknown'),
             invoke_count: 0,
           },
           async () => {

--- a/src/cli/commands/dev/command.tsx
+++ b/src/cli/commands/dev/command.tsx
@@ -204,7 +204,7 @@ export const registerDev = (program: Command) => {
               agent_protocol: standardize(AgentProtocol, 'unknown'),
               invoke_count: 0,
             },
-            async () => {
+            async recorder => {
               if (!positionalPrompt) {
                 throw new ValidationError('A command is required with --exec. Usage: agentcore dev --exec "whoami"');
               }
@@ -217,18 +217,12 @@ export const registerDev = (program: Command) => {
                   '--exec is only supported for Container build agents. For CodeZip agents, use your terminal to run commands directly.'
                 );
               }
+              recorder.set({
+                agent_protocol: standardize(AgentProtocol, (targetAgent?.protocol ?? 'http').toLowerCase()),
+              });
               const containerName = `agentcore-dev-${agentName}`.toLowerCase();
               await execInContainer(positionalPrompt, containerName);
-              return {
-                success: true as const,
-                _telemetryAttrs: {
-                  dev_action: 'exec' as const,
-                  ui_mode: 'terminal' as const,
-                  has_stream: false,
-                  agent_protocol: standardize(AgentProtocol, (targetAgent?.protocol ?? 'http').toLowerCase()),
-                  invoke_count: 0,
-                },
-              };
+              return { success: true as const };
             }
           );
           // TODO: Remove cast once withCommandRunTelemetry's return type is narrowed
@@ -248,7 +242,7 @@ export const registerDev = (program: Command) => {
               agent_protocol: standardize(AgentProtocol, 'unknown'),
               invoke_count: 1,
             },
-            async () => {
+            async recorder => {
               const workingDir = getWorkingDirectory();
               const invokeProject = await loadProjectConfig(workingDir);
 
@@ -265,6 +259,9 @@ export const registerDev = (program: Command) => {
               }
 
               const protocol = targetAgent?.protocol ?? 'HTTP';
+              recorder.set({
+                agent_protocol: standardize(AgentProtocol, protocol.toLowerCase()),
+              });
 
               if (protocol === 'A2A') invokePort = 9000;
               else if (protocol === 'MCP') invokePort = 8000;
@@ -286,16 +283,7 @@ export const registerDev = (program: Command) => {
                 await invokeDevServer(invokePort, invokePrompt, opts.stream ?? false, headers);
               }
 
-              return {
-                success: true as const,
-                _telemetryAttrs: {
-                  dev_action: 'invoke' as const,
-                  ui_mode: 'terminal' as const,
-                  has_stream: opts.stream ?? false,
-                  agent_protocol: standardize(AgentProtocol, protocol.toLowerCase()),
-                  invoke_count: 1,
-                },
-              };
+              return { success: true as const };
             }
           );
           // TODO: Remove cast once withCommandRunTelemetry's return type is narrowed
@@ -314,7 +302,7 @@ export const registerDev = (program: Command) => {
             agent_protocol: standardize(AgentProtocol, 'unknown'),
             invoke_count: 0,
           },
-          async () => {
+          async recorder => {
             const project = await loadProjectConfig(workingDir);
             if (!project) {
               throw new NoProjectError();
@@ -365,6 +353,10 @@ export const registerDev = (program: Command) => {
               if (!config) {
                 throw new ValidationError('No dev-supported agents found.');
               }
+
+              recorder.set({
+                agent_protocol: standardize(AgentProtocol, config.protocol.toLowerCase()),
+              });
 
               const isA2A = config.protocol === 'A2A';
               const isMcp = config.protocol === 'MCP';
@@ -426,18 +418,11 @@ export const registerDev = (program: Command) => {
                 });
               });
 
-              return {
-                success: true as const,
-                blockingPromise: serverPromise,
-                _telemetryAttrs: {
-                  dev_action: 'server' as const,
-                  ui_mode: 'terminal' as const,
-                  has_stream: false,
-                  agent_protocol: standardize(AgentProtocol, config.protocol.toLowerCase()),
-                  invoke_count: 0,
-                },
-              };
+              return { success: true as const, blockingPromise: serverPromise };
             }
+            recorder.set({
+              agent_protocol: standardize(AgentProtocol, (targetDevAgent?.protocol ?? 'http').toLowerCase()),
+            });
 
             // --no-browser: terminal TUI mode
             if (!opts.browser) {
@@ -471,17 +456,11 @@ export const registerDev = (program: Command) => {
                   exitAltScreen();
                   collector?.stop();
                 }),
-                _telemetryAttrs: {
-                  dev_action: 'server' as const,
-                  ui_mode: 'terminal' as const,
-                  has_stream: false,
-                  agent_protocol: standardize(AgentProtocol, (targetDevAgent?.protocol ?? 'http').toLowerCase()),
-                  invoke_count: 0,
-                },
               };
             }
 
             // Default: browser mode (blocks forever)
+            recorder.set({ ui_mode: 'browser' as const });
             return {
               success: true as const,
               blockingPromise: runBrowserMode({
@@ -492,13 +471,6 @@ export const registerDev = (program: Command) => {
                 otelEnvVars,
                 collector,
               }),
-              _telemetryAttrs: {
-                dev_action: 'server' as const,
-                ui_mode: 'browser' as const,
-                has_stream: false,
-                agent_protocol: standardize(AgentProtocol, (targetDevAgent?.protocol ?? 'http').toLowerCase()),
-                invoke_count: 0,
-              },
             };
           }
         );

--- a/src/cli/commands/dev/command.tsx
+++ b/src/cli/commands/dev/command.tsx
@@ -1,5 +1,6 @@
 import {
   ConnectionError,
+  NoProjectError,
   ResourceNotFoundError,
   type Result,
   ValidationError,
@@ -28,7 +29,6 @@ import { OtelCollector, startOtelCollector } from '../../operations/dev/otel';
 import { withCommandRunTelemetry } from '../../telemetry/cli-command-run.js';
 import { TelemetryClientAccessor } from '../../telemetry/client-accessor.js';
 import { AgentProtocol, standardize } from '../../telemetry/schemas/common-shapes.js';
-import { FatalError } from '../../tui/components';
 import { LayoutProvider } from '../../tui/context';
 import { COMMAND_DESCRIPTIONS } from '../../tui/copy';
 import { requireProject, requireTTY } from '../../tui/guards';
@@ -198,17 +198,16 @@ export const registerDev = (program: Command) => {
         // Exec mode: run shell command in the dev container
         if (opts.exec) {
           if (!positionalPrompt) {
-            console.error('A command is required with --exec. Usage: agentcore dev --exec "whoami"');
-            process.exit(1);
+            throw new ValidationError('A command is required with --exec. Usage: agentcore dev --exec "whoami"');
           }
           const workingDir = getWorkingDirectory();
           const project = await loadProjectConfig(workingDir);
           const agentName = opts.runtime ?? project?.runtimes[0]?.name ?? 'unknown';
           const targetAgent = project?.runtimes.find(a => a.name === agentName);
           if (targetAgent?.build !== 'Container') {
-            console.error('Error: --exec is only supported for Container build agents.');
-            console.error('For CodeZip agents, use your terminal to run commands directly.');
-            process.exit(1);
+            throw new ValidationError(
+              '--exec is only supported for Container build agents. For CodeZip agents, use your terminal to run commands directly.'
+            );
           }
           const containerName = `agentcore-dev-${agentName}`.toLowerCase();
           const execResult = await withCommandRunTelemetry(
@@ -243,9 +242,9 @@ export const registerDev = (program: Command) => {
             targetAgent = invokeProject.runtimes.find(a => a.name === opts.runtime);
           } else if (invokeProject && invokeProject.runtimes.length > 1 && !opts.runtime) {
             const names = invokeProject.runtimes.map(a => a.name).join(', ');
-            console.error(`Error: Multiple runtimes found. Use --runtime to specify which one.`);
-            console.error(`Available: ${names}`);
-            process.exit(1);
+            throw new ValidationError(
+              `Multiple runtimes found. Use --runtime to specify which one. Available: ${names}`
+            );
           }
 
           const protocol = targetAgent?.protocol ?? 'HTTP';
@@ -294,13 +293,11 @@ export const registerDev = (program: Command) => {
         const project = await loadProjectConfig(workingDir);
 
         if (!project) {
-          render(<FatalError message="No agentcore project found." suggestedCommand="agentcore create" />);
-          process.exit(1);
+          throw new NoProjectError();
         }
 
         if (!project.runtimes || project.runtimes.length === 0) {
-          render(<FatalError message="No agents defined in project." suggestedCommand="agentcore add agent" />);
-          process.exit(1);
+          throw new ValidationError('No agents defined in project. Run `agentcore add agent` to fix this.');
         }
 
         // Warn about VPC mode limitations in local dev
@@ -313,8 +310,7 @@ export const registerDev = (program: Command) => {
 
         const supportedAgents = getDevSupportedAgents(project);
         if (supportedAgents.length === 0) {
-          render(<FatalError message="No agents support dev mode. Dev mode requires an agent with an entrypoint." />);
-          process.exit(1);
+          throw new ValidationError('No agents support dev mode. Dev mode requires an agent with an entrypoint.');
         }
 
         // Start local OTEL collector so agent traces are captured in dev mode.
@@ -335,9 +331,9 @@ export const registerDev = (program: Command) => {
           // Require --agent if multiple agents
           if (project.runtimes.length > 1 && !opts.runtime) {
             const names = project.runtimes.map(a => a.name).join(', ');
-            console.error(`Error: Multiple runtimes found. Use --runtime to specify which one.`);
-            console.error(`Available: ${names}`);
-            process.exit(1);
+            throw new ValidationError(
+              `Multiple runtimes found. Use --runtime to specify which one. Available: ${names}`
+            );
           }
 
           const agentName = opts.runtime ?? project.runtimes[0]?.name;
@@ -346,8 +342,7 @@ export const registerDev = (program: Command) => {
           const config = getDevConfig(workingDir, project, configRoot ?? undefined, agentName);
 
           if (!config) {
-            console.error('Error: No dev-supported agents found.');
-            process.exit(1);
+            throw new ValidationError('No dev-supported agents found.');
           }
 
           // Create logger for log file path
@@ -359,8 +354,9 @@ export const registerDev = (program: Command) => {
           const fixedPort = isA2A ? 9000 : isMcp ? 8000 : getAgentPort(project, config.agentName, port);
           const actualPort = await findAvailablePort(fixedPort);
           if ((isA2A || isMcp) && actualPort !== fixedPort) {
-            console.error(`Error: Port ${fixedPort} is in use. ${config.protocol} agents require port ${fixedPort}.`);
-            process.exit(1);
+            throw new ValidationError(
+              `Port ${fixedPort} is in use. ${config.protocol} agents require port ${fixedPort}.`
+            );
           }
           if (actualPort !== fixedPort) {
             console.log(`Port ${fixedPort} in use, using ${actualPort}`);

--- a/src/cli/commands/dev/command.tsx
+++ b/src/cli/commands/dev/command.tsx
@@ -504,7 +504,7 @@ export const registerDev = (program: Command) => {
         );
         // TODO: Remove cast once withCommandRunTelemetry's return type is narrowed
         if (!serverResult.success) throw (serverResult as unknown as { error: Error }).error;
-        if ('blockingPromise' in serverResult) await serverResult.blockingPromise;
+        await serverResult.blockingPromise;
         process.exit(0);
       } catch (error) {
         console.error(`Error: ${getErrorMessage(error)}`);

--- a/src/cli/commands/dev/command.tsx
+++ b/src/cli/commands/dev/command.tsx
@@ -2,7 +2,6 @@ import {
   ConnectionError,
   NoProjectError,
   ResourceNotFoundError,
-  type Result,
   ValidationError,
   findConfigRoot,
   getWorkingDirectory,
@@ -27,11 +26,10 @@ import {
 } from '../../operations/dev';
 import { OtelCollector, startOtelCollector } from '../../operations/dev/otel';
 import { withCommandRunTelemetry } from '../../telemetry/cli-command-run.js';
-import { TelemetryClientAccessor } from '../../telemetry/client-accessor.js';
 import { AgentProtocol, standardize } from '../../telemetry/schemas/common-shapes.js';
 import { LayoutProvider } from '../../tui/context';
 import { COMMAND_DESCRIPTIONS } from '../../tui/copy';
-import { requireProject, requireTTY } from '../../tui/guards';
+import { requireTTY } from '../../tui/guards';
 import { parseHeaderFlags } from '../shared/header-utils';
 import { runBrowserMode } from './browser-mode';
 import type { Command } from '@commander-js/extra-typings';
@@ -197,73 +195,80 @@ export const registerDev = (program: Command) => {
 
         // Exec mode: run shell command in the dev container
         if (opts.exec) {
-          if (!positionalPrompt) {
-            throw new ValidationError('A command is required with --exec. Usage: agentcore dev --exec "whoami"');
-          }
-          const workingDir = getWorkingDirectory();
-          const project = await loadProjectConfig(workingDir);
-          const agentName = opts.runtime ?? project?.runtimes[0]?.name ?? 'unknown';
-          const targetAgent = project?.runtimes.find(a => a.name === agentName);
-          if (targetAgent?.build !== 'Container') {
-            throw new ValidationError(
-              '--exec is only supported for Container build agents. For CodeZip agents, use your terminal to run commands directly.'
-            );
-          }
-          const containerName = `agentcore-dev-${agentName}`.toLowerCase();
           const execResult = await withCommandRunTelemetry(
             'dev',
             {
               dev_action: 'exec' as const,
               ui_mode: 'terminal' as const,
               has_stream: false,
-              agent_protocol: standardize(AgentProtocol, (targetAgent?.protocol ?? 'http').toLowerCase()),
+              agent_protocol: 'http' as const,
               invoke_count: 0,
             },
-            async (): Promise<Result> => {
+            async () => {
+              if (!positionalPrompt) {
+                throw new ValidationError('A command is required with --exec. Usage: agentcore dev --exec "whoami"');
+              }
+              const workingDir = getWorkingDirectory();
+              const project = await loadProjectConfig(workingDir);
+              const agentName = opts.runtime ?? project?.runtimes[0]?.name ?? 'unknown';
+              const targetAgent = project?.runtimes.find(a => a.name === agentName);
+              if (targetAgent?.build !== 'Container') {
+                throw new ValidationError(
+                  '--exec is only supported for Container build agents. For CodeZip agents, use your terminal to run commands directly.'
+                );
+              }
+              const containerName = `agentcore-dev-${agentName}`.toLowerCase();
               await execInContainer(positionalPrompt, containerName);
-              return { success: true };
+              return {
+                success: true as const,
+                _telemetryAttrs: {
+                  dev_action: 'exec' as const,
+                  ui_mode: 'terminal' as const,
+                  has_stream: false,
+                  agent_protocol: standardize(AgentProtocol, (targetAgent?.protocol ?? 'http').toLowerCase()),
+                  invoke_count: 0,
+                },
+              };
             }
           );
-          if (!execResult.success) throw execResult.error;
+          // TODO: Remove cast once withCommandRunTelemetry's return type is narrowed
+          if (!execResult.success) throw (execResult as unknown as { error: Error }).error;
           return;
         }
 
         // If a prompt is provided, invoke a running dev server
         const invokePrompt = positionalPrompt;
         if (invokePrompt !== undefined) {
-          const workingDir = getWorkingDirectory();
-          const invokeProject = await loadProjectConfig(workingDir);
-
-          // Determine which agent/port to invoke
-          let invokePort = port;
-          let targetAgent = invokeProject?.runtimes[0];
-          if (opts.runtime && invokeProject) {
-            invokePort = getAgentPort(invokeProject, opts.runtime, port);
-            targetAgent = invokeProject.runtimes.find(a => a.name === opts.runtime);
-          } else if (invokeProject && invokeProject.runtimes.length > 1 && !opts.runtime) {
-            const names = invokeProject.runtimes.map(a => a.name).join(', ');
-            throw new ValidationError(
-              `Multiple runtimes found. Use --runtime to specify which one. Available: ${names}`
-            );
-          }
-
-          const protocol = targetAgent?.protocol ?? 'HTTP';
-
-          // Override port for protocols with fixed framework ports
-          if (protocol === 'A2A') invokePort = 9000;
-          else if (protocol === 'MCP') invokePort = 8000;
-
           const invokeResult = await withCommandRunTelemetry(
             'dev',
             {
               dev_action: 'invoke' as const,
               ui_mode: 'terminal' as const,
               has_stream: opts.stream ?? false,
-              agent_protocol: standardize(AgentProtocol, protocol.toLowerCase()),
+              agent_protocol: 'http' as const,
               invoke_count: 1,
             },
-            async (): Promise<Result> => {
-              // Protocol-aware dispatch
+            async () => {
+              const workingDir = getWorkingDirectory();
+              const invokeProject = await loadProjectConfig(workingDir);
+
+              let invokePort = port;
+              let targetAgent = invokeProject?.runtimes[0];
+              if (opts.runtime && invokeProject) {
+                invokePort = getAgentPort(invokeProject, opts.runtime, port);
+                targetAgent = invokeProject.runtimes.find(a => a.name === opts.runtime);
+              } else if (invokeProject && invokeProject.runtimes.length > 1 && !opts.runtime) {
+                const names = invokeProject.runtimes.map(a => a.name).join(', ');
+                throw new ValidationError(
+                  `Multiple runtimes found. Use --runtime to specify which one. Available: ${names}`
+                );
+              }
+
+              const protocol = targetAgent?.protocol ?? 'HTTP';
+
+              if (protocol === 'A2A') invokePort = 9000;
+              else if (protocol === 'MCP') invokePort = 8000;
+
               if (protocol === 'MCP') {
                 await handleMcpInvoke(invokePort, invokePrompt, opts.tool, opts.input, headers);
               } else if (protocol === 'A2A') {
@@ -280,114 +285,116 @@ export const registerDev = (program: Command) => {
               } else {
                 await invokeDevServer(invokePort, invokePrompt, opts.stream ?? false, headers);
               }
-              return { success: true };
+
+              return {
+                success: true as const,
+                _telemetryAttrs: {
+                  dev_action: 'invoke' as const,
+                  ui_mode: 'terminal' as const,
+                  has_stream: opts.stream ?? false,
+                  agent_protocol: standardize(AgentProtocol, protocol.toLowerCase()),
+                  invoke_count: 1,
+                },
+              };
             }
           );
-          if (!invokeResult.success) throw invokeResult.error;
+          // TODO: Remove cast once withCommandRunTelemetry's return type is narrowed
+          if (!invokeResult.success) throw (invokeResult as unknown as { error: Error }).error;
           return;
         }
 
-        requireProject();
-
         const workingDir = getWorkingDirectory();
-        const project = await loadProjectConfig(workingDir);
 
-        if (!project) {
-          throw new NoProjectError();
-        }
+        const serverResult = await withCommandRunTelemetry(
+          'dev',
+          {
+            dev_action: 'server' as const,
+            ui_mode: 'terminal' as const,
+            has_stream: false,
+            agent_protocol: 'http' as const,
+            invoke_count: 0,
+          },
+          async () => {
+            const project = await loadProjectConfig(workingDir);
+            if (!project) {
+              throw new NoProjectError();
+            }
+            if (!project.runtimes || project.runtimes.length === 0) {
+              throw new ValidationError('No agents defined in project. Run `agentcore add agent` to fix this.');
+            }
 
-        if (!project.runtimes || project.runtimes.length === 0) {
-          throw new ValidationError('No agents defined in project. Run `agentcore add agent` to fix this.');
-        }
+            const targetDevAgent = opts.runtime
+              ? project.runtimes.find(a => a.name === opts.runtime)
+              : project.runtimes[0];
+            if (targetDevAgent?.networkMode === 'VPC') {
+              console.log(
+                '\x1b[33mWarning: This agent uses VPC network mode. Local dev server runs outside your VPC. Network behavior may differ from deployed environment.\x1b[0m\n'
+              );
+            }
 
-        // Warn about VPC mode limitations in local dev
-        const targetDevAgent = opts.runtime ? project.runtimes.find(a => a.name === opts.runtime) : project.runtimes[0];
-        if (targetDevAgent?.networkMode === 'VPC') {
-          console.log(
-            '\x1b[33mWarning: This agent uses VPC network mode. Local dev server runs outside your VPC. Network behavior may differ from deployed environment.\x1b[0m\n'
-          );
-        }
+            const supportedAgents = getDevSupportedAgents(project);
+            if (supportedAgents.length === 0) {
+              throw new ValidationError('No agents support dev mode. Dev mode requires an agent with an entrypoint.');
+            }
 
-        const supportedAgents = getDevSupportedAgents(project);
-        if (supportedAgents.length === 0) {
-          throw new ValidationError('No agents support dev mode. Dev mode requires an agent with an entrypoint.');
-        }
+            const configRoot = findConfigRoot(workingDir);
+            let otelEnvVars: Record<string, string> = {};
+            let collector: OtelCollector | undefined;
 
-        // Start local OTEL collector so agent traces are captured in dev mode.
-        // Persists traces to .cli/traces/ so they survive dev server restarts.
-        const configRoot = findConfigRoot(workingDir);
-        let otelEnvVars: Record<string, string> = {};
-        let collector: OtelCollector | undefined;
+            if (opts.traces !== false) {
+              const persistTracesDir = path.join(configRoot ?? workingDir, '.cli', 'traces');
+              const otelResult = await startOtelCollector(persistTracesDir);
+              collector = otelResult.collector;
+              otelEnvVars = otelResult.otelEnvVars;
+            }
 
-        if (opts.traces !== false) {
-          const persistTracesDir = path.join(configRoot ?? workingDir, '.cli', 'traces');
-          const otelResult = await startOtelCollector(persistTracesDir);
-          collector = otelResult.collector;
-          otelEnvVars = otelResult.otelEnvVars;
-        }
+            // --logs: non-interactive server mode
+            if (opts.logs) {
+              if (project.runtimes.length > 1 && !opts.runtime) {
+                const names = project.runtimes.map(a => a.name).join(', ');
+                throw new ValidationError(
+                  `Multiple runtimes found. Use --runtime to specify which one. Available: ${names}`
+                );
+              }
 
-        // If --logs provided, run non-interactive mode
-        if (opts.logs) {
-          // Require --agent if multiple agents
-          if (project.runtimes.length > 1 && !opts.runtime) {
-            const names = project.runtimes.map(a => a.name).join(', ');
-            throw new ValidationError(
-              `Multiple runtimes found. Use --runtime to specify which one. Available: ${names}`
-            );
-          }
+              const agentName = opts.runtime ?? project.runtimes[0]?.name;
+              const { envVars } = await loadDevEnv(workingDir);
+              const mergedEnvVars = { ...envVars, ...otelEnvVars };
+              const config = getDevConfig(workingDir, project, configRoot ?? undefined, agentName);
 
-          const agentName = opts.runtime ?? project.runtimes[0]?.name;
-          const { envVars } = await loadDevEnv(workingDir);
-          const mergedEnvVars = { ...envVars, ...otelEnvVars };
-          const config = getDevConfig(workingDir, project, configRoot ?? undefined, agentName);
+              if (!config) {
+                throw new ValidationError('No dev-supported agents found.');
+              }
 
-          if (!config) {
-            throw new ValidationError('No dev-supported agents found.');
-          }
+              const isA2A = config.protocol === 'A2A';
+              const isMcp = config.protocol === 'MCP';
+              const fixedPort = isA2A ? 9000 : isMcp ? 8000 : getAgentPort(project, config.agentName, port);
+              const actualPort = await findAvailablePort(fixedPort);
+              if ((isA2A || isMcp) && actualPort !== fixedPort) {
+                throw new ValidationError(
+                  `Port ${fixedPort} is in use. ${config.protocol} agents require port ${fixedPort}.`
+                );
+              }
 
-          // Create logger for log file path
-          const logger = new ExecLogger({ command: 'dev' });
+              const logger = new ExecLogger({ command: 'dev' });
 
-          // Calculate port: A2A/MCP use fixed framework ports, HTTP uses configurable port
-          const isA2A = config.protocol === 'A2A';
-          const isMcp = config.protocol === 'MCP';
-          const fixedPort = isA2A ? 9000 : isMcp ? 8000 : getAgentPort(project, config.agentName, port);
-          const actualPort = await findAvailablePort(fixedPort);
-          if ((isA2A || isMcp) && actualPort !== fixedPort) {
-            throw new ValidationError(
-              `Port ${fixedPort} is in use. ${config.protocol} agents require port ${fixedPort}.`
-            );
-          }
-          if (actualPort !== fixedPort) {
-            console.log(`Port ${fixedPort} in use, using ${actualPort}`);
-          }
+              if (actualPort !== fixedPort) {
+                console.log(`Port ${fixedPort} in use, using ${actualPort}`);
+              }
 
-          // Get provider info from agent config
-          const providerInfo = '(see agent code)';
+              console.log(`Starting dev server...`);
+              console.log(`Agent: ${config.agentName}`);
+              if (config.protocol !== 'MCP') {
+                console.log(`Provider: (see agent code)`);
+              }
+              if (config.protocol !== 'HTTP') {
+                console.log(`Protocol: ${config.protocol}`);
+              }
+              console.log(`Server: ${getEndpointUrl(actualPort, config.protocol)}`);
+              console.log(`Log: ${logger.getRelativeLogPath()}`);
+              console.log(`Press Ctrl+C to stop\n`);
 
-          console.log(`Starting dev server...`);
-          console.log(`Agent: ${config.agentName}`);
-          if (config.protocol !== 'MCP') {
-            console.log(`Provider: ${providerInfo}`);
-          }
-          if (config.protocol !== 'HTTP') {
-            console.log(`Protocol: ${config.protocol}`);
-          }
-          console.log(`Server: ${getEndpointUrl(actualPort, config.protocol)}`);
-          console.log(`Log: ${logger.getRelativeLogPath()}`);
-          console.log(`Press Ctrl+C to stop\n`);
-
-          const devResult = await withCommandRunTelemetry(
-            'dev',
-            {
-              dev_action: 'server' as const,
-              ui_mode: 'terminal' as const,
-              has_stream: false,
-              agent_protocol: standardize(AgentProtocol, (config.protocol ?? 'http').toLowerCase()),
-              invoke_count: 0,
-            },
-            async (): Promise<Result> => {
-              await new Promise<void>((resolve, reject) => {
+              const serverPromise = new Promise<void>((resolve, reject) => {
                 const devCallbacks = {
                   onLog: (level: string, msg: string) => {
                     const prefix = level === 'error' ? '❌' : level === 'warn' ? '⚠️' : '→';
@@ -418,34 +425,30 @@ export const registerDev = (program: Command) => {
                   server.kill();
                 });
               });
-              return { success: true as const };
+
+              return {
+                success: true as const,
+                blockingPromise: serverPromise,
+                _telemetryAttrs: {
+                  dev_action: 'server' as const,
+                  ui_mode: 'terminal' as const,
+                  has_stream: false,
+                  agent_protocol: standardize(AgentProtocol, config.protocol.toLowerCase()),
+                  invoke_count: 0,
+                },
+              };
             }
-          );
-          if (!devResult.success) throw devResult.error;
-          process.exit(0);
-        }
 
-        // If --no-browser provided, launch terminal TUI mode
-        if (!opts.browser) {
-          requireTTY();
-          // Enter alternate screen buffer for fullscreen mode
-          process.stdout.write(ENTER_ALT_SCREEN);
+            // --no-browser: terminal TUI mode
+            if (!opts.browser) {
+              requireTTY();
+              process.stdout.write(ENTER_ALT_SCREEN);
 
-          const exitAltScreen = () => {
-            process.stdout.write(EXIT_ALT_SCREEN);
-            process.stdout.write(SHOW_CURSOR);
-          };
+              const exitAltScreen = () => {
+                process.stdout.write(EXIT_ALT_SCREEN);
+                process.stdout.write(SHOW_CURSOR);
+              };
 
-          const tuiResult = await withCommandRunTelemetry(
-            'dev',
-            {
-              dev_action: 'server' as const,
-              ui_mode: 'terminal' as const,
-              has_stream: false,
-              agent_protocol: standardize(AgentProtocol, (targetDevAgent?.protocol ?? 'http').toLowerCase()),
-              invoke_count: 0,
-            },
-            async (): Promise<Result> => {
               const { DevScreen } = await import('../../tui/screens/dev/DevScreen');
               const { unmount, waitUntilExit } = render(
                 <LayoutProvider>
@@ -462,44 +465,47 @@ export const registerDev = (program: Command) => {
                 </LayoutProvider>
               );
 
-              await waitUntilExit();
-              exitAltScreen();
-              return { success: true };
+              return {
+                success: true as const,
+                blockingPromise: waitUntilExit().finally(() => {
+                  exitAltScreen();
+                  collector?.stop();
+                }),
+                _telemetryAttrs: {
+                  dev_action: 'server' as const,
+                  ui_mode: 'terminal' as const,
+                  has_stream: false,
+                  agent_protocol: standardize(AgentProtocol, (targetDevAgent?.protocol ?? 'http').toLowerCase()),
+                  invoke_count: 0,
+                },
+              };
             }
-          );
-          if (!tuiResult.success) throw tuiResult.error;
-          collector?.stop();
-          process.exit(0);
-        }
 
-        // Default: launch web UI in browser
-        // NOTE: Do not copy this pattern. runBrowserMode blocks forever (internal
-        // await new Promise(() => {})) so we cannot use withCommandRunTelemetry here.
-        // We emit telemetry eagerly before the blocking call.
-        {
-          const client = await TelemetryClientAccessor.get().catch(() => undefined);
-          if (client) {
-            client.emit('cli.command_run', 0, {
-              command_group: 'dev',
-              command: 'dev',
-              exit_reason: 'success',
-              dev_action: 'server',
-              ui_mode: 'browser',
-              has_stream: false,
-              agent_protocol: standardize(AgentProtocol, (targetDevAgent?.protocol ?? 'http').toLowerCase()),
-              invoke_count: 0,
-            });
-            await client.flush();
+            // Default: browser mode (blocks forever)
+            return {
+              success: true as const,
+              blockingPromise: runBrowserMode({
+                workingDir,
+                project,
+                port,
+                agentName: opts.runtime,
+                otelEnvVars,
+                collector,
+              }),
+              _telemetryAttrs: {
+                dev_action: 'server' as const,
+                ui_mode: 'browser' as const,
+                has_stream: false,
+                agent_protocol: standardize(AgentProtocol, (targetDevAgent?.protocol ?? 'http').toLowerCase()),
+                invoke_count: 0,
+              },
+            };
           }
-          await runBrowserMode({
-            workingDir,
-            project,
-            port,
-            agentName: opts.runtime,
-            otelEnvVars,
-            collector,
-          });
-        }
+        );
+        // TODO: Remove cast once withCommandRunTelemetry's return type is narrowed
+        if (!serverResult.success) throw (serverResult as unknown as { error: Error }).error;
+        if ('blockingPromise' in serverResult) await serverResult.blockingPromise;
+        process.exit(0);
       } catch (error) {
         console.error(`Error: ${getErrorMessage(error)}`);
         process.exit(1);

--- a/src/cli/telemetry/__tests__/client.test.ts
+++ b/src/cli/telemetry/__tests__/client.test.ts
@@ -167,8 +167,8 @@ describe('withCommandRunTelemetry', () => {
     });
   });
 
-  describe('_telemetryAttrs', () => {
-    it('returned _telemetryAttrs override upfront attrs on success', async () => {
+  describe('AttributeRecorder', () => {
+    it('recorder.set() overrides initial attributes on success', async () => {
       await withCommandRunTelemetry(
         'dev',
         {
@@ -178,16 +178,16 @@ describe('withCommandRunTelemetry', () => {
           agent_protocol: 'http',
           invoke_count: 0,
         },
-        async () => ({
-          success: true as const,
-          _telemetryAttrs: {
+        async recorder => {
+          recorder.set({
             dev_action: 'invoke',
             ui_mode: 'browser',
             has_stream: true,
             agent_protocol: 'a2a',
             invoke_count: 5,
-          } as const,
-        })
+          });
+          return { success: true as const };
+        }
       );
 
       expect(sink.metrics).toHaveLength(1);
@@ -200,7 +200,7 @@ describe('withCommandRunTelemetry', () => {
       });
     });
 
-    it('returned _telemetryAttrs override upfront attrs on failure result', async () => {
+    it('recorder.set() overrides initial attributes on failure result', async () => {
       await withCommandRunTelemetry(
         'dev',
         {
@@ -210,17 +210,12 @@ describe('withCommandRunTelemetry', () => {
           agent_protocol: 'http',
           invoke_count: 0,
         },
-        async () => ({
-          success: false as const,
-          error: new Error('port in use'),
-          _telemetryAttrs: {
-            dev_action: 'server',
-            ui_mode: 'terminal',
-            has_stream: false,
+        async recorder => {
+          recorder.set({
             agent_protocol: 'mcp',
-            invoke_count: 0,
-          } as const,
-        })
+          });
+          return { success: false as const, error: new Error('port in use') };
+        }
       );
 
       expect(sink.metrics).toHaveLength(1);
@@ -230,7 +225,7 @@ describe('withCommandRunTelemetry', () => {
       });
     });
 
-    it('falls back to upfront attrs when _telemetryAttrs is not returned', async () => {
+    it('uses initial attributes when recorder.set() is never called', async () => {
       await withCommandRunTelemetry(
         'dev',
         {
@@ -250,32 +245,7 @@ describe('withCommandRunTelemetry', () => {
       });
     });
 
-    it('does not leak _telemetryAttrs to the caller', async () => {
-      const result = await withCommandRunTelemetry(
-        'dev',
-        {
-          dev_action: 'server',
-          ui_mode: 'terminal',
-          has_stream: false,
-          agent_protocol: 'http',
-          invoke_count: 0,
-        },
-        async () => ({
-          success: true as const,
-          _telemetryAttrs: {
-            dev_action: 'server',
-            ui_mode: 'terminal',
-            has_stream: false,
-            agent_protocol: 'mcp',
-            invoke_count: 0,
-          } as const,
-        })
-      );
-
-      expect('_telemetryAttrs' in result).toBe(false);
-    });
-
-    it('partially returned _telemetryAttrs merge with upfront attrs preserving non-overlapping keys', async () => {
+    it('partial recorder.set() merges with initial attributes preserving non-overlapping keys', async () => {
       await withCommandRunTelemetry(
         'dev',
         {
@@ -285,12 +255,12 @@ describe('withCommandRunTelemetry', () => {
           agent_protocol: 'http',
           invoke_count: 0,
         },
-        async () => ({
-          success: true as const,
-          _telemetryAttrs: {
+        async recorder => {
+          recorder.set({
             agent_protocol: 'mcp',
-          } as const,
-        })
+          });
+          return { success: true as const };
+        }
       );
 
       expect(sink.metrics).toHaveLength(1);
@@ -300,6 +270,29 @@ describe('withCommandRunTelemetry', () => {
         has_stream: 'false',
         agent_protocol: 'mcp',
         invoke_count: 0,
+      });
+    });
+
+    it('recorder.set() called before throw is preserved in telemetry', async () => {
+      await withCommandRunTelemetry(
+        'dev',
+        {
+          dev_action: 'server',
+          ui_mode: 'terminal',
+          has_stream: false,
+          agent_protocol: 'http',
+          invoke_count: 0,
+        },
+        async recorder => {
+          recorder.set({ agent_protocol: 'a2a' });
+          throw new Error('crash');
+        }
+      );
+
+      expect(sink.metrics).toHaveLength(1);
+      expect(sink.metrics[0]!.attrs).toMatchObject({
+        exit_reason: 'failure',
+        agent_protocol: 'a2a',
       });
     });
   });

--- a/src/cli/telemetry/__tests__/client.test.ts
+++ b/src/cli/telemetry/__tests__/client.test.ts
@@ -186,7 +186,7 @@ describe('withCommandRunTelemetry', () => {
             has_stream: true,
             agent_protocol: 'a2a',
             invoke_count: 5,
-          },
+          } as const,
         })
       );
 
@@ -219,7 +219,7 @@ describe('withCommandRunTelemetry', () => {
             has_stream: false,
             agent_protocol: 'mcp',
             invoke_count: 0,
-          },
+          } as const,
         })
       );
 
@@ -268,11 +268,39 @@ describe('withCommandRunTelemetry', () => {
             has_stream: false,
             agent_protocol: 'mcp',
             invoke_count: 0,
-          },
+          } as const,
         })
       );
 
       expect('_telemetryAttrs' in result).toBe(false);
+    });
+
+    it('partially returned _telemetryAttrs merge with upfront attrs preserving non-overlapping keys', async () => {
+      await withCommandRunTelemetry(
+        'dev',
+        {
+          dev_action: 'server',
+          ui_mode: 'terminal',
+          has_stream: false,
+          agent_protocol: 'http',
+          invoke_count: 0,
+        },
+        async () => ({
+          success: true as const,
+          _telemetryAttrs: {
+            agent_protocol: 'mcp',
+          } as const,
+        })
+      );
+
+      expect(sink.metrics).toHaveLength(1);
+      expect(sink.metrics[0]!.attrs).toMatchObject({
+        dev_action: 'server',
+        ui_mode: 'terminal',
+        has_stream: 'false',
+        agent_protocol: 'mcp',
+        invoke_count: 0,
+      });
     });
   });
 });

--- a/src/cli/telemetry/__tests__/client.test.ts
+++ b/src/cli/telemetry/__tests__/client.test.ts
@@ -166,4 +166,113 @@ describe('withCommandRunTelemetry', () => {
       error_name: 'UnknownError',
     });
   });
+
+  describe('_telemetryAttrs', () => {
+    it('returned _telemetryAttrs override upfront attrs on success', async () => {
+      await withCommandRunTelemetry(
+        'dev',
+        {
+          dev_action: 'server',
+          ui_mode: 'terminal',
+          has_stream: false,
+          agent_protocol: 'http',
+          invoke_count: 0,
+        },
+        async () => ({
+          success: true as const,
+          _telemetryAttrs: {
+            dev_action: 'invoke',
+            ui_mode: 'browser',
+            has_stream: true,
+            agent_protocol: 'a2a',
+            invoke_count: 5,
+          },
+        })
+      );
+
+      expect(sink.metrics).toHaveLength(1);
+      expect(sink.metrics[0]!.attrs).toMatchObject({
+        dev_action: 'invoke',
+        ui_mode: 'browser',
+        has_stream: 'true',
+        agent_protocol: 'a2a',
+        invoke_count: 5,
+      });
+    });
+
+    it('returned _telemetryAttrs override upfront attrs on failure result', async () => {
+      await withCommandRunTelemetry(
+        'dev',
+        {
+          dev_action: 'server',
+          ui_mode: 'terminal',
+          has_stream: false,
+          agent_protocol: 'http',
+          invoke_count: 0,
+        },
+        async () => ({
+          success: false as const,
+          error: new Error('port in use'),
+          _telemetryAttrs: {
+            dev_action: 'server',
+            ui_mode: 'terminal',
+            has_stream: false,
+            agent_protocol: 'mcp',
+            invoke_count: 0,
+          },
+        })
+      );
+
+      expect(sink.metrics).toHaveLength(1);
+      expect(sink.metrics[0]!.attrs).toMatchObject({
+        exit_reason: 'failure',
+        agent_protocol: 'mcp',
+      });
+    });
+
+    it('falls back to upfront attrs when _telemetryAttrs is not returned', async () => {
+      await withCommandRunTelemetry(
+        'dev',
+        {
+          dev_action: 'server',
+          ui_mode: 'terminal',
+          has_stream: false,
+          agent_protocol: 'http',
+          invoke_count: 0,
+        },
+        async () => ({ success: true as const })
+      );
+
+      expect(sink.metrics).toHaveLength(1);
+      expect(sink.metrics[0]!.attrs).toMatchObject({
+        agent_protocol: 'http',
+        dev_action: 'server',
+      });
+    });
+
+    it('does not leak _telemetryAttrs to the caller', async () => {
+      const result = await withCommandRunTelemetry(
+        'dev',
+        {
+          dev_action: 'server',
+          ui_mode: 'terminal',
+          has_stream: false,
+          agent_protocol: 'http',
+          invoke_count: 0,
+        },
+        async () => ({
+          success: true as const,
+          _telemetryAttrs: {
+            dev_action: 'server',
+            ui_mode: 'terminal',
+            has_stream: false,
+            agent_protocol: 'mcp',
+            invoke_count: 0,
+          },
+        })
+      );
+
+      expect('_telemetryAttrs' in result).toBe(false);
+    });
+  });
 });

--- a/src/cli/telemetry/attribute-recorder.ts
+++ b/src/cli/telemetry/attribute-recorder.ts
@@ -1,0 +1,16 @@
+export interface AttributeRecorder<T extends Record<string, unknown>> {
+  set<K extends keyof T>(attrs: Pick<T, K>): void;
+  get(): Partial<T>;
+}
+
+export function createAttributeRecorder<T extends Record<string, unknown>>(): AttributeRecorder<T> {
+  let recorded: Partial<T> = {};
+  return {
+    set<K extends keyof T>(attrs: Pick<T, K>) {
+      recorded = { ...recorded, ...attrs };
+    },
+    get() {
+      return recorded;
+    },
+  };
+}

--- a/src/cli/telemetry/cli-command-run.ts
+++ b/src/cli/telemetry/cli-command-run.ts
@@ -86,7 +86,9 @@ async function trackCommandRun<C extends Command>(
 export async function withCommandRunTelemetry<C extends Command, R extends Result>(
   command: C,
   attrs: CommandAttrs<C>,
-  fn: () => (R & { _telemetryAttrs?: CommandAttrs<C> }) | Promise<R & { _telemetryAttrs?: CommandAttrs<C> }>
+  fn: () =>
+    | (R & { _telemetryAttrs?: Partial<CommandAttrs<C>> })
+    | Promise<R & { _telemetryAttrs?: Partial<CommandAttrs<C>> }>
 ): Promise<R> {
   const client = await getTelemetryClient();
   const start = performance.now();
@@ -97,7 +99,13 @@ export async function withCommandRunTelemetry<C extends Command, R extends Resul
       const durationMs = Math.round(performance.now() - start);
       if (!result.success) {
         const { category, source } = classifyError(result.error);
-        recordCommandRun(client, command, { exit_reason: 'failure', error_name: category, error_source: source }, merged, durationMs);
+        recordCommandRun(
+          client,
+          command,
+          { exit_reason: 'failure', error_name: category, error_source: source },
+          merged,
+          durationMs
+        );
       } else {
         recordCommandRun(client, command, { exit_reason: 'success' }, merged, durationMs);
       }
@@ -107,7 +115,13 @@ export async function withCommandRunTelemetry<C extends Command, R extends Resul
   } catch (e) {
     if (client) {
       const { category, source } = classifyError(e);
-      recordCommandRun(client, command, { exit_reason: 'failure', error_name: category, error_source: source }, attrs, Math.round(performance.now() - start));
+      recordCommandRun(
+        client,
+        command,
+        { exit_reason: 'failure', error_name: category, error_source: source },
+        attrs,
+        Math.round(performance.now() - start)
+      );
     }
     return { success: false, error: e instanceof Error ? e : new Error(getErrorMessage(e)) } as R;
   } finally {

--- a/src/cli/telemetry/cli-command-run.ts
+++ b/src/cli/telemetry/cli-command-run.ts
@@ -78,37 +78,41 @@ async function trackCommandRun<C extends Command>(
  * is returned to the caller. If the callback throws, telemetry is recorded and
  * the exception is converted to a result type such that callers do not need to handle result + try/catch.
  * If telemetry is unavailable, the callback runs untracked.
+ *
+ * The callback may return `_telemetryAttrs` to override or supplement the upfront `attrs`.
+ * Returned attrs are merged with the upfront attrs (returned takes priority).
+ * On throw, only the upfront attrs are used since the callback never produced a value.
  */
 export async function withCommandRunTelemetry<C extends Command, R extends Result>(
   command: C,
   attrs: CommandAttrs<C>,
-  fn: () => R | Promise<R>
+  fn: () => (R & { _telemetryAttrs?: CommandAttrs<C> }) | Promise<R & { _telemetryAttrs?: CommandAttrs<C> }>
 ): Promise<R> {
   const client = await getTelemetryClient();
-
-  let result: R | undefined;
+  const start = performance.now();
   try {
-    if (!client) return fn();
-    await trackCommandRun(
-      client,
-      command,
-      async () => {
-        result = await fn();
-        if (!result.success) throw result.error;
-        return attrs;
-      },
-      attrs
-    );
-  } catch (e) {
-    // trackCommandRun re-throws after recording failure telemetry.
-    // If result was set, fn() returned a failure result — return it directly.
-    // If not, fn() itself threw — convert to a failure result so callers
-    // that don't wrap in try/catch (e.g. TUI hooks) don't leak unhandled rejections.
-    if (!result) {
-      return { success: false, error: e instanceof Error ? e : new Error(getErrorMessage(e)) } as R;
+    const result = await fn();
+    if (client) {
+      const merged = result._telemetryAttrs ? { ...attrs, ...result._telemetryAttrs } : attrs;
+      const durationMs = Math.round(performance.now() - start);
+      if (!result.success) {
+        const { category, source } = classifyError(result.error);
+        recordCommandRun(client, command, { exit_reason: 'failure', error_name: category, error_source: source }, merged, durationMs);
+      } else {
+        recordCommandRun(client, command, { exit_reason: 'success' }, merged, durationMs);
+      }
     }
+    const { _telemetryAttrs, ...cleanResult } = result;
+    return cleanResult as R;
+  } catch (e) {
+    if (client) {
+      const { category, source } = classifyError(e);
+      recordCommandRun(client, command, { exit_reason: 'failure', error_name: category, error_source: source }, attrs, Math.round(performance.now() - start));
+    }
+    return { success: false, error: e instanceof Error ? e : new Error(getErrorMessage(e)) } as R;
+  } finally {
+    await client?.flush();
   }
-  return result!;
 }
 
 /**

--- a/src/cli/telemetry/cli-command-run.ts
+++ b/src/cli/telemetry/cli-command-run.ts
@@ -1,11 +1,14 @@
 import type { Result } from '../../lib/result';
 import { getErrorMessage } from '../errors';
+import { type AttributeRecorder, createAttributeRecorder } from './attribute-recorder.js';
 import { TelemetryClientAccessor } from './client-accessor.js';
 import { TelemetryClient } from './client.js';
 import { classifyError } from './error.js';
 import { COMMAND_SCHEMAS, type Command, type CommandAttrs, deriveCommandGroup } from './schemas/command-run.js';
 import { type CommandResult, CommandResultSchema, resilientParse } from './schemas/common-shapes.js';
 import { performance } from 'perf_hooks';
+
+export type { AttributeRecorder } from './attribute-recorder.js';
 
 async function getTelemetryClient() {
   try {
@@ -79,23 +82,22 @@ async function trackCommandRun<C extends Command>(
  * the exception is converted to a result type such that callers do not need to handle result + try/catch.
  * If telemetry is unavailable, the callback runs untracked.
  *
- * The callback may return `_telemetryAttrs` to override or supplement the upfront `attrs`.
- * Returned attrs are merged with the upfront attrs (returned takes priority).
- * On throw, only the upfront attrs are used since the callback never produced a value.
+ * The callback receives an AttributeRecorder to dynamically set or override attributes.
+ * Initial attributes are seeded into the recorder; the callback may call recorder.set()
+ * to override or supplement them at any point during execution.
  */
 export async function withCommandRunTelemetry<C extends Command, R extends Result>(
   command: C,
-  attrs: CommandAttrs<C>,
-  fn: () =>
-    | (R & { _telemetryAttrs?: Partial<CommandAttrs<C>> })
-    | Promise<R & { _telemetryAttrs?: Partial<CommandAttrs<C>> }>
+  attributes: CommandAttrs<C>,
+  fn: (recorder: AttributeRecorder<CommandAttrs<C>>) => R | Promise<R>
 ): Promise<R> {
   const client = await getTelemetryClient();
+  const recorder = createAttributeRecorder<CommandAttrs<C>>();
+  recorder.set(attributes);
   const start = performance.now();
   try {
-    const result = await fn();
+    const result = await fn(recorder);
     if (client) {
-      const merged = result._telemetryAttrs ? { ...attrs, ...result._telemetryAttrs } : attrs;
       const durationMs = Math.round(performance.now() - start);
       if (!result.success) {
         const { category, source } = classifyError(result.error);
@@ -103,15 +105,14 @@ export async function withCommandRunTelemetry<C extends Command, R extends Resul
           client,
           command,
           { exit_reason: 'failure', error_name: category, error_source: source },
-          merged,
+          recorder.get(),
           durationMs
         );
       } else {
-        recordCommandRun(client, command, { exit_reason: 'success' }, merged, durationMs);
+        recordCommandRun(client, command, { exit_reason: 'success' }, recorder.get(), durationMs);
       }
     }
-    const { _telemetryAttrs, ...cleanResult } = result;
-    return cleanResult as R;
+    return result;
   } catch (e) {
     if (client) {
       const { category, source } = classifyError(e);
@@ -119,7 +120,7 @@ export async function withCommandRunTelemetry<C extends Command, R extends Resul
         client,
         command,
         { exit_reason: 'failure', error_name: category, error_source: source },
-        attrs,
+        recorder.get(),
         Math.round(performance.now() - start)
       );
     }


### PR DESCRIPTION
## Description

The `dev` command had two telemetry gaps:

1. **Blocking paths never flushed telemetry.** `dev --logs` and browser mode block forever. The process is killed before `withCommandRunTelemetry` can flush. The workaround was eager `client.emit()` calls that always reported `exit_reason: success`, but this is not ideal. 

2. **Validation failures were invisible.** Errors like "agent not found", "port in use", or "no project" happened outside `withCommandRunTelemetry`, so no failure metric was emitted.

This PR fixes both by:
- Adding `_telemetryAttrs` support to `withCommandRunTelemetry` (callback can return dynamic attrs that merge with fallback)
- Converting validation errors from `process.exit(1)` to thrown errors
- Wrapping all dev server logic in a single `withCommandRunTelemetry` where blocking promises are started (not awaited) inside the callback and awaited after telemetry flushes

## Related Issue

Closes #

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

Additional testing:
- Added integration tests verifying server startup emits success telemetry and validation failure emits failure telemetry
- Added unit tests for `_telemetryAttrs` merge behavior
- Manually verified all 7 dev command flows with `AGENTCORE_TELEMETRY_AUDIT=1`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.