### PR TITLE
ci: smoke-test CDK synth to catch cloud-assembly schema mismatches

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -56,6 +56,18 @@ jobs:
           agentcore --version
           agentcore create --name sanitytest --language Python --framework Strands --model-provider Bedrock --memory none --json
           test -f sanitytest/agentcore/agentcore.json
+      # Synthesize the generated CDK app against whatever aws-cdk-lib `create` just
+      # resolved from the template's floating range. This is the only CI step that
+      # exercises the cloud-assembly schema write+read path with the LATEST published
+      # aws-cdk-lib, so it catches upstream CDK schema bumps that outrun the bundled
+      # CDK reader (the regression in #1465). Runs without AWS credentials.
+      - name: Smoke-test CDK synth (catches cloud-assembly schema mismatch)
+        if: matrix.node-version == '20.x'
+        working-directory: sanitytest/agentcore/cdk
+        run: |
+          echo '[{"name":"default","account":"000000000000","region":"us-east-1"}]' > ../aws-targets.json
+          npm run cdk -- synth --quiet
+          test -f cdk.out/manifest.json
       - name: Upload tarball artifact
         if: matrix.node-version == '20.x'
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Description

Follow-up to #1465. That PR fixed a customer-facing deploy break — `aws-cdk-lib@2.258.0` bumped the cloud-assembly schema to 54, but the bundled CDK reader only read up to 53, so freshly-created projects failed at **Synthesize CloudFormation** with `AssemblyVersionMismatch`. **No test caught it.** This PR adds the guard that would have.

### Why nothing caught #1465

| Test layer | Synthesizes? | Floating `aws-cdk-lib`? | Cadence | Caught it? |
|---|---|---|---|---|
| Unit (240) | ❌ no | ❌ pinned via shrinkwrap | every PR | No — structurally can't |
| `build-and-test` sanity | ❌ `create` only | ✅ floating | every PR | No — stops before synth |
| PR e2e | ✅ yes | ✅ floating | PR + authorized user | Only if a PR fired in the window |
| Full e2e | ✅ yes | ✅ floating | **Monday cron** + push to main | No — next run was 3 days later |

The break came from an **upstream transitive publish** (`aws-cdk-lib@2.258.0`, 2026-06-04) sliding into the generated template's floating `^2.248.0` range — not from a commit. Unit tests run against the **pinned** shrinkwrap tree, so they test a different dependency graph than a customer's fresh `npm install` resolves. The one always-on job that touches a generated project stops at `create` and never synthesizes.

## Change

Add a credential-free `cdk synth` smoke test immediately after `agentcore create` in the always-on PR build job (Node 20.x). `agentcore create` already auto-installs the generated CDK app against the template's floating range — resolving the **latest** published `aws-cdk-lib` — so this step writes a manifest at the newest schema and reads it back through the bundled `aws-cdk` binary. It goes red the moment upstream CDK's schema outruns the bundled reader.

```yaml
- name: Smoke-test CDK synth (catches cloud-assembly schema mismatch)
  if: matrix.node-version == '20.x'
  working-directory: sanitytest/agentcore/cdk
  run: |
    echo '[{"name":"default","account":"000000000000","region":"us-east-1"}]' > ../aws-targets.json
    npm run cdk -- synth --quiet
    test -f cdk.out/manifest.json
```

- **Credential-free:** `synth` performs no AWS calls. (`deploy --dry-run` can't be used here — its STS `GetCallerIdentity` validation runs *before* synth, so it would fail on missing credentials in CI without ever reaching the schema path.)
- **Catches the whole class:** exercises the `aws-cdk` binary reader; #1465's break was the `toolkit-lib` reader. Both lag the same upstream schema, so one synth smoke test guards either reader falling behind.

## Type of Change

- [x] Other: CI / test-coverage hardening (no runtime code change)

## Testing

Verified the guard's exact command against a freshly-created project:

- **Pre-fix binary** (`aws-cdk@2.1100.1`) + `aws-cdk-lib@2.258.0` (schema 54) → **fails**: `Cloud assembly schema version mismatch: Maximum schema version supported is 49.x.x, but found 54.0.0` — i.e. it would have caught #1465.
- **Shipped binary** (`aws-cdk@2.1126.0`, from #1465) + `aws-cdk-lib@2.258.0` → **passes**, manifest written at schema 54.
- Confirmed `agentcore create --json` auto-installs the CDK app (no `--skip-install`), resolving the floating `aws-cdk-lib@2.258.0`.
- Confirmed the synth runs with all AWS credential env unset.

- [x] I ran `npm run typecheck` (via pre-commit hook)
- [x] I ran `npm run lint` (prettier + secretlint via pre-commit hook)
- [x] No `src/` changes — workflow-only, no snapshots affected

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes generate no new warnings
- [x] Workflow `run:` block uses only static literals — no untrusted `github.event.*` interpolation