### PR TITLE
fix: pin google-genai < 2.0.0 in Gemini agent templates

### DIFF
--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -1242,7 +1242,7 @@ dependencies = [
     "aws-opentelemetry-distro",
     "bedrock-agentcore[a2a] >= 1.0.3",
     "google-adk >= 1.0.0, < 2.0.0",
-    "google-genai >= 1.0.0",
+    "google-genai >= 1.0.0, < 2.0.0",
 ]
 
 [tool.hatch.build.targets.wheel]
@@ -1603,6 +1603,7 @@ dependencies = [
     {{#if (eq modelProvider "Anthropic")}}"langchain-anthropic >= 0.3.0",
     {{/if}}{{#if (eq modelProvider "Bedrock")}}"langchain-aws >= 0.2.0",
     {{/if}}{{#if (eq modelProvider "Gemini")}}"langchain-google-genai >= 2.0.0",
+    "google-genai >= 1.0.0, < 2.0.0",
     {{/if}}{{#if (eq modelProvider "OpenAI")}}"langchain-openai >= 0.2.0",
     {{/if}}"aws-opentelemetry-distro",
     "opentelemetry-instrumentation-langchain >= 0.59.0",
@@ -2190,7 +2191,7 @@ dependencies = [
     "bedrock-agentcore >= 1.0.3",
     "fastapi >= 0.115.12",
     "google-adk >= 1.16.0, < 2.0.0",
-    "google-genai >= 1.0.0",
+    "google-genai >= 1.0.0, < 2.0.0",
     "opentelemetry-distro",
     "opentelemetry-exporter-otlp",
     "uvicorn >= 0.34.3",
@@ -2499,6 +2500,7 @@ dependencies = [
     {{#if (eq modelProvider "Anthropic")}}"langchain-anthropic >= 0.3.0",
     {{/if}}{{#if (eq modelProvider "Bedrock")}}"langchain-aws >= 0.2.0",
     {{/if}}{{#if (eq modelProvider "Gemini")}}"langchain-google-genai >= 2.0.0",
+    "google-genai >= 1.0.0, < 2.0.0",
     {{/if}}{{#if (eq modelProvider "OpenAI")}}"langchain-openai >= 0.2.0",
     {{/if}}"aws-opentelemetry-distro",
     "opentelemetry-instrumentation-langchain >= 0.59.0",
@@ -3674,6 +3676,7 @@ dependencies = [
     "opentelemetry-distro",
     "opentelemetry-exporter-otlp",
     "google-adk >= 1.17.0, < 2.0.0",
+    "google-genai >= 1.0.0, < 2.0.0",
     "bedrock-agentcore >= 1.0.3",
     "botocore[crt] >= 1.35.0",
     {{#if hasGateway}}{{#if (includes gatewayAuthTypes "AWS_IAM")}}"mcp-proxy-for-aws >= 1.1.0",
@@ -4202,6 +4205,7 @@ dependencies = [
 {{/if}}
 {{#if (eq modelProvider "Gemini")}}
     "langchain-google-genai >= 3.0.3",
+    "google-genai >= 1.0.0, < 2.0.0",
 {{/if}}
     {{#if hasGateway}}{{#if (includes gatewayAuthTypes "AWS_IAM")}}"mcp-proxy-for-aws >= 1.1.0",
     {{/if}}{{/if}}

--- a/src/assets/python/a2a/googleadk/base/pyproject.toml
+++ b/src/assets/python/a2a/googleadk/base/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "aws-opentelemetry-distro",
     "bedrock-agentcore[a2a] >= 1.0.3",
     "google-adk >= 1.0.0, < 2.0.0",
-    "google-genai >= 1.0.0",
+    "google-genai >= 1.0.0, < 2.0.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/assets/python/a2a/langchain_langgraph/base/pyproject.toml
+++ b/src/assets/python/a2a/langchain_langgraph/base/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     {{#if (eq modelProvider "Anthropic")}}"langchain-anthropic >= 0.3.0",
     {{/if}}{{#if (eq modelProvider "Bedrock")}}"langchain-aws >= 0.2.0",
     {{/if}}{{#if (eq modelProvider "Gemini")}}"langchain-google-genai >= 2.0.0",
+    "google-genai >= 1.0.0, < 2.0.0",
     {{/if}}{{#if (eq modelProvider "OpenAI")}}"langchain-openai >= 0.2.0",
     {{/if}}"aws-opentelemetry-distro",
     "opentelemetry-instrumentation-langchain >= 0.59.0",

--- a/src/assets/python/agui/googleadk/base/pyproject.toml
+++ b/src/assets/python/agui/googleadk/base/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "bedrock-agentcore >= 1.0.3",
     "fastapi >= 0.115.12",
     "google-adk >= 1.16.0, < 2.0.0",
-    "google-genai >= 1.0.0",
+    "google-genai >= 1.0.0, < 2.0.0",
     "opentelemetry-distro",
     "opentelemetry-exporter-otlp",
     "uvicorn >= 0.34.3",

--- a/src/assets/python/agui/langchain_langgraph/base/pyproject.toml
+++ b/src/assets/python/agui/langchain_langgraph/base/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     {{#if (eq modelProvider "Anthropic")}}"langchain-anthropic >= 0.3.0",
     {{/if}}{{#if (eq modelProvider "Bedrock")}}"langchain-aws >= 0.2.0",
     {{/if}}{{#if (eq modelProvider "Gemini")}}"langchain-google-genai >= 2.0.0",
+    "google-genai >= 1.0.0, < 2.0.0",
     {{/if}}{{#if (eq modelProvider "OpenAI")}}"langchain-openai >= 0.2.0",
     {{/if}}"aws-opentelemetry-distro",
     "opentelemetry-instrumentation-langchain >= 0.59.0",

--- a/src/assets/python/http/googleadk/base/pyproject.toml
+++ b/src/assets/python/http/googleadk/base/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "opentelemetry-distro",
     "opentelemetry-exporter-otlp",
     "google-adk >= 1.17.0, < 2.0.0",
+    "google-genai >= 1.0.0, < 2.0.0",
     "bedrock-agentcore >= 1.0.3",
     "botocore[crt] >= 1.35.0",
     {{#if hasGateway}}{{#if (includes gatewayAuthTypes "AWS_IAM")}}"mcp-proxy-for-aws >= 1.1.0",

--- a/src/assets/python/http/langchain_langgraph/base/pyproject.toml
+++ b/src/assets/python/http/langchain_langgraph/base/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
 {{/if}}
 {{#if (eq modelProvider "Gemini")}}
     "langchain-google-genai >= 3.0.3",
+    "google-genai >= 1.0.0, < 2.0.0",
 {{/if}}
     {{#if hasGateway}}{{#if (includes gatewayAuthTypes "AWS_IAM")}}"mcp-proxy-for-aws >= 1.1.0",
     {{/if}}{{/if}}


### PR DESCRIPTION
## Summary

- Pin `google-genai >= 1.0.0, < 2.0.0` across all GoogleADK and LangGraph Gemini templates to prevent incompatible major version resolution
- Fixes e2e test failures (`langgraph-gemini` and `googleadk-gemini`) that started on June 1 due to transitive dependency resolution pulling `google-genai 2.x`

## Root Cause

`google-genai 2.0.0+` introduced breaking API changes:
- `vertexai` parameter renamed to `enterprise` in Client instantiation
- New Interactions API structure with renamed SSE events
- `langchain-google-genai 4.2.4` (released May 28) started allowing `google-genai 2.x`, so fresh installs resolve to 2.7.0

The templates had no upper bound on `google-genai`, either directly (in GoogleADK templates) or transitively (via `langchain-google-genai` in LangGraph templates).

## Changes

| Template | Fix |
|----------|-----|
| `python/http/googleadk` | Added explicit `google-genai >= 1.0.0, < 2.0.0` |
| `python/a2a/googleadk` | Tightened existing `google-genai >= 1.0.0` → `< 2.0.0` |
| `python/agui/googleadk` | Tightened existing `google-genai >= 1.0.0` → `< 2.0.0` |
| `python/http/langchain_langgraph` (Gemini block) | Added explicit `google-genai >= 1.0.0, < 2.0.0` |
| `python/a2a/langchain_langgraph` (Gemini block) | Added explicit `google-genai >= 1.0.0, < 2.0.0` |
| `python/agui/langchain_langgraph` (Gemini block) | Added explicit `google-genai >= 1.0.0, < 2.0.0` |

## Test plan

- [x] `npm run build` passes
- [x] Asset snapshot tests updated and passing (124 tests)
- [x] Pre-commit hooks (typecheck, lint, secretlint) pass
- [ ] E2E re-run should show Gemini tests recovering