### PR TITLE
fix(ci): disable telemetry in release workflow to fix test failures

### DIFF
--- a/.github/workflows/release-main-and-preview.yml
+++ b/.github/workflows/release-main-and-preview.yml
@@ -45,6 +45,9 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  AGENTCORE_TELEMETRY_DISABLED: '1'
+
 jobs:
   # ═══════════════════════════════════════════════════════════════════
   # Step 1 — Prepare release (bump both versions, single PR)


### PR DESCRIPTION
## Summary

- Adds `AGENTCORE_TELEMETRY_DISABLED: '1'` to the release workflow, matching what `build-and-test.yml` already sets
- Fixes the 7 unit test failures in the "Update snapshots" step that have been blocking releases

## Root Cause

The `prepare-release` job runs `npm run test:update-snapshots` (all unit tests, unsharded) without `AGENTCORE_TELEMETRY_DISABLED`. This causes `withCommandRunTelemetry` in the TUI hooks (`useLogsFlow`, `useRemoveResource`) to trigger real I/O during `createClient()`:

1. `getOrCreateInstallationId()` → `access()` + `mkdir()` + `writeFile()` to `~/.agentcore/config.json`
2. `OtelMetricSink` construction (network connection attempt)
3. `client.flush()` in the finally block (actual export attempt)

This I/O doesn't resolve within the 50-100ms `setTimeout` delays used by the LogsScreen and useRemove tests, so assertions fire while components are still in their loading state.

`build-and-test.yml` avoids this by setting `AGENTCORE_TELEMETRY_DISABLED=1` at the workflow level.

## Test plan

- [x] Verified locally: tests pass with `AGENTCORE_TELEMETRY_DISABLED=1`, fail without it
- [ ] Re-run the release workflow after merge to confirm it passes