### PR TITLE
feat: check for spans in agent log group

### DIFF
--- a/src/cli/operations/deploy/post-deploy-ab-tests.ts
+++ b/src/cli/operations/deploy/post-deploy-ab-tests.ts
@@ -673,6 +673,7 @@ async function getOrCreateABTestRole(options: CreateABTestRoleOptions): Promise<
         ],
         Resource: [
           `${arnPrefix(region)}:logs:*:${accountId}:log-group:/aws/bedrock-agentcore/evaluations/*`,
+          `${arnPrefix(region)}:logs:*:${accountId}:log-group:/aws/bedrock-agentcore/runtimes/*`,
           `${arnPrefix(region)}:logs:*:${accountId}:log-group:aws/spans`,
           `${arnPrefix(region)}:logs:*:${accountId}:log-group:aws/spans:*`,
         ],

--- a/src/cli/operations/eval/__tests__/run-eval.test.ts
+++ b/src/cli/operations/eval/__tests__/run-eval.test.ts
@@ -118,20 +118,29 @@ function makeToolCallSpanRow(sessionId: string, traceId: string, spanId: string,
 
 function setupCloudWatchToReturn(spanRows: unknown[][], runtimeLogRows: unknown[][] = []) {
   let queryCount = 0;
+  const queryResults = new Map<string, unknown[][]>();
+
   mockSend.mockImplementation((cmd: { input: unknown }) => {
     const input = cmd.input as Record<string, unknown>;
 
     if ('queryString' in input) {
-      // StartQueryCommand
       queryCount++;
-      return Promise.resolve({ queryId: `q-${queryCount}` });
+      const queryId = `q-${queryCount}`;
+      const logGroup = input.logGroupName as string;
+      const queryStr = input.queryString as string;
+
+      if (logGroup === 'aws/spans') {
+        queryResults.set(queryId, spanRows);
+      } else if (queryStr.includes('filter traceId in')) {
+        queryResults.set(queryId, runtimeLogRows);
+      } else {
+        queryResults.set(queryId, []);
+      }
+      return Promise.resolve({ queryId });
     }
 
-    // GetQueryResultsCommand — return Complete immediately
-    if (queryCount === 1) {
-      return Promise.resolve({ status: 'Complete', results: spanRows });
-    }
-    return Promise.resolve({ status: 'Complete', results: runtimeLogRows });
+    const queryId = (input as { queryId?: string }).queryId ?? '';
+    return Promise.resolve({ status: 'Complete', results: queryResults.get(queryId) ?? [] });
   });
 }
 

--- a/src/cli/operations/eval/run-eval.ts
+++ b/src/cli/operations/eval/run-eval.ts
@@ -11,7 +11,7 @@ import { runDatasetScenariosAndCollectSpans } from './shared/dataset-session-pro
 import { runEvaluatorsOverSessions } from './shared/evaluator-runner';
 import {
   SPANS_LOG_GROUP,
-  executeQuery,
+  executeQueryGraceful,
   extractTraceIds,
   fetchSessionSpans,
   sanitizeQueryValue,
@@ -240,11 +240,17 @@ export async function discoverSessions(opts: DiscoverSessionsOptions): Promise<S
   const query = `fields attributes.session.id as sessionId
      | parse resource.attributes.cloud.resource_id "runtime/*/" as parsedAgentId
      | filter parsedAgentId = '${sanitizeQueryValue(opts.runtimeId)}'
+     | filter ispresent(kind)
      | stats count(*) as spanCount, min(@timestamp) as firstSeen by sessionId
      | sort firstSeen desc
      | limit ${MAX_DISCOVERED_SESSIONS}`;
 
-  const rows = await executeQuery(client, SPANS_LOG_GROUP, query, startTimeSec, endTimeSec);
+  const runtimeLogGroupName = runtimeLogGroup(opts.runtimeId);
+  const [spansRows, runtimeRows] = await Promise.all([
+    executeQueryGraceful(client, SPANS_LOG_GROUP, query, startTimeSec, endTimeSec),
+    executeQueryGraceful(client, runtimeLogGroupName, query, startTimeSec, endTimeSec),
+  ]);
+  const rows = [...spansRows, ...runtimeRows];
 
   const sessions: SessionInfo[] = [];
   for (const row of rows) {

--- a/src/cli/operations/eval/shared/span-collector.ts
+++ b/src/cli/operations/eval/shared/span-collector.ts
@@ -154,6 +154,28 @@ export function sanitizeQueryValue(value: string): string {
 }
 
 /**
+ * Execute a CloudWatch Logs Insights query, returning [] if the log group does not exist.
+ */
+export async function executeQueryGraceful(
+  client: CloudWatchLogsClient,
+  logGroupName: string,
+  queryString: string,
+  startTimeSec: number,
+  endTimeSec: number
+): Promise<ResultField[][]> {
+  try {
+    return await executeQuery(client, logGroupName, queryString, startTimeSec, endTimeSec);
+  } catch (err) {
+    const errName = (err as { name?: string })?.name;
+    const msg = err instanceof Error ? err.message : String(err);
+    if (errName === 'ResourceNotFoundException' || msg.includes('does not exist')) {
+      return [];
+    }
+    throw err;
+  }
+}
+
+/**
  * Execute a CloudWatch Logs Insights query and wait for results.
  */
 export async function executeQuery(
@@ -264,11 +286,11 @@ export async function fetchSessionSpans(opts: FetchSpansOptions): Promise<Sessio
     region,
   });
 
-  // 1. Query proper OTel spans from the aws/spans log group
+  // 1. Query proper OTel spans from both log groups
   let spanQuery = `fields @message, attributes.session.id as sessionId, traceId
      | parse resource.attributes.cloud.resource_id "runtime/*/" as parsedAgentId
      | filter parsedAgentId = '${sanitizeQueryValue(runtimeId)}'
-     | filter ispresent(scope.name)`;
+     | filter ispresent(scope.name) and ispresent(kind)`;
 
   if (opts.sessionId) {
     spanQuery += `\n     | filter attributes.session.id = '${sanitizeQueryValue(opts.sessionId)}'`;
@@ -279,13 +301,17 @@ export async function fetchSessionSpans(opts: FetchSpansOptions): Promise<Sessio
 
   spanQuery += `\n     | sort startTimeUnixNano asc\n     | limit 10000`;
 
-  const spanRows = await executeQuery(client, SPANS_LOG_GROUP, spanQuery, startTimeSec, endTimeSec);
+  const [sharedSpanRows, runtimeSpanRows] = await Promise.all([
+    executeQueryGraceful(client, SPANS_LOG_GROUP, spanQuery, startTimeSec, endTimeSec),
+    executeQueryGraceful(client, runtimeLogGroup, spanQuery, startTimeSec, endTimeSec),
+  ]);
+  const allSpanRows = [...sharedSpanRows, ...runtimeSpanRows];
 
   // Group spans by session and collect trace IDs
   const sessionMap = new Map<string, DocumentType[]>();
   const traceIds = new Set<string>();
 
-  for (const row of spanRows) {
+  for (const row of allSpanRows) {
     const messageField = row.find(f => f.field === '@message');
     const sessionField = row.find(f => f.field === 'sessionId');
     const traceField = row.find(f => f.field === 'traceId');
@@ -338,7 +364,7 @@ export async function fetchSessionSpans(opts: FetchSpansOptions): Promise<Sessio
     // Match runtime logs to sessions via traceId
     // Build traceId → sessionId mapping from spans
     const traceToSession = new Map<string, string>();
-    for (const row of spanRows) {
+    for (const row of allSpanRows) {
       const traceField = row.find(f => f.field === 'traceId');
       const sessionField = row.find(f => f.field === 'sessionId');
       if (traceField?.value && sessionField?.value) {

--- a/src/cli/operations/recommendation/__tests__/fetch-session-spans.test.ts
+++ b/src/cli/operations/recommendation/__tests__/fetch-session-spans.test.ts
@@ -54,6 +54,17 @@ function makeLogRecord(traceId: string, spanId: string, sessionId: string) {
   };
 }
 
+function mockThreeCalls(
+  sharedSpans: { timestamp: number; message: string }[],
+  runtimeSpans: { timestamp: number; message: string }[],
+  logRecords: { timestamp: number; message: string }[]
+) {
+  mockSearchLogs
+    .mockReturnValueOnce(fakeLogStream(sharedSpans))
+    .mockReturnValueOnce(fakeLogStream(runtimeSpans))
+    .mockReturnValueOnce(fakeLogStream(logRecords));
+}
+
 describe('fetchSessionSpans', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -63,8 +74,7 @@ describe('fetchSessionSpans', () => {
     const spanEvents = [makeSpanRecord('trace1', 'span1'), makeSpanRecord('trace1', 'span2')];
     const logEvents = [makeLogRecord('trace1', 'span3', SESSION_ID)];
 
-    // First call = aws/spans, second call = runtime log group
-    mockSearchLogs.mockReturnValueOnce(fakeLogStream(spanEvents)).mockReturnValueOnce(fakeLogStream(logEvents));
+    mockThreeCalls(spanEvents, [], logEvents);
 
     const result = await fetchSessionSpans({
       region: 'us-east-1',
@@ -84,7 +94,10 @@ describe('fetchSessionSpans', () => {
       makeLogRecord('trace1', 'span3', 'other-session-id'),
     ];
 
-    mockSearchLogs.mockReturnValueOnce(fakeLogStream(spanEvents)).mockReturnValueOnce(fakeLogStream(logEvents));
+    mockSearchLogs
+      .mockReturnValueOnce(fakeLogStream(spanEvents))
+      .mockReturnValueOnce(fakeLogStream([]))
+      .mockReturnValueOnce(fakeLogStream(logEvents));
 
     const result = await fetchSessionSpans({
       region: 'us-east-1',
@@ -97,7 +110,7 @@ describe('fetchSessionSpans', () => {
   });
 
   it('returns empty spans when no records found', async () => {
-    mockSearchLogs.mockReturnValueOnce(fakeLogStream([])).mockReturnValueOnce(fakeLogStream([]));
+    mockThreeCalls([], [], []);
 
     const result = await fetchSessionSpans({
       region: 'us-east-1',
@@ -111,9 +124,11 @@ describe('fetchSessionSpans', () => {
   });
 
   it('handles ResourceNotFoundException gracefully (log group does not exist)', async () => {
-    // Spans log group works, runtime log group does not exist
     mockSearchLogs
       .mockReturnValueOnce(fakeLogStream([makeSpanRecord('t1', 's1')]))
+      .mockReturnValueOnce(
+        fakeErrorStream(new Error('ResourceNotFoundException: The specified log group does not exist'))
+      )
       .mockReturnValueOnce(
         fakeErrorStream(new Error('ResourceNotFoundException: The specified log group does not exist'))
       );
@@ -133,6 +148,7 @@ describe('fetchSessionSpans', () => {
   it('rethrows non-ResourceNotFoundException errors', async () => {
     mockSearchLogs
       .mockReturnValueOnce(fakeLogStream([]))
+      .mockReturnValueOnce(fakeLogStream([]))
       .mockReturnValueOnce(fakeErrorStream(new Error('AccessDeniedException: Not authorized')));
 
     await expect(
@@ -147,7 +163,7 @@ describe('fetchSessionSpans', () => {
   it('skips unparseable log messages', async () => {
     const spanEvents = [{ timestamp: Date.now(), message: 'not-valid-json' }, makeSpanRecord('trace1', 'span1')];
 
-    mockSearchLogs.mockReturnValueOnce(fakeLogStream(spanEvents)).mockReturnValueOnce(fakeLogStream([]));
+    mockThreeCalls(spanEvents, [], []);
 
     const result = await fetchSessionSpans({
       region: 'us-east-1',
@@ -159,7 +175,7 @@ describe('fetchSessionSpans', () => {
   });
 
   it('uses correct log group names', async () => {
-    mockSearchLogs.mockReturnValueOnce(fakeLogStream([])).mockReturnValueOnce(fakeLogStream([]));
+    mockThreeCalls([], [], []);
 
     await fetchSessionSpans({
       region: 'us-east-1',
@@ -168,23 +184,26 @@ describe('fetchSessionSpans', () => {
       lookbackDays: 3,
     });
 
-    expect(mockSearchLogs).toHaveBeenCalledTimes(2);
+    expect(mockSearchLogs).toHaveBeenCalledTimes(3);
 
-    // First call: aws/spans
+    // First call: aws/spans (span records)
     const spanCall = mockSearchLogs.mock.calls[0]![0];
     expect(spanCall.logGroupName).toBe('aws/spans');
     expect(spanCall.filterPattern).toContain(SESSION_ID);
 
-    // Second call: runtime log group
-    const logCall = mockSearchLogs.mock.calls[1]![0];
+    // Second call: runtime log group (span records)
+    const runtimeSpanCall = mockSearchLogs.mock.calls[1]![0];
+    expect(runtimeSpanCall.logGroupName).toBe('/aws/bedrock-agentcore/runtimes/myproject_MyAgent-QMd093Gl4O-DEFAULT');
+    expect(runtimeSpanCall.filterPattern).toContain(SESSION_ID);
+
+    // Third call: runtime log group (log records)
+    const logCall = mockSearchLogs.mock.calls[2]![0];
     expect(logCall.logGroupName).toBe('/aws/bedrock-agentcore/runtimes/myproject_MyAgent-QMd093Gl4O-DEFAULT');
     expect(logCall.filterPattern).toContain('"body" "input"');
   });
 
   it('calls onProgress callback', async () => {
-    mockSearchLogs
-      .mockReturnValueOnce(fakeLogStream([makeSpanRecord('t1', 's1')]))
-      .mockReturnValueOnce(fakeLogStream([]));
+    mockThreeCalls([makeSpanRecord('t1', 's1')], [], []);
 
     const progress: string[] = [];
     await fetchSessionSpans({
@@ -212,7 +231,7 @@ describe('fetchSessionSpans', () => {
       }),
     };
 
-    mockSearchLogs.mockReturnValueOnce(fakeLogStream([])).mockReturnValueOnce(fakeLogStream([logEvent]));
+    mockThreeCalls([], [], [logEvent]);
 
     const result = await fetchSessionSpans({
       region: 'us-east-1',

--- a/src/cli/operations/recommendation/fetch-session-spans.ts
+++ b/src/cli/operations/recommendation/fetch-session-spans.ts
@@ -51,9 +51,8 @@ export async function fetchSessionSpans(options: FetchSessionSpansOptions): Prom
   const endTimeMs = Date.now();
   const startTimeMs = endTimeMs - lookbackDays * 24 * 60 * 60 * 1000;
 
-  // Fetch span records and log records in parallel
-  onProgress?.('Fetching span records from aws/spans...');
-  const [spanRecords, logRecords] = await Promise.all([
+  onProgress?.('Fetching span records from aws/spans and runtime log group...');
+  const [sharedSpanRecords, runtimeSpanRecords, logRecords] = await Promise.all([
     collectLogEvents({
       logGroupName: SPANS_LOG_GROUP,
       region,
@@ -66,16 +65,22 @@ export async function fetchSessionSpans(options: FetchSessionSpansOptions): Prom
       region,
       startTimeMs,
       endTimeMs,
-      // Filter for log records that contain body with input messages
+      filterPattern: `"session.id" "${sessionId}"`,
+    }),
+    collectLogEvents({
+      logGroupName: runtimeLogGroupName,
+      region,
+      startTimeMs,
+      endTimeMs,
       filterPattern: `"body" "input"`,
     }),
   ]);
 
-  onProgress?.(`Found ${spanRecords.length} span records, ${logRecords.length} log record candidates`);
+  const allSpanRecords = [...sharedSpanRecords, ...runtimeSpanRecords];
+  onProgress?.(`Found ${allSpanRecords.length} span records, ${logRecords.length} log record candidates`);
 
-  // Parse span records — these are already OTEL spans with attributes.session.id
   const spans: SessionSpan[] = [];
-  for (const event of spanRecords) {
+  for (const event of allSpanRecords) {
     try {
       const parsed = JSON.parse(event.message) as SessionSpan;
       spans.push(parsed);

--- a/src/cli/operations/traces/get-trace.ts
+++ b/src/cli/operations/traces/get-trace.ts
@@ -18,6 +18,7 @@ const TRACE_ID_PATTERN = /^[a-fA-F0-9-]+$/;
 
 async function fetchSpans(
   region: string,
+  runtimeId: string,
   traceId: string,
   startTime?: number,
   endTime?: number
@@ -29,12 +30,7 @@ async function fetchSpans(
     };
   }
 
-  const result = await runInsightsQuery({
-    region,
-    logGroupName: SPANS_LOG_GROUP,
-    startTime,
-    endTime,
-    queryString: `fields traceId, spanId, parentSpanId, name, kind,
+  const queryString = `fields traceId, spanId, parentSpanId, name, kind,
   startTimeUnixNano, endTimeUnixNano, durationNano,
   status.code as statusCode,
   resource.attributes.service.name as serviceName,
@@ -45,13 +41,28 @@ async function fetchSpans(
   attributes.session.id as sessionId
 | filter ispresent(traceId) and ispresent(resource.attributes.service.name)
 | filter resource.attributes.aws.service.type = "gen_ai_agent"
+| filter ispresent(kind)
 | filter traceId = '${traceId}'
-| sort startTimeUnixNano asc`,
-  });
+| sort startTimeUnixNano asc`;
 
-  if (!result.success) return { success: false, error: result.error };
+  const queryOpts = { region, queryString, startTime, endTime };
+  const results = await Promise.all([
+    runInsightsQuery({ ...queryOpts, logGroupName: SPANS_LOG_GROUP }),
+    runInsightsQuery({ ...queryOpts, logGroupName: runtimeLogGroup(runtimeId) }),
+  ]);
 
-  const spans: CloudWatchSpanRecord[] = result.rows
+  const allRows: Record<string, string>[] = [];
+  for (const result of results) {
+    if (result.success) {
+      allRows.push(...result.rows);
+    } else if (result.error instanceof ResourceNotFoundError) {
+      continue;
+    } else {
+      return { success: false, error: result.error };
+    }
+  }
+
+  const spans: CloudWatchSpanRecord[] = allRows
     .filter(row => row.traceId && row.spanId)
     .map(row => ({
       traceId: row.traceId!,
@@ -100,7 +111,9 @@ export async function fetchTraceRecords(options: FetchTraceRecordsOptions): Prom
 | sort @timestamp asc
 | limit 10000`,
     }),
-    includeSpans ? fetchSpans(region, traceId, options.startTime, options.endTime) : Promise.resolve(undefined),
+    includeSpans
+      ? fetchSpans(region, runtimeId, traceId, options.startTime, options.endTime)
+      : Promise.resolve(undefined),
   ]);
 
   if (!recordsResult.success) {

--- a/src/cli/tui/screens/ab-test/ABTestDetailScreen.tsx
+++ b/src/cli/tui/screens/ab-test/ABTestDetailScreen.tsx
@@ -8,6 +8,7 @@ import { dnsSuffix } from '../../../aws/partition';
 import { getErrorMessage } from '../../../errors';
 import { GradientText, Screen } from '../../components';
 import { CloudWatchLogsClient, FilterLogEventsCommand } from '@aws-sdk/client-cloudwatch-logs';
+import type { FilterLogEventsCommandInput, FilteredLogEvent } from '@aws-sdk/client-cloudwatch-logs';
 import { Box, Text, useInput } from 'ink';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
@@ -123,12 +124,13 @@ async function runDebugChecks(test: GetABTestResult, region: string): Promise<De
     results.push({ label: 'Gateway Role', status: 'fail', detail: getErrorMessage(err) });
   }
 
-  // 5. Runtime spans — check for experiment metadata per variant in aws/spans
+  // 5. Runtime spans — check for experiment metadata per variant in aws/spans and runtime log group
   //    service.name in spans follows the pattern: {projectName}_{agentName}.{endpoint}
   //    We derive the service name prefix from the deployed state runtimeId (strip random suffix).
   const twoHoursAgo = Date.now() - 2 * 60 * 60 * 1000;
   const variantNames = test.variants.map(v => v.name);
   let serviceNamePrefix: string | undefined;
+  let runtimeId: string | undefined;
   try {
     const configIO = new ConfigIO();
     const deployedState = await configIO.readDeployedState();
@@ -136,8 +138,8 @@ async function runDebugChecks(test: GetABTestResult, region: string): Promise<De
       const runtimes = target.resources?.runtimes ?? {};
       const firstRuntime = Object.values(runtimes)[0];
       if (firstRuntime?.runtimeId) {
-        // runtimeId is "{projectName}_{agentName}-{randomSuffix}", strip the suffix
-        serviceNamePrefix = firstRuntime.runtimeId.replace(/-[^-]+$/, '');
+        runtimeId = firstRuntime.runtimeId;
+        serviceNamePrefix = runtimeId.replace(/-[^-]+$/, '');
         break;
       }
     }
@@ -145,35 +147,47 @@ async function runDebugChecks(test: GetABTestResult, region: string): Promise<De
     // Fall back to abTestArn-only filtering if deployed state isn't readable
   }
 
+  const runtimeLogGroupName = runtimeId ? `/aws/bedrock-agentcore/runtimes/${runtimeId}-DEFAULT` : undefined;
+  const logGroupsToQuery = ['aws/spans'];
+  if (runtimeLogGroupName) {
+    logGroupsToQuery.push(runtimeLogGroupName);
+  }
+
+  const queryAllGroups = (params: Omit<FilterLogEventsCommandInput, 'logGroupName'>) =>
+    Promise.all(
+      logGroupsToQuery.map(lg =>
+        logsClient
+          .send(new FilterLogEventsCommand({ ...params, logGroupName: lg }))
+          .catch(() => ({ events: [] as FilteredLogEvent[] }))
+      )
+    );
+
   try {
     const baseFilter = serviceNamePrefix ? `"${serviceNamePrefix}"` : '"gen_ai_agent"';
-    const [allRuntimeSpans, ...variantSpanResults] = await Promise.all([
-      logsClient.send(
-        new FilterLogEventsCommand({
-          logGroupName: 'aws/spans',
-          startTime: twoHoursAgo,
-          filterPattern: baseFilter,
-          limit: 1,
-        })
-      ),
-      ...variantNames.map(name =>
-        logsClient.send(
-          new FilterLogEventsCommand({
-            logGroupName: 'aws/spans',
-            startTime: twoHoursAgo,
-            filterPattern: `"${test.abTestArn}" "${name}"`,
-            limit: 50,
-          })
-        )
-      ),
-    ]);
 
-    const hasRuntimeSpans = (allRuntimeSpans.events?.length ?? 0) > 0;
-    const totalExperimentSpans = variantSpanResults.reduce((sum, r) => sum + (r.events?.length ?? 0), 0);
+    const runtimeSpanResults = await queryAllGroups({
+      startTime: twoHoursAgo,
+      filterPattern: baseFilter,
+      limit: 1,
+    });
+    const hasRuntimeSpans = runtimeSpanResults.some(r => (r.events?.length ?? 0) > 0);
+
+    const variantSpanCounts = await Promise.all(
+      variantNames.map(async name => {
+        const results = await queryAllGroups({
+          startTime: twoHoursAgo,
+          filterPattern: `"${test.abTestArn}" "${name}"`,
+          limit: 50,
+        });
+        return results.reduce((sum, r) => sum + (r.events?.length ?? 0), 0);
+      })
+    );
+
+    const totalExperimentSpans = variantSpanCounts.reduce((sum, count) => sum + count, 0);
 
     for (let i = 0; i < variantNames.length; i++) {
       const name = variantNames[i];
-      const count = variantSpanResults[i]?.events?.length ?? 0;
+      const count = variantSpanCounts[i] ?? 0;
       const label = `Runtime Experiment Spans — ${name} (2h)`;
 
       if (count > 0) {


### PR DESCRIPTION
## Description

Add runtime log group as an additional span source alongside aws/spans for all span query sites.

For every place we check the aws/spans log group, also check for spans in the runtime log group and union the results. These changes are backwards compatible so command still work with spans in either location.

Changes:
  - get-trace.ts — fetchSpans now queries both aws/spans and the runtime log group in parallel, concatenates results, swallows ResourceNotFoundException from either
  - span-collector.ts — fetchSessionSpans now queries both aws/spans and the runtime log group for OTEL spans in parallel, concatenates results; added executeQueryGraceful helper
  - run-eval.ts — discoverSessions now queries both aws/spans and the runtime log group in parallel, concatenates results
  - fetch-session-spans.ts (`recommendation` command) — now makes 3 parallel calls instead of 2: aws/spans for span records, runtime log group for span records, runtime log group for log records
  - ABTestDetailScreen.tsx — debug checks now query both aws/spans and the runtime log group for experiment spans, summing counts across both
  - post-deploy-ab-tests.ts — added runtime log group ARN wildcard to the AB test role's IAM policy so the online eval service can read spans there

I tested by running the following commands on agents writing spans to aws/spans and the agent log group:
* agentcore traces list and traces get
* agentcore run eval
* agentcore run recommendation


## Related Issue

<!-- Every PR must be associated with an issue. Link it below using #issue-number format. -->

Closes #

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [x] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
