### PR TITLE
feat: add Mastra TypeScript framework template

### DIFF
--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -604,6 +604,12 @@ exports[`Assets Directory Snapshots > File listing > should match the expected f
   "python/mcp/standalone/base/main.py",
   "python/mcp/standalone/base/pyproject.toml",
   "typescript/.gitkeep",
+  "typescript/http/mastra/base/README.md",
+  "typescript/http/mastra/base/gitignore.template",
+  "typescript/http/mastra/base/main.ts",
+  "typescript/http/mastra/base/model/load.ts",
+  "typescript/http/mastra/base/package.json",
+  "typescript/http/mastra/base/tsconfig.json",
   "typescript/http/strands/base/README.md",
   "typescript/http/strands/base/gitignore.template",
   "typescript/http/strands/base/main.ts",
@@ -5683,6 +5689,281 @@ When modifying JSON config files:
 `;
 
 exports[`Assets Directory Snapshots > TypeScript assets > typescript/typescript/.gitkeep should match snapshot 1`] = `""`;
+
+exports[`Assets Directory Snapshots > TypeScript assets > typescript/typescript/http/mastra/base/README.md should match snapshot 1`] = `
+"# {{name}}
+
+Mastra agent running on Amazon Bedrock AgentCore Runtime.
+
+## Development
+
+\`\`\`bash
+npm install
+npm run dev
+\`\`\`
+
+## Build
+
+\`\`\`bash
+npm run build
+npm start
+\`\`\`
+"
+`;
+
+exports[`Assets Directory Snapshots > TypeScript assets > typescript/typescript/http/mastra/base/gitignore.template should match snapshot 1`] = `
+"node_modules/
+dist/
+.env
+.env.local
+"
+`;
+
+exports[`Assets Directory Snapshots > TypeScript assets > typescript/typescript/http/mastra/base/main.ts should match snapshot 1`] = `
+"import { BedrockAgentCoreApp } from 'bedrock-agentcore/runtime';
+import { Agent } from '@mastra/core/agent';
+import { loadModel } from './model/load.js';
+
+const SYSTEM_PROMPT = \`You are a helpful assistant.\`;
+
+let cachedAgent: Agent | null = null;
+
+async function getOrCreateAgent(): Promise<Agent> {
+  if (!cachedAgent) {
+    const model = await loadModel();
+    cachedAgent = new Agent({
+      id: '{{name}}',
+      name: '{{name}}',
+      instructions: SYSTEM_PROMPT,
+      model,
+    });
+  }
+  return cachedAgent;
+}
+
+const app = new BedrockAgentCoreApp({
+  invocationHandler: {
+    async *process(payload: any, context: any) {
+      const agent = await getOrCreateAgent();
+      const stream = await agent.stream(payload.prompt ?? '');
+
+      for await (const chunk of stream.fullStream) {
+        if (chunk.type === 'text-delta') {
+          yield { data: chunk.payload.text };
+        }
+      }
+    },
+  },
+});
+
+app.run({ port: parseInt(process.env.PORT ?? '8080') });
+"
+`;
+
+exports[`Assets Directory Snapshots > TypeScript assets > typescript/typescript/http/mastra/base/model/load.ts should match snapshot 1`] = `
+"{{#if (eq modelProvider "Bedrock")}}
+import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
+import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
+
+const provider = fromNodeProviderChain();
+const bedrockRegion = process.env.AWS_REGION ?? 'us-east-1';
+
+const bedrock = createAmazonBedrock({
+  region: bedrockRegion,
+  credentialProvider: async () => {
+    const creds = await provider();
+    return {
+      accessKeyId: creds.accessKeyId,
+      secretAccessKey: creds.secretAccessKey,
+      sessionToken: creds.sessionToken,
+    };
+  },
+});
+
+function getDefaultBedrockModelId(region: string): string {
+  if (region === 'ap-northeast-1') {
+    return 'jp.anthropic.claude-sonnet-4-5-20250929-v1:0';
+  }
+  if (region.startsWith('eu-')) {
+    return 'eu.anthropic.claude-sonnet-4-5-20250929-v1:0';
+  }
+  if (region === 'ap-southeast-2') {
+    return 'au.anthropic.claude-sonnet-4-5-20250929-v1:0';
+  }
+  if (region.startsWith('us-')) {
+    return 'us.anthropic.claude-sonnet-4-5-20250929-v1:0';
+  }
+  return 'global.anthropic.claude-sonnet-4-5-20250929-v1:0';
+}
+
+export function loadModel() {
+  return bedrock(process.env.BEDROCK_MODEL_ID ?? getDefaultBedrockModelId(bedrockRegion));
+}
+{{/if}}
+{{#if (eq modelProvider "Anthropic")}}
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { withApiKey } from 'bedrock-agentcore/identity';
+
+const IDENTITY_PROVIDER_NAME = '{{identityProviders.[0].name}}';
+const IDENTITY_ENV_VAR = '{{identityProviders.[0].envVarName}}';
+
+async function getApiKey(): Promise<string> {
+  if (process.env.LOCAL_DEV === '1') {
+    const apiKey = process.env[IDENTITY_ENV_VAR] ?? process.env.ANTHROPIC_API_KEY;
+    if (!apiKey) {
+      throw new Error(\`\${IDENTITY_ENV_VAR} or ANTHROPIC_API_KEY not found. Add your key to agentcore/.env.local\`);
+    }
+    return apiKey;
+  }
+  return withApiKey({ providerName: IDENTITY_PROVIDER_NAME })(async (apiKey: string) => apiKey)();
+}
+
+let _anthropic: ReturnType<typeof createAnthropic> | undefined;
+
+async function getProvider() {
+  if (!_anthropic) {
+    const apiKey = await getApiKey();
+    _anthropic = createAnthropic({ apiKey });
+  }
+  return _anthropic;
+}
+
+export async function loadModel() {
+  const anthropic = await getProvider();
+  return anthropic('claude-sonnet-4-5-20250929');
+}
+{{/if}}
+{{#if (eq modelProvider "OpenAI")}}
+import { createOpenAI } from '@ai-sdk/openai';
+import { withApiKey } from 'bedrock-agentcore/identity';
+
+const IDENTITY_PROVIDER_NAME = '{{identityProviders.[0].name}}';
+const IDENTITY_ENV_VAR = '{{identityProviders.[0].envVarName}}';
+
+async function getApiKey(): Promise<string> {
+  if (process.env.LOCAL_DEV === '1') {
+    const apiKey = process.env[IDENTITY_ENV_VAR] ?? process.env.OPENAI_API_KEY;
+    if (!apiKey) {
+      throw new Error(\`\${IDENTITY_ENV_VAR} or OPENAI_API_KEY not found. Add your key to agentcore/.env.local\`);
+    }
+    return apiKey;
+  }
+  return withApiKey({ providerName: IDENTITY_PROVIDER_NAME })(async (apiKey: string) => apiKey)();
+}
+
+let _openai: ReturnType<typeof createOpenAI> | undefined;
+
+async function getProvider() {
+  if (!_openai) {
+    const apiKey = await getApiKey();
+    _openai = createOpenAI({ apiKey });
+  }
+  return _openai;
+}
+
+export async function loadModel() {
+  const openai = await getProvider();
+  return openai('gpt-4.1');
+}
+{{/if}}
+{{#if (eq modelProvider "Gemini")}}
+import { createGoogleGenerativeAI } from '@ai-sdk/google';
+import { withApiKey } from 'bedrock-agentcore/identity';
+
+const IDENTITY_PROVIDER_NAME = '{{identityProviders.[0].name}}';
+const IDENTITY_ENV_VAR = '{{identityProviders.[0].envVarName}}';
+
+async function getApiKey(): Promise<string> {
+  if (process.env.LOCAL_DEV === '1') {
+    const apiKey = process.env[IDENTITY_ENV_VAR] ?? process.env.GEMINI_API_KEY;
+    if (!apiKey) {
+      throw new Error(\`\${IDENTITY_ENV_VAR} or GEMINI_API_KEY not found. Add your key to agentcore/.env.local\`);
+    }
+    return apiKey;
+  }
+  return withApiKey({ providerName: IDENTITY_PROVIDER_NAME })(async (apiKey: string) => apiKey)();
+}
+
+let _google: ReturnType<typeof createGoogleGenerativeAI> | undefined;
+
+async function getProvider() {
+  if (!_google) {
+    const apiKey = await getApiKey();
+    _google = createGoogleGenerativeAI({ apiKey });
+  }
+  return _google;
+}
+
+export async function loadModel() {
+  const google = await getProvider();
+  return google('gemini-2.5-flash');
+}
+{{/if}}
+"
+`;
+
+exports[`Assets Directory Snapshots > TypeScript assets > typescript/typescript/http/mastra/base/package.json should match snapshot 1`] = `
+"{
+  "name": "{{name}}",
+  "version": "0.1.0",
+  "description": "AgentCore Runtime Application using Mastra",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/main.js",
+    "dev": "tsx watch main.ts"
+  },
+  "dependencies": {
+    "@mastra/core": "^1.37.1",
+    "ai": "^6.0.0",
+    {{#if (eq modelProvider "Bedrock")}}
+    "@ai-sdk/amazon-bedrock": "^4.0.0",
+    "@aws-sdk/credential-providers": "^3.0.0",
+    {{/if}}
+    {{#if (eq modelProvider "Anthropic")}}
+    "@ai-sdk/anthropic": "^3.0.0",
+    {{/if}}
+    {{#if (eq modelProvider "OpenAI")}}
+    "@ai-sdk/openai": "^3.0.0",
+    {{/if}}
+    {{#if (eq modelProvider "Gemini")}}
+    "@ai-sdk/google": "^3.0.0",
+    {{/if}}
+    "bedrock-agentcore": "^0.2.4",
+    "tsx": "^4.19.0",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0"
+  }
+}
+"
+`;
+
+exports[`Assets Directory Snapshots > TypeScript assets > typescript/typescript/http/mastra/base/tsconfig.json should match snapshot 1`] = `
+"{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": false,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "types": ["node"]
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}
+"
+`;
 
 exports[`Assets Directory Snapshots > TypeScript assets > typescript/typescript/http/strands/base/README.md should match snapshot 1`] = `
 "This is a project generated by the AgentCore CLI!

--- a/src/assets/typescript/http/mastra/base/README.md
+++ b/src/assets/typescript/http/mastra/base/README.md
@@ -1,0 +1,17 @@
+# {{name}}
+
+Mastra agent running on Amazon Bedrock AgentCore Runtime.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```
+
+## Build
+
+```bash
+npm run build
+npm start
+```

--- a/src/assets/typescript/http/mastra/base/gitignore.template
+++ b/src/assets/typescript/http/mastra/base/gitignore.template
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.env
+.env.local

--- a/src/assets/typescript/http/mastra/base/main.ts
+++ b/src/assets/typescript/http/mastra/base/main.ts
@@ -1,0 +1,37 @@
+import { BedrockAgentCoreApp } from 'bedrock-agentcore/runtime';
+import { Agent } from '@mastra/core/agent';
+import { loadModel } from './model/load.js';
+
+const SYSTEM_PROMPT = `You are a helpful assistant.`;
+
+let cachedAgent: Agent | null = null;
+
+async function getOrCreateAgent(): Promise<Agent> {
+  if (!cachedAgent) {
+    const model = await loadModel();
+    cachedAgent = new Agent({
+      id: '{{name}}',
+      name: '{{name}}',
+      instructions: SYSTEM_PROMPT,
+      model,
+    });
+  }
+  return cachedAgent;
+}
+
+const app = new BedrockAgentCoreApp({
+  invocationHandler: {
+    async *process(payload: any, context: any) {
+      const agent = await getOrCreateAgent();
+      const stream = await agent.stream(payload.prompt ?? '');
+
+      for await (const chunk of stream.fullStream) {
+        if (chunk.type === 'text-delta') {
+          yield { data: chunk.payload.text };
+        }
+      }
+    },
+  },
+});
+
+app.run({ port: parseInt(process.env.PORT ?? '8080') });

--- a/src/assets/typescript/http/mastra/base/model/load.ts
+++ b/src/assets/typescript/http/mastra/base/model/load.ts
@@ -1,0 +1,138 @@
+{{#if (eq modelProvider "Bedrock")}}
+import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
+import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
+
+const provider = fromNodeProviderChain();
+const bedrockRegion = process.env.AWS_REGION ?? 'us-east-1';
+
+const bedrock = createAmazonBedrock({
+  region: bedrockRegion,
+  credentialProvider: async () => {
+    const creds = await provider();
+    return {
+      accessKeyId: creds.accessKeyId,
+      secretAccessKey: creds.secretAccessKey,
+      sessionToken: creds.sessionToken,
+    };
+  },
+});
+
+function getDefaultBedrockModelId(region: string): string {
+  if (region === 'ap-northeast-1') {
+    return 'jp.anthropic.claude-sonnet-4-5-20250929-v1:0';
+  }
+  if (region.startsWith('eu-')) {
+    return 'eu.anthropic.claude-sonnet-4-5-20250929-v1:0';
+  }
+  if (region === 'ap-southeast-2') {
+    return 'au.anthropic.claude-sonnet-4-5-20250929-v1:0';
+  }
+  if (region.startsWith('us-')) {
+    return 'us.anthropic.claude-sonnet-4-5-20250929-v1:0';
+  }
+  return 'global.anthropic.claude-sonnet-4-5-20250929-v1:0';
+}
+
+export function loadModel() {
+  return bedrock(process.env.BEDROCK_MODEL_ID ?? getDefaultBedrockModelId(bedrockRegion));
+}
+{{/if}}
+{{#if (eq modelProvider "Anthropic")}}
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { withApiKey } from 'bedrock-agentcore/identity';
+
+const IDENTITY_PROVIDER_NAME = '{{identityProviders.[0].name}}';
+const IDENTITY_ENV_VAR = '{{identityProviders.[0].envVarName}}';
+
+async function getApiKey(): Promise<string> {
+  if (process.env.LOCAL_DEV === '1') {
+    const apiKey = process.env[IDENTITY_ENV_VAR] ?? process.env.ANTHROPIC_API_KEY;
+    if (!apiKey) {
+      throw new Error(`${IDENTITY_ENV_VAR} or ANTHROPIC_API_KEY not found. Add your key to agentcore/.env.local`);
+    }
+    return apiKey;
+  }
+  return withApiKey({ providerName: IDENTITY_PROVIDER_NAME })(async (apiKey: string) => apiKey)();
+}
+
+let _anthropic: ReturnType<typeof createAnthropic> | undefined;
+
+async function getProvider() {
+  if (!_anthropic) {
+    const apiKey = await getApiKey();
+    _anthropic = createAnthropic({ apiKey });
+  }
+  return _anthropic;
+}
+
+export async function loadModel() {
+  const anthropic = await getProvider();
+  return anthropic('claude-sonnet-4-5-20250929');
+}
+{{/if}}
+{{#if (eq modelProvider "OpenAI")}}
+import { createOpenAI } from '@ai-sdk/openai';
+import { withApiKey } from 'bedrock-agentcore/identity';
+
+const IDENTITY_PROVIDER_NAME = '{{identityProviders.[0].name}}';
+const IDENTITY_ENV_VAR = '{{identityProviders.[0].envVarName}}';
+
+async function getApiKey(): Promise<string> {
+  if (process.env.LOCAL_DEV === '1') {
+    const apiKey = process.env[IDENTITY_ENV_VAR] ?? process.env.OPENAI_API_KEY;
+    if (!apiKey) {
+      throw new Error(`${IDENTITY_ENV_VAR} or OPENAI_API_KEY not found. Add your key to agentcore/.env.local`);
+    }
+    return apiKey;
+  }
+  return withApiKey({ providerName: IDENTITY_PROVIDER_NAME })(async (apiKey: string) => apiKey)();
+}
+
+let _openai: ReturnType<typeof createOpenAI> | undefined;
+
+async function getProvider() {
+  if (!_openai) {
+    const apiKey = await getApiKey();
+    _openai = createOpenAI({ apiKey });
+  }
+  return _openai;
+}
+
+export async function loadModel() {
+  const openai = await getProvider();
+  return openai('gpt-4.1');
+}
+{{/if}}
+{{#if (eq modelProvider "Gemini")}}
+import { createGoogleGenerativeAI } from '@ai-sdk/google';
+import { withApiKey } from 'bedrock-agentcore/identity';
+
+const IDENTITY_PROVIDER_NAME = '{{identityProviders.[0].name}}';
+const IDENTITY_ENV_VAR = '{{identityProviders.[0].envVarName}}';
+
+async function getApiKey(): Promise<string> {
+  if (process.env.LOCAL_DEV === '1') {
+    const apiKey = process.env[IDENTITY_ENV_VAR] ?? process.env.GEMINI_API_KEY;
+    if (!apiKey) {
+      throw new Error(`${IDENTITY_ENV_VAR} or GEMINI_API_KEY not found. Add your key to agentcore/.env.local`);
+    }
+    return apiKey;
+  }
+  return withApiKey({ providerName: IDENTITY_PROVIDER_NAME })(async (apiKey: string) => apiKey)();
+}
+
+let _google: ReturnType<typeof createGoogleGenerativeAI> | undefined;
+
+async function getProvider() {
+  if (!_google) {
+    const apiKey = await getApiKey();
+    _google = createGoogleGenerativeAI({ apiKey });
+  }
+  return _google;
+}
+
+export async function loadModel() {
+  const google = await getProvider();
+  return google('gemini-2.5-flash');
+}
+{{/if}}

--- a/src/assets/typescript/http/mastra/base/package.json
+++ b/src/assets/typescript/http/mastra/base/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "{{name}}",
+  "version": "0.1.0",
+  "description": "AgentCore Runtime Application using Mastra",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/main.js",
+    "dev": "tsx watch main.ts"
+  },
+  "dependencies": {
+    "@mastra/core": "^1.37.1",
+    "ai": "^6.0.0",
+    {{#if (eq modelProvider "Bedrock")}}
+    "@ai-sdk/amazon-bedrock": "^4.0.0",
+    "@aws-sdk/credential-providers": "^3.0.0",
+    {{/if}}
+    {{#if (eq modelProvider "Anthropic")}}
+    "@ai-sdk/anthropic": "^3.0.0",
+    {{/if}}
+    {{#if (eq modelProvider "OpenAI")}}
+    "@ai-sdk/openai": "^3.0.0",
+    {{/if}}
+    {{#if (eq modelProvider "Gemini")}}
+    "@ai-sdk/google": "^3.0.0",
+    {{/if}}
+    "bedrock-agentcore": "^0.2.4",
+    "tsx": "^4.19.0",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/src/assets/typescript/http/mastra/base/tsconfig.json
+++ b/src/assets/typescript/http/mastra/base/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": false,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "types": ["node"]
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/src/cli/commands/add/__tests__/validate.test.ts
+++ b/src/cli/commands/add/__tests__/validate.test.ts
@@ -184,6 +184,14 @@ describe('validate', () => {
       result = validateAddAgentOptions({
         ...validAgentOptionsCreate,
         language: 'TypeScript',
+        framework: 'Mastra',
+        modelProvider: 'Bedrock',
+      });
+      expect(result.valid).toBe(true);
+
+      result = validateAddAgentOptions({
+        ...validAgentOptionsCreate,
+        language: 'TypeScript',
         framework: 'LangChain_LangGraph',
       });
       expect(result.valid).toBe(false);

--- a/src/cli/commands/add/validate.ts
+++ b/src/cli/commands/add/validate.ts
@@ -17,6 +17,7 @@ import {
   TargetLanguageSchema,
   getSupportedFrameworksForProtocol,
   getSupportedModelProviders,
+  isTypeScriptSDKFramework,
   isValidKmsKeyArn,
   matchEnumValue,
 } from '../../../schema';
@@ -258,15 +259,10 @@ export function validateAddAgentOptions(options: AddAgentOptions): ValidationRes
     if (options.language === 'Other') {
       return { valid: false, error: 'Create path only supports Python or TypeScript' };
     }
-    if (
-      options.language === 'TypeScript' &&
-      options.framework &&
-      options.framework !== 'Strands' &&
-      options.framework !== 'VercelAI'
-    ) {
+    if (options.language === 'TypeScript' && options.framework && !isTypeScriptSDKFramework(options.framework)) {
       return {
         valid: false,
-        error: `Framework ${options.framework} is not yet available for TypeScript. Only Strands and Vercel AI SDK are supported.`,
+        error: `Framework ${options.framework} is not yet available for TypeScript. Only Strands, Vercel AI SDK, and Mastra are supported.`,
       };
     }
 

--- a/src/cli/commands/create/__tests__/validate.test.ts
+++ b/src/cli/commands/create/__tests__/validate.test.ts
@@ -133,6 +133,20 @@ describe('validateCreateOptions', () => {
     expect(result.valid).toBe(true);
   });
 
+  it('accepts TypeScript with Mastra framework and Bedrock model provider', () => {
+    const result = validateCreateOptions(
+      {
+        name: 'TestProjMastra',
+        language: 'TypeScript',
+        framework: 'Mastra',
+        modelProvider: 'Bedrock',
+        memory: 'none',
+      },
+      testDir
+    );
+    expect(result.valid).toBe(true);
+  });
+
   it('rejects TypeScript with a non-Strands framework', () => {
     const result = validateCreateOptions(
       {

--- a/src/cli/commands/create/command.tsx
+++ b/src/cli/commands/create/command.tsx
@@ -361,7 +361,7 @@ export const registerCreate = (program: Command) => {
     .option('--language <language>', 'Target language: Python or TypeScript (default: Python) [non-interactive]')
     .option(
       '--framework <framework>',
-      'Agent framework (Strands, LangChain_LangGraph, GoogleADK, OpenAIAgents, VercelAI) [non-interactive]'
+      'Agent framework (Strands, LangChain_LangGraph, GoogleADK, OpenAIAgents, VercelAI, Mastra) [non-interactive]'
     )
     .option('--model-provider <provider>', 'Model provider (Bedrock, Anthropic, OpenAI, Gemini) [non-interactive]')
     .option('--api-key <key>', 'API key for non-Bedrock providers [non-interactive]')

--- a/src/cli/commands/create/validate.ts
+++ b/src/cli/commands/create/validate.ts
@@ -9,6 +9,7 @@ import {
   TargetLanguageSchema,
   getSupportedFrameworksForProtocol,
   getSupportedModelProviders,
+  isTypeScriptSDKFramework,
   matchEnumValue,
 } from '../../../schema';
 import type { ProtocolMode } from '../../../schema';
@@ -192,11 +193,10 @@ export function validateCreateOptions(options: CreateOptions, cwd?: string): Val
       return { valid: false, error: `Invalid model provider: ${options.modelProvider}` };
     }
 
-    // TypeScript supports Strands and Vercel AI only
-    if (options.language === 'TypeScript' && fwResult.data !== 'Strands' && fwResult.data !== 'VercelAI') {
+    if (options.language === 'TypeScript' && !isTypeScriptSDKFramework(fwResult.data)) {
       return {
         valid: false,
-        error: `Framework ${options.framework} is not yet available for TypeScript. Only Strands and Vercel AI SDK are supported.`,
+        error: `Framework ${options.framework} is not yet available for TypeScript. Only Strands, Vercel AI SDK, and Mastra are supported.`,
       };
     }
 

--- a/src/cli/primitives/AgentPrimitive.tsx
+++ b/src/cli/primitives/AgentPrimitive.tsx
@@ -246,7 +246,7 @@ export class AgentPrimitive extends BasePrimitive<AddAgentOptions, RemovableReso
       .option('--language <lang>', 'Language: Python (create), or Python/TypeScript/Other (BYO) [non-interactive]')
       .option(
         '--framework <fw>',
-        'Framework: Strands, LangChain_LangGraph, GoogleADK, OpenAIAgents, VercelAI [non-interactive]'
+        'Framework: Strands, LangChain_LangGraph, GoogleADK, OpenAIAgents, VercelAI, Mastra [non-interactive]'
       )
       .option('--model-provider <provider>', 'Model provider: Bedrock, Anthropic, OpenAI, Gemini [non-interactive]')
       .option('--api-key <key>', 'API key for non-Bedrock providers [non-interactive]')

--- a/src/cli/telemetry/schemas/common-shapes.ts
+++ b/src/cli/telemetry/schemas/common-shapes.ts
@@ -73,7 +73,14 @@ export const FilterType = z.enum([
   'none',
 ]);
 export const AgentEnvironment = z.enum(['harness', 'runtime']);
-export const AgentFramework = z.enum(['strands', 'langchain_langgraph', 'googleadk', 'openaiagents']);
+export const AgentFramework = z.enum([
+  'strands',
+  'langchain_langgraph',
+  'googleadk',
+  'openaiagents',
+  'vercelai',
+  'mastra',
+]);
 export const GatewayTargetHost = z.enum(['lambda', 'agentcoreruntime']);
 export const GatewayTargetType = z.enum([
   'mcp-server',

--- a/src/cli/templates/MastraRenderer.ts
+++ b/src/cli/templates/MastraRenderer.ts
@@ -1,0 +1,9 @@
+import { BaseRenderer } from './BaseRenderer';
+import { TEMPLATE_ROOT } from './templateRoot';
+import type { AgentRenderConfig } from './types';
+
+export class MastraRenderer extends BaseRenderer {
+  constructor(config: AgentRenderConfig) {
+    super(config, 'mastra', TEMPLATE_ROOT, config.protocol ?? 'http');
+  }
+}

--- a/src/cli/templates/__tests__/BaseRenderer.test.ts
+++ b/src/cli/templates/__tests__/BaseRenderer.test.ts
@@ -52,6 +52,16 @@ describe('BaseRenderer', () => {
     expect(renderer.getTemplateDirPublic()).toBe('/templates/python/a2a/strands');
   });
 
+  it('getTemplateDir supports Mastra TypeScript HTTP templates', () => {
+    const renderer = new TestRenderer(
+      { targetLanguage: 'TypeScript', name: 'MyAgent', hasMemory: false, protocol: 'HTTP' },
+      'mastra',
+      '/templates'
+    );
+
+    expect(renderer.getTemplateDirPublic()).toBe('/templates/typescript/http/mastra');
+  });
+
   it('getTemplateDir uses explicit protocol over config', () => {
     const renderer = new TestRenderer(
       { targetLanguage: 'Python', name: 'MyAgent', hasMemory: false, protocol: 'A2A' },

--- a/src/cli/templates/index.ts
+++ b/src/cli/templates/index.ts
@@ -1,6 +1,7 @@
 import type { BaseRenderer } from './BaseRenderer';
 import { GoogleADKRenderer } from './GoogleADKRenderer';
 import { LangGraphRenderer } from './LangGraphRenderer';
+import { MastraRenderer } from './MastraRenderer';
 import { McpRenderer } from './McpRenderer';
 import { OpenAIAgentsRenderer } from './OpenAIAgentsRenderer';
 import { StrandsRenderer } from './StrandsRenderer';
@@ -12,6 +13,7 @@ export { CDKRenderer, type CDKRendererContext } from './CDKRenderer';
 export { renderGatewayTargetTemplate } from './GatewayTargetRenderer';
 export { GoogleADKRenderer } from './GoogleADKRenderer';
 export { LangGraphRenderer } from './LangGraphRenderer';
+export { MastraRenderer } from './MastraRenderer';
 export { McpRenderer } from './McpRenderer';
 export { OpenAIAgentsRenderer } from './OpenAIAgentsRenderer';
 export { StrandsRenderer } from './StrandsRenderer';
@@ -38,6 +40,8 @@ export function createRenderer(config: AgentRenderConfig): BaseRenderer {
       return new OpenAIAgentsRenderer(config);
     case 'VercelAI':
       return new VercelAIRenderer(config);
+    case 'Mastra':
+      return new MastraRenderer(config);
     default: {
       const _exhaustive: never = config.sdkFramework;
       throw new Error(`Unsupported SDK framework: ${String(_exhaustive)}`);

--- a/src/cli/tui/hooks/__tests__/useDevDeploy.test.tsx
+++ b/src/cli/tui/hooks/__tests__/useDevDeploy.test.tsx
@@ -1,9 +1,27 @@
 import { useDevDeploy } from '../useDevDeploy.js';
 import { Text } from 'ink';
 import { render } from 'ink-testing-library';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mockHandleDeploy = vi.fn();
+const { mockCanSkipDeploy, mockConfigIOInstance, mockHandleDeploy } = vi.hoisted(() => ({
+  mockCanSkipDeploy: vi.fn(),
+  mockConfigIOInstance: {
+    readAWSDeploymentTargets: vi.fn(),
+    readProjectSpec: vi.fn(),
+    writeAWSDeploymentTargets: vi.fn(),
+  },
+  mockHandleDeploy: vi.fn(),
+}));
+
+vi.mock('../../../../lib/index.js', () => ({
+  ConfigIO: vi.fn(function () {
+    return mockConfigIOInstance;
+  }),
+}));
+
+vi.mock('../../../operations/deploy/change-detection.js', () => ({
+  canSkipDeploy: mockCanSkipDeploy,
+}));
 
 vi.mock('../../../commands/deploy/actions.js', () => ({
   handleDeploy: (...args: unknown[]) => mockHandleDeploy(...args),
@@ -21,6 +39,17 @@ function Harness({ skip }: { skip?: boolean }) {
 describe('useDevDeploy', () => {
   afterEach(() => {
     vi.clearAllMocks();
+  });
+
+  beforeEach(() => {
+    mockCanSkipDeploy.mockResolvedValue(false);
+    mockConfigIOInstance.readAWSDeploymentTargets.mockResolvedValue([
+      { name: 'default', account: '123456789012', region: 'us-east-1' },
+    ]);
+    mockConfigIOInstance.readProjectSpec.mockResolvedValue({
+      harnesses: [{ name: 'test-harness', path: 'app/test-harness' }],
+      runtimes: [],
+    });
   });
 
   it('calls handleDeploy on mount', async () => {

--- a/src/cli/tui/screens/agent/types.ts
+++ b/src/cli/tui/screens/agent/types.ts
@@ -165,6 +165,7 @@ export const FRAMEWORK_OPTIONS = [
   { id: 'LangChain_LangGraph', title: 'LangChain + LangGraph', description: 'Popular open-source frameworks' },
   { id: 'GoogleADK', title: 'Google ADK', description: 'Google Agent Development Kit' },
   { id: 'OpenAIAgents', title: 'OpenAI Agents', description: 'OpenAI native agent SDK' },
+  { id: 'Mastra', title: 'Mastra', description: 'TypeScript agent framework' },
 ] as const;
 
 export const MODEL_PROVIDER_OPTIONS = [

--- a/src/cli/tui/screens/generate/types.ts
+++ b/src/cli/tui/screens/generate/types.ts
@@ -7,7 +7,12 @@ import type {
   SDKFramework,
   TargetLanguage,
 } from '../../../../schema';
-import { DEFAULT_MODEL_IDS, PROTOCOL_FRAMEWORK_MATRIX, getSupportedModelProviders } from '../../../../schema';
+import {
+  DEFAULT_MODEL_IDS,
+  PROTOCOL_FRAMEWORK_MATRIX,
+  getSupportedModelProviders,
+  isTypeScriptSDKFramework,
+} from '../../../../schema';
 import type { JwtConfigOptions } from '../../../primitives/auth-utils';
 
 export type GenerateStep =
@@ -138,17 +143,18 @@ export const SDK_OPTIONS = [
   { id: 'GoogleADK', title: 'Google ADK', description: 'Google Agent Development Kit' },
   { id: 'OpenAIAgents', title: 'OpenAI Agents', description: 'OpenAI native agent SDK' },
   { id: 'VercelAI', title: 'Vercel AI SDK', description: 'Vercel AI SDK for TypeScript agents' },
+  { id: 'Mastra', title: 'Mastra', description: 'TypeScript agent framework' },
 ] as const;
 
 /**
  * Get SDK options filtered by protocol compatibility and target language.
- * TypeScript currently only supports Strands.
+ * TypeScript currently supports a subset of HTTP SDK frameworks.
  */
 export function getSDKOptionsForProtocol(protocol: ProtocolMode, language?: TargetLanguage) {
   const supportedFrameworks = PROTOCOL_FRAMEWORK_MATRIX[protocol];
   const byProtocol = SDK_OPTIONS.filter(option => supportedFrameworks.includes(option.id));
   if (language === 'TypeScript') {
-    return byProtocol.filter(option => option.id === 'Strands' || option.id === 'VercelAI');
+    return byProtocol.filter(option => isTypeScriptSDKFramework(option.id));
   }
   return byProtocol;
 }

--- a/src/schema/__tests__/constants.test.ts
+++ b/src/schema/__tests__/constants.test.ts
@@ -35,6 +35,7 @@ describe('matchEnumValue', () => {
     expect(matchEnumValue(SDKFrameworkSchema, 'langchain_langgraph')).toBe('LangChain_LangGraph');
     expect(matchEnumValue(SDKFrameworkSchema, 'openaiagents')).toBe('OpenAIAgents');
     expect(matchEnumValue(SDKFrameworkSchema, 'googleadk')).toBe('GoogleADK');
+    expect(matchEnumValue(SDKFrameworkSchema, 'mastra')).toBe('Mastra');
   });
 });
 
@@ -42,6 +43,7 @@ describe('SDKFrameworkSchema', () => {
   it('accepts valid frameworks and rejects invalid', () => {
     expect(SDKFrameworkSchema.safeParse('Strands').success).toBe(true);
     expect(SDKFrameworkSchema.safeParse('OpenAIAgents').success).toBe(true);
+    expect(SDKFrameworkSchema.safeParse('Mastra').success).toBe(true);
     expect(SDKFrameworkSchema.safeParse('AutoGen').success).toBe(false);
     expect(SDKFrameworkSchema.safeParse('strands').success).toBe(false); // case-sensitive
   });
@@ -94,6 +96,10 @@ describe('getSupportedModelProviders', () => {
   it('returns only OpenAI for OpenAIAgents', () => {
     expect(getSupportedModelProviders('OpenAIAgents')).toEqual(['OpenAI']);
   });
+
+  it('returns all 4 providers for Mastra', () => {
+    expect(getSupportedModelProviders('Mastra')).toEqual(['Bedrock', 'Anthropic', 'OpenAI', 'Gemini']);
+  });
 });
 
 describe('isModelProviderSupported', () => {
@@ -142,7 +148,7 @@ describe('PROTOCOL_FRAMEWORK_MATRIX', () => {
 
   it('HTTP supports all visible frameworks', () => {
     expect(PROTOCOL_FRAMEWORK_MATRIX.HTTP).toEqual(
-      expect.arrayContaining(['Strands', 'LangChain_LangGraph', 'GoogleADK', 'OpenAIAgents'])
+      expect.arrayContaining(['Strands', 'LangChain_LangGraph', 'GoogleADK', 'OpenAIAgents', 'Mastra'])
     );
   });
 
@@ -186,6 +192,11 @@ describe('isFrameworkSupportedForProtocol', () => {
 
   it('returns false for OpenAIAgents + A2A', () => {
     expect(isFrameworkSupportedForProtocol('A2A', 'OpenAIAgents')).toBe(false);
+  });
+
+  it('returns true for Mastra + HTTP and false for Mastra + A2A', () => {
+    expect(isFrameworkSupportedForProtocol('HTTP', 'Mastra')).toBe(true);
+    expect(isFrameworkSupportedForProtocol('A2A', 'Mastra')).toBe(false);
   });
 
   it('returns false for any framework + MCP', () => {

--- a/src/schema/constants.ts
+++ b/src/schema/constants.ts
@@ -4,8 +4,22 @@ import { z } from 'zod';
 // Feature Constants (shared across all schemas)
 // ============================================================================
 
-export const SDKFrameworkSchema = z.enum(['Strands', 'LangChain_LangGraph', 'GoogleADK', 'OpenAIAgents', 'VercelAI']);
+export const SDKFrameworkSchema = z.enum([
+  'Strands',
+  'LangChain_LangGraph',
+  'GoogleADK',
+  'OpenAIAgents',
+  'VercelAI',
+  'Mastra',
+]);
 export type SDKFramework = z.infer<typeof SDKFrameworkSchema>;
+
+export const TYPESCRIPT_SDK_FRAMEWORKS = ['Strands', 'VercelAI', 'Mastra'] as const satisfies readonly SDKFramework[];
+export type TypeScriptSDKFramework = (typeof TYPESCRIPT_SDK_FRAMEWORKS)[number];
+
+export function isTypeScriptSDKFramework(framework: SDKFramework): framework is TypeScriptSDKFramework {
+  return TYPESCRIPT_SDK_FRAMEWORKS.includes(framework as TypeScriptSDKFramework);
+}
 
 export const TargetLanguageSchema = z.enum(['Python', 'TypeScript', 'Other']);
 export type TargetLanguage = z.infer<typeof TargetLanguageSchema>;
@@ -48,6 +62,7 @@ export const SDK_MODEL_PROVIDER_MATRIX: Record<SDKFramework, readonly ModelProvi
   GoogleADK: ['Gemini'] as const,
   OpenAIAgents: ['OpenAI'] as const,
   VercelAI: ['Bedrock', 'Anthropic', 'OpenAI', 'Gemini'] as const,
+  Mastra: ['Bedrock', 'Anthropic', 'OpenAI', 'Gemini'] as const,
 };
 
 /**
@@ -108,6 +123,8 @@ export const RESERVED_PROJECT_NAMES: readonly string[] = [
   'aguiprotocol',
   'vercelai',
   'aisdk',
+  'mastra',
+  'mastracore',
   // Common utilities
   'httpx',
   'pytest',
@@ -189,7 +206,7 @@ export type ProtocolMode = z.infer<typeof ProtocolModeSchema>;
  * MCP is a standalone tool server with no framework.
  */
 export const PROTOCOL_FRAMEWORK_MATRIX: Record<ProtocolMode, readonly SDKFramework[]> = {
-  HTTP: ['Strands', 'LangChain_LangGraph', 'GoogleADK', 'OpenAIAgents', 'VercelAI'] as const,
+  HTTP: ['Strands', 'LangChain_LangGraph', 'GoogleADK', 'OpenAIAgents', 'VercelAI', 'Mastra'] as const,
   MCP: [] as const,
   A2A: ['Strands', 'GoogleADK', 'LangChain_LangGraph'] as const,
   AGUI: ['Strands', 'LangChain_LangGraph', 'GoogleADK'] as const,


### PR DESCRIPTION
## Description

Adds Mastra as a supported TypeScript HTTP framework template for AgentCore agents.

This change wires Mastra through the create/add validation paths, TUI framework options, renderer selection, telemetry framework enum, and asset snapshot coverage. The new template uses `@mastra/core` with AI SDK providers and provides a working AgentCore Runtime HTTP entrypoint.

## Related Issue

Closes #1429

Related to #1207

## Documentation PR

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [x] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

Additional validation:
- Ran `npm run build`
- Generated a Mastra TypeScript agent and verified local `/invocations` streaming
- Deployed the generated Mastra project to AgentCore Runtime in `ap-northeast-1`
- Verified deployed invocation with `agentcore invoke --stream --target default --runtime MastraTest "hi"`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.