### PR TITLE
fix(scripts): filter non-version tags in changelog auto-generation

### DIFF
--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -183,7 +183,7 @@ function getGitLog(sinceTag?: string): string {
     } else {
       // Try to get the last tag
       try {
-        const lastTag = execSync('git describe --tags --abbrev=0', { encoding: 'utf-8' }).trim();
+        const lastTag = execSync("git describe --tags --abbrev=0 --match 'v*'", { encoding: 'utf-8' }).trim();
         cmd += ` ${lastTag}..HEAD`;
       } catch {
         // No tags exist, get last 20 commits


### PR DESCRIPTION
## Summary

Fixes empty changelog auto-generation in the release workflow.

## Root Cause

The `prerelease-tarball.yml` workflow creates a floating `prerelease` tag on every push to main. `bump-version.ts` uses `git describe --tags --abbrev=0` to find the last release tag, but it picks up `prerelease` instead of `v0.16.0`. Since `prerelease` points at (or near) HEAD, `git log prerelease..HEAD` returns 0 commits → empty changelog section.

This is why [PR #1443](https://github.com/aws/agentcore-cli/pull/1443) and prior releases have had empty changelogs even though the input is optional and auto-generation should have kicked in.

## Fix

Add `--match 'v*'` to `git describe` so it only considers version tags.

## Test plan

- [x] `git describe --tags --abbrev=0 --match 'v*'` returns `v0.16.0` (not `prerelease`)
- [x] `bump-version.ts patch` without `--changelog` generates full categorized changelog from 14 commits since v0.16.0
- [ ] Next release workflow run produces a non-empty changelog