### PR TITLE
feat: add Bedrock Mantle API format support for harness

### DIFF
--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -113,6 +113,7 @@ async function main() {
     apiKeyArn?: string;
     efsAccessPoints?: { accessPointArn: string; mountPath: string }[];
     s3AccessPoints?: { accessPointArn: string; mountPath: string }[];
+    apiFormat?: 'converse_stream' | 'responses' | 'chat_completions';
   }[] = [];
   for (const entry of specAny.harnesses ?? []) {
     const harnessDir = path.resolve(projectRoot, entry.path);
@@ -131,6 +132,7 @@ async function main() {
         apiKeyArn: harnessSpec.model?.apiKeyArn,
         efsAccessPoints: harnessSpec.efsAccessPoints,
         s3AccessPoints: harnessSpec.s3AccessPoints,
+        apiFormat: harnessSpec.model?.apiFormat,
       });
     } catch (err) {
       throw new Error(

--- a/src/assets/cdk/bin/cdk.ts
+++ b/src/assets/cdk/bin/cdk.ts
@@ -68,6 +68,7 @@ async function main() {
     apiKeyArn?: string;
     efsAccessPoints?: { accessPointArn: string; mountPath: string }[];
     s3AccessPoints?: { accessPointArn: string; mountPath: string }[];
+    apiFormat?: 'converse_stream' | 'responses' | 'chat_completions';
   }[] = [];
   for (const entry of specAny.harnesses ?? []) {
     const harnessDir = path.resolve(projectRoot, entry.path);
@@ -86,6 +87,7 @@ async function main() {
         apiKeyArn: harnessSpec.model?.apiKeyArn,
         efsAccessPoints: harnessSpec.efsAccessPoints,
         s3AccessPoints: harnessSpec.s3AccessPoints,
+        apiFormat: harnessSpec.model?.apiFormat,
       });
     } catch (err) {
       throw new Error(

--- a/src/cli/aws/agentcore-harness.ts
+++ b/src/cli/aws/agentcore-harness.ts
@@ -28,6 +28,7 @@ export interface BedrockModelConfig {
 export interface OpenAiModelConfig {
   modelId: string;
   apiKeyArn?: string;
+  apiFormat?: 'responses' | 'chat_completions';
   temperature?: number;
   topP?: number;
   maxTokens?: number;

--- a/src/cli/aws/agentcore-harness.ts
+++ b/src/cli/aws/agentcore-harness.ts
@@ -19,6 +19,7 @@ export type HarnessStatus = 'CREATING' | 'READY' | 'UPDATING' | 'DELETING' | 'DE
 
 export interface BedrockModelConfig {
   modelId: string;
+  apiFormat?: 'converse_stream' | 'responses' | 'chat_completions';
   temperature?: number;
   topP?: number;
   maxTokens?: number;

--- a/src/cli/commands/add/types.ts
+++ b/src/cli/commands/add/types.ts
@@ -97,6 +97,7 @@ export interface AddHarnessCliOptions {
   name?: string;
   modelProvider?: string;
   modelId?: string;
+  apiFormat?: string;
   apiKeyArn?: string;
   container?: string;
   memory?: boolean;

--- a/src/cli/commands/add/validate.ts
+++ b/src/cli/commands/add/validate.ts
@@ -1,16 +1,13 @@
 import { ConfigIO, findConfigRoot } from '../../../lib';
 import {
   AgentNameSchema,
-  BedrockApiFormatSchema,
   BuildTypeSchema,
   DatasetNameSchema,
   DatasetSchemaTypeSchema,
   GatewayAuthorizerTypeSchema,
   GatewayExceptionLevelSchema,
   GatewayNameSchema,
-  HarnessApiFormatSchema,
   ModelProviderSchema,
-  OpenAiApiFormatSchema,
   ProtocolModeSchema,
   RuntimeAuthorizerTypeSchema,
   SDKFrameworkSchema,
@@ -22,6 +19,7 @@ import {
   getSupportedModelProviders,
   isValidKmsKeyArn,
   matchEnumValue,
+  validateApiFormat,
 } from '../../../schema';
 import { ARN_VALIDATION_MESSAGE, isValidArn } from '../shared/arn-utils';
 import { validateHeaderAllowlist } from '../shared/header-utils';
@@ -896,32 +894,10 @@ const VALID_GATEWAY_OUTBOUND_AUTH = ['awsIam', 'none', 'oauth'] as const;
 
 export function validateAddHarnessOptions(options: AddHarnessCliOptions): ValidationResult {
   if (options.apiFormat) {
-    const allFormats = HarnessApiFormatSchema.options;
-    if (!allFormats.includes(options.apiFormat as (typeof allFormats)[number])) {
-      return {
-        valid: false,
-        error: `Invalid API format: ${options.apiFormat}. Use ${allFormats.join(', ')}`,
-      };
-    }
     const provider = options.modelProvider ?? 'bedrock';
-    if (provider === 'bedrock') {
-      const bedrockFormats = BedrockApiFormatSchema.options;
-      if (!bedrockFormats.includes(options.apiFormat as (typeof bedrockFormats)[number])) {
-        return {
-          valid: false,
-          error: `Invalid API format for bedrock: ${options.apiFormat}. Use ${bedrockFormats.join(', ')}`,
-        };
-      }
-    } else if (provider === 'open_ai') {
-      const openAiFormats = OpenAiApiFormatSchema.options;
-      if (!openAiFormats.includes(options.apiFormat as (typeof openAiFormats)[number])) {
-        return {
-          valid: false,
-          error: `Invalid API format for open_ai: ${options.apiFormat}. Use ${openAiFormats.join(', ')}`,
-        };
-      }
-    } else {
-      return { valid: false, error: '--api-format is only supported for bedrock and open_ai providers' };
+    const formatResult = validateApiFormat(options.apiFormat, provider);
+    if (!formatResult.valid) {
+      return { valid: false, error: formatResult.error };
     }
   }
 

--- a/src/cli/commands/add/validate.ts
+++ b/src/cli/commands/add/validate.ts
@@ -8,7 +8,9 @@ import {
   GatewayAuthorizerTypeSchema,
   GatewayExceptionLevelSchema,
   GatewayNameSchema,
+  HarnessApiFormatSchema,
   ModelProviderSchema,
+  OpenAiApiFormatSchema,
   ProtocolModeSchema,
   RuntimeAuthorizerTypeSchema,
   SDKFrameworkSchema,
@@ -894,16 +896,32 @@ const VALID_GATEWAY_OUTBOUND_AUTH = ['awsIam', 'none', 'oauth'] as const;
 
 export function validateAddHarnessOptions(options: AddHarnessCliOptions): ValidationResult {
   if (options.apiFormat) {
-    const validFormats = BedrockApiFormatSchema.options;
-    if (!validFormats.includes(options.apiFormat as (typeof validFormats)[number])) {
+    const allFormats = HarnessApiFormatSchema.options;
+    if (!allFormats.includes(options.apiFormat as (typeof allFormats)[number])) {
       return {
         valid: false,
-        error: `Invalid API format: ${options.apiFormat}. Use ${validFormats.join(', ')}`,
+        error: `Invalid API format: ${options.apiFormat}. Use ${allFormats.join(', ')}`,
       };
     }
     const provider = options.modelProvider ?? 'bedrock';
-    if (provider !== 'bedrock') {
-      return { valid: false, error: '--api-format is only supported for the bedrock provider' };
+    if (provider === 'bedrock') {
+      const bedrockFormats = BedrockApiFormatSchema.options;
+      if (!bedrockFormats.includes(options.apiFormat as (typeof bedrockFormats)[number])) {
+        return {
+          valid: false,
+          error: `Invalid API format for bedrock: ${options.apiFormat}. Use ${bedrockFormats.join(', ')}`,
+        };
+      }
+    } else if (provider === 'open_ai') {
+      const openAiFormats = OpenAiApiFormatSchema.options;
+      if (!openAiFormats.includes(options.apiFormat as (typeof openAiFormats)[number])) {
+        return {
+          valid: false,
+          error: `Invalid API format for open_ai: ${options.apiFormat}. Use ${openAiFormats.join(', ')}`,
+        };
+      }
+    } else {
+      return { valid: false, error: '--api-format is only supported for bedrock and open_ai providers' };
     }
   }
 

--- a/src/cli/commands/add/validate.ts
+++ b/src/cli/commands/add/validate.ts
@@ -1,6 +1,7 @@
 import { ConfigIO, findConfigRoot } from '../../../lib';
 import {
   AgentNameSchema,
+  BedrockApiFormatSchema,
   BuildTypeSchema,
   DatasetNameSchema,
   DatasetSchemaTypeSchema,
@@ -892,6 +893,20 @@ const VALID_HARNESS_TOOLS = [
 const VALID_GATEWAY_OUTBOUND_AUTH = ['awsIam', 'none', 'oauth'] as const;
 
 export function validateAddHarnessOptions(options: AddHarnessCliOptions): ValidationResult {
+  if (options.apiFormat) {
+    const validFormats = BedrockApiFormatSchema.options;
+    if (!validFormats.includes(options.apiFormat as (typeof validFormats)[number])) {
+      return {
+        valid: false,
+        error: `Invalid API format: ${options.apiFormat}. Use ${validFormats.join(', ')}`,
+      };
+    }
+    const provider = options.modelProvider ?? 'bedrock';
+    if (provider !== 'bedrock') {
+      return { valid: false, error: '--api-format is only supported for the bedrock provider' };
+    }
+  }
+
   if (options.tools) {
     const toolNames = options.tools.split(',').map(s => s.trim());
     for (const tool of toolNames) {

--- a/src/cli/commands/create/__tests__/harness-validate.test.ts
+++ b/src/cli/commands/create/__tests__/harness-validate.test.ts
@@ -27,6 +27,52 @@ const vpcOptions = {
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
+// apiFormat validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('validateCreateHarnessOptions - apiFormat', () => {
+  it('accepts valid apiFormat for bedrock provider', () => {
+    const result = validateCreateHarnessOptions({ ...baseOptions, apiFormat: 'responses' }, makeCwd());
+    expect(result.valid).toBe(true);
+  });
+
+  it('accepts chat_completions format', () => {
+    const result = validateCreateHarnessOptions({ ...baseOptions, apiFormat: 'chat_completions' }, makeCwd());
+    expect(result.valid).toBe(true);
+  });
+
+  it('accepts converse_stream format', () => {
+    const result = validateCreateHarnessOptions({ ...baseOptions, apiFormat: 'converse_stream' }, makeCwd());
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects invalid apiFormat value', () => {
+    const result = validateCreateHarnessOptions({ ...baseOptions, apiFormat: 'invalid_format' }, makeCwd());
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('Invalid API format');
+  });
+
+  it('rejects apiFormat for non-bedrock provider', () => {
+    const result = validateCreateHarnessOptions(
+      {
+        ...baseOptions,
+        modelProvider: 'open_ai',
+        apiKeyArn: 'arn:aws:secretsmanager:us-east-1:123:secret:key',
+        apiFormat: 'responses',
+      },
+      makeCwd()
+    );
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('only supported for the bedrock provider');
+  });
+
+  it('passes when apiFormat is not specified', () => {
+    const result = validateCreateHarnessOptions(baseOptions, makeCwd());
+    expect(result.valid).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // EFS access point validation
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/src/cli/commands/create/__tests__/harness-validate.test.ts
+++ b/src/cli/commands/create/__tests__/harness-validate.test.ts
@@ -52,7 +52,7 @@ describe('validateCreateHarnessOptions - apiFormat', () => {
     expect(result.error).toContain('Invalid API format');
   });
 
-  it('rejects apiFormat for non-bedrock provider', () => {
+  it('accepts responses format for open_ai provider', () => {
     const result = validateCreateHarnessOptions(
       {
         ...baseOptions,
@@ -62,8 +62,48 @@ describe('validateCreateHarnessOptions - apiFormat', () => {
       },
       makeCwd()
     );
+    expect(result.valid).toBe(true);
+  });
+
+  it('accepts chat_completions format for open_ai provider', () => {
+    const result = validateCreateHarnessOptions(
+      {
+        ...baseOptions,
+        modelProvider: 'open_ai',
+        apiKeyArn: 'arn:aws:secretsmanager:us-east-1:123:secret:key',
+        apiFormat: 'chat_completions',
+      },
+      makeCwd()
+    );
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects converse_stream for open_ai provider', () => {
+    const result = validateCreateHarnessOptions(
+      {
+        ...baseOptions,
+        modelProvider: 'open_ai',
+        apiKeyArn: 'arn:aws:secretsmanager:us-east-1:123:secret:key',
+        apiFormat: 'converse_stream',
+      },
+      makeCwd()
+    );
     expect(result.valid).toBe(false);
-    expect(result.error).toContain('only supported for the bedrock provider');
+    expect(result.error).toContain('Invalid API format for open_ai');
+  });
+
+  it('rejects apiFormat for gemini provider', () => {
+    const result = validateCreateHarnessOptions(
+      {
+        ...baseOptions,
+        modelProvider: 'gemini',
+        apiKeyArn: 'arn:aws:secretsmanager:us-east-1:123:secret:key',
+        apiFormat: 'responses',
+      },
+      makeCwd()
+    );
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('only supported for bedrock and open_ai');
   });
 
   it('passes when apiFormat is not specified', () => {

--- a/src/cli/commands/create/harness-action.ts
+++ b/src/cli/commands/create/harness-action.ts
@@ -1,5 +1,5 @@
 import { CONFIG_DIR } from '../../../lib';
-import type { HarnessModelProvider, NetworkMode } from '../../../schema';
+import type { BedrockApiFormat, HarnessModelProvider, NetworkMode } from '../../../schema';
 import { harnessPrimitive } from '../../primitives/registry';
 import { type ProgressCallback, createProject } from './action';
 import type { CreateResult } from './types';
@@ -12,6 +12,7 @@ export interface CreateHarnessProjectOptions {
   cwd: string;
   modelProvider: HarnessModelProvider;
   modelId: string;
+  apiFormat?: BedrockApiFormat;
   apiKeyArn?: string;
   skipMemory?: boolean;
   containerUri?: string;
@@ -59,6 +60,7 @@ export async function createProjectWithHarness(options: CreateHarnessProjectOpti
       name: options.name,
       modelProvider: options.modelProvider,
       modelId: options.modelId,
+      apiFormat: options.apiFormat,
       apiKeyArn: options.apiKeyArn,
       containerUri: options.containerUri,
       dockerfilePath: options.dockerfilePath,

--- a/src/cli/commands/create/harness-action.ts
+++ b/src/cli/commands/create/harness-action.ts
@@ -1,5 +1,5 @@
 import { CONFIG_DIR } from '../../../lib';
-import type { BedrockApiFormat, HarnessModelProvider, NetworkMode } from '../../../schema';
+import type { HarnessApiFormat, HarnessModelProvider, NetworkMode } from '../../../schema';
 import { harnessPrimitive } from '../../primitives/registry';
 import { type ProgressCallback, createProject } from './action';
 import type { CreateResult } from './types';
@@ -12,7 +12,7 @@ export interface CreateHarnessProjectOptions {
   cwd: string;
   modelProvider: HarnessModelProvider;
   modelId: string;
-  apiFormat?: BedrockApiFormat;
+  apiFormat?: HarnessApiFormat;
   apiKeyArn?: string;
   skipMemory?: boolean;
   containerUri?: string;

--- a/src/cli/commands/create/harness-validate.ts
+++ b/src/cli/commands/create/harness-validate.ts
@@ -1,10 +1,4 @@
-import {
-  BedrockApiFormatSchema,
-  HarnessApiFormatSchema,
-  MAX_EFS_MOUNTS,
-  MAX_S3_MOUNTS,
-  OpenAiApiFormatSchema,
-} from '../../../schema';
+import { MAX_EFS_MOUNTS, MAX_S3_MOUNTS, validateApiFormat } from '../../../schema';
 import { HarnessNameSchema, ProjectNameSchema } from '../../../schema';
 import {
   validateAccessPointMounts,
@@ -110,31 +104,9 @@ export function validateCreateHarnessOptions(options: CreateHarnessCliOptions, c
   }
 
   if (options.apiFormat) {
-    const allFormats = HarnessApiFormatSchema.options;
-    if (!allFormats.includes(options.apiFormat as (typeof allFormats)[number])) {
-      return {
-        valid: false,
-        error: `Invalid API format: ${options.apiFormat}. Use ${allFormats.join(', ')}`,
-      };
-    }
-    if (options.modelProvider === 'bedrock') {
-      const bedrockFormats = BedrockApiFormatSchema.options;
-      if (!bedrockFormats.includes(options.apiFormat as (typeof bedrockFormats)[number])) {
-        return {
-          valid: false,
-          error: `Invalid API format for bedrock: ${options.apiFormat}. Use ${bedrockFormats.join(', ')}`,
-        };
-      }
-    } else if (options.modelProvider === 'open_ai') {
-      const openAiFormats = OpenAiApiFormatSchema.options;
-      if (!openAiFormats.includes(options.apiFormat as (typeof openAiFormats)[number])) {
-        return {
-          valid: false,
-          error: `Invalid API format for open_ai: ${options.apiFormat}. Use ${openAiFormats.join(', ')}`,
-        };
-      }
-    } else {
-      return { valid: false, error: '--api-format is only supported for bedrock and open_ai providers' };
+    const formatResult = validateApiFormat(options.apiFormat, options.modelProvider ?? 'bedrock');
+    if (!formatResult.valid) {
+      return { valid: false, error: formatResult.error };
     }
   }
 

--- a/src/cli/commands/create/harness-validate.ts
+++ b/src/cli/commands/create/harness-validate.ts
@@ -1,4 +1,10 @@
-import { BedrockApiFormatSchema, MAX_EFS_MOUNTS, MAX_S3_MOUNTS } from '../../../schema';
+import {
+  BedrockApiFormatSchema,
+  HarnessApiFormatSchema,
+  MAX_EFS_MOUNTS,
+  MAX_S3_MOUNTS,
+  OpenAiApiFormatSchema,
+} from '../../../schema';
 import { HarnessNameSchema, ProjectNameSchema } from '../../../schema';
 import {
   validateAccessPointMounts,
@@ -104,15 +110,31 @@ export function validateCreateHarnessOptions(options: CreateHarnessCliOptions, c
   }
 
   if (options.apiFormat) {
-    const validFormats = BedrockApiFormatSchema.options;
-    if (!validFormats.includes(options.apiFormat as (typeof validFormats)[number])) {
+    const allFormats = HarnessApiFormatSchema.options;
+    if (!allFormats.includes(options.apiFormat as (typeof allFormats)[number])) {
       return {
         valid: false,
-        error: `Invalid API format: ${options.apiFormat}. Use ${validFormats.join(', ')}`,
+        error: `Invalid API format: ${options.apiFormat}. Use ${allFormats.join(', ')}`,
       };
     }
-    if (options.modelProvider !== 'bedrock') {
-      return { valid: false, error: '--api-format is only supported for the bedrock provider' };
+    if (options.modelProvider === 'bedrock') {
+      const bedrockFormats = BedrockApiFormatSchema.options;
+      if (!bedrockFormats.includes(options.apiFormat as (typeof bedrockFormats)[number])) {
+        return {
+          valid: false,
+          error: `Invalid API format for bedrock: ${options.apiFormat}. Use ${bedrockFormats.join(', ')}`,
+        };
+      }
+    } else if (options.modelProvider === 'open_ai') {
+      const openAiFormats = OpenAiApiFormatSchema.options;
+      if (!openAiFormats.includes(options.apiFormat as (typeof openAiFormats)[number])) {
+        return {
+          valid: false,
+          error: `Invalid API format for open_ai: ${options.apiFormat}. Use ${openAiFormats.join(', ')}`,
+        };
+      }
+    } else {
+      return { valid: false, error: '--api-format is only supported for bedrock and open_ai providers' };
     }
   }
 

--- a/src/cli/commands/create/harness-validate.ts
+++ b/src/cli/commands/create/harness-validate.ts
@@ -13,6 +13,7 @@ export interface CreateHarnessCliOptions {
   projectName?: string;
   modelProvider?: string;
   modelId?: string;
+  apiFormat?: string;
   apiKeyArn?: string;
   container?: string;
   noMemory?: boolean;
@@ -100,6 +101,19 @@ export function validateCreateHarnessOptions(options: CreateHarnessCliOptions, c
 
   if (options.modelProvider !== 'bedrock' && !options.apiKeyArn) {
     return { valid: false, error: `--api-key-arn is required for ${options.modelProvider} provider` };
+  }
+
+  if (options.apiFormat) {
+    const validFormats = ['converse_stream', 'responses', 'chat_completions'];
+    if (!validFormats.includes(options.apiFormat)) {
+      return {
+        valid: false,
+        error: `Invalid API format: ${options.apiFormat}. Use converse_stream, responses, or chat_completions`,
+      };
+    }
+    if (options.modelProvider !== 'bedrock') {
+      return { valid: false, error: '--api-format is only supported for the bedrock provider' };
+    }
   }
 
   // Validate EFS access point ARN/path pairs

--- a/src/cli/commands/create/harness-validate.ts
+++ b/src/cli/commands/create/harness-validate.ts
@@ -1,4 +1,4 @@
-import { MAX_EFS_MOUNTS, MAX_S3_MOUNTS } from '../../../schema';
+import { BedrockApiFormatSchema, MAX_EFS_MOUNTS, MAX_S3_MOUNTS } from '../../../schema';
 import { HarnessNameSchema, ProjectNameSchema } from '../../../schema';
 import {
   validateAccessPointMounts,
@@ -104,11 +104,11 @@ export function validateCreateHarnessOptions(options: CreateHarnessCliOptions, c
   }
 
   if (options.apiFormat) {
-    const validFormats = ['converse_stream', 'responses', 'chat_completions'];
-    if (!validFormats.includes(options.apiFormat)) {
+    const validFormats = BedrockApiFormatSchema.options;
+    if (!validFormats.includes(options.apiFormat as (typeof validFormats)[number])) {
       return {
         valid: false,
-        error: `Invalid API format: ${options.apiFormat}. Use converse_stream, responses, or chat_completions`,
+        error: `Invalid API format: ${options.apiFormat}. Use ${validFormats.join(', ')}`,
       };
     }
     if (options.modelProvider !== 'bedrock') {

--- a/src/cli/operations/deploy/imperative/deployers/__tests__/harness-mapper.test.ts
+++ b/src/cli/operations/deploy/imperative/deployers/__tests__/harness-mapper.test.ts
@@ -87,6 +87,51 @@ describe('mapHarnessSpecToCreateOptions', () => {
       });
     });
 
+    it('maps bedrock with apiFormat responses', async () => {
+      const opts = baseOptions({
+        harnessSpec: {
+          name: 'h',
+          model: { provider: 'bedrock', modelId: 'openai.gpt-oss-120b', apiFormat: 'responses' },
+          tools: [],
+          skills: [],
+        } as any,
+      });
+      const result = await mapHarnessSpecToCreateOptions(opts);
+      expect(result.model).toEqual({
+        bedrockModelConfig: { modelId: 'openai.gpt-oss-120b', apiFormat: 'responses' },
+      });
+    });
+
+    it('maps bedrock with apiFormat chat_completions', async () => {
+      const opts = baseOptions({
+        harnessSpec: {
+          name: 'h',
+          model: { provider: 'bedrock', modelId: 'openai.gpt-oss-120b', apiFormat: 'chat_completions' },
+          tools: [],
+          skills: [],
+        } as any,
+      });
+      const result = await mapHarnessSpecToCreateOptions(opts);
+      expect(result.model).toEqual({
+        bedrockModelConfig: { modelId: 'openai.gpt-oss-120b', apiFormat: 'chat_completions' },
+      });
+    });
+
+    it('omits apiFormat when converse_stream (default)', async () => {
+      const opts = baseOptions({
+        harnessSpec: {
+          name: 'h',
+          model: { provider: 'bedrock', modelId: 'claude', apiFormat: 'converse_stream' },
+          tools: [],
+          skills: [],
+        } as any,
+      });
+      const result = await mapHarnessSpecToCreateOptions(opts);
+      expect(result.model).toEqual({
+        bedrockModelConfig: { modelId: 'claude' },
+      });
+    });
+
     it('includes optional model params when set', async () => {
       const opts = baseOptions({
         harnessSpec: {

--- a/src/cli/operations/deploy/imperative/deployers/__tests__/harness-mapper.test.ts
+++ b/src/cli/operations/deploy/imperative/deployers/__tests__/harness-mapper.test.ts
@@ -132,6 +132,50 @@ describe('mapHarnessSpecToCreateOptions', () => {
       });
     });
 
+    it('maps open_ai with apiFormat chat_completions', async () => {
+      const opts = baseOptions({
+        harnessSpec: {
+          name: 'h',
+          model: {
+            provider: 'open_ai',
+            modelId: 'gpt-5',
+            apiKeyArn: 'arn:aws:secretsmanager:us-east-1:123:secret:key',
+            apiFormat: 'chat_completions',
+          },
+          tools: [],
+          skills: [],
+        } as any,
+      });
+      const result = await mapHarnessSpecToCreateOptions(opts);
+      expect(result.model).toEqual({
+        openAiModelConfig: {
+          modelId: 'gpt-5',
+          apiKeyArn: 'arn:aws:secretsmanager:us-east-1:123:secret:key',
+          apiFormat: 'chat_completions',
+        },
+      });
+    });
+
+    it('omits apiFormat for open_ai when responses (default)', async () => {
+      const opts = baseOptions({
+        harnessSpec: {
+          name: 'h',
+          model: {
+            provider: 'open_ai',
+            modelId: 'gpt-5',
+            apiKeyArn: 'arn:aws:secretsmanager:us-east-1:123:secret:key',
+            apiFormat: 'responses',
+          },
+          tools: [],
+          skills: [],
+        } as any,
+      });
+      const result = await mapHarnessSpecToCreateOptions(opts);
+      expect(result.model).toEqual({
+        openAiModelConfig: { modelId: 'gpt-5', apiKeyArn: 'arn:aws:secretsmanager:us-east-1:123:secret:key' },
+      });
+    });
+
     it('includes optional model params when set', async () => {
       const opts = baseOptions({
         harnessSpec: {

--- a/src/cli/operations/deploy/imperative/deployers/harness-mapper.ts
+++ b/src/cli/operations/deploy/imperative/deployers/harness-mapper.ts
@@ -171,6 +171,7 @@ function mapModel(model: HarnessSpec['model']): HarnessModelConfiguration {
         openAiModelConfig: {
           modelId,
           ...(apiKeyArn && { apiKeyArn }),
+          ...(apiFormat && apiFormat !== 'responses' && { apiFormat: apiFormat as 'responses' | 'chat_completions' }),
           ...(temperature !== undefined && { temperature }),
           ...(topP !== undefined && { topP }),
           ...(maxTokens !== undefined && { maxTokens }),

--- a/src/cli/operations/deploy/imperative/deployers/harness-mapper.ts
+++ b/src/cli/operations/deploy/imperative/deployers/harness-mapper.ts
@@ -153,13 +153,14 @@ export async function mapHarnessSpecToCreateOptions(options: MapHarnessOptions):
 // ============================================================================
 
 function mapModel(model: HarnessSpec['model']): HarnessModelConfiguration {
-  const { provider, modelId, apiKeyArn, temperature, topP, topK, maxTokens } = model;
+  const { provider, modelId, apiKeyArn, apiFormat, temperature, topP, topK, maxTokens } = model;
 
   switch (provider) {
     case 'bedrock':
       return {
         bedrockModelConfig: {
           modelId,
+          ...(apiFormat && apiFormat !== 'converse_stream' && { apiFormat }),
           ...(temperature !== undefined && { temperature }),
           ...(topP !== undefined && { topP }),
           ...(maxTokens !== undefined && { maxTokens }),

--- a/src/cli/primitives/HarnessPrimitive.ts
+++ b/src/cli/primitives/HarnessPrimitive.ts
@@ -1,6 +1,6 @@
 import { APP_DIR, ConfigIO, type Result, findConfigRoot } from '../../lib';
 import type {
-  BedrockApiFormat,
+  HarnessApiFormat,
   HarnessGatewayOutboundAuth,
   HarnessModelProvider,
   HarnessSpec,
@@ -28,7 +28,7 @@ export interface AddHarnessOptions {
   name: string;
   modelProvider: HarnessModelProvider;
   modelId: string;
-  apiFormat?: BedrockApiFormat;
+  apiFormat?: HarnessApiFormat;
   apiKeyArn?: string;
   systemPrompt?: string;
   skipMemory?: boolean;
@@ -352,7 +352,10 @@ export class HarnessPrimitive extends BasePrimitive<AddHarnessOptions, Removable
       .option('--name <name>', 'Harness name (start with letter, alphanumeric + underscores, max 48 chars)')
       .option('--model-provider <provider>', 'Model provider: bedrock, open_ai, gemini')
       .option('--model-id <id>', 'Model ID (e.g., anthropic.claude-3-5-sonnet-20240620-v1:0)')
-      .option('--api-format <format>', 'API format for Bedrock: converse_stream, responses, chat_completions')
+      .option(
+        '--api-format <format>',
+        'API format: converse_stream, responses, chat_completions (bedrock); responses, chat_completions (open_ai)'
+      )
       .option('--api-key-arn <arn>', 'API key ARN for non-Bedrock providers')
       .option('--container <uri-or-path>', 'Container image URI or path to a Dockerfile')
       .option('--no-memory', 'Skip auto-creating memory')
@@ -466,10 +469,11 @@ export class HarnessPrimitive extends BasePrimitive<AddHarnessOptions, Removable
               const { DEFAULT_BEDROCK_MANTLE_MODEL_ID, DEFAULT_MODEL_IDS } =
                 await import('../tui/screens/harness/types');
               const provider = (cliOptions.modelProvider ?? 'bedrock') as HarnessModelProvider;
-              const isMantleFormat =
-                cliOptions.apiFormat === 'responses' || cliOptions.apiFormat === 'chat_completions';
+              const isBedrockMantle =
+                provider === 'bedrock' &&
+                (cliOptions.apiFormat === 'responses' || cliOptions.apiFormat === 'chat_completions');
               const modelId =
-                cliOptions.modelId ?? (isMantleFormat ? DEFAULT_BEDROCK_MANTLE_MODEL_ID : DEFAULT_MODEL_IDS[provider]);
+                cliOptions.modelId ?? (isBedrockMantle ? DEFAULT_BEDROCK_MANTLE_MODEL_ID : DEFAULT_MODEL_IDS[provider]);
 
               const containerOption = this.parseContainerFlag(cliOptions.container);
 
@@ -477,7 +481,7 @@ export class HarnessPrimitive extends BasePrimitive<AddHarnessOptions, Removable
                 name: cliOptions.name,
                 modelProvider: provider,
                 modelId,
-                apiFormat: cliOptions.apiFormat as BedrockApiFormat | undefined,
+                apiFormat: cliOptions.apiFormat as HarnessApiFormat | undefined,
                 apiKeyArn: cliOptions.apiKeyArn,
                 containerUri: containerOption.containerUri,
                 dockerfilePath: containerOption.dockerfilePath,

--- a/src/cli/primitives/HarnessPrimitive.ts
+++ b/src/cli/primitives/HarnessPrimitive.ts
@@ -1,5 +1,6 @@
 import { APP_DIR, ConfigIO, type Result, findConfigRoot } from '../../lib';
 import type {
+  BedrockApiFormat,
   HarnessGatewayOutboundAuth,
   HarnessModelProvider,
   HarnessSpec,
@@ -27,6 +28,7 @@ export interface AddHarnessOptions {
   name: string;
   modelProvider: HarnessModelProvider;
   modelId: string;
+  apiFormat?: BedrockApiFormat;
   apiKeyArn?: string;
   systemPrompt?: string;
   skipMemory?: boolean;
@@ -151,6 +153,7 @@ export class HarnessPrimitive extends BasePrimitive<AddHarnessOptions, Removable
         model: {
           provider: options.modelProvider,
           modelId: options.modelId,
+          ...(options.apiFormat && { apiFormat: options.apiFormat }),
           ...(options.apiKeyArn && { apiKeyArn: options.apiKeyArn }),
         },
         tools,
@@ -349,6 +352,7 @@ export class HarnessPrimitive extends BasePrimitive<AddHarnessOptions, Removable
       .option('--name <name>', 'Harness name (start with letter, alphanumeric + underscores, max 48 chars)')
       .option('--model-provider <provider>', 'Model provider: bedrock, open_ai, gemini')
       .option('--model-id <id>', 'Model ID (e.g., anthropic.claude-3-5-sonnet-20240620-v1:0)')
+      .option('--api-format <format>', 'API format for Bedrock: converse_stream, responses, chat_completions')
       .option('--api-key-arn <arn>', 'API key ARN for non-Bedrock providers')
       .option('--container <uri-or-path>', 'Container image URI or path to a Dockerfile')
       .option('--no-memory', 'Skip auto-creating memory')
@@ -394,6 +398,7 @@ export class HarnessPrimitive extends BasePrimitive<AddHarnessOptions, Removable
           name?: string;
           modelProvider?: string;
           modelId?: string;
+          apiFormat?: string;
           apiKeyArn?: string;
           container?: string;
           memory?: boolean;
@@ -458,9 +463,13 @@ export class HarnessPrimitive extends BasePrimitive<AddHarnessOptions, Removable
                 process.exit(1);
               }
 
-              const { DEFAULT_MODEL_IDS } = await import('../tui/screens/harness/types');
+              const { DEFAULT_BEDROCK_MANTLE_MODEL_ID, DEFAULT_MODEL_IDS } =
+                await import('../tui/screens/harness/types');
               const provider = (cliOptions.modelProvider ?? 'bedrock') as HarnessModelProvider;
-              const modelId = cliOptions.modelId ?? DEFAULT_MODEL_IDS[provider];
+              const isMantleFormat =
+                cliOptions.apiFormat === 'responses' || cliOptions.apiFormat === 'chat_completions';
+              const modelId =
+                cliOptions.modelId ?? (isMantleFormat ? DEFAULT_BEDROCK_MANTLE_MODEL_ID : DEFAULT_MODEL_IDS[provider]);
 
               const containerOption = this.parseContainerFlag(cliOptions.container);
 
@@ -468,6 +477,7 @@ export class HarnessPrimitive extends BasePrimitive<AddHarnessOptions, Removable
                 name: cliOptions.name,
                 modelProvider: provider,
                 modelId,
+                apiFormat: cliOptions.apiFormat as BedrockApiFormat | undefined,
                 apiKeyArn: cliOptions.apiKeyArn,
                 containerUri: containerOption.containerUri,
                 dockerfilePath: containerOption.dockerfilePath,

--- a/src/cli/tui/screens/create/useCreateFlow.ts
+++ b/src/cli/tui/screens/create/useCreateFlow.ts
@@ -650,6 +650,7 @@ export function useCreateFlow(cwd: string): CreateFlowState {
                 name: addHarnessConfig.name,
                 modelProvider: addHarnessConfig.modelProvider,
                 modelId: addHarnessConfig.modelId,
+                apiFormat: addHarnessConfig.apiFormat,
                 apiKeyArn: addHarnessConfig.apiKeyArn,
                 skipMemory: addHarnessConfig.skipMemory,
                 containerUri: addHarnessConfig.containerUri,

--- a/src/cli/tui/screens/harness/AddHarnessFlow.tsx
+++ b/src/cli/tui/screens/harness/AddHarnessFlow.tsx
@@ -50,6 +50,7 @@ export function AddHarnessFlow({ isInteractive = true, onExit, onBack, onDev, on
         name: config.name,
         modelProvider: config.modelProvider,
         modelId: config.modelId,
+        apiFormat: config.apiFormat,
         apiKeyArn: config.apiKeyArn,
         skipMemory: config.skipMemory,
         containerUri: config.containerUri,

--- a/src/cli/tui/screens/harness/AddHarnessScreen.tsx
+++ b/src/cli/tui/screens/harness/AddHarnessScreen.tsx
@@ -1,5 +1,5 @@
 import type { HarnessModelProvider, RuntimeAuthorizerType } from '../../../../schema';
-import { BedrockApiFormatSchema, MAX_EFS_MOUNTS, MAX_S3_MOUNTS, NetworkModeSchema } from '../../../../schema';
+import { HarnessApiFormatSchema, MAX_EFS_MOUNTS, MAX_S3_MOUNTS, NetworkModeSchema } from '../../../../schema';
 import { HarnessNameSchema, HarnessTruncationStrategySchema } from '../../../../schema/schemas/primitives/harness';
 import { ARN_VALIDATION_MESSAGE, isValidArn } from '../../../commands/shared/arn-utils';
 import {
@@ -27,14 +27,15 @@ import { buildMountListItems } from '../agent/buildMountListItems';
 import type { AddHarnessConfig, AdvancedSetting, ContainerMode } from './types';
 import {
   ADVANCED_SETTING_OPTIONS,
-  API_FORMAT_OPTIONS,
   AUTHORIZER_TYPE_OPTIONS,
+  BEDROCK_API_FORMAT_OPTIONS,
   CONTAINER_MODE_OPTIONS,
   GATEWAY_OUTBOUND_AUTH_OPTIONS,
   HARNESS_STEP_LABELS,
   MEMORY_OPTIONS,
   MODEL_PROVIDER_OPTIONS,
   NETWORK_MODE_OPTIONS,
+  OPENAI_API_FORMAT_OPTIONS,
   TOOL_SELECT_OPTIONS,
   TRUNCATION_STRATEGY_OPTIONS,
 } from './types';
@@ -62,8 +63,13 @@ export function AddHarnessScreen({ existingHarnessNames, onComplete, onExit }: A
   );
 
   const apiFormatItems: SelectableItem[] = useMemo(
-    () => API_FORMAT_OPTIONS.map(opt => ({ id: opt.id, title: opt.title, description: opt.description })),
-    []
+    () =>
+      (wizard.config.modelProvider === 'open_ai' ? OPENAI_API_FORMAT_OPTIONS : BEDROCK_API_FORMAT_OPTIONS).map(opt => ({
+        id: opt.id,
+        title: opt.title,
+        description: opt.description,
+      })),
+    [wizard.config.modelProvider]
   );
 
   const containerModeItems: SelectableItem[] = useMemo(
@@ -151,7 +157,7 @@ export function AddHarnessScreen({ existingHarnessNames, onComplete, onExit }: A
 
   const apiFormatNav = useListNavigation({
     items: apiFormatItems,
-    onSelect: item => wizard.setApiFormat(BedrockApiFormatSchema.parse(item.id)),
+    onSelect: item => wizard.setApiFormat(HarnessApiFormatSchema.parse(item.id)),
     onExit: () => wizard.goBack(),
     isActive: isApiFormatStep,
   });

--- a/src/cli/tui/screens/harness/AddHarnessScreen.tsx
+++ b/src/cli/tui/screens/harness/AddHarnessScreen.tsx
@@ -1,5 +1,5 @@
 import type { HarnessModelProvider, RuntimeAuthorizerType } from '../../../../schema';
-import { MAX_EFS_MOUNTS, MAX_S3_MOUNTS, NetworkModeSchema } from '../../../../schema';
+import { BedrockApiFormatSchema, MAX_EFS_MOUNTS, MAX_S3_MOUNTS, NetworkModeSchema } from '../../../../schema';
 import { HarnessNameSchema, HarnessTruncationStrategySchema } from '../../../../schema/schemas/primitives/harness';
 import { ARN_VALIDATION_MESSAGE, isValidArn } from '../../../commands/shared/arn-utils';
 import {
@@ -27,6 +27,7 @@ import { buildMountListItems } from '../agent/buildMountListItems';
 import type { AddHarnessConfig, AdvancedSetting, ContainerMode } from './types';
 import {
   ADVANCED_SETTING_OPTIONS,
+  API_FORMAT_OPTIONS,
   AUTHORIZER_TYPE_OPTIONS,
   CONTAINER_MODE_OPTIONS,
   GATEWAY_OUTBOUND_AUTH_OPTIONS,
@@ -57,6 +58,11 @@ export function AddHarnessScreen({ existingHarnessNames, onComplete, onExit }: A
 
   const modelProviderItems: SelectableItem[] = useMemo(
     () => MODEL_PROVIDER_OPTIONS.map(opt => ({ id: opt.id, title: opt.title, description: opt.description })),
+    []
+  );
+
+  const apiFormatItems: SelectableItem[] = useMemo(
+    () => API_FORMAT_OPTIONS.map(opt => ({ id: opt.id, title: opt.title, description: opt.description })),
     []
   );
 
@@ -102,6 +108,7 @@ export function AddHarnessScreen({ existingHarnessNames, onComplete, onExit }: A
 
   const isNameStep = wizard.step === 'name';
   const isModelProviderStep = wizard.step === 'model-provider';
+  const isApiFormatStep = wizard.step === 'api-format';
   const isApiKeyArnStep = wizard.step === 'api-key-arn';
   const isContainerStep = wizard.step === 'container';
   const isContainerUriStep = wizard.step === 'container-uri';
@@ -140,6 +147,13 @@ export function AddHarnessScreen({ existingHarnessNames, onComplete, onExit }: A
     onSelect: item => wizard.setModelProvider(item.id as HarnessModelProvider),
     onExit: () => wizard.goBack(),
     isActive: isModelProviderStep,
+  });
+
+  const apiFormatNav = useListNavigation({
+    items: apiFormatItems,
+    onSelect: item => wizard.setApiFormat(BedrockApiFormatSchema.parse(item.id)),
+    onExit: () => wizard.goBack(),
+    isActive: isApiFormatStep,
   });
 
   const containerModeNav = useListNavigation({
@@ -220,6 +234,7 @@ export function AddHarnessScreen({ existingHarnessNames, onComplete, onExit }: A
     : isAdvancedStep || isToolsSelectStep
       ? 'Space toggle · Enter confirm · Esc back'
       : isModelProviderStep ||
+          isApiFormatStep ||
           isMemoryStep ||
           isContainerStep ||
           isNetworkModeStep ||
@@ -239,6 +254,10 @@ export function AddHarnessScreen({ existingHarnessNames, onComplete, onExit }: A
       { label: 'Model Provider', value: wizard.config.modelProvider },
       { label: 'Model ID', value: wizard.config.modelId },
     ];
+
+    if (wizard.config.apiFormat) {
+      fields.push({ label: 'API Format', value: wizard.config.apiFormat });
+    }
 
     if (wizard.config.apiKeyArn) {
       fields.push({ label: 'API Key ARN', value: wizard.config.apiKeyArn });
@@ -415,6 +434,15 @@ export function AddHarnessScreen({ existingHarnessNames, onComplete, onExit }: A
             description="Choose where to run your models"
             items={modelProviderItems}
             selectedIndex={modelProviderNav.selectedIndex}
+          />
+        )}
+
+        {isApiFormatStep && (
+          <WizardSelect
+            title="Select API format"
+            description="Choose the API format for model invocation (Responses and ChatCompletions use Bedrock Mantle)"
+            items={apiFormatItems}
+            selectedIndex={apiFormatNav.selectedIndex}
           />
         )}
 

--- a/src/cli/tui/screens/harness/types.ts
+++ b/src/cli/tui/screens/harness/types.ts
@@ -1,4 +1,4 @@
-import type { BedrockApiFormat, HarnessModelProvider, NetworkMode, RuntimeAuthorizerType } from '../../../../schema';
+import type { HarnessApiFormat, HarnessModelProvider, NetworkMode, RuntimeAuthorizerType } from '../../../../schema';
 import type { JwtConfig } from '../../components/jwt-config';
 
 export type ContainerMode = 'none' | 'uri' | 'dockerfile';
@@ -44,7 +44,7 @@ export interface AddHarnessConfig {
   name: string;
   modelProvider: HarnessModelProvider;
   modelId: string;
-  apiFormat?: BedrockApiFormat;
+  apiFormat?: HarnessApiFormat;
   apiKeyArn?: string;
   skipMemory?: boolean;
   containerMode?: ContainerMode;
@@ -133,7 +133,7 @@ export const MODEL_PROVIDER_OPTIONS = [
   },
 ] as const;
 
-export const API_FORMAT_OPTIONS = [
+export const BEDROCK_API_FORMAT_OPTIONS = [
   {
     id: 'converse_stream' as const,
     title: 'Converse Stream',
@@ -150,6 +150,21 @@ export const API_FORMAT_OPTIONS = [
     description: 'OpenAI Chat Completions API via Bedrock Mantle',
   },
 ] as const;
+
+export const OPENAI_API_FORMAT_OPTIONS = [
+  {
+    id: 'responses' as const,
+    title: 'Responses',
+    description: 'OpenAI Responses API (default)',
+  },
+  {
+    id: 'chat_completions' as const,
+    title: 'Chat Completions',
+    description: 'OpenAI Chat Completions API',
+  },
+] as const;
+
+export const API_FORMAT_OPTIONS = BEDROCK_API_FORMAT_OPTIONS;
 
 export const TRUNCATION_STRATEGY_OPTIONS = [
   { id: 'sliding_window' as const, title: 'Sliding window', description: 'Keep most recent messages' },

--- a/src/cli/tui/screens/harness/types.ts
+++ b/src/cli/tui/screens/harness/types.ts
@@ -1,4 +1,4 @@
-import type { HarnessModelProvider, NetworkMode, RuntimeAuthorizerType } from '../../../../schema';
+import type { BedrockApiFormat, HarnessModelProvider, NetworkMode, RuntimeAuthorizerType } from '../../../../schema';
 import type { JwtConfig } from '../../components/jwt-config';
 
 export type ContainerMode = 'none' | 'uri' | 'dockerfile';
@@ -6,6 +6,7 @@ export type ContainerMode = 'none' | 'uri' | 'dockerfile';
 export type AddHarnessStep =
   | 'name'
   | 'model-provider'
+  | 'api-format'
   | 'api-key-arn'
   | 'container'
   | 'container-uri'
@@ -43,6 +44,7 @@ export interface AddHarnessConfig {
   name: string;
   modelProvider: HarnessModelProvider;
   modelId: string;
+  apiFormat?: BedrockApiFormat;
   apiKeyArn?: string;
   skipMemory?: boolean;
   containerMode?: ContainerMode;
@@ -74,6 +76,7 @@ export interface AddHarnessConfig {
 export const HARNESS_STEP_LABELS: Record<AddHarnessStep, string> = {
   name: 'Name',
   'model-provider': 'Model provider',
+  'api-format': 'API format',
   'api-key-arn': 'API key ARN',
   container: 'Custom environment',
   'container-uri': 'Container URI',
@@ -114,6 +117,8 @@ export const DEFAULT_MODEL_IDS: Record<HarnessModelProvider, string> = {
   gemini: 'gemini-2.5-flash',
 };
 
+export const DEFAULT_BEDROCK_MANTLE_MODEL_ID = 'openai.gpt-oss-120b';
+
 export const MODEL_PROVIDER_OPTIONS = [
   { id: 'bedrock' as const, title: 'Amazon Bedrock', description: `Default: ${DEFAULT_MODEL_IDS.bedrock}` },
   {
@@ -125,6 +130,24 @@ export const MODEL_PROVIDER_OPTIONS = [
     id: 'gemini' as const,
     title: 'Google Gemini',
     description: `Default: ${DEFAULT_MODEL_IDS.gemini} (requires API key ARN)`,
+  },
+] as const;
+
+export const API_FORMAT_OPTIONS = [
+  {
+    id: 'converse_stream' as const,
+    title: 'Converse Stream',
+    description: 'Standard Bedrock Converse API (default)',
+  },
+  {
+    id: 'responses' as const,
+    title: 'Responses',
+    description: 'OpenAI Responses API via Bedrock Mantle',
+  },
+  {
+    id: 'chat_completions' as const,
+    title: 'Chat Completions',
+    description: 'OpenAI Chat Completions API via Bedrock Mantle',
   },
 ] as const;
 

--- a/src/cli/tui/screens/harness/useAddHarnessWizard.ts
+++ b/src/cli/tui/screens/harness/useAddHarnessWizard.ts
@@ -1,8 +1,9 @@
-import type { HarnessModelProvider, NetworkMode, RuntimeAuthorizerType } from '../../../../schema';
+import type { BedrockApiFormat, HarnessModelProvider, NetworkMode, RuntimeAuthorizerType } from '../../../../schema';
+import { isPreviewEnabled } from '../../../feature-flags';
 import type { JwtConfig } from '../../components/jwt-config';
 import { HARNESS_FILESYSTEM_STEP_NAMES, useFilesystemMountState } from '../../hooks/useFilesystemMountState';
 import type { AddHarnessConfig, AddHarnessStep, AdvancedSetting, ContainerMode } from './types';
-import { DEFAULT_MODEL_IDS } from './types';
+import { DEFAULT_BEDROCK_MANTLE_MODEL_ID, DEFAULT_MODEL_IDS } from './types';
 import { useCallback, useMemo, useState } from 'react';
 
 const ADVANCED_SETTING_ORDER: AdvancedSetting[] = [
@@ -56,6 +57,10 @@ export function useAddHarnessWizard() {
 
   const allSteps = useMemo(() => {
     const steps: AddHarnessStep[] = ['name', 'model-provider'];
+
+    if (config.modelProvider === 'bedrock' && isPreviewEnabled()) {
+      steps.push('api-format');
+    }
 
     if (config.modelProvider !== 'bedrock') {
       steps.push('api-key-arn');
@@ -249,12 +254,24 @@ export function useAddHarnessWizard() {
   );
 
   const setModelProvider = useCallback((modelProvider: HarnessModelProvider) => {
-    setConfig(c => ({ ...c, modelProvider, modelId: DEFAULT_MODEL_IDS[modelProvider] }));
-    if (modelProvider !== 'bedrock') {
+    setConfig(c => ({ ...c, modelProvider, modelId: DEFAULT_MODEL_IDS[modelProvider], apiFormat: undefined }));
+    if (modelProvider === 'bedrock' && isPreviewEnabled()) {
+      setStep('api-format');
+    } else if (modelProvider !== 'bedrock') {
       setStep('api-key-arn');
     } else {
       setStep('container');
     }
+  }, []);
+
+  const setApiFormat = useCallback((apiFormat: BedrockApiFormat) => {
+    const isMantle = apiFormat !== 'converse_stream';
+    setConfig(c => ({
+      ...c,
+      apiFormat: isMantle ? apiFormat : undefined,
+      modelId: isMantle ? DEFAULT_BEDROCK_MANTLE_MODEL_ID : DEFAULT_MODEL_IDS.bedrock,
+    }));
+    setStep('container');
   }, []);
 
   const setApiKeyArn = useCallback(
@@ -532,6 +549,7 @@ export function useAddHarnessWizard() {
     goBack,
     setName,
     setModelProvider,
+    setApiFormat,
     setApiKeyArn,
     setContainerMode,
     setContainerUri,

--- a/src/cli/tui/screens/harness/useAddHarnessWizard.ts
+++ b/src/cli/tui/screens/harness/useAddHarnessWizard.ts
@@ -1,4 +1,4 @@
-import type { BedrockApiFormat, HarnessModelProvider, NetworkMode, RuntimeAuthorizerType } from '../../../../schema';
+import type { HarnessApiFormat, HarnessModelProvider, NetworkMode, RuntimeAuthorizerType } from '../../../../schema';
 import { isPreviewEnabled } from '../../../feature-flags';
 import type { JwtConfig } from '../../components/jwt-config';
 import { HARNESS_FILESYSTEM_STEP_NAMES, useFilesystemMountState } from '../../hooks/useFilesystemMountState';
@@ -58,7 +58,7 @@ export function useAddHarnessWizard() {
   const allSteps = useMemo(() => {
     const steps: AddHarnessStep[] = ['name', 'model-provider'];
 
-    if (config.modelProvider === 'bedrock' && isPreviewEnabled()) {
+    if ((config.modelProvider === 'bedrock' || config.modelProvider === 'open_ai') && isPreviewEnabled()) {
       steps.push('api-format');
     }
 
@@ -264,13 +264,18 @@ export function useAddHarnessWizard() {
     }
   }, []);
 
-  const setApiFormat = useCallback((apiFormat: BedrockApiFormat) => {
-    const isMantle = apiFormat !== 'converse_stream';
-    setConfig(c => ({
-      ...c,
-      apiFormat: isMantle ? apiFormat : undefined,
-      modelId: isMantle ? DEFAULT_BEDROCK_MANTLE_MODEL_ID : DEFAULT_MODEL_IDS.bedrock,
-    }));
+  const setApiFormat = useCallback((apiFormat: HarnessApiFormat) => {
+    setConfig(c => {
+      if (c.modelProvider === 'bedrock') {
+        const isMantle = apiFormat !== 'converse_stream';
+        return {
+          ...c,
+          apiFormat: isMantle ? apiFormat : undefined,
+          modelId: isMantle ? DEFAULT_BEDROCK_MANTLE_MODEL_ID : DEFAULT_MODEL_IDS.bedrock,
+        };
+      }
+      return { ...c, apiFormat };
+    });
     setStep('container');
   }, []);
 

--- a/src/schema/schemas/agentcore-project.ts
+++ b/src/schema/schemas/agentcore-project.ts
@@ -98,6 +98,7 @@ export {
   HarnessNameSchema,
   HarnessSpecSchema,
   HarnessToolTypeSchema,
+  validateApiFormat,
 } from './primitives/harness';
 
 // ============================================================================

--- a/src/schema/schemas/agentcore-project.ts
+++ b/src/schema/schemas/agentcore-project.ts
@@ -80,14 +80,18 @@ export type { HttpGatewayTarget } from './primitives/http-gateway';
 export { HttpGatewayTargetSchema } from './primitives/http-gateway';
 export type {
   BedrockApiFormat,
+  HarnessApiFormat,
   HarnessGatewayOutboundAuth,
   HarnessMemoryRef,
   HarnessModel,
   HarnessModelProvider,
   HarnessSpec,
+  OpenAiApiFormat,
 } from './primitives/harness';
 export {
   BedrockApiFormatSchema,
+  HarnessApiFormatSchema,
+  OpenAiApiFormatSchema,
   GatewayOAuthGrantTypeSchema,
   HarnessGatewayOutboundAuthSchema,
   HarnessModelProviderSchema,

--- a/src/schema/schemas/agentcore-project.ts
+++ b/src/schema/schemas/agentcore-project.ts
@@ -79,19 +79,21 @@ export { ABTestModeSchema, TargetRefSchema, GatewayFilterSchema } from './primit
 export type { HttpGatewayTarget } from './primitives/http-gateway';
 export { HttpGatewayTargetSchema } from './primitives/http-gateway';
 export type {
+  BedrockApiFormat,
   HarnessGatewayOutboundAuth,
   HarnessMemoryRef,
   HarnessModel,
-  HarnessSpec,
   HarnessModelProvider,
+  HarnessSpec,
 } from './primitives/harness';
 export {
+  BedrockApiFormatSchema,
   GatewayOAuthGrantTypeSchema,
   HarnessGatewayOutboundAuthSchema,
+  HarnessModelProviderSchema,
   HarnessNameSchema,
   HarnessSpecSchema,
   HarnessToolTypeSchema,
-  HarnessModelProviderSchema,
 } from './primitives/harness';
 
 // ============================================================================

--- a/src/schema/schemas/primitives/__tests__/harness.test.ts
+++ b/src/schema/schemas/primitives/__tests__/harness.test.ts
@@ -754,7 +754,7 @@ describe('HarnessSpecSchema', () => {
     });
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues.some(i => i.message.includes('converse_stream is not a valid API format'))).toBe(true);
+      expect(result.error.issues.some(i => i.message.includes('Invalid API format for open_ai'))).toBe(true);
     }
   });
 
@@ -770,7 +770,7 @@ describe('HarnessSpecSchema', () => {
     });
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues.some(i => i.message.includes('not supported for the "gemini" provider'))).toBe(true);
+      expect(result.error.issues.some(i => i.message.includes('only supported for bedrock and open_ai'))).toBe(true);
     }
   });
 

--- a/src/schema/schemas/primitives/__tests__/harness.test.ts
+++ b/src/schema/schemas/primitives/__tests__/harness.test.ts
@@ -691,4 +691,52 @@ describe('HarnessSpecSchema', () => {
     });
     expect(result.success).toBe(true);
   });
+
+  it('accepts bedrock model with apiFormat responses', () => {
+    const result = HarnessSpecSchema.safeParse({
+      ...minimalHarness,
+      model: { provider: 'bedrock', modelId: 'openai.gpt-oss-120b', apiFormat: 'responses' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts bedrock model with apiFormat chat_completions', () => {
+    const result = HarnessSpecSchema.safeParse({
+      ...minimalHarness,
+      model: { provider: 'bedrock', modelId: 'openai.gpt-oss-120b', apiFormat: 'chat_completions' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts bedrock model with apiFormat converse_stream', () => {
+    const result = HarnessSpecSchema.safeParse({
+      ...minimalHarness,
+      model: { provider: 'bedrock', modelId: 'anthropic.claude-v2', apiFormat: 'converse_stream' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects apiFormat for non-bedrock providers', () => {
+    const result = HarnessSpecSchema.safeParse({
+      ...minimalHarness,
+      model: {
+        provider: 'open_ai',
+        modelId: 'gpt-4o',
+        apiKeyArn: 'arn:aws:secretsmanager:us-east-1:123:secret:key',
+        apiFormat: 'responses',
+      },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some(i => i.message.includes('apiFormat is only supported'))).toBe(true);
+    }
+  });
+
+  it('rejects invalid apiFormat value', () => {
+    const result = HarnessSpecSchema.safeParse({
+      ...minimalHarness,
+      model: { provider: 'bedrock', modelId: 'anthropic.claude-v2', apiFormat: 'invalid_format' },
+    });
+    expect(result.success).toBe(false);
+  });
 });

--- a/src/schema/schemas/primitives/__tests__/harness.test.ts
+++ b/src/schema/schemas/primitives/__tests__/harness.test.ts
@@ -716,7 +716,7 @@ describe('HarnessSpecSchema', () => {
     expect(result.success).toBe(true);
   });
 
-  it('rejects apiFormat for non-bedrock providers', () => {
+  it('accepts apiFormat responses for open_ai provider', () => {
     const result = HarnessSpecSchema.safeParse({
       ...minimalHarness,
       model: {
@@ -726,9 +726,51 @@ describe('HarnessSpecSchema', () => {
         apiFormat: 'responses',
       },
     });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts apiFormat chat_completions for open_ai provider', () => {
+    const result = HarnessSpecSchema.safeParse({
+      ...minimalHarness,
+      model: {
+        provider: 'open_ai',
+        modelId: 'gpt-4o',
+        apiKeyArn: 'arn:aws:secretsmanager:us-east-1:123:secret:key',
+        apiFormat: 'chat_completions',
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects converse_stream for open_ai provider', () => {
+    const result = HarnessSpecSchema.safeParse({
+      ...minimalHarness,
+      model: {
+        provider: 'open_ai',
+        modelId: 'gpt-4o',
+        apiKeyArn: 'arn:aws:secretsmanager:us-east-1:123:secret:key',
+        apiFormat: 'converse_stream',
+      },
+    });
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues.some(i => i.message.includes('apiFormat is only supported'))).toBe(true);
+      expect(result.error.issues.some(i => i.message.includes('converse_stream is not a valid API format'))).toBe(true);
+    }
+  });
+
+  it('rejects apiFormat for gemini provider', () => {
+    const result = HarnessSpecSchema.safeParse({
+      ...minimalHarness,
+      model: {
+        provider: 'gemini',
+        modelId: 'gemini-2.5-flash',
+        apiKeyArn: 'arn:aws:secretsmanager:us-east-1:123:secret:key',
+        apiFormat: 'responses',
+      },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some(i => i.message.includes('not supported for the "gemini" provider'))).toBe(true);
     }
   });
 

--- a/src/schema/schemas/primitives/harness.ts
+++ b/src/schema/schemas/primitives/harness.ts
@@ -33,12 +33,18 @@ export type HarnessModelProvider = z.infer<typeof HarnessModelProviderSchema>;
 export const BedrockApiFormatSchema = z.enum(['converse_stream', 'responses', 'chat_completions']);
 export type BedrockApiFormat = z.infer<typeof BedrockApiFormatSchema>;
 
+export const OpenAiApiFormatSchema = z.enum(['responses', 'chat_completions']);
+export type OpenAiApiFormat = z.infer<typeof OpenAiApiFormatSchema>;
+
+export const HarnessApiFormatSchema = z.enum(['converse_stream', 'responses', 'chat_completions']);
+export type HarnessApiFormat = z.infer<typeof HarnessApiFormatSchema>;
+
 export const HarnessModelSchema = z
   .object({
     provider: HarnessModelProviderSchema,
     modelId: z.string().min(1, 'Model ID is required'),
     apiKeyArn: z.string().optional(),
-    apiFormat: BedrockApiFormatSchema.optional(),
+    apiFormat: HarnessApiFormatSchema.optional(),
     temperature: z.number().min(0).max(2).optional(),
     topP: z.number().min(0).max(1).optional(),
     topK: z.number().min(0).max(1).optional(),
@@ -52,12 +58,21 @@ export const HarnessModelSchema = z
         path: ['topK'],
       });
     }
-    if (model.apiFormat !== undefined && model.provider !== 'bedrock') {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: 'apiFormat is only supported for the "bedrock" provider',
-        path: ['apiFormat'],
-      });
+    if (model.apiFormat !== undefined) {
+      if (model.provider === 'gemini') {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'apiFormat is not supported for the "gemini" provider',
+          path: ['apiFormat'],
+        });
+      } else if (model.provider === 'open_ai' && model.apiFormat === 'converse_stream') {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            'converse_stream is not a valid API format for the "open_ai" provider. Use responses or chat_completions',
+          path: ['apiFormat'],
+        });
+      }
     }
   });
 

--- a/src/schema/schemas/primitives/harness.ts
+++ b/src/schema/schemas/primitives/harness.ts
@@ -59,17 +59,16 @@ export const HarnessModelSchema = z
       });
     }
     if (model.apiFormat !== undefined) {
-      if (model.provider === 'gemini') {
+      if (model.provider !== 'bedrock' && model.provider !== 'open_ai') {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
-          message: 'apiFormat is not supported for the "gemini" provider',
+          message: '--api-format is only supported for bedrock and open_ai providers',
           path: ['apiFormat'],
         });
       } else if (model.provider === 'open_ai' && model.apiFormat === 'converse_stream') {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
-          message:
-            'converse_stream is not a valid API format for the "open_ai" provider. Use responses or chat_completions',
+          message: `Invalid API format for open_ai: ${model.apiFormat}. Use ${OpenAiApiFormatSchema.options.join(', ')}`,
           path: ['apiFormat'],
         });
       }
@@ -77,6 +76,21 @@ export const HarnessModelSchema = z
   });
 
 export type HarnessModel = z.infer<typeof HarnessModelSchema>;
+
+export function validateApiFormat(
+  apiFormat: string,
+  provider: string
+): { valid: true } | { valid: false; error: string } {
+  const allFormats = HarnessApiFormatSchema.options as readonly string[];
+  if (!allFormats.includes(apiFormat)) {
+    return { valid: false, error: `Invalid API format: ${apiFormat}. Use ${allFormats.join(', ')}` };
+  }
+  const result = HarnessModelSchema.safeParse({ provider, modelId: 'placeholder', apiFormat });
+  if (result.success) return { valid: true };
+  const apiFormatIssue = result.error.issues.find(i => i.path.includes('apiFormat'));
+  if (apiFormatIssue) return { valid: false, error: apiFormatIssue.message };
+  return { valid: true };
+}
 
 // ============================================================================
 // Tool Configuration

--- a/src/schema/schemas/primitives/harness.ts
+++ b/src/schema/schemas/primitives/harness.ts
@@ -85,10 +85,18 @@ export function validateApiFormat(
   if (!allFormats.includes(apiFormat)) {
     return { valid: false, error: `Invalid API format: ${apiFormat}. Use ${allFormats.join(', ')}` };
   }
+  if (provider !== 'bedrock' && provider !== 'open_ai') {
+    return { valid: false, error: '--api-format is only supported for bedrock and open_ai providers' };
+  }
   const result = HarnessModelSchema.safeParse({ provider, modelId: 'placeholder', apiFormat });
   if (result.success) return { valid: true };
   const apiFormatIssue = result.error.issues.find(i => i.path.includes('apiFormat'));
-  if (apiFormatIssue) return { valid: false, error: apiFormatIssue.message };
+  if (apiFormatIssue) {
+    return {
+      valid: false,
+      error: `Invalid API format for ${provider}: ${apiFormat}. Use ${(provider === 'open_ai' ? OpenAiApiFormatSchema : BedrockApiFormatSchema).options.join(', ')}`,
+    };
+  }
   return { valid: true };
 }
 

--- a/src/schema/schemas/primitives/harness.ts
+++ b/src/schema/schemas/primitives/harness.ts
@@ -30,11 +30,15 @@ export const HarnessNameSchema = z
 export const HarnessModelProviderSchema = z.enum(['bedrock', 'open_ai', 'gemini']);
 export type HarnessModelProvider = z.infer<typeof HarnessModelProviderSchema>;
 
+export const BedrockApiFormatSchema = z.enum(['converse_stream', 'responses', 'chat_completions']);
+export type BedrockApiFormat = z.infer<typeof BedrockApiFormatSchema>;
+
 export const HarnessModelSchema = z
   .object({
     provider: HarnessModelProviderSchema,
     modelId: z.string().min(1, 'Model ID is required'),
     apiKeyArn: z.string().optional(),
+    apiFormat: BedrockApiFormatSchema.optional(),
     temperature: z.number().min(0).max(2).optional(),
     topP: z.number().min(0).max(1).optional(),
     topK: z.number().min(0).max(1).optional(),
@@ -46,6 +50,13 @@ export const HarnessModelSchema = z
         code: z.ZodIssueCode.custom,
         message: 'topK is only supported for the "gemini" provider',
         path: ['topK'],
+      });
+    }
+    if (model.apiFormat !== undefined && model.provider !== 'bedrock') {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'apiFormat is only supported for the "bedrock" provider',
+        path: ['apiFormat'],
       });
     }
   });

--- a/src/schema/schemas/primitives/index.ts
+++ b/src/schema/schemas/primitives/index.ts
@@ -73,6 +73,7 @@ export {
 
 export type {
   BedrockApiFormat,
+  HarnessApiFormat,
   HarnessGatewayOutboundAuth,
   HarnessMemoryRef,
   HarnessModel,
@@ -81,10 +82,13 @@ export type {
   HarnessTool,
   HarnessToolType,
   HarnessTruncationConfig,
+  OpenAiApiFormat,
 } from './harness';
 export {
   AllowedToolSchema,
   BedrockApiFormatSchema,
+  HarnessApiFormatSchema,
+  OpenAiApiFormatSchema,
   GatewayOAuthGrantTypeSchema,
   HarnessGatewayOutboundAuthSchema,
   HarnessMemoryRefSchema,

--- a/src/schema/schemas/primitives/index.ts
+++ b/src/schema/schemas/primitives/index.ts
@@ -72,6 +72,7 @@ export {
 } from './policy';
 
 export type {
+  BedrockApiFormat,
   HarnessGatewayOutboundAuth,
   HarnessMemoryRef,
   HarnessModel,
@@ -83,6 +84,7 @@ export type {
 } from './harness';
 export {
   AllowedToolSchema,
+  BedrockApiFormatSchema,
   GatewayOAuthGrantTypeSchema,
   HarnessGatewayOutboundAuthSchema,
   HarnessMemoryRefSchema,


### PR DESCRIPTION
## Summary

- Adds `apiFormat` field to harness model configuration allowing users to select the API format for model invocation
- **Bedrock**: `converse_stream` (default), `responses`, or `chat_completions` (via Bedrock Mantle)
- **OpenAI**: `responses` (default) or `chat_completions`
- When user selects `responses` or `chat_completions` for Bedrock, the CLI defaults model ID to `openai.gpt-oss-120b` and adds Bedrock Mantle IAM permissions to the harness execution role
- Feature is gated behind `isPreviewEnabled()` since harness is in preview
- Wire format matches the Loopy service Smithy model: `apiFormat` lives inside provider-specific model config (`bedrockModelConfig` / `openAiModelConfig`)

## Changes

| Area | Files |
|------|-------|
| Schema | `primitives/harness.ts`, `primitives/index.ts`, `agentcore-project.ts` |
| API types | `aws/agentcore-harness.ts` |
| Deploy mapper | `harness-mapper.ts` |
| TUI wizard | `types.ts`, `useAddHarnessWizard.ts`, `AddHarnessScreen.tsx`, `AddHarnessFlow.tsx`, `useCreateFlow.ts` |
| CLI command | `HarnessPrimitive.ts`, `harness-action.ts`, `harness-validate.ts` |
| Validation (add) | `add/validate.ts` |
| CDK IAM | `AgentCoreHarnessRole.ts` (in agentcore-cdk repo) |
| CDK asset | `assets/cdk/bin/cdk.ts` |

## Test plan

- [x] Unit tests pass (harness-validate: 22 tests, harness-mapper: 37 tests, 122 snapshot tests)
- [x] TypeScript compiles cleanly
- [x] CLI validation: bedrock + responses ✅, open_ai + responses ✅, open_ai + chat_completions ✅, open_ai + converse_stream ❌ (correctly rejected), gemini + any format ❌ (correctly rejected)
- [x] E2E: `agentcore add harness --api-format responses` → deploy → harness READY (account 998846730471, ap-southeast-2)
- [x] E2E: Invoke confirms routing through Bedrock Mantle (got IAM permission error on `bedrock-mantle:CreateInference` as expected — CDK IAM PR needed)
- [ ] CDK repo changes need separate PR (tracked below)

## Notes

- CDK PR: https://github.com/aws/agentcore-l3-cdk-constructs/pull/231
- Addresses review feedback from @davisarthur: OpenAI also supports apiFormat per the Smithy model (`HarnessOpenAiApiFormat` enum with `responses` and `chat_completions`)
- `converse_stream` is omitted from API payloads for Bedrock (it's the default); `responses` is omitted for OpenAI (it's the default)