### PR TITLE
fix(telemetry): track preflight error for telemetry

### DIFF
--- a/src/cli/telemetry/schemas/common-shapes.ts
+++ b/src/cli/telemetry/schemas/common-shapes.ts
@@ -126,6 +126,7 @@ export const ErrorName = z.enum([
   'ServerError',
   'TimeoutError',
   'UnsupportedLanguageError',
+  'UserCancellationError',
   'ValidationError',
   'UnknownError',
 ]);

--- a/src/cli/tui/hooks/useCdkPreflight.ts
+++ b/src/cli/tui/hooks/useCdkPreflight.ts
@@ -1,4 +1,4 @@
-import { ConfigIO, SecureCredentials } from '../../../lib';
+import { ConfigIO, SecureCredentials, toError } from '../../../lib';
 import { AwsCredentialsError } from '../../../lib/errors/types';
 import type { DeployedState } from '../../../schema';
 import { applyTargetRegionToEnv } from '../../aws';
@@ -66,6 +66,8 @@ export interface PreflightResult {
   hasTokenExpiredError: boolean;
   /** True if preflight failed due to missing AWS credentials (not configured) */
   hasCredentialsError: boolean;
+  /** The error that caused preflight to fail, if any */
+  lastError?: Error;
   /** Missing credentials that need to be provided */
   missingCredentials: MissingCredential[];
   /** KMS key ARN used for identity token vault encryption */
@@ -134,6 +136,7 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
     Record<string, { credentialProviderArn: string; clientSecretArn?: string; callbackUrl?: string }>
   >({});
   const [teardownConfirmed, setTeardownConfirmed] = useState(false);
+  const lastErrorRef = useRef<Error | undefined>(undefined);
 
   // Guard against concurrent runs (React StrictMode, re-renders, etc.)
   const isRunningRef = useRef(false);
@@ -155,6 +158,12 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
 
   const resetSteps = () => {
     setSteps(BASE_PREFLIGHT_STEPS.map(s => ({ ...s, status: 'pending' as const })));
+  };
+
+  const failPreflight = (err: unknown) => {
+    lastErrorRef.current = toError(err);
+    setPhase('error');
+    isRunningRef.current = false;
   };
 
   // Dispose wrapper and clear ref
@@ -231,8 +240,7 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
   }, []);
 
   const cancelTeardown = useCallback(() => {
-    setPhase('error');
-    isRunningRef.current = false;
+    failPreflight(new Error('Teardown cancelled'));
     restoreRegionEnv();
   }, [restoreRegionEnv]);
 
@@ -269,6 +277,7 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
     if (phase !== 'running') return;
     if (isRunningRef.current) return;
     isRunningRef.current = true;
+    lastErrorRef.current = undefined;
 
     const handleUnhandledRejection = (reason: unknown) => {
       const error = formatError(reason);
@@ -287,8 +296,7 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
         }
         return prev;
       });
-      setPhase('error');
-      isRunningRef.current = false;
+      failPreflight(reason);
     };
 
     process.on('unhandledRejection', handleUnhandledRejection);
@@ -329,8 +337,7 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
             userMessage = getErrorMessage(err);
           }
           updateStep(STEP_VALIDATE, { status: 'error', error: userMessage });
-          setPhase('error');
-          isRunningRef.current = false;
+          failPreflight(err);
           return;
         }
 
@@ -354,8 +361,7 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
             const userMessage =
               isInteractive && err instanceof AwsCredentialsError ? err.shortMessage : getErrorMessage(err);
             updateStep(STEP_VALIDATE, { status: 'error', error: userMessage });
-            setPhase('error');
-            isRunningRef.current = false;
+            failPreflight(err);
             return;
           }
         }
@@ -369,8 +375,7 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
             const errorMsg = depsResult.errors.join('\n');
             logger.endStep('error', errorMsg);
             updateStep(STEP_DEPS, { status: 'error', error: errorMsg });
-            setPhase('error');
-            isRunningRef.current = false;
+            failPreflight(new Error(errorMsg));
             return;
           }
           // Log version info
@@ -386,8 +391,7 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
           const errorMsg = formatError(err);
           logger.endStep('error', errorMsg);
           updateStep(STEP_DEPS, { status: 'error', error: logger.getFailureMessage('Check dependencies') });
-          setPhase('error');
-          isRunningRef.current = false;
+          failPreflight(err);
           return;
         }
 
@@ -402,8 +406,7 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
           const errorMsg = formatError(err);
           logger.endStep('error', errorMsg);
           updateStep(STEP_BUILD, { status: 'error', error: logger.getFailureMessage('Build CDK project') });
-          setPhase('error');
-          isRunningRef.current = false;
+          failPreflight(err);
           return;
         }
 
@@ -450,8 +453,7 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
             status: 'error',
             error: logger.getFailureMessage('Synthesize CloudFormation'),
           });
-          setPhase('error');
-          isRunningRef.current = false;
+          failPreflight(err);
           return;
         }
 
@@ -466,8 +468,7 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
               const errorMsg = stackStatus.message ?? `Stack ${stackStatus.blockingStack} is not in a deployable state`;
               logger.endStep('error', errorMsg);
               updateStepByLabel(LABEL_STACK_STATUS, { status: 'error', error: errorMsg });
-              setPhase('error');
-              isRunningRef.current = false;
+              failPreflight(new Error(errorMsg));
               return;
             }
             logger.endStep('success');
@@ -482,8 +483,7 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
               status: 'error',
               error: logger.getFailureMessage('Check stack status'),
             });
-            setPhase('error');
-            isRunningRef.current = false;
+            failPreflight(err);
             return;
           }
         } else {
@@ -520,8 +520,7 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
           }
           return prev;
         });
-        setPhase('error');
-        isRunningRef.current = false;
+        failPreflight(err);
       }
     };
 
@@ -566,8 +565,7 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
             status: 'error',
             error: logger.getFailureMessage('Synthesize CloudFormation'),
           });
-          setPhase('error');
-          isRunningRef.current = false;
+          failPreflight(err);
           return;
         }
 
@@ -582,8 +580,7 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
               const errorMsg = stackStatus.message ?? `Stack ${stackStatus.blockingStack} is not in a deployable state`;
               logger.endStep('error', errorMsg);
               updateStepByLabel(LABEL_STACK_STATUS, { status: 'error', error: errorMsg });
-              setPhase('error');
-              isRunningRef.current = false;
+              failPreflight(new Error(errorMsg));
               return;
             }
             logger.endStep('success');
@@ -598,8 +595,7 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
               status: 'error',
               error: logger.getFailureMessage('Check stack status'),
             });
-            setPhase('error');
-            isRunningRef.current = false;
+            failPreflight(err);
             return;
           }
         } else {
@@ -647,8 +643,7 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
         } else if (hasOAuth) {
           updateStepByLabel(LABEL_OAUTH, { status: 'error', error: errorMsg });
         }
-        setPhase('error');
-        isRunningRef.current = false;
+        failPreflight(new Error(errorMsg));
         return;
       }
 
@@ -697,8 +692,7 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
           if (identityResult.hasErrors) {
             logger.endStep('error', 'Some API key providers failed to set up');
             updateStepByLabel(LABEL_API_KEY, { status: 'error', error: 'Some API key providers failed' });
-            setPhase('error');
-            isRunningRef.current = false;
+            failPreflight(new Error('Some API key providers failed to set up'));
             return;
           }
 
@@ -741,8 +735,7 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
           if (oauthResult.hasErrors) {
             logger.endStep('error', 'Some OAuth providers failed to set up');
             updateStepByLabel(LABEL_OAUTH, { status: 'error', error: 'Some OAuth providers failed' });
-            setPhase('error');
-            isRunningRef.current = false;
+            failPreflight(new Error('Some OAuth providers failed to set up'));
             return;
           }
 
@@ -807,8 +800,7 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
             status: 'error',
             error: logger.getFailureMessage('Synthesize CloudFormation'),
           });
-          setPhase('error');
-          isRunningRef.current = false;
+          failPreflight(err);
           return;
         }
 
@@ -822,8 +814,7 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
               const errorMsg = stackStatus.message ?? `Stack ${stackStatus.blockingStack} is not in a deployable state`;
               logger.endStep('error', errorMsg);
               updateStepByLabel(LABEL_STACK_STATUS, { status: 'error', error: errorMsg });
-              setPhase('error');
-              isRunningRef.current = false;
+              failPreflight(new Error(errorMsg));
               return;
             }
             logger.endStep('success');
@@ -838,8 +829,7 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
               status: 'error',
               error: logger.getFailureMessage('Check stack status'),
             });
-            setPhase('error');
-            isRunningRef.current = false;
+            failPreflight(err);
             return;
           }
         } else {
@@ -872,8 +862,7 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
               : s
           )
         );
-        setPhase('error');
-        isRunningRef.current = false;
+        failPreflight(err);
       }
     };
 
@@ -908,8 +897,7 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
               : s
           )
         );
-        setPhase('error');
-        isRunningRef.current = false;
+        failPreflight(err);
       }
     };
 
@@ -925,6 +913,7 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
     switchableIoHost,
     hasTokenExpiredError,
     hasCredentialsError,
+    lastError: lastErrorRef.current,
     missingCredentials,
     identityKmsKeyArn,
     allCredentials,

--- a/src/cli/tui/hooks/useCdkPreflight.ts
+++ b/src/cli/tui/hooks/useCdkPreflight.ts
@@ -1,5 +1,5 @@
 import { ConfigIO, SecureCredentials, toError } from '../../../lib';
-import { AwsCredentialsError } from '../../../lib/errors/types';
+import { AwsCredentialsError, UserCancellationError } from '../../../lib/errors/types';
 import type { DeployedState } from '../../../schema';
 import { applyTargetRegionToEnv } from '../../aws';
 import { validateAwsCredentials } from '../../aws/account';
@@ -240,7 +240,7 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
   }, []);
 
   const cancelTeardown = useCallback(() => {
-    failPreflight(new Error('Teardown cancelled'));
+    failPreflight(new UserCancellationError());
     restoreRegionEnv();
   }, [restoreRegionEnv]);
 

--- a/src/cli/tui/screens/deploy/useDeployFlow.ts
+++ b/src/cli/tui/screens/deploy/useDeployFlow.ts
@@ -598,8 +598,20 @@ export function useDeployFlow(options: DeployFlowOptions = {}): DeployFlowState 
   // Start deploy when preflight completes OR when shouldStartDeploy is set
   useEffect(() => {
     if (diffMode) return; // Diff mode uses its own effect
-    const shouldStart = skipPreflight ? shouldStartDeploy : preflight.phase === 'complete';
+    const preflightDone = preflight.phase === 'complete' || preflight.phase === 'error';
+    const shouldStart = skipPreflight ? shouldStartDeploy : preflightDone;
     if (!shouldStart) return;
+
+    // Preflight failed — emit telemetry and bail
+    if (preflight.phase === 'error') {
+      const error = preflight.lastError ?? new Error('Preflight failed');
+      const attrs = context ? computeDeployAttrs(context.projectSpec, 'deploy') : { ...DEFAULT_DEPLOY_ATTRS };
+      withCommandRunTelemetry('deploy', attrs, () => ({ success: false as const, error })).catch(() => {
+        /* telemetry is best-effort */
+      });
+      return;
+    }
+
     if (deployStep.status !== 'pending') return;
     if (!cdkToolkitWrapper) return;
 
@@ -772,6 +784,7 @@ export function useDeployFlow(options: DeployFlowOptions = {}): DeployFlowState 
     };
 
     void withCommandRunTelemetry('deploy', attrs, run);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- preflight.lastError and context are read only on error path
   }, [
     preflight.phase,
     cdkToolkitWrapper,
@@ -791,8 +804,22 @@ export function useDeployFlow(options: DeployFlowOptions = {}): DeployFlowState 
   // Start diff when preflight completes (diff mode only)
   useEffect(() => {
     if (!diffMode) return;
-    const shouldStart = skipPreflight ? shouldStartDeploy : preflight.phase === 'complete';
+    const preflightDone = preflight.phase === 'complete' || preflight.phase === 'error';
+    const shouldStart = skipPreflight ? shouldStartDeploy : preflightDone;
     if (!shouldStart) return;
+
+    // Preflight failed — emit telemetry and bail
+    if (preflight.phase === 'error') {
+      const error = preflight.lastError ?? new Error('Preflight failed');
+      const attrs = context
+        ? computeDeployAttrs(context.projectSpec, 'diff')
+        : { ...DEFAULT_DEPLOY_ATTRS, deploy_mode: 'diff' as const };
+      withCommandRunTelemetry('deploy', attrs, () => ({ success: false as const, error })).catch(() => {
+        /* telemetry is best-effort */
+      });
+      return;
+    }
+
     if (diffStep.status !== 'pending') return;
     if (!cdkToolkitWrapper) return;
 
@@ -845,6 +872,7 @@ export function useDeployFlow(options: DeployFlowOptions = {}): DeployFlowState 
     };
 
     void withCommandRunTelemetry('deploy', attrs, run);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- preflight.lastError and context are read only on error path
   }, [
     diffMode,
     preflight.phase,

--- a/src/lib/errors/types.ts
+++ b/src/lib/errors/types.ts
@@ -290,3 +290,12 @@ export class PollExhaustedError extends BaseError {
     super(`Polling exhausted after ${maxAttempts} attempts`, { defaultSource: 'service', ...options });
   }
 }
+
+/**
+ * Error indicating user cancellation interuption
+ */
+export class UserCancellationError extends BaseError {
+  constructor(options?: BaseErrorOptions) {
+    super(`User cancelled`, { defaultSource: 'user', ...options });
+  }
+}


### PR DESCRIPTION
## Description

### Problem
The deploy TUI isn't emitting telemetry when the preflight steps fail. This is because the telemetry wrapper is only wrapping the post-preflight logic. 

### Solution
Ideally, we would wrap all logic in a telemetry wrapper, but the deploy flow leverages React hooks that are not linear. Specifically, when preflight steps finish it triggers a hook that invokes the main deployment. Because they are disjointed flows via events, we need another solution. 

The solution proposed here is to store the error from the earlier failure, and bail fast and emit when we get into the core deploy flow. This allows us to emit the correct information, but loses the duration of the failure from the preflight. We could theoretically store this in another Ref and then emit directly, but this significantly increases complexity, since we now need a way to override duration on the metric and need to manage a timer in a react hook that may trigger multiple times.

I also feel fairly certain that we will revisit this deploy code for a significant refactor as part of future work since its current flow is difficult to understand and extend. 

### Testing
ran deploy w/o AWS credentials and saw the error pop up in telemetry. 

```
> AWS_ACCESS_KEY_ID=FAKEKEY agentcore deploy

  AgentCore Deploy

  [error]   Validate project
            → AWS credentials are invalid.

  To fix this:
    1. Check your AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
    2. Or Run: aws login

  Log: agentcore/.cli/logs/deploy/deploy-20260528-083049.log

  Esc back · Ctrl+C quit

[audit mode] Telemetry written to [...]/deploy-b6c80bbe-baf3-4bf1-a06b-488f439
ec08b.json

```

Then error in file is AWSCredentialsError


## Related Issue

Closes #

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.