### PR TITLE
fix: redact sensitive tokens from invoke CLI output

### DIFF
--- a/src/cli/aws/agentcore-control.ts
+++ b/src/cli/aws/agentcore-control.ts
@@ -409,8 +409,10 @@ export async function getMemoryDetail(options: GetMemoryOptions): Promise<Memory
 
   const tags = await fetchTags(client, memory.arn, 'memory');
 
-  const rawKeys = memory.indexedKeys;
-  const indexedKeys = rawKeys?.flatMap(k => {
+  const rawKeys = (memory as unknown as Record<string, unknown>).indexedKeys as
+    | { key?: string; type?: string }[]
+    | undefined;
+  const indexedKeys = rawKeys?.flatMap((k: { key?: string; type?: string }) => {
     if (!k.key || !k.type) {
       console.warn(`Warning: Skipping malformed indexed key from API response: ${JSON.stringify(k)}`);
       return [];
@@ -561,7 +563,7 @@ export async function getEvaluator(options: GetEvaluatorOptions): Promise<GetEva
     status: response.status ?? 'UNKNOWN',
     description: response.description,
     evaluatorConfig,
-    kmsKeyArn: response.kmsKeyArn,
+    kmsKeyArn: (response as unknown as Record<string, unknown>).kmsKeyArn as string | undefined,
     tags,
   };
 }

--- a/src/cli/commands/invoke/__tests__/redact-sensitive-text.test.ts
+++ b/src/cli/commands/invoke/__tests__/redact-sensitive-text.test.ts
@@ -1,0 +1,50 @@
+import { redactSensitiveText } from '../command.js';
+import { describe, expect, it } from 'vitest';
+
+describe('redactSensitiveText', () => {
+  it('redacts Bearer tokens', () => {
+    expect(redactSensitiveText('Authorization: Bearer eyJhbGciOiJSUzI1NiJ9.payload.sig')).toBe(
+      'Authorization: Bearer [REDACTED]'
+    );
+  });
+
+  it('redacts Bearer tokens in JSON', () => {
+    expect(redactSensitiveText('{"header":"Bearer eyJhbGciOiJSUzI1NiJ9.payload.sig"}')).toBe(
+      '{"header":"Bearer [REDACTED]"}'
+    );
+  });
+
+  it('redacts client_secret in key=value form', () => {
+    expect(redactSensitiveText('client_secret=abc123def')).toBe('client_secret=[REDACTED]');
+  });
+
+  it('redacts client_secret in JSON form', () => {
+    expect(redactSensitiveText('{"client_secret":"abc123def"}')).toBe('{"client_secret":"[REDACTED]"}');
+  });
+
+  it('redacts token in key=value form', () => {
+    expect(redactSensitiveText('token=eyJhbGciOiJSUzI1NiJ9')).toBe('token=[REDACTED]');
+  });
+
+  it('redacts token in JSON form', () => {
+    expect(redactSensitiveText('{"token":"eyJhbGciOiJSUzI1NiJ9"}')).toBe('{"token":"[REDACTED]"}');
+  });
+
+  it('redacts access_token in JSON form', () => {
+    expect(redactSensitiveText('{"access_token":"jwt.token.here"}')).toBe('{"access_token":"[REDACTED]"}');
+  });
+
+  it('redacts client-secret with hyphen', () => {
+    expect(redactSensitiveText('client-secret=mysecret')).toBe('client-secret=[REDACTED]');
+  });
+
+  it('does not modify text without sensitive content', () => {
+    const input = 'Agent responded successfully with 200 OK';
+    expect(redactSensitiveText(input)).toBe(input);
+  });
+
+  it('handles multiple sensitive values in one string', () => {
+    const input = 'Bearer abc123 and client_secret=xyz789';
+    expect(redactSensitiveText(input)).toBe('Bearer [REDACTED] and client_secret=[REDACTED]');
+  });
+});

--- a/src/cli/commands/invoke/command.tsx
+++ b/src/cli/commands/invoke/command.tsx
@@ -49,7 +49,7 @@ async function handleInvokeCLI(options: InvokeOptions, preloadedContext?: Invoke
     if (isPreviewEnabled() && options.harnessArn) {
       const region = options.region ?? process.env.AWS_REGION ?? process.env.AWS_DEFAULT_REGION;
       if (!region) {
-        const msg = redactSensitiveText('--region is required with --harness-arn (or set AWS_REGION)');
+        const msg = '--region is required with --harness-arn (or set AWS_REGION)';
         if (options.json) {
           console.log(JSON.stringify({ success: false, error: msg }));
         } else {

--- a/src/cli/commands/invoke/command.tsx
+++ b/src/cli/commands/invoke/command.tsx
@@ -49,7 +49,7 @@ async function handleInvokeCLI(options: InvokeOptions, preloadedContext?: Invoke
     if (isPreviewEnabled() && options.harnessArn) {
       const region = options.region ?? process.env.AWS_REGION ?? process.env.AWS_DEFAULT_REGION;
       if (!region) {
-        const msg = '--region is required with --harness-arn (or set AWS_REGION)';
+        const msg = redactSensitiveText('--region is required with --harness-arn (or set AWS_REGION)');
         if (options.json) {
           console.log(JSON.stringify({ success: false, error: msg }));
         } else {
@@ -87,11 +87,11 @@ async function handleInvokeCLI(options: InvokeOptions, preloadedContext?: Invoke
   }
 }
 
-function redactSensitiveText(value: string): string {
+export function redactSensitiveText(value: string): string {
   return value
     .replace(/(bearer\s+)[a-z0-9\-._~+/]+=*/gi, '$1[REDACTED]')
-    .replace(/(client[_-]?secret\s*[:=]\s*)([^,\s]+)/gi, '$1[REDACTED]')
-    .replace(/(token\s*[:=]\s*)([^,\s]+)/gi, '$1[REDACTED]');
+    .replace(/(client[_-]?secret["']?\s*[:=]\s*["']?)([^"',\s}]+)/gi, '$1[REDACTED]')
+    .replace(/((?:access[_-]?)?token["']?\s*[:=]\s*["']?)([^"',\s}]+)/gi, '$1[REDACTED]');
 }
 
 function printInvokeResult(result: InvokeResult, options: InvokeOptions): void {
@@ -352,10 +352,11 @@ export const registerInvoke = (program: Command) => {
           });
         }
       } catch (error) {
+        const msg = redactSensitiveText(getErrorMessage(error));
         if (cliOptions.json) {
-          console.log(JSON.stringify({ success: false, error: getErrorMessage(error) }));
+          console.log(JSON.stringify({ success: false, error: msg }));
         } else {
-          render(<Text color="red">Error: {getErrorMessage(error)}</Text>);
+          render(<Text color="red">Error: {msg}</Text>);
         }
         process.exit(1);
       }

--- a/src/cli/commands/invoke/command.tsx
+++ b/src/cli/commands/invoke/command.tsx
@@ -87,11 +87,20 @@ async function handleInvokeCLI(options: InvokeOptions, preloadedContext?: Invoke
   }
 }
 
+function redactSensitiveText(value: string): string {
+  return value
+    .replace(/(bearer\s+)[a-z0-9\-._~+/]+=*/gi, '$1[REDACTED]')
+    .replace(/(client[_-]?secret\s*[:=]\s*)([^,\s]+)/gi, '$1[REDACTED]')
+    .replace(/(token\s*[:=]\s*)([^,\s]+)/gi, '$1[REDACTED]');
+}
+
 function printInvokeResult(result: InvokeResult, options: InvokeOptions): void {
   if (options.json) {
-    console.log(JSON.stringify(serializeResult(result)));
+    const serialized = serializeResult(result);
+    if (typeof serialized.response === 'string') serialized.response = redactSensitiveText(serialized.response);
+    if (typeof serialized.error === 'string') serialized.error = redactSensitiveText(serialized.error);
+    console.log(JSON.stringify(serialized));
   } else if (options.stream) {
-    // Streaming already wrote to stdout, just show session and log path
     if (result.sessionId) {
       console.error(`\nSession: ${result.sessionId}`);
       console.error(`To resume: agentcore invoke --session-id ${result.sessionId}`);
@@ -100,11 +109,10 @@ function printInvokeResult(result: InvokeResult, options: InvokeOptions): void {
       console.error(`Log: ${result.logFilePath}`);
     }
   } else {
-    // Non-streaming, non-json: print provider info and response or error
     if (result.success && result.response) {
-      console.log(result.response);
+      console.log(redactSensitiveText(result.response));
     } else if (!result.success && result.error) {
-      console.error(result.error.message);
+      console.error(redactSensitiveText(result.error.message));
     }
     if (result.sessionId) {
       console.error(`\nSession: ${result.sessionId}`);


### PR DESCRIPTION
## Summary

Restores `redactSensitiveText()` that was present on the preview branch but dropped during the preview→main consolidation (PR #1341).

Without this, bearer tokens and client secrets can appear verbatim in `--json` output or error messages when invoking harnesses with CUSTOM_JWT auth.

Redacts:
- `Bearer <token>` → `Bearer [REDACTED]`
- `client_secret=<value>` → `client_secret=[REDACTED]`
- `token=<value>` → `token=[REDACTED]`

## Test plan

- [x] TypeScript compiles cleanly
- [x] Lint/prettier pass
- [ ] Manual: invoke with `--bearer-token` + `--json`, verify token is redacted in output