### PR TITLE
fix(telemetry): re-throw exceptions in withCommandRunTelemetry

### DIFF
--- a/src/cli/commands/dev/command.tsx
+++ b/src/cli/commands/dev/command.tsx
@@ -6,7 +6,7 @@ import {
   findConfigRoot,
   getWorkingDirectory,
 } from '../../../lib';
-import { buildFailureResult } from '../../../lib/result.js';
+import { failureResult } from '../../../lib/result.js';
 import { getErrorMessage } from '../../errors';
 import { detectContainerRuntime } from '../../external-requirements';
 import { isPreviewEnabled } from '../../feature-flags';
@@ -211,7 +211,7 @@ export const registerDev = (program: Command) => {
             },
             async recorder => {
               if (!positionalPrompt) {
-                return buildFailureResult(
+                return failureResult(
                   new ValidationError('A command is required with --exec. Usage: agentcore dev --exec "whoami"')
                 );
               }
@@ -220,7 +220,7 @@ export const registerDev = (program: Command) => {
               const agentName = opts.runtime ?? project?.runtimes[0]?.name ?? 'unknown';
               const targetAgent = project?.runtimes.find(a => a.name === agentName);
               if (targetAgent?.build !== 'Container') {
-                return buildFailureResult(
+                return failureResult(
                   new ValidationError(
                     '--exec is only supported for Container build agents. For CodeZip agents, use your terminal to run commands directly.'
                   )

--- a/src/cli/commands/dev/command.tsx
+++ b/src/cli/commands/dev/command.tsx
@@ -6,6 +6,7 @@ import {
   findConfigRoot,
   getWorkingDirectory,
 } from '../../../lib';
+import { buildFailureResult } from '../../../lib/result.js';
 import { getErrorMessage } from '../../errors';
 import { detectContainerRuntime } from '../../external-requirements';
 import { isPreviewEnabled } from '../../feature-flags';
@@ -210,15 +211,19 @@ export const registerDev = (program: Command) => {
             },
             async recorder => {
               if (!positionalPrompt) {
-                throw new ValidationError('A command is required with --exec. Usage: agentcore dev --exec "whoami"');
+                return buildFailureResult(
+                  new ValidationError('A command is required with --exec. Usage: agentcore dev --exec "whoami"')
+                );
               }
               const workingDir = getWorkingDirectory();
               const project = await loadProjectConfig(workingDir);
               const agentName = opts.runtime ?? project?.runtimes[0]?.name ?? 'unknown';
               const targetAgent = project?.runtimes.find(a => a.name === agentName);
               if (targetAgent?.build !== 'Container') {
-                throw new ValidationError(
-                  '--exec is only supported for Container build agents. For CodeZip agents, use your terminal to run commands directly.'
+                return buildFailureResult(
+                  new ValidationError(
+                    '--exec is only supported for Container build agents. For CodeZip agents, use your terminal to run commands directly.'
+                  )
                 );
               }
               recorder.set({
@@ -229,8 +234,7 @@ export const registerDev = (program: Command) => {
               return { success: true as const };
             }
           );
-          // TODO: Remove cast once withCommandRunTelemetry's return type is narrowed
-          if (!execResult.success) throw (execResult as unknown as { error: Error }).error;
+          if (!execResult.success) throw execResult.error;
           return;
         }
 

--- a/src/cli/commands/import/__tests__/import-evaluator.test.ts
+++ b/src/cli/commands/import/__tests__/import-evaluator.test.ts
@@ -14,7 +14,7 @@ import { toEvaluatorSpec } from '../import-evaluator';
 import { buildImportTemplate, findLogicalIdByProperty, findLogicalIdsByType } from '../template-utils';
 import type { CfnTemplate } from '../template-utils';
 import type { ResourceToImport } from '../types';
-import { describe, expect, it } from 'vitest';
+import { assert, describe, expect, it } from 'vitest';
 
 // ============================================================================
 // toEvaluatorSpec Conversion Tests
@@ -46,19 +46,20 @@ describe('toEvaluatorSpec', () => {
 
     const result = toEvaluatorSpec(detail, 'my_evaluator');
 
-    expect(result.name).toBe('my_evaluator');
-    expect(result.level).toBe('SESSION');
-    expect(result.description).toBe('Test evaluator');
-    expect(result.config.llmAsAJudge).toBeDefined();
-    expect(result.config.llmAsAJudge!.model).toBe('anthropic.claude-3-5-sonnet-20241022-v2:0');
-    expect(result.config.llmAsAJudge!.instructions).toBe('Evaluate the response quality');
-    expect(result.config.llmAsAJudge!.ratingScale.numerical).toHaveLength(2);
-    expect(result.config.llmAsAJudge!.ratingScale.numerical![0]).toEqual({
+    assert(result.success);
+    expect(result.evaluator.name).toBe('my_evaluator');
+    expect(result.evaluator.level).toBe('SESSION');
+    expect(result.evaluator.description).toBe('Test evaluator');
+    expect(result.evaluator.config.llmAsAJudge).toBeDefined();
+    expect(result.evaluator.config.llmAsAJudge!.model).toBe('anthropic.claude-3-5-sonnet-20241022-v2:0');
+    expect(result.evaluator.config.llmAsAJudge!.instructions).toBe('Evaluate the response quality');
+    expect(result.evaluator.config.llmAsAJudge!.ratingScale.numerical).toHaveLength(2);
+    expect(result.evaluator.config.llmAsAJudge!.ratingScale.numerical![0]).toEqual({
       value: 1,
       label: 'Poor',
       definition: 'Low quality response',
     });
-    expect(result.tags).toEqual({ env: 'test' });
+    expect(result.evaluator.tags).toEqual({ env: 'test' });
   });
 
   it('maps LLM-as-a-Judge evaluator with categorical rating scale', () => {
@@ -84,16 +85,17 @@ describe('toEvaluatorSpec', () => {
 
     const result = toEvaluatorSpec(detail, 'categorical_eval');
 
-    expect(result.level).toBe('TRACE');
-    expect(result.config.llmAsAJudge).toBeDefined();
-    expect(result.config.llmAsAJudge!.ratingScale.categorical).toHaveLength(2);
-    expect(result.config.llmAsAJudge!.ratingScale.categorical![0]).toEqual({
+    assert(result.success);
+    expect(result.evaluator.level).toBe('TRACE');
+    expect(result.evaluator.config.llmAsAJudge).toBeDefined();
+    expect(result.evaluator.config.llmAsAJudge!.ratingScale.categorical).toHaveLength(2);
+    expect(result.evaluator.config.llmAsAJudge!.ratingScale.categorical![0]).toEqual({
       label: 'Pass',
       definition: 'Response meets criteria',
     });
     // No description or tags
-    expect(result.description).toBeUndefined();
-    expect(result.tags).toBeUndefined();
+    expect(result.evaluator.description).toBeUndefined();
+    expect(result.evaluator.tags).toBeUndefined();
   });
 
   it('maps code-based evaluator as external with Lambda ARN', () => {
@@ -112,14 +114,15 @@ describe('toEvaluatorSpec', () => {
 
     const result = toEvaluatorSpec(detail, 'code_eval');
 
-    expect(result.name).toBe('code_eval');
-    expect(result.level).toBe('TOOL_CALL');
-    expect(result.config.codeBased).toBeDefined();
-    expect(result.config.codeBased!.external).toBeDefined();
-    expect(result.config.codeBased!.external!.lambdaArn).toBe(
+    assert(result.success);
+    expect(result.evaluator.name).toBe('code_eval');
+    expect(result.evaluator.level).toBe('TOOL_CALL');
+    expect(result.evaluator.config.codeBased).toBeDefined();
+    expect(result.evaluator.config.codeBased!.external).toBeDefined();
+    expect(result.evaluator.config.codeBased!.external!.lambdaArn).toBe(
       'arn:aws:lambda:us-west-2:123456789012:function:my-eval-function'
     );
-    expect(result.config.llmAsAJudge).toBeUndefined();
+    expect(result.evaluator.config.llmAsAJudge).toBeUndefined();
   });
 
   it('uses provided local name instead of evaluator name from AWS', () => {
@@ -140,10 +143,11 @@ describe('toEvaluatorSpec', () => {
 
     const result = toEvaluatorSpec(detail, 'custom_local_name');
 
-    expect(result.name).toBe('custom_local_name');
+    assert(result.success);
+    expect(result.evaluator.name).toBe('custom_local_name');
   });
 
-  it('throws when evaluator has no recognizable config', () => {
+  it('returns failure when evaluator has no recognizable config', () => {
     const detail: GetEvaluatorResult = {
       evaluatorId: 'eval-no-config',
       evaluatorArn: 'arn:aws:bedrock-agentcore:us-west-2:123456789012:evaluator/eval-no-config',
@@ -152,10 +156,12 @@ describe('toEvaluatorSpec', () => {
       status: 'ACTIVE',
     };
 
-    expect(() => toEvaluatorSpec(detail, 'broken_eval')).toThrow('Evaluator "broken_eval" has no recognizable config');
+    const result = toEvaluatorSpec(detail, 'broken_eval');
+    assert(!result.success);
+    expect(result.error.message).toContain('Evaluator "broken_eval" has no recognizable config');
   });
 
-  it('throws when evaluatorConfig is empty object', () => {
+  it('returns failure when evaluatorConfig is empty object', () => {
     const detail: GetEvaluatorResult = {
       evaluatorId: 'eval-empty',
       evaluatorArn: 'arn:aws:bedrock-agentcore:us-west-2:123456789012:evaluator/eval-empty',
@@ -165,7 +171,9 @@ describe('toEvaluatorSpec', () => {
       evaluatorConfig: {},
     };
 
-    expect(() => toEvaluatorSpec(detail, 'empty_config_eval')).toThrow('has no recognizable config');
+    const result = toEvaluatorSpec(detail, 'empty_config_eval');
+    assert(!result.success);
+    expect(result.error.message).toContain('has no recognizable config');
   });
 
   it('omits description when not present', () => {
@@ -186,7 +194,8 @@ describe('toEvaluatorSpec', () => {
 
     const result = toEvaluatorSpec(detail, 'no_desc_eval');
 
-    expect(result.description).toBeUndefined();
+    assert(result.success);
+    expect(result.evaluator.description).toBeUndefined();
   });
 
   it('omits tags when empty', () => {
@@ -208,7 +217,8 @@ describe('toEvaluatorSpec', () => {
 
     const result = toEvaluatorSpec(detail, 'empty_tags_eval');
 
-    expect(result.tags).toBeUndefined();
+    assert(result.success);
+    expect(result.evaluator.tags).toBeUndefined();
   });
 
   it('forwards kmsKeyArn when present', () => {
@@ -230,7 +240,10 @@ describe('toEvaluatorSpec', () => {
 
     const result = toEvaluatorSpec(detail, 'kms_eval');
 
-    expect(result.kmsKeyArn).toBe('arn:aws:kms:us-west-2:123456789012:key/12345678-1234-1234-1234-123456789012');
+    assert(result.success);
+    expect(result.evaluator.kmsKeyArn).toBe(
+      'arn:aws:kms:us-west-2:123456789012:key/12345678-1234-1234-1234-123456789012'
+    );
   });
 
   it('omits kmsKeyArn when not present', () => {
@@ -251,7 +264,8 @@ describe('toEvaluatorSpec', () => {
 
     const result = toEvaluatorSpec(detail, 'no_kms_eval');
 
-    expect(result.kmsKeyArn).toBeUndefined();
+    assert(result.success);
+    expect(result.evaluator.kmsKeyArn).toBeUndefined();
   });
 });
 

--- a/src/cli/commands/import/__tests__/import-gateway-targets.test.ts
+++ b/src/cli/commands/import/__tests__/import-gateway-targets.test.ts
@@ -10,7 +10,7 @@
  */
 import type { GatewayTargetDetail } from '../../../aws/agentcore-control';
 import { toGatewayTargetSpec } from '../import-gateway';
-import { describe, expect, it, vi } from 'vitest';
+import { assert, describe, expect, it, vi } from 'vitest';
 
 /** Helper to build a minimal GatewayTargetDetail with only the fields under test. */
 function baseDetail(overrides: Partial<GatewayTargetDetail> = {}): GatewayTargetDetail {
@@ -48,12 +48,12 @@ describe('toGatewayTargetSpec — apiGateway', () => {
     const onProgress = vi.fn();
     const result = toGatewayTargetSpec(detail, new Map(), onProgress);
 
-    expect(result).toBeDefined();
-    expect(result!.name).toBe('test_target');
-    expect(result!.targetType).toBe('apiGateway');
+    assert(result.success);
+    expect(result.target!.name).toBe('test_target');
+    expect(result.target!.targetType).toBe('apiGateway');
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const apigw = (result as any).apiGateway;
+    const apigw = (result.target as any).apiGateway;
     expect(apigw.restApiId).toBe('abc123');
     expect(apigw.stage).toBe('prod');
     expect(apigw.apiGatewayToolConfiguration.toolFilters).toEqual([
@@ -84,8 +84,9 @@ describe('toGatewayTargetSpec — apiGateway', () => {
     const onProgress = vi.fn();
     const result = toGatewayTargetSpec(detail, new Map(), onProgress);
 
+    assert(result.success);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const apigw = (result as any).apiGateway;
+    const apigw = (result.target as any).apiGateway;
     expect(apigw.apiGatewayToolConfiguration.toolOverrides).toEqual([
       { name: 'listPets', path: '/pets', method: 'GET', description: 'List all pets' },
       { name: 'createPet', path: '/pets', method: 'POST' },
@@ -110,8 +111,9 @@ describe('toGatewayTargetSpec — apiGateway', () => {
     const onProgress = vi.fn();
     const result = toGatewayTargetSpec(detail, new Map(), onProgress);
 
+    assert(result.success);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const apigw = (result as any).apiGateway;
+    const apigw = (result.target as any).apiGateway;
     expect(apigw.apiGatewayToolConfiguration.toolOverrides).toBeUndefined();
   });
 
@@ -144,8 +146,8 @@ describe('toGatewayTargetSpec — apiGateway', () => {
     const onProgress = vi.fn();
     const result = toGatewayTargetSpec(detail, credentials, onProgress);
 
-    expect(result).toBeDefined();
-    expect(result!.outboundAuth).toEqual({
+    assert(result.success);
+    expect(result.target!.outboundAuth).toEqual({
       type: 'OAUTH',
       credentialName: 'my_oauth_cred',
       scopes: ['read', 'write'],
@@ -172,12 +174,12 @@ describe('toGatewayTargetSpec — openApiSchema', () => {
     const onProgress = vi.fn();
     const result = toGatewayTargetSpec(detail, new Map(), onProgress);
 
-    expect(result).toBeDefined();
-    expect(result!.name).toBe('test_target');
-    expect(result!.targetType).toBe('openApiSchema');
+    assert(result.success);
+    expect(result.target!.name).toBe('test_target');
+    expect(result.target!.targetType).toBe('openApiSchema');
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const schemaSource = (result as any).schemaSource;
+    const schemaSource = (result.target as any).schemaSource;
     expect(schemaSource.s3.uri).toBe('s3://my-bucket/schema.yaml');
     expect(schemaSource.s3.bucketOwnerAccountId).toBe('123456789012');
   });
@@ -194,7 +196,8 @@ describe('toGatewayTargetSpec — openApiSchema', () => {
     const onProgress = vi.fn();
     const result = toGatewayTargetSpec(detail, new Map(), onProgress);
 
-    expect(result).toBeUndefined();
+    assert(result.success);
+    expect(result.target).toBeUndefined();
     expect(onProgress).toHaveBeenCalledWith(expect.stringContaining('(openApiSchema) has no S3 URI, skipping'));
   });
 });
@@ -218,12 +221,12 @@ describe('toGatewayTargetSpec — smithyModel', () => {
     const onProgress = vi.fn();
     const result = toGatewayTargetSpec(detail, new Map(), onProgress);
 
-    expect(result).toBeDefined();
-    expect(result!.name).toBe('test_target');
-    expect(result!.targetType).toBe('smithyModel');
+    assert(result.success);
+    expect(result.target!.name).toBe('test_target');
+    expect(result.target!.targetType).toBe('smithyModel');
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const schemaSource = (result as any).schemaSource;
+    const schemaSource = (result.target as any).schemaSource;
     expect(schemaSource.s3.uri).toBe('s3://models-bucket/model.json');
     expect(schemaSource.s3.bucketOwnerAccountId).toBeUndefined();
   });
@@ -240,7 +243,8 @@ describe('toGatewayTargetSpec — smithyModel', () => {
     const onProgress = vi.fn();
     const result = toGatewayTargetSpec(detail, new Map(), onProgress);
 
-    expect(result).toBeUndefined();
+    assert(result.success);
+    expect(result.target).toBeUndefined();
     expect(onProgress).toHaveBeenCalledWith(expect.stringContaining('(smithyModel) has no S3 URI, skipping'));
   });
 });
@@ -265,12 +269,12 @@ describe('toGatewayTargetSpec — lambda', () => {
     const onProgress = vi.fn();
     const result = toGatewayTargetSpec(detail, new Map(), onProgress);
 
-    expect(result).toBeDefined();
-    expect(result!.name).toBe('test_target');
-    expect(result!.targetType).toBe('lambdaFunctionArn');
+    assert(result.success);
+    expect(result.target!.name).toBe('test_target');
+    expect(result.target!.targetType).toBe('lambdaFunctionArn');
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const lambdaConfig = (result as any).lambdaFunctionArn;
+    const lambdaConfig = (result.target as any).lambdaFunctionArn;
     expect(lambdaConfig.lambdaArn).toBe('arn:aws:lambda:us-west-2:123456789012:function:my-func');
     expect(lambdaConfig.toolSchemaFile).toBe('s3://schemas/tools.json');
   });
@@ -290,7 +294,8 @@ describe('toGatewayTargetSpec — lambda', () => {
     const onProgress = vi.fn();
     const result = toGatewayTargetSpec(detail, new Map(), onProgress);
 
-    expect(result).toBeUndefined();
+    assert(result.success);
+    expect(result.target).toBeUndefined();
     expect(onProgress).toHaveBeenCalledWith(expect.stringContaining('(lambda) has no ARN, skipping'));
   });
 
@@ -309,7 +314,8 @@ describe('toGatewayTargetSpec — lambda', () => {
     const onProgress = vi.fn();
     const result = toGatewayTargetSpec(detail, new Map(), onProgress);
 
-    expect(result).toBeUndefined();
+    assert(result.success);
+    expect(result.target).toBeUndefined();
     expect(onProgress).toHaveBeenCalledWith(
       expect.stringContaining('has inline tool schema, which cannot be imported')
     );
@@ -349,7 +355,8 @@ describe('toGatewayTargetSpec — unrecognized target type', () => {
     const onProgress = vi.fn();
     const result = toGatewayTargetSpec(detail, new Map(), onProgress);
 
-    expect(result).toBeUndefined();
+    assert(result.success);
+    expect(result.target).toBeUndefined();
     expect(onProgress).toHaveBeenCalledWith(expect.stringContaining('unrecognized target type'));
   });
 });

--- a/src/cli/commands/import/__tests__/import-gateway.test.ts
+++ b/src/cli/commands/import/__tests__/import-gateway.test.ts
@@ -6,7 +6,7 @@ import {
   _resolveOutboundAuth as resolveOutboundAuth,
   _toGatewayTargetSpec as toGatewayTargetSpec,
 } from '../import-gateway';
-import { describe, expect, it, vi } from 'vitest';
+import { assert, describe, expect, it, vi } from 'vitest';
 
 // ============================================================================
 // Helpers
@@ -39,12 +39,13 @@ describe('toGatewayTargetSpec — mcpServer targets', () => {
 
     const result = toGatewayTargetSpec(detail, credentials, onProgress);
 
-    expect(result).toEqual({
+    assert(result.success);
+    expect(result.target).toEqual({
       name: 'my-mcp-target',
       targetType: 'mcpServer',
       endpoint: 'https://example.com/mcp',
     });
-    expect(result).not.toHaveProperty('outboundAuth');
+    expect(result.target).not.toHaveProperty('outboundAuth');
     expect(onProgress).not.toHaveBeenCalled();
   });
 
@@ -73,7 +74,8 @@ describe('toGatewayTargetSpec — mcpServer targets', () => {
 
     const result = toGatewayTargetSpec(detail, credentials, onProgress);
 
-    expect(result).toEqual({
+    assert(result.success);
+    expect(result.target).toEqual({
       name: 'my-mcp-target',
       targetType: 'mcpServer',
       endpoint: 'https://example.com/mcp',
@@ -109,7 +111,8 @@ describe('toGatewayTargetSpec — mcpServer targets', () => {
 
     const result = toGatewayTargetSpec(detail, credentials, onProgress);
 
-    expect(result).toEqual({
+    assert(result.success);
+    expect(result.target).toEqual({
       name: 'my-mcp-target',
       targetType: 'mcpServer',
       endpoint: 'https://example.com/mcp',
@@ -120,7 +123,7 @@ describe('toGatewayTargetSpec — mcpServer targets', () => {
     });
   });
 
-  it('throws when OAuth credential not found in project', () => {
+  it('returns failure when OAuth credential not found in project', () => {
     const providerArn = 'arn:aws:bedrock:us-east-1:123456789012:credential-provider/missing-oauth';
     const detail = makeDetail({
       targetConfiguration: {
@@ -143,12 +146,12 @@ describe('toGatewayTargetSpec — mcpServer targets', () => {
     const credentials = new Map<string, string>();
     const onProgress = vi.fn();
 
-    expect(() => toGatewayTargetSpec(detail, credentials, onProgress)).toThrow(
-      'uses an OAuth credential provider not found'
-    );
+    const result = toGatewayTargetSpec(detail, credentials, onProgress);
+    assert(!result.success);
+    expect(result.error.message).toContain('uses an OAuth credential provider not found');
   });
 
-  it('throws when API_KEY credential not found in project', () => {
+  it('returns failure when API_KEY credential not found in project', () => {
     const providerArn = 'arn:aws:bedrock:us-east-1:123456789012:credential-provider/missing-apikey';
     const detail = makeDetail({
       targetConfiguration: {
@@ -170,9 +173,9 @@ describe('toGatewayTargetSpec — mcpServer targets', () => {
     const credentials = new Map<string, string>();
     const onProgress = vi.fn();
 
-    expect(() => toGatewayTargetSpec(detail, credentials, onProgress)).toThrow(
-      'uses an API Key credential provider not found'
-    );
+    const result = toGatewayTargetSpec(detail, credentials, onProgress);
+    assert(!result.success);
+    expect(result.error.message).toContain('uses an API Key credential provider not found');
   });
 
   it('returns undefined and warns when target has no MCP configuration', () => {
@@ -184,7 +187,8 @@ describe('toGatewayTargetSpec — mcpServer targets', () => {
 
     const result = toGatewayTargetSpec(detail, credentials, onProgress);
 
-    expect(result).toBeUndefined();
+    assert(result.success);
+    expect(result.target).toBeUndefined();
     expect(onProgress).toHaveBeenCalledWith(expect.stringContaining('no MCP configuration'));
   });
 });
@@ -214,7 +218,8 @@ describe('resolveOutboundAuth — scopes handling', () => {
 
     const result = resolveOutboundAuth(detail, credentials, onProgress);
 
-    expect(result).toEqual({
+    assert(result.success);
+    expect(result.auth).toEqual({
       type: 'OAUTH',
       credentialName: 'scoped-cred',
       scopes: ['openid', 'profile', 'email'],
@@ -241,10 +246,11 @@ describe('resolveOutboundAuth — scopes handling', () => {
 
     const result = resolveOutboundAuth(detail, credentials, onProgress);
 
-    expect(result).toEqual({
+    assert(result.success);
+    expect(result.auth).toEqual({
       type: 'OAUTH',
       credentialName: 'no-scope-cred',
     });
-    expect(result).not.toHaveProperty('scopes');
+    expect(result.auth).not.toHaveProperty('scopes');
   });
 });

--- a/src/cli/commands/import/__tests__/import-online-eval.test.ts
+++ b/src/cli/commands/import/__tests__/import-online-eval.test.ts
@@ -12,7 +12,7 @@ import { extractAgentName, toOnlineEvalConfigSpec } from '../import-online-eval'
 import { buildImportTemplate, findLogicalIdByProperty, findLogicalIdsByType } from '../template-utils';
 import type { CfnTemplate } from '../template-utils';
 import type { ResourceToImport } from '../types';
-import { describe, expect, it } from 'vitest';
+import { assert, describe, expect, it } from 'vitest';
 
 // ============================================================================
 // extractAgentName Tests
@@ -64,12 +64,13 @@ describe('toOnlineEvalConfigSpec', () => {
 
     const result = toOnlineEvalConfigSpec(detail, 'QualityMonitor', 'my_agent', ['my_evaluator']);
 
-    expect(result.name).toBe('QualityMonitor');
-    expect(result.agent).toBe('my_agent');
-    expect(result.evaluators).toEqual(['my_evaluator']);
-    expect(result.samplingRate).toBe(50);
-    expect(result.description).toBe('Monitor agent quality');
-    expect(result.enableOnCreate).toBe(true);
+    assert(result.success);
+    expect(result.config.name).toBe('QualityMonitor');
+    expect(result.config.agent).toBe('my_agent');
+    expect(result.config.evaluators).toEqual(['my_evaluator']);
+    expect(result.config.samplingRate).toBe(50);
+    expect(result.config.description).toBe('Monitor agent quality');
+    expect(result.config.enableOnCreate).toBe(true);
   });
 
   it('omits enableOnCreate when execution status is DISABLED', () => {
@@ -86,7 +87,8 @@ describe('toOnlineEvalConfigSpec', () => {
 
     const result = toOnlineEvalConfigSpec(detail, 'DisabledConfig', 'agent', ['eval_one']);
 
-    expect(result.enableOnCreate).toBeUndefined();
+    assert(result.success);
+    expect(result.config.enableOnCreate).toBeUndefined();
   });
 
   it('omits description when not present', () => {
@@ -103,10 +105,11 @@ describe('toOnlineEvalConfigSpec', () => {
 
     const result = toOnlineEvalConfigSpec(detail, 'NoDesc', 'agent', ['eval_one']);
 
-    expect(result.description).toBeUndefined();
+    assert(result.success);
+    expect(result.config.description).toBeUndefined();
   });
 
-  it('throws when sampling percentage is missing', () => {
+  it('returns failure when sampling percentage is missing', () => {
     const detail: GetOnlineEvalConfigResult = {
       configId: 'oec-no-sampling',
       configArn: 'arn:aws:bedrock-agentcore:us-west-2:123456789012:online-evaluation-config/oec-no-sampling',
@@ -117,9 +120,9 @@ describe('toOnlineEvalConfigSpec', () => {
       evaluatorIds: ['eval-1'],
     };
 
-    expect(() => toOnlineEvalConfigSpec(detail, 'NoSampling', 'agent', ['eval_one'])).toThrow(
-      'has no sampling configuration'
-    );
+    const result = toOnlineEvalConfigSpec(detail, 'NoSampling', 'agent', ['eval_one']);
+    assert(!result.success);
+    expect(result.error.message).toContain('has no sampling configuration');
   });
 
   it('supports multiple evaluator references', () => {
@@ -139,9 +142,10 @@ describe('toOnlineEvalConfigSpec', () => {
       'arn:aws:bedrock-agentcore:us-west-2:123456789012:evaluator/eval-2',
     ]);
 
-    expect(result.evaluators).toHaveLength(2);
-    expect(result.evaluators[0]).toBe('local_eval');
-    expect(result.evaluators[1]).toMatch(/^arn:/);
+    assert(result.success);
+    expect(result.config.evaluators).toHaveLength(2);
+    expect(result.config.evaluators[0]).toBe('local_eval');
+    expect(result.config.evaluators[1]).toMatch(/^arn:/);
   });
 });
 

--- a/src/cli/commands/import/import-evaluator.ts
+++ b/src/cli/commands/import/import-evaluator.ts
@@ -88,6 +88,7 @@ const evaluatorDescriptor: ResourceImportDescriptor<GetEvaluatorResult, Evaluato
     if (!result.success)
       return { success: false, error: result.error, resourceType: 'evaluator' as const, resourceName: localName };
     (spec.evaluators ??= []).push(result.evaluator);
+    return { success: true, resourceType: 'evaluator', resourceName: localName };
   },
 
   cfnResourceType: 'AWS::BedrockAgentCore::Evaluator',

--- a/src/cli/commands/import/import-evaluator.ts
+++ b/src/cli/commands/import/import-evaluator.ts
@@ -1,5 +1,5 @@
 import { ValidationError } from '../../../lib';
-import { type Result, buildFailureResult } from '../../../lib/result';
+import { type Result, failureResult } from '../../../lib/result';
 import type { Evaluator } from '../../../schema';
 import type { EvaluatorSummary, GetEvaluatorResult } from '../../aws/agentcore-control';
 import {
@@ -42,7 +42,7 @@ export function toEvaluatorSpec(detail: GetEvaluatorResult, localName: string): 
       },
     };
   } else {
-    return buildFailureResult(
+    return failureResult(
       new ValidationError(
         `Evaluator "${detail.evaluatorName}" has no recognizable config. ` +
           'Only LLM-as-a-Judge and code-based evaluators can be imported.'

--- a/src/cli/commands/import/import-evaluator.ts
+++ b/src/cli/commands/import/import-evaluator.ts
@@ -1,3 +1,5 @@
+import { ValidationError } from '../../../lib';
+import { type Result, buildFailureResult } from '../../../lib/result';
 import type { Evaluator } from '../../../schema';
 import type { EvaluatorSummary, GetEvaluatorResult } from '../../aws/agentcore-control';
 import {
@@ -17,7 +19,7 @@ import type { Command } from '@commander-js/extra-typings';
 /**
  * Map an AWS GetEvaluator response to the CLI Evaluator spec format.
  */
-export function toEvaluatorSpec(detail: GetEvaluatorResult, localName: string): Evaluator {
+export function toEvaluatorSpec(detail: GetEvaluatorResult, localName: string): Result<{ evaluator: Evaluator }> {
   const level = detail.level || 'SESSION';
 
   let config: Evaluator['config'];
@@ -40,19 +42,24 @@ export function toEvaluatorSpec(detail: GetEvaluatorResult, localName: string): 
       },
     };
   } else {
-    throw new Error(
-      `Evaluator "${detail.evaluatorName}" has no recognizable config. ` +
-        'Only LLM-as-a-Judge and code-based evaluators can be imported.'
+    return buildFailureResult(
+      new ValidationError(
+        `Evaluator "${detail.evaluatorName}" has no recognizable config. ` +
+          'Only LLM-as-a-Judge and code-based evaluators can be imported.'
+      )
     );
   }
 
   return {
-    name: localName,
-    level,
-    ...(detail.description && { description: detail.description }),
-    config,
-    ...(detail.kmsKeyArn && { kmsKeyArn: detail.kmsKeyArn }),
-    ...(detail.tags && Object.keys(detail.tags).length > 0 && { tags: detail.tags }),
+    success: true,
+    evaluator: {
+      name: localName,
+      level,
+      ...(detail.description && { description: detail.description }),
+      config,
+      ...(detail.kmsKeyArn && { kmsKeyArn: detail.kmsKeyArn }),
+      ...(detail.tags && Object.keys(detail.tags).length > 0 && { tags: detail.tags }),
+    },
   };
 }
 
@@ -77,7 +84,10 @@ const evaluatorDescriptor: ResourceImportDescriptor<GetEvaluatorResult, Evaluato
 
   getExistingNames: spec => (spec.evaluators ?? []).map(e => e.name),
   addToProjectSpec: (detail, localName, spec) => {
-    (spec.evaluators ??= []).push(toEvaluatorSpec(detail, localName));
+    const result = toEvaluatorSpec(detail, localName);
+    if (!result.success)
+      return { success: false, error: result.error, resourceType: 'evaluator' as const, resourceName: localName };
+    (spec.evaluators ??= []).push(result.evaluator);
   },
 
   cfnResourceType: 'AWS::BedrockAgentCore::Evaluator',

--- a/src/cli/commands/import/import-gateway.ts
+++ b/src/cli/commands/import/import-gateway.ts
@@ -1,4 +1,5 @@
-import { toError } from '../../../lib';
+import { ValidationError, toError } from '../../../lib';
+import { type Result, failureResult } from '../../../lib/result.js';
 import type {
   AgentCoreGateway,
   AgentCoreGatewayTarget,
@@ -45,22 +46,27 @@ function toGatewayTargetSpec(
   detail: GatewayTargetDetail,
   credentials: Map<string, string>,
   onProgress: (msg: string) => void
-): AgentCoreGatewayTarget | undefined {
+): Result<{ target: AgentCoreGatewayTarget | undefined }> {
   const mcp = detail.targetConfiguration?.mcp;
   if (!mcp) {
     onProgress(`Warning: Target "${detail.name}" has no MCP configuration, skipping`);
-    return undefined;
+    return { success: true, target: undefined };
   }
 
-  const outboundAuth = resolveOutboundAuth(detail, credentials, onProgress);
+  const authResult = resolveOutboundAuth(detail, credentials, onProgress);
+  if (!authResult.success) return authResult;
+  const outboundAuth = authResult.auth;
 
   // MCP Server (external endpoint)
   if (mcp.mcpServer) {
     return {
-      name: detail.name,
-      targetType: 'mcpServer',
-      endpoint: mcp.mcpServer.endpoint,
-      ...(outboundAuth && { outboundAuth }),
+      success: true,
+      target: {
+        name: detail.name,
+        targetType: 'mcpServer',
+        endpoint: mcp.mcpServer.endpoint,
+        ...(outboundAuth && { outboundAuth }),
+      },
     };
   }
 
@@ -92,7 +98,7 @@ function toGatewayTargetSpec(
       ...(outboundAuth && { outboundAuth }),
     };
     /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment */
-    return target;
+    return { success: true, target };
   }
 
   // OpenAPI Schema
@@ -100,19 +106,22 @@ function toGatewayTargetSpec(
     const schema = mcp.openApiSchema;
     if (schema.s3?.uri) {
       return {
-        name: detail.name,
-        targetType: 'openApiSchema',
-        schemaSource: {
-          s3: {
-            uri: schema.s3.uri,
-            ...(schema.s3.bucketOwnerAccountId && { bucketOwnerAccountId: schema.s3.bucketOwnerAccountId }),
+        success: true,
+        target: {
+          name: detail.name,
+          targetType: 'openApiSchema',
+          schemaSource: {
+            s3: {
+              uri: schema.s3.uri,
+              ...(schema.s3.bucketOwnerAccountId && { bucketOwnerAccountId: schema.s3.bucketOwnerAccountId }),
+            },
           },
+          ...(outboundAuth && { outboundAuth }),
         },
-        ...(outboundAuth && { outboundAuth }),
       };
     }
     onProgress(`Warning: Target "${detail.name}" (openApiSchema) has no S3 URI, skipping`);
-    return undefined;
+    return { success: true, target: undefined };
   }
 
   // Smithy Model
@@ -120,19 +129,22 @@ function toGatewayTargetSpec(
     const schema = mcp.smithyModel;
     if (schema.s3?.uri) {
       return {
-        name: detail.name,
-        targetType: 'smithyModel',
-        schemaSource: {
-          s3: {
-            uri: schema.s3.uri,
-            ...(schema.s3.bucketOwnerAccountId && { bucketOwnerAccountId: schema.s3.bucketOwnerAccountId }),
+        success: true,
+        target: {
+          name: detail.name,
+          targetType: 'smithyModel',
+          schemaSource: {
+            s3: {
+              uri: schema.s3.uri,
+              ...(schema.s3.bucketOwnerAccountId && { bucketOwnerAccountId: schema.s3.bucketOwnerAccountId }),
+            },
           },
+          ...(outboundAuth && { outboundAuth }),
         },
-        ...(outboundAuth && { outboundAuth }),
       };
     }
     onProgress(`Warning: Target "${detail.name}" (smithyModel) has no S3 URI, skipping`);
-    return undefined;
+    return { success: true, target: undefined };
   }
 
   // Lambda (compute-backed) → map to lambdaFunctionArn
@@ -140,7 +152,7 @@ function toGatewayTargetSpec(
     const lambdaArn = mcp.lambda.lambdaArn;
     if (!lambdaArn) {
       onProgress(`Warning: Target "${detail.name}" (lambda) has no ARN, skipping`);
-      return undefined;
+      return { success: true, target: undefined };
     }
 
     // Extract tool schema S3 URI if available
@@ -152,23 +164,26 @@ function toGatewayTargetSpec(
     if (s3Uri) {
       onProgress(`Mapping compute-backed Lambda target "${detail.name}" to lambdaFunctionArn type`);
       return {
-        name: detail.name,
-        targetType: 'lambdaFunctionArn',
-        lambdaFunctionArn: {
-          lambdaArn,
-          toolSchemaFile: s3Uri,
+        success: true,
+        target: {
+          name: detail.name,
+          targetType: 'lambdaFunctionArn',
+          lambdaFunctionArn: {
+            lambdaArn,
+            toolSchemaFile: s3Uri,
+          },
+          ...(outboundAuth && { outboundAuth }),
         },
-        ...(outboundAuth && { outboundAuth }),
       };
     }
 
     // Lambda without S3 schema — can't import as lambdaFunctionArn since toolSchemaFile is required
     onProgress(`Warning: Target "${detail.name}" (lambda) has inline tool schema, which cannot be imported. Skipping.`);
-    return undefined;
+    return { success: true, target: undefined };
   }
 
   onProgress(`Warning: Target "${detail.name}" has an unrecognized target type, skipping`);
-  return undefined;
+  return { success: true, target: undefined };
 }
 
 /**
@@ -178,9 +193,9 @@ function resolveOutboundAuth(
   detail: GatewayTargetDetail,
   credentials: Map<string, string>,
   _onProgress: (msg: string) => void
-): OutboundAuth | undefined {
+): Result<{ auth: OutboundAuth | undefined }> {
   const configs = detail.credentialProviderConfigurations;
-  if (!configs || configs.length === 0) return undefined;
+  if (!configs || configs.length === 0) return { success: true, auth: undefined };
 
   for (const config of configs) {
     if (config.credentialProviderType === 'OAUTH' && config.credentialProvider?.oauthCredentialProvider) {
@@ -188,16 +203,21 @@ function resolveOutboundAuth(
       const credentialName = credentials.get(providerArn);
       if (credentialName) {
         return {
-          type: 'OAUTH',
-          credentialName,
-          ...(config.credentialProvider.oauthCredentialProvider.scopes?.length && {
-            scopes: config.credentialProvider.oauthCredentialProvider.scopes,
-          }),
+          success: true,
+          auth: {
+            type: 'OAUTH',
+            credentialName,
+            ...(config.credentialProvider.oauthCredentialProvider.scopes?.length && {
+              scopes: config.credentialProvider.oauthCredentialProvider.scopes,
+            }),
+          },
         };
       }
-      throw new Error(
-        `Target "${detail.name}" uses an OAuth credential provider not found in this project's deployed state. ` +
-          'Import the credential first with `agentcore add credential` and re-run.'
+      return failureResult(
+        new ValidationError(
+          `Target "${detail.name}" uses an OAuth credential provider not found in this project's deployed state. ` +
+            'Import the credential first with `agentcore add credential` and re-run.'
+        )
       );
     }
 
@@ -205,18 +225,20 @@ function resolveOutboundAuth(
       const providerArn = config.credentialProvider.apiKeyCredentialProvider.providerArn;
       const credentialName = credentials.get(providerArn);
       if (credentialName) {
-        return { type: 'API_KEY', credentialName };
+        return { success: true, auth: { type: 'API_KEY', credentialName } };
       }
-      throw new Error(
-        `Target "${detail.name}" uses an API Key credential provider not found in this project's deployed state. ` +
-          'Import the credential first with `agentcore add credential` and re-run.'
+      return failureResult(
+        new ValidationError(
+          `Target "${detail.name}" uses an API Key credential provider not found in this project's deployed state. ` +
+            'Import the credential first with `agentcore add credential` and re-run.'
+        )
       );
     }
 
     // GATEWAY_IAM_ROLE — no outbound auth needed
   }
 
-  return undefined;
+  return { success: true, auth: undefined };
 }
 
 /**
@@ -470,9 +492,17 @@ export async function handleImportGateway(options: ImportResourceOptions): Promi
     const mappedTargets: AgentCoreGatewayTarget[] = [];
     for (const td of targetDetails) {
       const mapped = toGatewayTargetSpec(td, credentialArnMap, onProgress);
-      if (mapped) {
-        mappedTargets.push(mapped);
+      if (!mapped.success) {
+        logger.endStep('error', mapped.error.message);
+        logger.finalize(false);
+        return {
+          ...mapped,
+          resourceType: 'gateway' as const,
+          resourceName: td.name,
+          logPath: logger.getRelativeLogPath(),
+        };
       }
+      if (mapped.target) mappedTargets.push(mapped.target);
     }
 
     const gatewaySpec = toGatewaySpec(gatewayDetail, mappedTargets, localName);

--- a/src/cli/commands/import/import-memory.ts
+++ b/src/cli/commands/import/import-memory.ts
@@ -105,6 +105,7 @@ const memoryDescriptor: ResourceImportDescriptor<MemoryDetail, MemorySummary> = 
   getExistingNames: spec => (spec.memories ?? []).map(m => m.name),
   addToProjectSpec: (detail, localName, spec) => {
     (spec.memories ??= []).push(toMemorySpec(detail, localName));
+    return { success: true, resourceType: 'memory', resourceName: localName };
   },
 
   cfnResourceType: 'AWS::BedrockAgentCore::Memory',

--- a/src/cli/commands/import/import-online-eval.ts
+++ b/src/cli/commands/import/import-online-eval.ts
@@ -98,6 +98,7 @@ function createOnlineEvalDescriptor(): ResourceImportDescriptor<GetOnlineEvalCon
       if (!result.success)
         return { success: false, error: result.error, resourceType: 'online-eval' as const, resourceName: localName };
       (spec.onlineEvalConfigs ??= []).push(result.config);
+      return { success: true, resourceType: 'online-eval', resourceName: localName };
     },
 
     cfnResourceType: 'AWS::BedrockAgentCore::OnlineEvaluationConfig',

--- a/src/cli/commands/import/import-online-eval.ts
+++ b/src/cli/commands/import/import-online-eval.ts
@@ -1,3 +1,5 @@
+import { ValidationError } from '../../../lib';
+import { type Result, failureResult } from '../../../lib/result';
 import type { OnlineEvalConfig } from '../../../schema';
 import type { GetOnlineEvalConfigResult, OnlineEvalConfigSummary } from '../../aws/agentcore-control';
 import {
@@ -33,18 +35,23 @@ export function toOnlineEvalConfigSpec(
   localName: string,
   agentName: string,
   evaluatorArns: string[]
-): OnlineEvalConfig {
+): Result<{ config: OnlineEvalConfig }> {
   if (detail.samplingPercentage == null) {
-    throw new Error(`Online eval config "${detail.configName}" has no sampling configuration. Cannot import.`);
+    return failureResult(
+      new ValidationError(`Online eval config "${detail.configName}" has no sampling configuration. Cannot import.`)
+    );
   }
 
   return {
-    name: localName,
-    agent: agentName,
-    evaluators: evaluatorArns,
-    samplingRate: detail.samplingPercentage,
-    ...(detail.description && { description: detail.description }),
-    ...(detail.executionStatus === 'ENABLED' && { enableOnCreate: true }),
+    success: true,
+    config: {
+      name: localName,
+      agent: agentName,
+      evaluators: evaluatorArns,
+      samplingRate: detail.samplingPercentage,
+      ...(detail.description && { description: detail.description }),
+      ...(detail.executionStatus === 'ENABLED' && { enableOnCreate: true }),
+    },
   };
 }
 
@@ -87,9 +94,10 @@ function createOnlineEvalDescriptor(): ResourceImportDescriptor<GetOnlineEvalCon
 
     getExistingNames: spec => (spec.onlineEvalConfigs ?? []).map(c => c.name),
     addToProjectSpec: (detail, localName, spec) => {
-      (spec.onlineEvalConfigs ??= []).push(
-        toOnlineEvalConfigSpec(detail, localName, resolvedAgentName, resolvedEvaluatorArns)
-      );
+      const result = toOnlineEvalConfigSpec(detail, localName, resolvedAgentName, resolvedEvaluatorArns);
+      if (!result.success)
+        return { success: false, error: result.error, resourceType: 'online-eval' as const, resourceName: localName };
+      (spec.onlineEvalConfigs ??= []).push(result.config);
     },
 
     cfnResourceType: 'AWS::BedrockAgentCore::OnlineEvaluationConfig',

--- a/src/cli/commands/import/import-runtime.ts
+++ b/src/cli/commands/import/import-runtime.ts
@@ -112,6 +112,7 @@ function createRuntimeDescriptor(
     getExistingNames: spec => spec.runtimes.map(r => r.name),
     addToProjectSpec: (detail, localName, spec) => {
       spec.runtimes.push(toAgentEnvSpec(detail, localName, resolvedCodeLocation, resolvedEntrypoint));
+      return { success: true, resourceType: 'runtime', resourceName: localName };
     },
 
     cfnResourceType: 'AWS::BedrockAgentCore::Runtime',

--- a/src/cli/commands/import/resource-import.ts
+++ b/src/cli/commands/import/resource-import.ts
@@ -142,7 +142,7 @@ export async function executeResourceImport<TDetail, TSummary>(
     logger.startStep('Update project config');
     configSnapshot = JSON.parse(JSON.stringify(projectSpec)) as AgentCoreProjectSpec;
     const addResult = descriptor.addToProjectSpec(detail, localName, projectSpec);
-    if (addResult && !addResult.success) {
+    if (!addResult.success) {
       logger.endStep('error', addResult.error.message);
       logger.finalize(false);
       return { ...addResult, logPath: logger.getRelativeLogPath() };

--- a/src/cli/commands/import/resource-import.ts
+++ b/src/cli/commands/import/resource-import.ts
@@ -141,7 +141,8 @@ export async function executeResourceImport<TDetail, TSummary>(
     // 7. Update project config
     logger.startStep('Update project config');
     configSnapshot = JSON.parse(JSON.stringify(projectSpec)) as AgentCoreProjectSpec;
-    descriptor.addToProjectSpec(detail, localName, projectSpec);
+    const addResult = descriptor.addToProjectSpec(detail, localName, projectSpec);
+    if (addResult && !addResult.success) return addResult;
     await ctx.configIO.writeProjectSpec(projectSpec);
     configWritten = true;
     onProgress(`Added ${descriptor.displayName} "${localName}" to agentcore.json`);

--- a/src/cli/commands/import/resource-import.ts
+++ b/src/cli/commands/import/resource-import.ts
@@ -142,7 +142,11 @@ export async function executeResourceImport<TDetail, TSummary>(
     logger.startStep('Update project config');
     configSnapshot = JSON.parse(JSON.stringify(projectSpec)) as AgentCoreProjectSpec;
     const addResult = descriptor.addToProjectSpec(detail, localName, projectSpec);
-    if (addResult && !addResult.success) return addResult;
+    if (addResult && !addResult.success) {
+      logger.endStep('error', addResult.error.message);
+      logger.finalize(false);
+      return { ...addResult, logPath: logger.getRelativeLogPath() };
+    }
     await ctx.configIO.writeProjectSpec(projectSpec);
     configWritten = true;
     onProgress(`Added ${descriptor.displayName} "${localName}" to agentcore.json`);

--- a/src/cli/commands/import/types.ts
+++ b/src/cli/commands/import/types.ts
@@ -202,12 +202,7 @@ export interface ResourceImportDescriptor<TDetail, TSummary> {
    * Convert the AWS detail to local spec and add it to the project spec.
    * Called after beforeConfigWrite — descriptor factories may rely on state set during that hook.
    */
-  // TODO: update all implementations to return result, then narrow down return type
-  addToProjectSpec: (
-    detail: TDetail,
-    localName: string,
-    projectSpec: AgentCoreProjectSpec
-  ) => ImportResourceResult | void;
+  addToProjectSpec: (detail: TDetail, localName: string, projectSpec: AgentCoreProjectSpec) => ImportResourceResult;
 
   // ---- CFN template matching ----
 

--- a/src/cli/commands/import/types.ts
+++ b/src/cli/commands/import/types.ts
@@ -202,7 +202,12 @@ export interface ResourceImportDescriptor<TDetail, TSummary> {
    * Convert the AWS detail to local spec and add it to the project spec.
    * Called after beforeConfigWrite — descriptor factories may rely on state set during that hook.
    */
-  addToProjectSpec: (detail: TDetail, localName: string, projectSpec: AgentCoreProjectSpec) => void;
+  // TODO: update all implementations to return result, then narrow down return type
+  addToProjectSpec: (
+    detail: TDetail,
+    localName: string,
+    projectSpec: AgentCoreProjectSpec
+  ) => ImportResourceResult | void;
 
   // ---- CFN template matching ----
 

--- a/src/cli/telemetry/__tests__/client.test.ts
+++ b/src/cli/telemetry/__tests__/client.test.ts
@@ -147,20 +147,14 @@ describe('withCommandRunTelemetry', () => {
     expect(sink.metrics).toHaveLength(0);
   });
 
-  it('records failure and returns error result when callback throws', async () => {
+  it('records failure and re-throws when callback throws', async () => {
     type R = { success: true } | { success: false; error: Error };
-    const result = await withCommandRunTelemetry<'telemetry.status', R>(
-      'telemetry.status',
-      {},
-      async (): Promise<R> => {
+    await expect(
+      withCommandRunTelemetry<'telemetry.status', R>('telemetry.status', {}, async (): Promise<R> => {
         throw new Error('network timeout');
-      }
-    );
+      })
+    ).rejects.toThrow('network timeout');
 
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error.message).toBe('network timeout');
-    }
     expect(sink.metrics).toHaveLength(1);
     expect(sink.metrics[0]!.attrs).toMatchObject({
       command: 'telemetry.status',
@@ -280,21 +274,23 @@ describe('withCommandRunTelemetry', () => {
     });
 
     it('recorder.set() called before throw is preserved in telemetry', async () => {
-      await withCommandRunTelemetry(
-        'dev',
-        {
-          agent_environment: 'runtime',
-          dev_action: 'server',
-          ui_mode: 'terminal',
-          has_stream: false,
-          agent_protocol: 'http',
-          invoke_count: 0,
-        },
-        async recorder => {
-          recorder.set({ agent_protocol: 'a2a' });
-          throw new Error('crash');
-        }
-      );
+      await expect(
+        withCommandRunTelemetry(
+          'dev',
+          {
+            agent_environment: 'runtime',
+            dev_action: 'server',
+            ui_mode: 'terminal',
+            has_stream: false,
+            agent_protocol: 'http',
+            invoke_count: 0,
+          },
+          async recorder => {
+            recorder.set({ agent_protocol: 'a2a' });
+            throw new Error('crash');
+          }
+        )
+      ).rejects.toThrow('crash');
 
       expect(sink.metrics).toHaveLength(1);
       expect(sink.metrics[0]!.attrs).toMatchObject({

--- a/src/cli/telemetry/cli-command-run.ts
+++ b/src/cli/telemetry/cli-command-run.ts
@@ -83,8 +83,8 @@ async function trackCommandRun<C extends Command>(
  * Use in TUI hooks and CLI paths where the caller handles output and control flow.
  *
  * If the callback returns a failure result, telemetry is recorded and the result
- * is returned to the caller. If the callback throws, telemetry is recorded and
- * the exception is converted to a result type such that callers do not need to handle result + try/catch.
+ * is returned to the caller. If the callback throws, telemetry is recorded before
+ * rethrowing the exception.
  * If telemetry is unavailable, the callback runs untracked.
  *
  * The callback receives an AttributeRecorder to dynamically set or override attributes.
@@ -129,7 +129,7 @@ export async function withCommandRunTelemetry<C extends Command, R extends Resul
         Math.round(performance.now() - start)
       );
     }
-    return { success: false, error: e instanceof Error ? e : new Error(getErrorMessage(e)) } as R;
+    throw e;
   } finally {
     await client?.flush();
   }

--- a/src/cli/tui/screens/logs/useLogsFlow.ts
+++ b/src/cli/tui/screens/logs/useLogsFlow.ts
@@ -1,3 +1,4 @@
+import { toError } from '../../../../lib';
 import type { AgentContext } from '../../../commands/logs/action';
 import { resolveAgentContext } from '../../../commands/logs/action';
 import { loadDeployedProjectConfig } from '../../../operations/resolve-agent';
@@ -30,7 +31,12 @@ export function useLogsFlow(): UseLogsFlowResult {
   useEffect(() => {
     const load = async () => {
       const result = await withCommandRunTelemetry('logs', { has_query: false, has_level_filter: false }, async () => {
-        const context = await loadDeployedProjectConfig();
+        let context;
+        try {
+          context = await loadDeployedProjectConfig();
+        } catch (err) {
+          return { success: false as const, error: toError(err) };
+        }
         const runtimeNames = context.project.runtimes.map(r => r.name);
 
         if (runtimeNames.length === 0) {

--- a/src/lib/result.ts
+++ b/src/lib/result.ts
@@ -56,7 +56,7 @@ export function unwrapResult<R extends Result>(result: R, defaultValue?: Unwrapp
   throw result.error;
 }
 
-export function buildFailureResult<E extends Error>(e: E): FailureResult<E> {
+export function failureResult<E extends Error>(e: E): FailureResult<E> {
   return {
     success: false,
     error: e,

--- a/src/lib/result.ts
+++ b/src/lib/result.ts
@@ -1,3 +1,5 @@
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions -- discriminated union member; interface would allow declaration merging which breaks type narrowing
+type FailureResult<E extends Error> = { success: false; error: E };
 /**
  * Discriminated union for fallible operations, inspired by Rust's Result<T, E>.
  *
@@ -12,7 +14,7 @@
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export type Result<T extends Record<string, unknown> = {}, E extends Error = Error> =
   | ({ success: true } & T)
-  | { success: false; error: E };
+  | FailureResult<E>;
 
 /**
  * Converts a Result object to a JSON-serializable form.
@@ -52,4 +54,11 @@ export function unwrapResult<R extends Result>(result: R, defaultValue?: Unwrapp
     return defaultValue;
   }
   throw result.error;
+}
+
+export function buildFailureResult<E extends Error>(e: E): FailureResult<E> {
+  return {
+    success: false,
+    error: e,
+  };
 }


### PR DESCRIPTION
## Description

`withCommandRunTelemetry`'s catch block previously converted any thrown exception into a `{success:false, error}` result and returned it. This silently swallowed exceptions and violated the `R extends Result` type constraint. 

This PR changes the catch block to re-throw, then audits every callsite for callbacks that claimed to return `Result` but could actually throw. 

## Related Issue

Closes #

## Documentation PR

N/A

## Type of Change

- [x] Bug fix

## Testing

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.