### PR TITLE
fix(deploy): preserve error typing through CDK wrapper and preflight

### DIFF
--- a/src/cli/cdk/toolkit-lib/wrapper.ts
+++ b/src/cli/cdk/toolkit-lib/wrapper.ts
@@ -1,6 +1,6 @@
 import { CONFIG_DIR } from '../../../lib';
 import { CDK_APP_ENTRY, CDK_PROJECT_DIR } from '../../constants';
-import { getErrorMessage, isChangesetInProgressError } from '../../errors';
+import { isChangesetInProgressError } from '../../errors';
 import type { CdkToolkitWrapperOptions, DeployOptions, DestroyOptions, DiffOptions, ListOptions } from './types';
 import {
   BaseCredentials,
@@ -36,18 +36,10 @@ async function withErrorContext<T>(context: string, operation: () => Promise<T>)
   try {
     return await operation();
   } catch (err) {
-    const message = getErrorMessage(err);
-    const stack = err instanceof Error ? err.stack : undefined;
-    const cause = err instanceof Error ? err.cause : undefined;
-
-    const error = new Error(`CDK ${context} failed: ${message}`);
-    if (stack) {
-      error.stack = `CDK ${context} failed: ${message}\n\nOriginal stack:\n${stack}`;
+    if (err instanceof Error) {
+      err.message = `CDK ${context} failed: ${err.message}`;
     }
-    if (cause) {
-      error.cause = cause;
-    }
-    throw error;
+    throw err;
   }
 }
 

--- a/src/cli/commands/deploy/actions.ts
+++ b/src/cli/commands/deploy/actions.ts
@@ -155,7 +155,7 @@ export async function handleDeploy(options: ValidatedDeployOptions): Promise<Dep
       logger.finalize(false);
       return {
         success: false,
-        error: new Error(
+        error: new ValidationError(
           'This will delete all deployed resources and the CloudFormation stack. Run with --yes to confirm teardown.'
         ),
         logPath: logger.getRelativeLogPath(),

--- a/src/cli/operations/deploy/preflight.ts
+++ b/src/cli/operations/deploy/preflight.ts
@@ -145,7 +145,7 @@ function validateRuntimeNames(projectSpec: AgentCoreProjectSpec): void {
     if (agentName) {
       const combinedName = `${projectName}_${agentName}`;
       if (combinedName.length > MAX_RUNTIME_NAME_LENGTH) {
-        throw new Error(
+        throw new ValidationError(
           `Runtime name too long: "${combinedName}" (${combinedName.length} chars). ` +
             `AWS limits runtime names to ${MAX_RUNTIME_NAME_LENGTH} characters. ` +
             `Shorten the project name or agent name in agentcore.json.`

--- a/src/cli/operations/deploy/preflight.ts
+++ b/src/cli/operations/deploy/preflight.ts
@@ -1,4 +1,5 @@
 import { ConfigIO, DOCKERFILE_NAME, getDockerfilePath, requireConfigRoot, resolveCodeLocation } from '../../../lib';
+import { ValidationError } from '../../../lib/errors/types';
 import type { AgentCoreProjectSpec, AwsDeploymentTarget } from '../../../schema';
 import { validateAwsCredentials } from '../../aws/account';
 import { LocalCdkProject } from '../../cdk/local-cdk-project';
@@ -109,7 +110,7 @@ export async function validateProject(): Promise<PreflightContext> {
       // No deployed state file — no existing stack
     }
     if (!hasExistingStack) {
-      throw new Error(
+      throw new ValidationError(
         'No resources defined in project. Add at least one resource (agent, memory, evaluator, or gateway) before deploying.'
       );
     }


### PR DESCRIPTION
## Description

### Problem 

High rate of unknown errors from deploy in telemetry. There are a few places this could happen:
1. `withErrorContext` discarded all error typing by recreating errors as generic errors. 
2. Preflight/teardown user errors were thrown as plain `Error`. 

Net effect: deploy failures now carry their real type through to telemetry and error handling.

## Related Issue

<!-- No tracking issue was provided. Replace with the appropriate issue before merge. -->

Closes #

## Documentation PR

N/A — no user-facing documentation changes; this only affects internal error typing/telemetry classification.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

Notes:
- `typecheck` and `lint` pass on the changed files (`wrapper.ts`, `actions.ts`, `preflight.ts`).
- Full `test:unit` was not run cleanly in this environment due to a missing optional dependency unrelated to this change. The one failing test observed (`LogsScreen > shows error when no runtimes are defined`) reproduces identically on `origin/main` with these changes stashed, so it is pre-existing and not a regression.

## Checklist

- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
