### PR TITLE
fix(logs): wire up cli telemetry and model user errors

### DIFF
--- a/src/cli/commands/logs/command.tsx
+++ b/src/cli/commands/logs/command.tsx
@@ -2,6 +2,7 @@ import { COMMAND_DESCRIPTIONS } from '../../constants';
 import { getErrorMessage } from '../../errors';
 import { handleLogsEval } from '../../operations/eval';
 import type { LogsEvalOptions } from '../../operations/eval';
+import { withCommandRunTelemetry } from '../../telemetry/cli-command-run.js';
 import { requireProject } from '../../tui/guards';
 import { handleLogs } from './action';
 import type { LogsOptions } from './types';
@@ -31,7 +32,11 @@ export const registerLogs = (program: Command) => {
       requireProject();
 
       try {
-        const result = await handleLogs(cliOptions);
+        const result = await withCommandRunTelemetry(
+          'logs',
+          { has_query: !!cliOptions.query, has_level_filter: !!cliOptions.level },
+          () => handleLogs(cliOptions)
+        );
 
         if (!result.success) {
           render(<Text color="red">{result.error.message}</Text>);
@@ -56,7 +61,9 @@ export const registerLogs = (program: Command) => {
       requireProject();
 
       try {
-        const result = await handleLogsEval(cliOptions);
+        const result = await withCommandRunTelemetry('logs.evals', { has_follow: !!cliOptions.follow }, () =>
+          handleLogsEval(cliOptions)
+        );
 
         if (!result.success) {
           render(<Text color="red">{result.error.message}</Text>);

--- a/src/cli/tui/screens/logs/useLogsFlow.ts
+++ b/src/cli/tui/screens/logs/useLogsFlow.ts
@@ -1,4 +1,4 @@
-import { toError } from '../../../../lib';
+import { ValidationError, toError } from '../../../../lib';
 import type { AgentContext } from '../../../commands/logs/action';
 import { resolveAgentContext } from '../../../commands/logs/action';
 import { loadDeployedProjectConfig } from '../../../operations/resolve-agent';
@@ -40,7 +40,7 @@ export function useLogsFlow(): UseLogsFlowResult {
         const runtimeNames = context.project.runtimes.map(r => r.name);
 
         if (runtimeNames.length === 0) {
-          return { success: false as const, error: new Error('No runtimes defined in agentcore.json') };
+          return { success: false as const, error: new ValidationError('No runtimes defined in agentcore.json') };
         }
 
         const resolved: AgentContext[] = [];
@@ -54,7 +54,7 @@ export function useLogsFlow(): UseLogsFlowResult {
         if (resolved.length === 0) {
           return {
             success: false as const,
-            error: new Error('No deployed agents found. Run `agentcore deploy` first.'),
+            error: new ValidationError('No deployed agents found. Run `agentcore deploy` first.'),
           };
         }
 


### PR DESCRIPTION
## Description

Two changes to improve telemetry coverage for the `logs` command:

1. **Wire up CLI telemetry** (`commands/logs/command.tsx`): `handleLogs` and `handleLogsEval` are now wrapped in `withCommandRunTelemetry`. Before this, only the interactive TUI path emitted `cli.command_run`; the CLI path recorded nothing. 

2. **Model user errors** (`tui/screens/logs/useLogsFlow.ts`): Two conditions that returned plain `new Error(...)` now return `ValidationError`. 


## Related Issue

Closes #

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
