### PR TITLE
fix(dev): skip redundant deploy when TUI deploy already succeeded

### DIFF
--- a/src/cli/tui/screens/deploy/useDeployFlow.ts
+++ b/src/cli/tui/screens/deploy/useDeployFlow.ts
@@ -16,6 +16,7 @@ import { DEFAULT_DEPLOY_ATTRS, computeDeployAttrs } from '../../../commands/depl
 import { getErrorMessage, isChangesetInProgressError, isExpiredTokenError } from '../../../errors';
 import { ExecLogger } from '../../../logging';
 import { performStackTeardown, setupTransactionSearch } from '../../../operations/deploy';
+import { computeProjectDeployHash } from '../../../operations/deploy/change-detection';
 import { getGatewayTargetStatuses } from '../../../operations/deploy/gateway-status';
 import { deleteOrphanedABTests, setupABTests } from '../../../operations/deploy/post-deploy-ab-tests';
 import {
@@ -334,6 +335,17 @@ export function useDeployFlow(options: DeployFlowOptions = {}): DeployFlowState 
       policies,
       datasets,
     });
+
+    try {
+      const deployHash = await computeProjectDeployHash(configIO);
+      const targetState = deployedState.targets[target.name];
+      if (targetState?.resources) {
+        targetState.resources.deployHash = deployHash;
+      }
+    } catch {
+      // hash computation is best-effort
+    }
+
     await configIO.writeDeployedState(deployedState);
 
     // Post-deploy: Sync dataset examples from local JSONL to service DRAFT.


### PR DESCRIPTION
## Summary

- **Bug**: After deploying a harness project via the interactive TUI (`agentcore deploy`), running `agentcore dev` would always redeploy even with no changes
- **Root cause**: The TUI deploy flow (`useDeployFlow.ts`) wrote deployed state but never stored the `deployHash`. When `agentcore dev` called `canSkipDeploy`, the stored hash was `undefined`, so the hash comparison always failed.
- **Fix**: Compute and store `deployHash` in the TUI deploy flow after `buildDeployedState`, matching the existing behavior in `handleDeploy` (used by the CLI `-y` path)

## Test plan

- [x] `npm run build` passes
- [x] All 214 deploy-related unit tests pass
- [x] Pre-commit hooks (eslint, prettier, typecheck, secretlint) pass
- [ ] Manual: create harness project → `agentcore deploy` (TUI) → `agentcore dev` → verify "No changes detected — skipping deploy" message appears
- [ ] Manual: create harness project → `agentcore deploy` (TUI) → modify `harness.json` → `agentcore dev` → verify deploy triggers