### PR TITLE
docs: Link to agentcore-samples repository in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,11 @@ Projects use JSON schema files in the `agentcore/` directory:
 - [Memory](docs/memory.md) - Memory strategies and sharing
 - [Local Development](docs/local-development.md) - Dev server and debugging
 
+## Examples
+
+See the [AgentCore Samples](https://github.com/awslabs/agentcore-samples) repository for end-to-end examples using the
+CLI, including multi-agent workflows, MCP gateway targets, and framework integrations.
+
 ## Feedback & Issues
 
 Found a bug or have a feature request? [Open an issue](https://github.com/aws/agentcore-cli/issues/new) on GitHub.


### PR DESCRIPTION
## Summary

- Add an Examples section to the README linking to the [agentcore-samples](https://github.com/awslabs/agentcore-samples) repository

Users following CLI examples (getting started, deploy, memory, gateway, workshops) currently have no pointer from this repo to the samples repo where those examples live.

## Test plan

- [ ] Verify link resolves correctly
- [ ] No code changes — docs only