### PR TITLE
feat: upgrade agent-inspector to v0.5.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/agentcore",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/agentcore",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -27,7 +27,7 @@
         "@aws-sdk/client-xray": "^3.1003.0",
         "@aws-sdk/credential-providers": "^3.893.0",
         "@aws-sdk/region-config-resolver": "^3.972.13",
-        "@aws/agent-inspector": "0.4.2",
+        "@aws/agent-inspector": "0.5.0",
         "@commander-js/extra-typings": "^14.0.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-metrics-otlp-http": "^0.215.0",
@@ -2913,9 +2913,9 @@
       }
     },
     "node_modules/@aws/agent-inspector": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@aws/agent-inspector/-/agent-inspector-0.4.2.tgz",
-      "integrity": "sha512-ubzDXaHIMrpGk0Qv3KUAxOfeHTg9HCQDDJiwVotaC1zO9s85BwfxyoetDNAdyAc9JTtHi8ojn5JdI92fODCe4w==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@aws/agent-inspector/-/agent-inspector-0.5.0.tgz",
+      "integrity": "sha512-CTkicUAnlMgVl4Jzw06K6wBH+25bLyIvssknsbe+FxarhgLcmhQwacc1OK5KiTDwKtii2vcnNlHYO52NCmBNWA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ag-ui/core": "^0.0.52",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "@aws-sdk/client-xray": "^3.1003.0",
     "@aws-sdk/credential-providers": "^3.893.0",
     "@aws-sdk/region-config-resolver": "^3.972.13",
-    "@aws/agent-inspector": "0.4.2",
+    "@aws/agent-inspector": "0.5.0",
     "@commander-js/extra-typings": "^14.0.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.215.0",


### PR DESCRIPTION
## Description

<!-- Provide a detailed description of the changes in this PR -->

Changes included:
* enable invoking deployed agent runtimes from agent inspector.

## Related Issue

<!-- Every PR must be associated with an issue. Link it below using #issue-number format. -->

Closes #

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:unit` and `npm run test:integ`
- [ ] I ran `npm run typecheck`
- [ ] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
