### PR TITLE
fix: restore --skills invoke override for harness

### DIFF
--- a/src/cli/commands/invoke/action.ts
+++ b/src/cli/commands/invoke/action.ts
@@ -605,6 +605,7 @@ export function buildHarnessBaseOpts(
   if (options.maxIterations != null) baseOpts.maxIterations = options.maxIterations;
   if (options.maxTokens != null) baseOpts.maxTokens = options.maxTokens;
   if (options.harnessTimeout != null) baseOpts.timeoutSeconds = options.harnessTimeout;
+  if (options.skills) baseOpts.skills = options.skills.split(',').map(p => ({ path: p.trim() }));
   if (options.systemPrompt) baseOpts.systemPrompt = [{ text: options.systemPrompt }];
   if (options.allowedTools) baseOpts.allowedTools = options.allowedTools.split(',').map(t => t.trim());
   if (options.actorId) baseOpts.actorId = options.actorId;

--- a/src/cli/commands/invoke/command.tsx
+++ b/src/cli/commands/invoke/command.tsx
@@ -174,6 +174,7 @@ export const registerInvoke = (program: Command) => {
         'Override timeout seconds (harness only) [non-interactive] [preview]',
         parseInt
       )
+      .option('--skills <paths>', 'Skills to use, comma-separated paths (harness only) [non-interactive] [preview]')
       .option('--system-prompt <text>', 'Override system prompt (harness only) [non-interactive] [preview]')
       .option(
         '--allowed-tools <tools>',
@@ -211,6 +212,7 @@ export const registerInvoke = (program: Command) => {
         maxIterations?: number;
         maxTokens?: number;
         harnessTimeout?: number;
+        skills?: string;
         systemPrompt?: string;
         allowedTools?: string;
         actorId?: string;
@@ -306,6 +308,7 @@ export const registerInvoke = (program: Command) => {
                 maxIterations: cliOptions.maxIterations,
                 maxTokens: cliOptions.maxTokens,
                 harnessTimeout: cliOptions.harnessTimeout,
+                skills: cliOptions.skills,
                 systemPrompt: cliOptions.systemPrompt,
                 allowedTools: cliOptions.allowedTools,
                 actorId: cliOptions.actorId,


### PR DESCRIPTION
## Summary

- Restores the `--skills` CLI flag for `agentcore invoke` (harness only, preview-gated)
- Adds skills handling back to `buildHarnessBaseOpts()` so it's sent to the InvokeHarness API

This was a regression from the preview→main feature flag consolidation. The type field existed in `InvokeOptions` but was never wired to a CLI flag or action handler.

## Test plan

- [x] TypeScript compiles cleanly
- [x] Lint/prettier pass
- [ ] Manual: `agentcore invoke --harness X --skills ./path/to/skill` sends skills in request body