### PR TITLE
feat: wire telemetry for validate command

### DIFF
--- a/integ-tests/validate.test.ts
+++ b/integ-tests/validate.test.ts
@@ -1,14 +1,15 @@
 /* eslint-disable security/detect-non-literal-fs-filename */
-import { createTestProject, runCLI } from '../src/test-utils/index.js';
+import { createTelemetryHelper, createTestProject, runCLI } from '../src/test-utils/index.js';
 import type { TestProject } from '../src/test-utils/index.js';
 import { randomUUID } from 'node:crypto';
 import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 
 describe('integration: validate command', () => {
   let project: TestProject;
+  const telemetry = createTelemetryHelper();
 
   beforeAll(async () => {
     project = await createTestProject({
@@ -19,16 +20,22 @@ describe('integration: validate command', () => {
     });
   });
 
+  afterEach(() => {
+    telemetry.clearEntries();
+  });
+
   afterAll(async () => {
+    telemetry.destroy();
     await project.cleanup();
   });
 
   it('validates a valid project successfully', async () => {
-    const result = await runCLI(['validate'], project.projectPath);
+    const result = await runCLI(['validate'], project.projectPath, { env: telemetry.env });
 
     expect(result.exitCode, `stderr: ${result.stderr}`).toBe(0);
     // validate outputs "Valid" on success (Ink text render)
     expect(result.stdout.toLowerCase()).toContain('valid');
+    telemetry.assertMetricEmitted({ command: 'validate', exit_reason: 'success' });
   });
 
   it('reports error for corrupted agentcore.json', async () => {
@@ -39,12 +46,13 @@ describe('integration: validate command', () => {
     try {
       await writeFile(configPath, '{invalid json!!!', 'utf-8');
 
-      const result = await runCLI(['validate'], project.projectPath);
+      const result = await runCLI(['validate'], project.projectPath, { env: telemetry.env });
 
       expect(result.exitCode).toBe(1);
       // Error message should appear in stdout (Ink render) or stderr
       const output = result.stdout + result.stderr;
       expect(output.length, 'Should produce error output').toBeGreaterThan(0);
+      telemetry.assertMetricEmitted({ command: 'validate', exit_reason: 'failure' });
     } finally {
       // Restore original config so other tests aren't affected
       await writeFile(configPath, originalContent, 'utf-8');
@@ -56,12 +64,13 @@ describe('integration: validate command', () => {
     await mkdir(emptyDir, { recursive: true });
 
     try {
-      const result = await runCLI(['validate'], emptyDir);
+      const result = await runCLI(['validate'], emptyDir, { env: telemetry.env });
 
       expect(result.exitCode).toBe(1);
       // Error message should appear somewhere in output
       const output = result.stdout + result.stderr;
       expect(output.length, 'Should produce error output').toBeGreaterThan(0);
+      telemetry.assertMetricEmitted({ command: 'validate', exit_reason: 'failure' });
     } finally {
       await rm(emptyDir, { recursive: true, force: true });
     }

--- a/src/cli/commands/validate/command.tsx
+++ b/src/cli/commands/validate/command.tsx
@@ -1,3 +1,4 @@
+import { withCommandRunTelemetry } from '../../telemetry/cli-command-run.js';
 import { COMMAND_DESCRIPTIONS } from '../../tui/copy';
 import { handleValidate } from './action';
 import type { Command } from '@commander-js/extra-typings';
@@ -9,8 +10,7 @@ export const registerValidate = (program: Command) => {
     .option('-d, --directory <path>', 'Project directory containing agentcore config')
     .description(COMMAND_DESCRIPTIONS.validate)
     .action(async options => {
-      const result = await handleValidate(options);
-
+      const result = await withCommandRunTelemetry('validate', {}, async () => handleValidate(options));
       if (result.success) {
         render(<Text color="green">Valid</Text>);
         process.exit(0);


### PR DESCRIPTION
## Description

Wire `withCommandRunTelemetry` for the `validate` CLI command, emitting success/failure metrics with the existing `validate: NoAttrs` schema.

This one is easy since it:
- returns a result already. 
- doesn't kill the process on errors. 
- doesn't have a tui. 

## Related Issue

N/A

## Documentation PR

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.