### PR TITLE
feat(scripts): extend bundle to support injectable output and version suffix

### DIFF
--- a/.github/workflows/prerelease-tarball.yml
+++ b/.github/workflows/prerelease-tarball.yml
@@ -17,6 +17,8 @@ jobs:
   prerelease-tarball:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      TARBALL_BASE: agentcore-cli-prerelease
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -37,23 +39,23 @@ jobs:
         env:
           CDK_REPO_TOKEN: ${{ steps.app-token.outputs.token }}
           CDK_REPO: ${{ secrets.CDK_REPO_NAME }}
+      - name: Compute version suffix
+        id: version
+        run: |
+          CLI_SHA=$(git rev-parse --short=5 HEAD)
+          CDK_SHA=$(git -C /tmp/cdk-repo rev-parse --short=5 HEAD)
+          SUFFIX="${CLI_SHA}-${CDK_SHA}"
+          echo "suffix=$SUFFIX" >> $GITHUB_OUTPUT
+          echo "Version suffix: $SUFFIX"
       - run: npm run bundle
         env:
           AGENTCORE_CDK_PATH: /tmp/cdk-repo
-      - name: Get tarball info
-        id: tarball
-        run: |
-          GA_TARBALL=$(ls *-[0-9]*[0-9].tgz 2>/dev/null | grep -v preview | head -1 | xargs basename)
-          PREVIEW_TARBALL=$(ls *preview*.tgz | head -1 | xargs basename)
-          echo "ga_name=$GA_TARBALL" >> $GITHUB_OUTPUT
-          echo "preview_name=$PREVIEW_TARBALL" >> $GITHUB_OUTPUT
-          echo "GA tarball: $GA_TARBALL"
-          echo "Preview tarball: $PREVIEW_TARBALL"
+          AGENTCORE_TARBALL_OUTPUT: ${{ env.TARBALL_BASE }}
+          AGENTCORE_TARBALL_VERSION_SUFFIX: ${{ steps.version.outputs.suffix }}
       - name: Create or update prerelease
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          GA_TARBALL: ${{ steps.tarball.outputs.ga_name }}
-          PREVIEW_TARBALL: ${{ steps.tarball.outputs.preview_name }}
+          VERSION_SUFFIX: ${{ steps.version.outputs.suffix }}
         run: |
           TAG="prerelease"
 
@@ -62,19 +64,21 @@ jobs:
 
           # Create a new pre-release with both tarballs
           gh release create "$TAG" \
-            "${GA_TARBALL}" \
-            "${PREVIEW_TARBALL}" \
+            "${TARBALL_BASE}.tgz" \
+            "${TARBALL_BASE}-preview.tgz" \
             --title "Prerelease" \
             --notes "Auto-generated tarballs from the latest commit on main.
 
+          Version: \`${VERSION_SUFFIX}\` (cli-cdk)
+
           **GA build** (no harness features):
           \`\`\`
-          npm install -g https://github.com/aws/agentcore-cli/releases/download/prerelease/${GA_TARBALL}
+          npm install -g https://github.com/aws/agentcore-cli/releases/download/prerelease/${TARBALL_BASE}.tgz
           \`\`\`
 
           **Preview build** (harness features enabled):
           \`\`\`
-          npm install -g https://github.com/aws/agentcore-cli/releases/download/prerelease/${PREVIEW_TARBALL}
+          npm install -g https://github.com/aws/agentcore-cli/releases/download/prerelease/${TARBALL_BASE}-preview.tgz
           \`\`\`" \
             --prerelease \
             --target "${{ github.sha }}"

--- a/scripts/bundle.mjs
+++ b/scripts/bundle.mjs
@@ -14,7 +14,12 @@
  *   npm run bundle
  *
  * Environment variables:
- *   AGENTCORE_CDK_PATH — absolute path to the agentcore-l3-cdk-constructs repo
+ *   AGENTCORE_CDK_PATH              — path to the agentcore-l3-cdk-constructs repo.
+ *                                     Falls back to ../agentcore-l3-cdk-constructs, then clones from GitHub.
+ *   AGENTCORE_TARBALL_OUTPUT        — output path (without .tgz) for the GA tarball.
+ *                                     Preview tarball gets '-preview' appended. Relative to cwd.
+ *   AGENTCORE_TARBALL_VERSION_SUFFIX — version prerelease suffix (e.g. "abc12-def34").
+ *                                     Defaults to a timestamp if not set.
  */
 import { execFileSync } from 'node:child_process';
 import * as fs from 'node:fs';
@@ -83,7 +88,12 @@ log('Starting bundle process...');
 
 const now = new Date();
 const timestamp = now.toISOString().replace(/[-:T]/g, '').slice(0, 14);
-log(`Bundle timestamp: ${timestamp}`);
+const versionSuffix = process.env.AGENTCORE_TARBALL_VERSION_SUFFIX || timestamp;
+if (!/^[\w.-]+$/.test(versionSuffix)) {
+  console.error(`ERROR: Invalid version suffix: ${versionSuffix}`);
+  process.exit(1);
+}
+log(`Bundle version suffix: ${versionSuffix}`);
 
 // Helper to bump a package version with a unique e2e timestamp tag.
 // Saves the original version so it can be restored after packing.
@@ -93,7 +103,7 @@ function bumpVersion(pkgDir) {
   const originalVersion = pkg.version;
   const baseVersion = originalVersion.split('-')[0];
   const prerelease = originalVersion.includes('-') ? originalVersion.split('-').slice(1).join('-') : '';
-  const tag = prerelease ? `${prerelease}-${timestamp}` : timestamp;
+  const tag = prerelease ? `${prerelease}-${versionSuffix}` : versionSuffix;
   pkg.version = `${baseVersion}-${tag}`;
   fs.writeFileSync(pkgJsonPath, JSON.stringify(pkg, null, 2) + '\n');
   log(`Bumped ${pkg.name} version: ${originalVersion} -> ${pkg.version}`);
@@ -104,6 +114,18 @@ function restoreVersion({ pkgJsonPath, originalVersion }) {
   const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
   pkg.version = originalVersion;
   fs.writeFileSync(pkgJsonPath, JSON.stringify(pkg, null, 2) + '\n');
+}
+
+/**
+ * If AGENTCORE_TARBALL_OUTPUT is set, return a resolved path using it as base.
+ * Appends '-preview' suffix for preview builds. Always appends .tgz.
+ */
+function resolveTarballPath(tarballPath, { preview = false } = {}) {
+  const envPath = process.env.AGENTCORE_TARBALL_OUTPUT;
+  if (!envPath) return tarballPath;
+  const suffix = preview ? '-preview' : '';
+  const base = envPath.replace(/\.tgz$/, '');
+  return path.resolve(`${base}${suffix}.tgz`);
 }
 
 // Step 1: Resolve and build CDK constructs
@@ -160,11 +182,16 @@ if (!fs.existsSync(cliTarballPath)) {
   console.error(`ERROR: Expected GA tarball at ${cliTarballPath} but not found.`);
   process.exit(1);
 }
-log(`Done! GA Tarball: ${cliTarballPath}`);
-log(`Install with: npm install -g ${cliTarballPath}`);
-log('When you run agentcore create, the bundled CDK constructs will be installed automatically.');
 
-const gaTarballPath = cliTarballPath;
+const gaTarballPath = resolveTarballPath(cliTarballPath);
+if (gaTarballPath !== cliTarballPath) {
+  fs.mkdirSync(path.dirname(gaTarballPath), { recursive: true });
+  fs.renameSync(cliTarballPath, gaTarballPath);
+  log(`Renamed tarball to: ${gaTarballPath}`);
+}
+log(`Done! GA Tarball: ${gaTarballPath}`);
+log(`Install with: npm install -g ${gaTarballPath}`);
+log('When you run agentcore create, the bundled CDK constructs will be installed automatically.');
 
 // Step 6: Rebuild CLI with BUILD_PREVIEW=1
 log('Rebuilding CLI with BUILD_PREVIEW=1 for preview tarball...');
@@ -176,7 +203,7 @@ function bumpPreviewVersion(pkgDir) {
   const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
   const originalVersion = pkg.version;
   const baseVersion = originalVersion.split('-')[0];
-  pkg.version = `${baseVersion}-preview-${timestamp}`;
+  pkg.version = `${baseVersion}-preview-${versionSuffix}`;
   fs.writeFileSync(pkgJsonPath, JSON.stringify(pkg, null, 2) + '\n');
   log(`Bumped ${pkg.name} version: ${originalVersion} -> ${pkg.version}`);
   return { pkgJsonPath, originalVersion, bumpedVersion: pkg.version };
@@ -200,9 +227,16 @@ if (!fs.existsSync(previewTarballPath)) {
   process.exit(1);
 }
 
+const finalPreviewPath = resolveTarballPath(previewTarballPath, { preview: true });
+if (finalPreviewPath !== previewTarballPath) {
+  fs.mkdirSync(path.dirname(finalPreviewPath), { recursive: true });
+  fs.renameSync(previewTarballPath, finalPreviewPath);
+  log(`Renamed tarball to: ${finalPreviewPath}`);
+}
+
 // Final output
 log(`GA tarball:      ${gaTarballPath}`);
-log(`Preview tarball: ${previewTarballPath}`);
+log(`Preview tarball: ${finalPreviewPath}`);
 log(`Install GA:      npm install -g ${gaTarballPath}`);
-log(`Install Preview: npm install -g ${previewTarballPath}`);
+log(`Install Preview: npm install -g ${finalPreviewPath}`);
 log('When you run agentcore create, the bundled CDK constructs will be installed automatically.');


### PR DESCRIPTION
## Description

We extend `scripts/bundle.mjs` and the prerelease workflow to support injectable tarball output paths and version suffixes via environment variables (`AGENTCORE_TARBALL_OUTPUT`, `AGENTCORE_TARBALL_VERSION_SUFFIX`). 

The prerelease workflow now publishes the prerelease artifacts to a static url that includes the commit hash for both repositories. 

This allows developers to set a local alias to the static url for easy downloads. The url is currently `https://github.com/aws/agentcore-cli/releases/download/prerelease/aws-agentcore-0.15.0-20260526224648.tgz` (changes on each commit), but will be `https://github.com/aws/agentcore-cli/releases/download/prerelease/agentcore-cli-prerelease.tgz` and should auto update on each push to main.

Additionally, the version number describes the commit this was built from (both CDK and CLI) to make sanity checks easier. 

### Notes
In testing I noticed github is having [availability issues](https://www.githubstatus.com/) causing clone to hang. This will stop the workflow from working in CI. 

I tested locally by pointing to a local instance of the CDK repo, and disabling the `git pull origin` call. 

## Related Issue

Closes #

## Documentation PR

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.