### PR TITLE
fix(e2e): skip Gemini invoke and logs tests

### DIFF
--- a/e2e-tests/e2e-helper.ts
+++ b/e2e-tests/e2e-helper.ts
@@ -32,6 +32,7 @@ interface E2EConfig {
   language?: 'Python' | 'TypeScript';
   /** Skip logs and traces tests. */
   skipObservability?: boolean;
+  skipInvoke?: boolean;
   /** Lifecycle configuration to pass via --idle-timeout / --max-lifetime flags. */
   lifecycleConfig?: {
     idleTimeout?: number;
@@ -138,7 +139,7 @@ export function createE2ESuite(cfg: E2EConfig) {
       deployTimeout
     );
 
-    it.skipIf(!canRun)(
+    it.skipIf(!canRun || !!cfg.skipInvoke)(
       'invokes the deployed agent',
       async () => {
         expect(projectPath, 'Project should have been created').toBeTruthy();
@@ -226,7 +227,7 @@ export function createE2ESuite(cfg: E2EConfig) {
       120000
     );
 
-    it.skipIf(!canRun || !!cfg.skipObservability)(
+    it.skipIf(!canRun || !!cfg.skipObservability || !!cfg.skipInvoke)(
       'logs returns entries from the invocation',
       async () => {
         await retry(

--- a/e2e-tests/googleadk-gemini.test.ts
+++ b/e2e-tests/googleadk-gemini.test.ts
@@ -1,3 +1,3 @@
 import { createE2ESuite } from './e2e-helper.js';
 
-createE2ESuite({ framework: 'GoogleADK', modelProvider: 'Gemini', requiredEnvVar: 'GEMINI_API_KEY' });
+createE2ESuite({ framework: 'GoogleADK', modelProvider: 'Gemini', requiredEnvVar: 'GEMINI_API_KEY', skipInvoke: true });

--- a/e2e-tests/harness-e2e-helper.ts
+++ b/e2e-tests/harness-e2e-helper.ts
@@ -22,6 +22,7 @@ interface HarnessE2EConfig {
   modelProvider: 'bedrock' | 'open_ai' | 'gemini';
   requiredEnvVar?: string;
   skipMemory?: boolean;
+  skipInvoke?: boolean;
 }
 
 export function createHarnessE2ESuite(cfg: HarnessE2EConfig) {
@@ -110,7 +111,7 @@ export function createHarnessE2ESuite(cfg: HarnessE2EConfig) {
       600000
     );
 
-    it.skipIf(!canRun)(
+    it.skipIf(!canRun || !!cfg.skipInvoke)(
       'invokes the deployed harness',
       async () => {
         expect(projectPath, 'Project should have been created').toBeTruthy();

--- a/e2e-tests/harness-gemini.test.ts
+++ b/e2e-tests/harness-gemini.test.ts
@@ -1,3 +1,8 @@
 import { createHarnessE2ESuite } from './harness-e2e-helper.js';
 
-createHarnessE2ESuite({ modelProvider: 'gemini', requiredEnvVar: 'GEMINI_API_KEY_ARN', skipMemory: true, skipInvoke: true });
+createHarnessE2ESuite({
+  modelProvider: 'gemini',
+  requiredEnvVar: 'GEMINI_API_KEY_ARN',
+  skipMemory: true,
+  skipInvoke: true,
+});

--- a/e2e-tests/harness-gemini.test.ts
+++ b/e2e-tests/harness-gemini.test.ts
@@ -1,3 +1,3 @@
 import { createHarnessE2ESuite } from './harness-e2e-helper.js';
 
-createHarnessE2ESuite({ modelProvider: 'gemini', requiredEnvVar: 'GEMINI_API_KEY_ARN', skipMemory: true });
+createHarnessE2ESuite({ modelProvider: 'gemini', requiredEnvVar: 'GEMINI_API_KEY_ARN', skipMemory: true, skipInvoke: true });

--- a/e2e-tests/langgraph-gemini.test.ts
+++ b/e2e-tests/langgraph-gemini.test.ts
@@ -1,3 +1,8 @@
 import { createE2ESuite } from './e2e-helper.js';
 
-createE2ESuite({ framework: 'LangChain_LangGraph', modelProvider: 'Gemini', requiredEnvVar: 'GEMINI_API_KEY', skipInvoke: true });
+createE2ESuite({
+  framework: 'LangChain_LangGraph',
+  modelProvider: 'Gemini',
+  requiredEnvVar: 'GEMINI_API_KEY',
+  skipInvoke: true,
+});

--- a/e2e-tests/langgraph-gemini.test.ts
+++ b/e2e-tests/langgraph-gemini.test.ts
@@ -1,3 +1,3 @@
 import { createE2ESuite } from './e2e-helper.js';
 
-createE2ESuite({ framework: 'LangChain_LangGraph', modelProvider: 'Gemini', requiredEnvVar: 'GEMINI_API_KEY' });
+createE2ESuite({ framework: 'LangChain_LangGraph', modelProvider: 'Gemini', requiredEnvVar: 'GEMINI_API_KEY', skipInvoke: true });

--- a/e2e-tests/strands-gemini.test.ts
+++ b/e2e-tests/strands-gemini.test.ts
@@ -1,3 +1,3 @@
 import { createE2ESuite } from './e2e-helper.js';
 
-createE2ESuite({ framework: 'Strands', modelProvider: 'Gemini', requiredEnvVar: 'GEMINI_API_KEY' });
+createE2ESuite({ framework: 'Strands', modelProvider: 'Gemini', requiredEnvVar: 'GEMINI_API_KEY', skipInvoke: true });


### PR DESCRIPTION
## Description

Temporarily skips the `invokes the deployed agent/harness` and `logs returns entries from the invocation` tests for all Gemini e2e suites (GoogleADK, LangGraph, Strands, Harness). These tests are failing on main due to a Gemini key issue unrelated to the CLI itself.

Adds a `skipInvoke` flag to `E2EConfig` and `HarnessE2EConfig`. When set, the invoke test and the downstream logs test (which depends on an invocation having occurred) are both skipped. All other tests (create, deploy, status, teardown) continue to run.

Follow-up to re-enable this: https://github.com/aws/agentcore-cli/issues/1435

### Testing
- ran gemini tests locally by manually fetching gemini key from secrets manager. 
```
 Test Files  3 passed | 1 skipped (4)
      Tests  15 passed | 11 skipped (26)
   Start at  02:21:08
   Duration  192.95s (transform 764ms, setup 0ms, import 4.46s, tests 562.50s, environment 0ms)

```

## Related Issue

Closes # https://github.com/aws/agentcore-cli/issues/1431

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

- Ran all 4 Gemini e2e test files locally against CI account — 15 passed, 11 skipped (invoke + logs + harness preview-only suite), 0 failed.
- [x] I ran `npm run typecheck`

## Checklist

- [ ] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.