### PR TITLE
fix(ci): pass filesystem env vars to e2e-tests-full vitest step

### DIFF
--- a/.github/workflows/e2e-tests-full.yml
+++ b/.github/workflows/e2e-tests-full.yml
@@ -89,6 +89,10 @@ jobs:
           ANTHROPIC_API_KEY: ${{ env.E2E_ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ env.E2E_OPENAI_API_KEY }}
           GEMINI_API_KEY: ${{ env.E2E_GEMINI_API_KEY }}
+          E2E_EFS_ACCESS_POINT_ARN: ${{ env.E2E_EFS_ACCESS_POINT_ARN }}
+          E2E_S3_ACCESS_POINT_ARN: ${{ env.E2E_S3_ACCESS_POINT_ARN }}
+          E2E_FILESYSTEM_SUBNET_ID: ${{ env.E2E_FILESYSTEM_SUBNET_ID }}
+          E2E_FILESYSTEM_SECURITY_GROUP_ID: ${{ env.E2E_FILESYSTEM_SECURITY_GROUP_ID }}
           CDK_TARBALL: ${{ env.CDK_TARBALL }}
         run: npx vitest run --project e2e --shard=${{ matrix.shard }}
   browser-tests:


### PR DESCRIPTION
## Description

`strands-bedrock-byo-filesystem.test.ts` fails on the **`E2E Tests (Full Suite)`** workflow (`e2e-tests-full.yml`) at the `agentcore create` step:

```
AssertionError: Create failed: (node:4489) Warning: NodeVersionSupportWarning: ...
```

The assertion message only includes `stderr` (a Node-version deprecation warning); the actual JSON error went to `stdout` which the test does not print on failure.

## Root cause

The Secrets Manager step (`aws-actions/aws-secretsmanager-get-secrets@v2`) retrieves these env vars at **job scope**:

- `E2E_EFS_ACCESS_POINT_ARN`
- `E2E_S3_ACCESS_POINT_ARN`
- `E2E_FILESYSTEM_SUBNET_ID`
- `E2E_FILESYSTEM_SECURITY_GROUP_ID`

But the `Run E2E tests` step's `env:` block doesn't pass them through, so the `vitest` subprocess never sees them. GitHub Actions does **not** auto-inherit job-level env vars into step subprocesses — they have to be listed explicitly in each step's `env:` block.

The PR workflow (`e2e-tests.yml`) already does this correctly. This PR brings `e2e-tests-full.yml` in line.

## Diff

```yaml
# .github/workflows/e2e-tests-full.yml — Run E2E tests step env:
   ANTHROPIC_API_KEY: ${{ env.E2E_ANTHROPIC_API_KEY }}
   OPENAI_API_KEY: ${{ env.E2E_OPENAI_API_KEY }}
   GEMINI_API_KEY: ${{ env.E2E_GEMINI_API_KEY }}
+  E2E_EFS_ACCESS_POINT_ARN: ${{ env.E2E_EFS_ACCESS_POINT_ARN }}
+  E2E_S3_ACCESS_POINT_ARN: ${{ env.E2E_S3_ACCESS_POINT_ARN }}
+  E2E_FILESYSTEM_SUBNET_ID: ${{ env.E2E_FILESYSTEM_SUBNET_ID }}
+  E2E_FILESYSTEM_SECURITY_GROUP_ID: ${{ env.E2E_FILESYSTEM_SECURITY_GROUP_ID }}
   CDK_TARBALL: ${{ env.CDK_TARBALL }}
```

## Type of Change

- [x] CI / test infrastructure fix

## Why now

CI run 27041082542 (post-merge of #1465 + #1468) had `(main, 5/6)` and `(npm, 5/6)` red because of this. The byo-filesystem test surfaces the missing env vars before any other test would, since other tests don't depend on them. PR is a 4-line additive change to one file.

## Verification

- [x] Inspected `e2e-tests.yml` for the same step pattern — confirmed it already passes these 4 vars
- [x] Inspected the test source's `requiredEnvVars` — matches exactly the 4 env vars added here
- [ ] Will be confirmed when the next `e2e-tests-full.yml` run picks up these changes

## Checklist

- [x] My changes generate no new warnings