### PR TITLE
fix: agentcore dev orphaned processes

### DIFF
--- a/src/cli/commands/dev/command.tsx
+++ b/src/cli/commands/dev/command.tsx
@@ -24,6 +24,7 @@ import {
   listMcpTools,
   loadDevEnv,
   loadProjectConfig,
+  onShutdownSignal,
 } from '../../operations/dev';
 import { OtelCollector, startOtelCollector } from '../../operations/dev/otel';
 import { withCommandRunTelemetry } from '../../telemetry/cli-command-run.js';
@@ -449,7 +450,7 @@ export const registerDev = (program: Command) => {
                 });
                 server.start().catch(reject);
 
-                process.once('SIGINT', () => {
+                onShutdownSignal(() => {
                   console.log('\nStopping server...');
                   collector?.stop();
                   server.kill();
@@ -488,6 +489,11 @@ export const registerDev = (program: Command) => {
                   />
                 </LayoutProvider>
               );
+
+              process.once('SIGTERM', () => {
+                exitAltScreen();
+                unmount();
+              });
 
               return {
                 success: true as const,

--- a/src/cli/operations/dev/__tests__/codezip-dev-server.test.ts
+++ b/src/cli/operations/dev/__tests__/codezip-dev-server.test.ts
@@ -21,6 +21,7 @@ const mockExistsSync = vi.mocked(existsSync);
 
 vi.mock('../../../../lib/utils/platform', () => ({
   getVenvExecutable: (venvPath: string, executable: string) => `${venvPath}/bin/${executable}`,
+  isWindows: false,
 }));
 
 function createMockChildProcess() {

--- a/src/cli/operations/dev/__tests__/dev-server.test.ts
+++ b/src/cli/operations/dev/__tests__/dev-server.test.ts
@@ -71,12 +71,11 @@ describe('DevServer', () => {
     it('calls spawn with correct cmd, args, cwd, env, and stdio when prepare succeeds', async () => {
       await server.start();
 
-      expect(mockSpawn).toHaveBeenCalledWith('test-cmd', ['--flag'], {
-        cwd: '/test',
-        env: { PATH: '/usr/bin' },
-        stdio: ['ignore', 'pipe', 'pipe'],
-        detached: true,
-      });
+      const spawnOpts = mockSpawn.mock.calls[0]![2] as Record<string, unknown>;
+      expect(spawnOpts.cwd).toBe('/test');
+      expect(spawnOpts.env).toEqual({ PATH: '/usr/bin' });
+      expect(spawnOpts.stdio).toEqual(['ignore', 'pipe', 'pipe']);
+      expect(spawnOpts.detached).toBe(process.platform !== 'win32');
     });
 
     it('returns child process on success', async () => {

--- a/src/cli/operations/dev/__tests__/dev-server.test.ts
+++ b/src/cli/operations/dev/__tests__/dev-server.test.ts
@@ -6,6 +6,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const mockSpawn = vi.fn();
 vi.mock('child_process', () => ({
   spawn: (...args: unknown[]) => mockSpawn(...args),
+  execSync: vi.fn(),
+}));
+vi.mock('../../../../lib/utils/platform', () => ({
+  isWindows: false,
 }));
 
 function createMockChildProcess() {

--- a/src/cli/operations/dev/__tests__/dev-server.test.ts
+++ b/src/cli/operations/dev/__tests__/dev-server.test.ts
@@ -75,6 +75,7 @@ describe('DevServer', () => {
         cwd: '/test',
         env: { PATH: '/usr/bin' },
         stdio: ['ignore', 'pipe', 'pipe'],
+        detached: true,
       });
     });
 
@@ -114,11 +115,24 @@ describe('DevServer', () => {
       expect(mockChild.kill).not.toHaveBeenCalled();
     });
 
-    it('sends SIGTERM first', async () => {
+    it('sends SIGTERM to child when pid is not available', async () => {
       await server.start();
 
       server.kill();
       expect(mockChild.kill).toHaveBeenCalledWith('SIGTERM');
+    });
+
+    it('sends SIGTERM to process group when pid is available', async () => {
+      mockChild.pid = 12345;
+      const processKillSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+
+      await server.start();
+      server.kill();
+
+      expect(processKillSpy).toHaveBeenCalledWith(-12345, 'SIGTERM');
+      expect(mockChild.kill).not.toHaveBeenCalled();
+
+      processKillSpy.mockRestore();
     });
 
     it('sends SIGKILL after 2s if not killed', async () => {

--- a/src/cli/operations/dev/dev-server.ts
+++ b/src/cli/operations/dev/dev-server.ts
@@ -72,20 +72,34 @@ export abstract class DevServer {
       cwd: spawnConfig.cwd,
       env: spawnConfig.env,
       stdio: ['ignore', 'pipe', 'pipe'],
+      detached: true,
     });
 
     this.attachHandlers();
     return this.child;
   }
 
-  /** Kill the dev server process. Sends SIGTERM, then SIGKILL after 2 seconds. */
+  /** Kill the dev server process tree. Sends SIGTERM to the process group, then SIGKILL after 2 seconds. */
   kill(): void {
     if (!this.child || this.child.killed) return;
-    this.child.kill('SIGTERM');
+    this.signalProcessTree('SIGTERM');
     const killTimer = setTimeout(() => {
-      if (this.child && !this.child.killed) this.child.kill('SIGKILL');
+      if (this.child && !this.child.killed) this.signalProcessTree('SIGKILL');
     }, 2000);
     killTimer.unref();
+  }
+
+  private signalProcessTree(signal: NodeJS.Signals): void {
+    const pid = this.child?.pid;
+    if (!pid) {
+      this.child!.kill(signal);
+      return;
+    }
+    try {
+      process.kill(-pid, signal);
+    } catch {
+      this.child!.kill(signal);
+    }
   }
 
   /** Mode-specific setup (e.g., venv creation, container image build). Returns false to abort. */

--- a/src/cli/operations/dev/dev-server.ts
+++ b/src/cli/operations/dev/dev-server.ts
@@ -1,5 +1,6 @@
+import { isWindows } from '../../../lib/utils/platform';
 import type { DevConfig } from './config';
-import { type ChildProcess, spawn } from 'child_process';
+import { type ChildProcess, execSync, spawn } from 'child_process';
 
 export type LogLevel = 'info' | 'warn' | 'error' | 'system';
 
@@ -72,7 +73,7 @@ export abstract class DevServer {
       cwd: spawnConfig.cwd,
       env: spawnConfig.env,
       stdio: ['ignore', 'pipe', 'pipe'],
-      detached: true,
+      detached: !isWindows,
     });
 
     this.attachHandlers();
@@ -96,7 +97,11 @@ export abstract class DevServer {
       return;
     }
     try {
-      process.kill(-pid, signal);
+      if (isWindows) {
+        execSync(`taskkill /pid ${pid} /T /F`, { stdio: 'ignore' });
+      } else {
+        process.kill(-pid, signal);
+      }
     } catch {
       this.child!.kill(signal);
     }

--- a/src/cli/operations/dev/index.ts
+++ b/src/cli/operations/dev/index.ts
@@ -19,6 +19,6 @@ export { listMcpTools, callMcpTool, type McpTool, type McpToolsResult } from './
 
 export { invokeAguiStreaming } from './invoke-agui';
 
-export { getEndpointUrl, formatMcpToolList } from './utils';
+export { getEndpointUrl, formatMcpToolList, onShutdownSignal } from './utils';
 
 export { loadDevEnv, type DevEnv } from './load-dev-env';

--- a/src/cli/operations/dev/utils.ts
+++ b/src/cli/operations/dev/utils.ts
@@ -110,6 +110,11 @@ export function convertEntrypointToModule(entrypoint: string): string {
   return `${path}:app`;
 }
 
+export function onShutdownSignal(handler: () => void): void {
+  process.once('SIGINT', handler);
+  process.once('SIGTERM', handler);
+}
+
 export function openBrowser(url: string): void {
   const isWindows = process.platform === 'win32';
   const cmd = isWindows ? 'cmd' : process.platform === 'darwin' ? 'open' : 'xdg-open';

--- a/src/cli/operations/dev/web-ui/run-web-ui.ts
+++ b/src/cli/operations/dev/web-ui/run-web-ui.ts
@@ -1,6 +1,6 @@
 import { ExecLogger } from '../../../logging';
 import { findAvailablePort } from '../server';
-import { openBrowser } from '../utils';
+import { onShutdownSignal, openBrowser } from '../utils';
 import { WEB_UI_DEFAULT_PORT } from './constants';
 import { type WebUIOptions, WebUIServer } from './web-server';
 
@@ -49,7 +49,7 @@ export async function runWebUI(opts: RunWebUIOptions): Promise<void> {
 
   webUI.start();
 
-  process.on('SIGINT', () => {
+  onShutdownSignal(() => {
     console.log('\nStopping servers...');
     webUI.stop();
   });


### PR DESCRIPTION
## Description

When `agentcore dev` is killed programmatically (SIGTERM/SIGKILL), the underlying uvicorn reloader and worker processes are not terminated. They get reparented to PID 1 and continue holding the port. Subsequent `agentcore dev` runs then fall back to a different port, leaking processes with each run.

Interactive Ctrl+C (SIGINT) was unaffected since it hits the entire process group and was already handled. This fix addresses only the programmatic `kill $PID` (SIGTERM) path used by scripts, CI, and agent tooling.

**Root cause:** Two issues combined:
1. Only SIGINT was handled — SIGTERM (from `kill $PID`) exited without triggering cleanup.
2. `child.kill('SIGTERM')` only signals the direct child PID. `uvicorn --reload` forks a reloader that spawns a worker, so grandchild processes survived.

**Fix:**
- Spawn the child with `detached: true` (POSIX) so it gets its own process group.
- Kill the entire process tree: `process.kill(-pid, signal)` on POSIX, `taskkill /pid <pid> /T /F` on Windows.
- Add SIGTERM handling to all three dev server code paths: `--logs` and browser/web-UI use `onShutdownSignal()` (SIGINT + SIGTERM), TUI adds SIGTERM only (Ink handles SIGINT).
- Extract `onShutdownSignal()` helper to avoid duplicating signal registration.

## Related Issue

Closes https://github.com/aws/agentcore-cli/issues/1440

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

Manually verified on macOS and Windows:
```bash
# macOS/Linux
agentcore dev --logs &
DEV_PID=$!
sleep 5
kill $DEV_PID
wait $DEV_PID 2>/dev/null
sleep 1
lsof -ti :8080  # No orphaned processes
```

Manually tested on windows by running agentcore dev and then Stop-Process on the node process, making sure no child processes remained.

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.