### PR TITLE
fix(deploy): bump @aws-cdk/cdk-assets-lib to read schema 54 asset manifests

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@aws-cdk/cdk-assets-lib": "^1.4.10",
         "@aws-cdk/toolkit-lib": "^1.28.0",
         "@aws-sdk/client-application-signals": "^3.1003.0",
         "@aws-sdk/client-bedrock": "^3.1012.0",
@@ -174,14 +175,13 @@
       }
     },
     "node_modules/@aws-cdk/cdk-assets-lib": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cdk-assets-lib/-/cdk-assets-lib-1.4.2.tgz",
-      "integrity": "sha512-RFDITy2nC9LPckAVymApxtLl9wzI0arUh/2h9d2LAjl2zeiVASr89WpRK/bA1RhHw3ElypEMa052DIAzt3RimA==",
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cdk-assets-lib/-/cdk-assets-lib-1.4.10.tgz",
+      "integrity": "sha512-LOJP992WcTV2GW5zazqx38QVKZFMiPMwMZVjdWj4K7NszlgMR9MWUHbj674UEBJ01ucmoi24qvLQwzfu90N95A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/cloud-assembly-api": "2.2.1",
-        "@aws-cdk/cloud-assembly-schema": ">=53.8.0",
-        "@aws-cdk/cx-api": "^2",
+        "@aws-cdk/cloud-assembly-api": "2.2.5",
+        "@aws-cdk/cloud-assembly-schema": ">=54.2.0",
         "@aws-sdk/client-ecr": "^3",
         "@aws-sdk/client-s3": "^3",
         "@aws-sdk/client-secrets-manager": "^3",
@@ -193,10 +193,43 @@
         "archiver": "^7.0.1",
         "fast-glob": "^3.3.3",
         "mime": "^2",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/@aws-cdk/cdk-assets-lib/node_modules/@aws-cdk/cloud-assembly-schema": {
+      "version": "54.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.2.0.tgz",
+      "integrity": "sha512-u3lFXmiXSBozxGBmKTCVD/2mTDsaXzLZH3KYiIQKcB+zPldXOeE5TnooBgKV9ih2jVTo8ML0HpkhfAq2eiv0eQ==",
+      "bundleDependencies": ["jsonschema", "semver"],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/@aws-cdk/cdk-assets-lib/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
+      "version": "1.5.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@aws-cdk/cdk-assets-lib/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
+      "version": "7.8.1",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@aws-cdk/cli-plugin-contract": {
@@ -210,39 +243,19 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-api/-/cloud-assembly-api-2.2.1.tgz",
-      "integrity": "sha512-24ARpDQzF39UTickUgDH6RIs5otPG4aaKJZ93XUSNwiPSR9T+h7gXSF982+NZVYK+7SetQaqrVbm4lcF6dmXWw==",
-      "bundleDependencies": ["jsonschema", "semver"],
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-api/-/cloud-assembly-api-2.2.5.tgz",
+      "integrity": "sha512-RrjdgAgOjc0rMSGhMmIq1IKRI2lSYEK5XLu+863pQjecxNaNQkrQCyI62Z3JClFnQnjBeFSfDoY78apS9Aa9tA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.4"
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
       },
       "engines": {
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=53.8.0"
-      }
-    },
-    "node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
-      "version": "7.7.4",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "@aws-cdk/cloud-assembly-schema": ">=53.28.0"
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
@@ -428,22 +441,6 @@
       },
       "peerDependencies": {
         "@aws-cdk/cli-plugin-contract": "^2"
-      }
-    },
-    "node_modules/@aws-cdk/toolkit-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-api/-/cloud-assembly-api-2.2.5.tgz",
-      "integrity": "sha512-RrjdgAgOjc0rMSGhMmIq1IKRI2lSYEK5XLu+863pQjecxNaNQkrQCyI62Z3JClFnQnjBeFSfDoY78apS9Aa9tA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "jsonschema": "^1.5.0",
-        "semver": "^7.8.0"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      },
-      "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=53.28.0"
       }
     },
     "node_modules/@aws-cdk/toolkit-lib/node_modules/@aws-cdk/cloud-assembly-schema": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "bundle": "node scripts/bundle.mjs"
   },
   "dependencies": {
+    "@aws-cdk/cdk-assets-lib": "^1.4.10",
     "@aws-cdk/toolkit-lib": "^1.28.0",
     "@aws-sdk/client-application-signals": "^3.1003.0",
     "@aws-sdk/client-bedrock": "^3.1012.0",


### PR DESCRIPTION
## Description

`agentcore deploy` still fails at the **asset-publish** step for projects that ship file/zip/docker assets when `aws-cdk-lib` resolves to `2.258.0+`:

```
Cannot read asset manifest '/.../cdk.out/AgentCore-….assets.json':
Cloud assembly schema version mismatch: Maximum schema version supported is 53.x.x, but found 54.0.0
```

This is the *second* schema-54 reader. PR #1465 fixed the synth-time reader (`@aws-cdk/toolkit-lib`, 1.16 → 1.28). The asset-publish phase that runs **after** synth uses a separate package, `@aws-cdk/cdk-assets-lib`, which the shrinkwrap held at 1.4.2 — schema floor `>=53.8.0`, can't read schema 54 manifests.

Registry-verified boundary:

| Package | Pinned `cloud-assembly-schema` | Reads schema 54? |
|---|---|---|
| `@aws-cdk/cdk-assets-lib@1.4.2` (current) | `>=53.8.0` | ❌ |
| `@aws-cdk/cdk-assets-lib@1.4.5` | `>=53.17.0` | ❌ |
| `@aws-cdk/cdk-assets-lib@1.4.10` | `>=54.2.0` | ✅ |

`toolkit-lib` declares `cdk-assets-lib: ^1` as a transitive dep, but that range is too wide — npm's regen during PR #1465 happily kept the existing 1.4.2 pin instead of moving forward. Adding `@aws-cdk/cdk-assets-lib: ^1.4.10` as a **direct** dependency forces the regen to resolve a schema-54-aware version.

### Why this only surfaced after #1465 shipped

- Dataset deploys synthesize CFN-only stacks — no file/zip/docker assets, so the asset-publisher reader is never invoked. (Dataset tests in shard 6 passed.)
- Agent deploys (CodeZip, Container) write `assets.json` entries that `cdk-assets-lib` parses → hits the wall.
- e2e \`(npm, 6/6)\` passed because the published \`@aws/agentcore-cdk\` resolves an older \`aws-cdk-lib\` that still emits schema 53 assets.
- e2e \`(main, 6/6)\` failed because it builds \`@aws/agentcore-cdk\` fresh from CDK main, pulling current \`aws-cdk-lib\` → schema 54 → second reader trips.

## Changes

- **`package.json`**: add `@aws-cdk/cdk-assets-lib` at `^1.4.10` as a direct dependency.
- **`npm-shrinkwrap.json`**: regenerated. `cdk-assets-lib` moves `1.4.2 → 1.4.10`; its nested `cloud-assembly-schema` moves to `54.2.0`.

No source changes. The asset-publisher API surface is unchanged across `1.4.2 → 1.4.10` (only schema-version handling was bumped).

## Type of Change

- [x] Bug fix

## Testing

Reproduced the customer scenario end-to-end against the patched CLI:

1. Fresh project resolving `aws-cdk-lib@2.258.0` (writes manifest schema **54.0.0**).
2. `agentcore deploy --yes` (BYO Strands agent, real assets, real AWS) → **success**: synth + asset publish + CFN deploy all pass. Runtime ARN created.
3. Confirmed at runtime: `cdk-assets-lib@1.4.10` loads `cloud-assembly-schema@54.2.0` (reader 54.2.0 ≥ writer 54.0.0).

- [x] `npm run typecheck` (passes)
- [x] `npm run lint` (0 errors, 29 pre-existing warnings unchanged)
- [x] `npm run test:unit` (passes)

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes generate no new warnings