### PR TITLE
fix(harness): resolve memorySpec by deployed ARN for arn-only memory refs

### DIFF
--- a/e2e-tests/harness-e2e-helper.ts
+++ b/e2e-tests/harness-e2e-helper.ts
@@ -203,10 +203,9 @@ export function createHarnessE2ESuite(cfg: HarnessE2EConfig) {
           async () => {
             try {
               const result = await getHarness({ region, harnessId });
-              expect(
-                ['DELETING', 'DELETED', 'DELETE_FAILED'],
-                `Expected DELETING, DELETED, or DELETE_FAILED, got ${result.harness.status}`
-              ).toContain(result.harness.status);
+              expect(['DELETING', 'DELETED'], `Expected DELETING or DELETED, got ${result.harness.status}`).toContain(
+                result.harness.status
+              );
             } catch (err: unknown) {
               const message = err instanceof Error ? err.message : String(err);
               expect(

--- a/e2e-tests/harness-e2e-helper.ts
+++ b/e2e-tests/harness-e2e-helper.ts
@@ -203,9 +203,10 @@ export function createHarnessE2ESuite(cfg: HarnessE2EConfig) {
           async () => {
             try {
               const result = await getHarness({ region, harnessId });
-              expect(['DELETING', 'DELETED'], `Expected DELETING or DELETED, got ${result.harness.status}`).toContain(
-                result.harness.status
-              );
+              expect(
+                ['DELETING', 'DELETED', 'DELETE_FAILED'],
+                `Expected DELETING, DELETED, or DELETE_FAILED, got ${result.harness.status}`
+              ).toContain(result.harness.status);
             } catch (err: unknown) {
               const message = err instanceof Error ? err.message : String(err);
               expect(

--- a/src/cli/operations/deploy/imperative/deployers/__tests__/harness-deployer.test.ts
+++ b/src/cli/operations/deploy/imperative/deployers/__tests__/harness-deployer.test.ts
@@ -313,6 +313,112 @@ describe('HarnessDeployer', () => {
     });
   });
 
+  describe('memorySpec resolution', () => {
+    const ROLE_ARN = 'arn:aws:iam::123456789012:role/HarnessRole';
+    const MEMORY_ARN = 'arn:aws:bedrock-agentcore:us-east-1:123456789012:memory/mem-123';
+    const CDK_OUTPUTS = { ApplicationHarnessMyHarnessRoleArnOutput123: ROLE_ARN };
+    const READY_HARNESS = {
+      harnessId: 'h-new',
+      harnessName: 'my_harness',
+      arn: 'arn:aws:bedrock-agentcore:us-east-1:123456789012:harness/h-new',
+      status: 'READY' as const,
+      executionRoleArn: ROLE_ARN,
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z',
+    };
+
+    const HARNESS_SPEC_WITH_MEMORY_ARN_JSON = JSON.stringify({
+      name: 'my_harness',
+      model: { provider: 'bedrock', modelId: 'anthropic.claude-3-sonnet-20240229-v1:0' },
+      tools: [],
+      skills: [],
+      memory: { arn: MEMORY_ARN },
+    });
+
+    it('resolves memorySpec by deployed ARN when memory.name is absent', async () => {
+      const { readFile: mockedReadFile } = await import('fs/promises');
+      const { mapHarnessSpecToCreateOptions: mockedMapHarness } = await import('../harness-mapper');
+
+      vi.mocked(mockedReadFile)
+        .mockResolvedValueOnce(HARNESS_SPEC_WITH_MEMORY_ARN_JSON as any)
+        .mockRejectedValueOnce(new Error('ENOENT'));
+      vi.mocked(mockedMapHarness).mockResolvedValueOnce({
+        region: 'us-east-1',
+        harnessName: 'my_harness',
+        executionRoleArn: ROLE_ARN,
+      } as any);
+      vi.mocked(createHarness).mockResolvedValueOnce({
+        harness: READY_HARNESS,
+      } as any);
+
+      const ctx = makeContext({
+        projectSpec: {
+          name: 'proj',
+          harnesses: [{ name: 'my_harness', path: 'harnesses/my_harness' }],
+          memories: [
+            {
+              name: 'my_memory',
+              eventExpiryDuration: 30,
+              strategies: [{ type: 'SEMANTIC', namespaces: ['/users/{actorId}/facts'] }],
+            },
+          ],
+        } as any,
+        deployedState: {
+          targets: {
+            dev: {
+              resources: {
+                memories: { my_memory: { memoryId: 'mem-123', memoryArn: MEMORY_ARN } },
+              },
+            },
+          },
+        } as any,
+        cdkOutputs: CDK_OUTPUTS,
+      });
+
+      await deployer.deploy(ctx);
+
+      expect(mockedMapHarness).toHaveBeenCalledWith(
+        expect.objectContaining({
+          memorySpec: {
+            name: 'my_memory',
+            eventExpiryDuration: 30,
+            strategies: [{ type: 'SEMANTIC', namespaces: ['/users/{actorId}/facts'] }],
+          },
+        })
+      );
+    });
+
+    it('returns undefined memorySpec for a fully external ARN not in deployedResources', async () => {
+      const { readFile: mockedReadFile } = await import('fs/promises');
+      const { mapHarnessSpecToCreateOptions: mockedMapHarness } = await import('../harness-mapper');
+
+      vi.mocked(mockedReadFile)
+        .mockResolvedValueOnce(HARNESS_SPEC_WITH_MEMORY_ARN_JSON as any)
+        .mockRejectedValueOnce(new Error('ENOENT'));
+      vi.mocked(mockedMapHarness).mockResolvedValueOnce({
+        region: 'us-east-1',
+        harnessName: 'my_harness',
+        executionRoleArn: ROLE_ARN,
+      } as any);
+      vi.mocked(createHarness).mockResolvedValueOnce({
+        harness: READY_HARNESS,
+      } as any);
+
+      const ctx = makeContext({
+        projectSpec: {
+          name: 'proj',
+          harnesses: [{ name: 'my_harness', path: 'harnesses/my_harness' }],
+          memories: [],
+        } as any,
+        cdkOutputs: CDK_OUTPUTS,
+      });
+
+      await deployer.deploy(ctx);
+
+      expect(mockedMapHarness).toHaveBeenCalledWith(expect.objectContaining({ memorySpec: undefined }));
+    });
+  });
+
   describe('teardown', () => {
     it('deletes all deployed harnesses', async () => {
       const ctx = makeContext({

--- a/src/cli/operations/deploy/imperative/deployers/harness-deployer.ts
+++ b/src/cli/operations/deploy/imperative/deployers/harness-deployer.ts
@@ -5,8 +5,9 @@
  * via the SigV4 API client. Harness role ARNs are resolved from CDK
  * stack outputs, and harness specs are read from disk (harness.json).
  */
-import type { HarnessDeployedState, HarnessSpec, Memory } from '../../../../../schema';
+import type { HarnessDeployedState, HarnessMemoryRef, HarnessSpec, Memory } from '../../../../../schema';
 import { HarnessSpecSchema } from '../../../../../schema';
+import type { DeployedResourceState } from '../../../../../schema/schemas/deployed-state';
 import type {
   CreateHarnessResult,
   Harness,
@@ -59,6 +60,20 @@ async function computeHarnessHash(
     }
   }
   return hash.digest('hex').slice(0, 16);
+}
+
+function resolveMemorySpec(
+  memories: Memory[] | undefined,
+  memoryRef: HarnessMemoryRef | undefined,
+  deployedResources: DeployedResourceState | undefined
+): Memory | undefined {
+  if (!memoryRef) return undefined;
+  if (memoryRef.name) return memories?.find(m => m.name === memoryRef.name);
+  if (memoryRef.arn && deployedResources?.memories) {
+    const entry = Object.entries(deployedResources.memories).find(([, v]) => v.memoryArn === memoryRef.arn);
+    if (entry) return memories?.find(m => m.name === entry[0]);
+  }
+  return undefined;
 }
 
 // ============================================================================
@@ -140,7 +155,7 @@ export class HarnessDeployer implements ImperativeDeployer<HarnessDeployedStateM
 
       const deployedResources = deployedState.targets?.[targetName]?.resources;
       const existingHarness = deployedHarnesses[entry.name];
-      const memorySpec = projectSpec.memories?.find(m => m.name === harnessSpec.memory?.name);
+      const memorySpec = resolveMemorySpec(projectSpec.memories, harnessSpec.memory, deployedResources);
 
       const configHash = await computeHarnessHash(harnessDir, harnessSpec, executionRoleArn, memorySpec);
 

--- a/src/schema/schemas/agentcore-project.ts
+++ b/src/schema/schemas/agentcore-project.ts
@@ -78,7 +78,13 @@ export type { ABTestMode, TargetRef, GatewayFilter, PerVariantOnlineEvaluationCo
 export { ABTestModeSchema, TargetRefSchema, GatewayFilterSchema } from './primitives/ab-test';
 export type { HttpGatewayTarget } from './primitives/http-gateway';
 export { HttpGatewayTargetSchema } from './primitives/http-gateway';
-export type { HarnessGatewayOutboundAuth, HarnessModel, HarnessSpec, HarnessModelProvider } from './primitives/harness';
+export type {
+  HarnessGatewayOutboundAuth,
+  HarnessMemoryRef,
+  HarnessModel,
+  HarnessSpec,
+  HarnessModelProvider,
+} from './primitives/harness';
 export {
   GatewayOAuthGrantTypeSchema,
   HarnessGatewayOutboundAuthSchema,


### PR DESCRIPTION
## Summary

- When a harness references memory by ARN only (no `name` field), `resolveMemorySpec` now walks `deployedResources.memories` to match by ARN and find the corresponding projectSpec memory
- Without this fix, ARN-only memory refs silently omit `retrievalConfig` and exclude the memory from `configHash`
- Exports `HarnessMemoryRef` from the schema barrel for use as the explicit parameter type

Cherry-picked from #1374 (third commit, missing from the feature-flag consolidation PR).

## Related Issue

Closes #1097

## Test plan

- [x] Unit tests for ARN-match path (`resolves memorySpec by deployed ARN when memory.name is absent`)
- [x] Unit test for undefined fallback for genuinely external memories
- [x] `npm run typecheck` passes
- [x] All existing harness-deployer tests continue to pass (17/17)