### PR TITLE
fix(ci): use cache for eslint/prettier/typecheck to speed up dev cycle

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,11 +54,11 @@
     "build:preview": "BUILD_PREVIEW=1 node esbuild.config.mjs",
     "build:harness": "BUILD_HARNESS=1 node esbuild.config.mjs",
     "cli": "npx tsx src/cli/index.ts",
-    "typecheck": "tsc --noEmit",
-    "lint": "eslint src/",
-    "lint:fix": "eslint src/ --fix",
-    "format": "prettier --write .",
-    "format:check": "prettier --check .",
+    "typecheck": "tsc --noEmit --incremental",
+    "lint": "eslint --cache src/",
+    "lint:fix": "eslint --cache src/ --fix",
+    "format": "prettier --cache --write .",
+    "format:check": "prettier --cache --check .",
     "secrets:check": "secretlint '**/*'",
     "security:audit": "npm audit --audit-level=high --omit=dev",
     "clean": "node -e \"require('fs').rmSync('dist', {recursive: true, force: true})\"",
@@ -169,10 +169,10 @@
   },
   "lint-staged": {
     "*.{ts,tsx}": [
-      "eslint --max-warnings=10"
+      "eslint --cache --max-warnings=10"
     ],
     "*.{ts,tsx,js,jsx,json,md,css,html,yml,yaml}": [
-      "prettier --check"
+      "prettier --cache --check"
     ],
     "*": [
       "secretlint"


### PR DESCRIPTION
## Description

Adds `--cache` to eslint and prettier, and `--incremental` to tsc across npm scripts and the lint-staged pre-commit hook.

### Benchmarks

| Tool | Cold | Warm (cached) | Speedup |
|------|------|---------------|---------|
| ESLint | 38.5s | 4.0s | ~9.5x |
| Prettier | 9.9s | 2.8s | ~3.5x |
| TypeScript | 12.4s | 7.2s | ~1.7x |

### References

- [ESLint `--cache`](https://eslint.org/docs/latest/use/command-line-interface#--cache)
- [Prettier `--cache`](https://prettier.io/docs/cli#--cache)
- [TypeScript `--incremental`](https://www.typescriptlang.org/tsconfig/#incremental)

## Related Issue

Closes #

## Documentation PR

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe): Developer experience / performance improvement

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.