### PR TITLE
fix(deploy): bump aws-cdk-lib to ^2.258.0 to unblock e2e workspace resolution

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -68,7 +68,7 @@
         "@typescript-eslint/parser": "^8.50.0",
         "@vitest/coverage-v8": "^4.0.18",
         "@xterm/headless": "^6.0.0",
-        "aws-cdk-lib": "^2.248.0",
+        "aws-cdk-lib": "^2.258.0",
         "constructs": "^10.4.4",
         "esbuild": "^0.28.0",
         "eslint": "^9.39.4",
@@ -95,7 +95,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "^2.248.0",
+        "aws-cdk-lib": "^2.258.0",
         "constructs": "^10.0.0"
       }
     },
@@ -142,16 +142,16 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.273",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.273.tgz",
-      "integrity": "sha512-X57HYUtHt9BQrlrzUNcMyRsDUCoakYNnY6qh5lNwRCHPtQoTfXmuISkfLk0AjLkcbS5lw1LLTQFiQhTDXfiTvg==",
+      "version": "2.2.282",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.282.tgz",
+      "integrity": "sha512-7hKMi5tTxDcKGIMIOq14PnY0GBcugW33Uh/2YHDZiEwSxLeFOCYBwhR+BFXONb/EJeVI3RETFgailNZbkcKF6g==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.1.tgz",
-      "integrity": "sha512-We4bmHaowOPHr+IQR4/FyTGjRfjgBj4ICMjtqmJeBDWad3Q/6St12NT07leNtyuukv2qMhtSZJQorD8KpKTwRA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.2.tgz",
+      "integrity": "sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -199,39 +199,6 @@
         "node": ">= 18.0.0"
       }
     },
-    "node_modules/@aws-cdk/cdk-assets-lib/node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "54.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.2.0.tgz",
-      "integrity": "sha512-u3lFXmiXSBozxGBmKTCVD/2mTDsaXzLZH3KYiIQKcB+zPldXOeE5TnooBgKV9ih2jVTo8ML0HpkhfAq2eiv0eQ==",
-      "bundleDependencies": ["jsonschema", "semver"],
-      "license": "Apache-2.0",
-      "dependencies": {
-        "jsonschema": "^1.5.0",
-        "semver": "^7.8.1"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      }
-    },
-    "node_modules/@aws-cdk/cdk-assets-lib/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
-      "version": "1.5.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@aws-cdk/cdk-assets-lib/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.8.1",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@aws-cdk/cli-plugin-contract": {
       "version": "2.182.1",
       "resolved": "https://registry.npmjs.org/@aws-cdk/cli-plugin-contract/-/cli-plugin-contract-2.182.1.tgz",
@@ -259,14 +226,14 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "53.28.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.28.0.tgz",
-      "integrity": "sha512-pZS+9bLGv2tCqcgxfA0WD3XjcqT3yE4ICvKeJEicw6aTdCxBl8FQ/AUsorY/6f2JrMS3kUQgvhXxA30MWcji0A==",
+      "version": "54.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.2.0.tgz",
+      "integrity": "sha512-u3lFXmiXSBozxGBmKTCVD/2mTDsaXzLZH3KYiIQKcB+zPldXOeE5TnooBgKV9ih2jVTo8ML0HpkhfAq2eiv0eQ==",
       "bundleDependencies": ["jsonschema", "semver"],
       "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "^1.5.0",
-        "semver": "^7.8.0"
+        "semver": "^7.8.1"
       },
       "engines": {
         "node": ">= 18.0.0"
@@ -281,7 +248,7 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.8.0",
+      "version": "7.8.1",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -441,39 +408,6 @@
       },
       "peerDependencies": {
         "@aws-cdk/cli-plugin-contract": "^2"
-      }
-    },
-    "node_modules/@aws-cdk/toolkit-lib/node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "54.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.2.0.tgz",
-      "integrity": "sha512-u3lFXmiXSBozxGBmKTCVD/2mTDsaXzLZH3KYiIQKcB+zPldXOeE5TnooBgKV9ih2jVTo8ML0HpkhfAq2eiv0eQ==",
-      "bundleDependencies": ["jsonschema", "semver"],
-      "license": "Apache-2.0",
-      "dependencies": {
-        "jsonschema": "^1.5.0",
-        "semver": "^7.8.1"
-      },
-      "engines": {
-        "node": ">= 18.0.0"
-      }
-    },
-    "node_modules/@aws-cdk/toolkit-lib/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
-      "version": "1.5.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@aws-cdk/toolkit-lib/node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.8.1",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@aws-cdk/toolkit-lib/node_modules/yaml": {
@@ -6937,9 +6871,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.257.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.257.0.tgz",
-      "integrity": "sha512-GoHfWklrBJcMwLtDlY64pvaT7cD2KyDXC8sik89DR6jHl6nQsBtYTKSJCM+C/k4jgXaecbv8myNX75FySejq0A==",
+      "version": "2.258.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.258.0.tgz",
+      "integrity": "sha512-OfFfg30ikBRJ3dimlzsWhPIrj6qug1p2XYsdB38CtMtcur7SufzoUczgI6kWjbQkOVcQgYzhzN29DErV0yZG7A==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
@@ -6957,19 +6891,19 @@
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "2.2.273",
-        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
-        "@aws-cdk/cloud-assembly-api": "^2.2.4",
-        "@aws-cdk/cloud-assembly-schema": "^53.25.0",
+        "@aws-cdk/asset-awscli-v1": "2.2.282",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.2",
+        "@aws-cdk/cloud-assembly-api": "^2.2.5",
+        "@aws-cdk/cloud-assembly-schema": "^54.0.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.3.3",
+        "fs-extra": "^11.3.5",
         "ignore": "^5.3.2",
         "jsonschema": "^1.5.0",
         "mime-types": "^2.1.35",
-        "minimatch": "^10.2.3",
+        "minimatch": "^10.2.5",
         "punycode": "^2.3.1",
-        "semver": "^7.7.4",
+        "semver": "^7.8.1",
         "table": "^6.9.0",
         "yaml": "1.10.3"
       },
@@ -6981,7 +6915,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.2.4",
+      "version": "2.2.5",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -6993,19 +6927,7 @@
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=53.25.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
-      "version": "7.8.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "@aws-cdk/cloud-assembly-schema": ">=53.28.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
@@ -7015,7 +6937,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/aws-cdk-lib/node_modules/ajv": {
-      "version": "8.18.0",
+      "version": "8.20.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7073,7 +6995,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "5.0.5",
+      "version": "5.0.6",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7140,7 +7062,7 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.3.3",
+      "version": "11.3.5",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7184,7 +7106,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
-      "version": "6.2.0",
+      "version": "6.2.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7265,7 +7187,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.7.4",
+      "version": "7.8.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "zod": "^4.3.5"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.248.0",
+    "aws-cdk-lib": "^2.258.0",
     "constructs": "^10.0.0"
   },
   "devDependencies": {
@@ -134,7 +134,7 @@
     "@typescript-eslint/parser": "^8.50.0",
     "@vitest/coverage-v8": "^4.0.18",
     "@xterm/headless": "^6.0.0",
-    "aws-cdk-lib": "^2.248.0",
+    "aws-cdk-lib": "^2.258.0",
     "constructs": "^10.4.4",
     "esbuild": "^0.28.0",
     "eslint": "^9.39.4",


### PR DESCRIPTION
## Description

PRs #1465 and #1468 fixed the bundled CLI's readers (`@aws-cdk/toolkit-lib` and `@aws-cdk/cdk-assets-lib`) to handle cloud-assembly schema 54. **End-user deploys via the global CLI install work correctly** — that path resolves cleanly because the global install's `node_modules` has no parallel `aws-cdk-lib` to fight over schema hoisting.

However, the e2e test `byo-custom-jwt.test.ts` continued to fail in CI on `main 6/6` with the schema-53 error. Investigation showed this is a workspace-resolution trap, not a customer-facing bug:

```
                                                  pinned schema dep                hoists where?
agentcore-cli/package.json
  aws-cdk-lib: ^2.248.0     → resolves 2.257.0    ^53.25.0           ┐
                                                                     ├→ top-level: 53.28.0  ❌
  @aws-cdk/cloud-assembly-api  (transitive)        >=53.28.0 (peer)  ┘  binds to 53.28.0

  @aws-cdk/toolkit-lib@1.28.0/node_modules/@aws-cdk/cloud-assembly-schema@54.2.0   ← unreachable
  @aws-cdk/cdk-assets-lib@1.4.10/node_modules/@aws-cdk/cloud-assembly-schema@54.2.0 ← unreachable
```

`byo-custom-jwt.test.ts` uses `runLocalCLI`, which spawns `node dist/cli/index.mjs` from the workspace root. Node's module resolution starts there. The workspace pulls in `aws-cdk-lib@2.257.0` (CLI's own dep, used by `src/assets/cdk/` template typechecks and the agent-import translator), whose peer `cloud-assembly-schema: ^53.25.0` hoists the schema package at 53.28.0 top-level. `@aws-cdk/cloud-assembly-api` — also hoisted, with peer `>=53.28.0` — then binds to that top-level 53-era schema, even though `toolkit-lib` and `cdk-assets-lib` have nested 54.2.0 copies that satisfy their own peers. Synth still throws `AssemblyVersionMismatch`.

This PR bumps the CLI's own `aws-cdk-lib` from `^2.248.0` to `^2.258.0`. `aws-cdk-lib@2.258.0`'s peer becomes `cloud-assembly-schema: ^54.0.0`, so npm hoists `54.2.0` at the top level. `cloud-assembly-api` then binds to the right schema. Resolution chain healed.

## Verification

After applying the bump locally:

```
top-level cloud-assembly-schema: 53.28.0 → 54.2.0  ✅
cloud-assembly-api now resolves: schema 54.2.0       ✅
```

Re-ran `e2e-tests/byo-custom-jwt.test.ts` against the patched CLI with `CDK_TARBALL` set (mimicking the `main` matrix leg), real AWS credentials, real synth + asset publish + CFN deploy:

```
✓ e2e: BYO agent with CUSTOM_JWT auth > deploys with CUSTOM_JWT authorizer configuration  270623ms
Tests: 1 passed | 6 skipped (7)
```

Where it previously threw `Cloud assembly schema version mismatch: Maximum schema version supported is 53.x.x, but found 54.0.0`.

## Changes

- **`package.json`**: `aws-cdk-lib` `^2.248.0 → ^2.258.0` (in both `dependencies` and `peerDependencies`).
- **`npm-shrinkwrap.json`**: regenerated. `aws-cdk-lib 2.257.0 → 2.258.0`; top-level `cloud-assembly-schema 53.28.0 → 54.2.0`.

No source changes.

## Type of Change

- [x] Bug fix
- [x] Test infrastructure fix

## Why this isn't a customer issue (and why it should still ship)

- End users running the global `agentcore` CLI binary go through `~/.../@aws/agentcore/node_modules/`, not the workspace. That tree has no parallel `aws-cdk-lib` and resolves schema 54.2.0 cleanly. Customer deploys already work after #1465/#1468.
- However, this PR also closes a latent fragility: any project that installs `@aws/agentcore` alongside an old `aws-cdk-lib` could hit the same hoisting trap (depending on npm version's deduplication heuristics). Pinning the CLI's own `aws-cdk-lib` peer to `^2.258.0` keeps the workspace resolution clean, makes CI green, and prevents this recurring at the next schema bump.

## Testing

- [x] `npm run typecheck` (passes)
- [x] `npm run lint` (no new errors)
- [x] `npm run test:unit`
- [x] `e2e-tests/byo-custom-jwt.test.ts > deploys with CUSTOM_JWT authorizer` passes against real AWS

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes generate no new warnings
- [x] Closes the schema-54 saga: #1465 (synth reader) + #1468 (asset publisher reader) + this PR (workspace writer alignment)