### PR TITLE
fix: allow skipping optional KMS key ARN in evaluator wizard

### DIFF
--- a/src/cli/tui/screens/evaluator/AddEvaluatorScreen.tsx
+++ b/src/cli/tui/screens/evaluator/AddEvaluatorScreen.tsx
@@ -385,6 +385,7 @@ export function AddEvaluatorScreen({ onComplete, onExit, existingEvaluatorNames 
             key="kms-key-arn"
             prompt="KMS key ARN for encryption (optional, press Enter to skip)"
             initialValue=""
+            allowEmpty
             onSubmit={wizard.setKmsKeyArn}
             onCancel={() => wizard.goBack()}
             customValidation={value =>


### PR DESCRIPTION
## Summary
- Adds `allowEmpty` prop to the KMS key ARN `TextInput` in the add evaluator wizard, allowing users to press Enter to skip the optional field
- The dataset wizard already had this prop set correctly; the evaluator wizard was the only one missing it

## Root Cause
`TextInput` blocks submission when the value is empty unless `allowEmpty` is set. The KMS field is optional but was missing this prop, causing the wizard to freeze at that step.

Fixes #1398

## Test plan
- [ ] Run `agentcore add evaluator` → choose LLM-as-a-Judge → complete steps up to KMS key ARN → press Enter with empty field → should advance to confirm step
- [ ] Enter a valid KMS ARN → should advance and show it in confirm
- [ ] Enter an invalid ARN → should show validation error