### PR TITLE
fix: resolve create harness Dockerfile paths from command cwd

### DIFF
--- a/src/cli/commands/create/command.tsx
+++ b/src/cli/commands/create/command.tsx
@@ -136,7 +136,8 @@ function printCreateHarnessSummary(projectName: string, harnessName: string): vo
 
 /** Handle CLI mode for the harness path (preview mode) */
 async function handleCreateHarnessCLI(options: CreateOptions): Promise<void> {
-  const cwd = options.outputDir ?? getWorkingDirectory();
+  const commandCwd = getWorkingDirectory();
+  const cwd = options.outputDir ?? commandCwd;
   const name = options.name ?? options.projectName;
   const projectName = options.projectName ?? name;
 
@@ -203,6 +204,7 @@ async function handleCreateHarnessCLI(options: CreateOptions): Promise<void> {
         apiKeyArn: options.apiKeyArn,
         containerUri: containerOption.containerUri,
         dockerfilePath: containerOption.dockerfilePath,
+        dockerfileBaseDir: commandCwd,
         skipMemory: options.harnessMemory === false,
         maxIterations: options.maxIterations ? Number(options.maxIterations) : undefined,
         maxTokens: options.maxTokens ? Number(options.maxTokens) : undefined,

--- a/src/cli/commands/create/harness-action.ts
+++ b/src/cli/commands/create/harness-action.ts
@@ -16,6 +16,7 @@ export interface CreateHarnessProjectOptions {
   skipMemory?: boolean;
   containerUri?: string;
   dockerfilePath?: string;
+  dockerfileBaseDir?: string;
   maxIterations?: number;
   maxTokens?: number;
   timeoutSeconds?: number;
@@ -62,6 +63,7 @@ export async function createProjectWithHarness(options: CreateHarnessProjectOpti
       apiKeyArn: options.apiKeyArn,
       containerUri: options.containerUri,
       dockerfilePath: options.dockerfilePath,
+      dockerfileBaseDir: options.dockerfileBaseDir ?? options.cwd,
       skipMemory: options.skipMemory,
       maxIterations: options.maxIterations,
       maxTokens: options.maxTokens,

--- a/src/cli/primitives/HarnessPrimitive.ts
+++ b/src/cli/primitives/HarnessPrimitive.ts
@@ -45,6 +45,7 @@ export interface AddHarnessOptions {
   efsAccessPoints?: { accessPointArn: string; mountPath: string }[];
   s3AccessPoints?: { accessPointArn: string; mountPath: string }[];
   withInvokeScript?: boolean;
+  dockerfileBaseDir?: string;
   selectedTools?: string[];
   mcpName?: string;
   mcpUrl?: string;
@@ -85,9 +86,10 @@ export class HarnessPrimitive extends BasePrimitive<AddHarnessOptions, Removable
       let dockerfile: string | undefined;
       if (options.dockerfilePath) {
         const projectRoot = dirname(configBaseDir);
+        const dockerfileBaseDir = options.dockerfileBaseDir ?? projectRoot;
         const srcPath = isAbsolute(options.dockerfilePath)
           ? options.dockerfilePath
-          : resolve(projectRoot, options.dockerfilePath);
+          : resolve(dockerfileBaseDir, options.dockerfilePath);
         try {
           await access(srcPath);
         } catch {

--- a/src/cli/primitives/__tests__/HarnessPrimitive.test.ts
+++ b/src/cli/primitives/__tests__/HarnessPrimitive.test.ts
@@ -1,0 +1,50 @@
+import { ConfigIO } from '../../../lib';
+import { createDefaultProjectSpec } from '../../project';
+import { HarnessPrimitive } from '../HarnessPrimitive';
+import { randomUUID } from 'node:crypto';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+describe('HarnessPrimitive', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.map(dir => rm(dir, { recursive: true, force: true })));
+    tempDirs.length = 0;
+  });
+
+  it('resolves create-flow Dockerfile paths from the command working directory', async () => {
+    const commandCwd = join(tmpdir(), `harness-dockerfile-${randomUUID()}`);
+    tempDirs.push(commandCwd);
+    const projectRoot = join(commandCwd, 'HarnessProject');
+    const configBaseDir = join(projectRoot, 'agentcore');
+    await mkdir(projectRoot, { recursive: true });
+
+    const configIO = new ConfigIO({ baseDir: configBaseDir });
+    await configIO.initializeBaseDir();
+    await configIO.writeAWSDeploymentTargets([]);
+    await configIO.writeDeployedState({ targets: {} });
+    await configIO.writeProjectSpec(createDefaultProjectSpec('HarnessProject'));
+
+    await writeFile(join(commandCwd, 'Dockerfile.custom'), 'FROM public.ecr.aws/docker/library/python:3.12\n');
+
+    const result = await new HarnessPrimitive().add({
+      name: 'MyHarness',
+      modelProvider: 'bedrock',
+      modelId: 'global.anthropic.claude-sonnet-4-6',
+      skipMemory: true,
+      dockerfilePath: './Dockerfile.custom',
+      dockerfileBaseDir: commandCwd,
+      configBaseDir,
+    });
+
+    expect(result.success).toBe(true);
+    const harnessDir = join(projectRoot, 'app', 'MyHarness');
+    await expect(readFile(join(harnessDir, 'Dockerfile.custom'), 'utf-8')).resolves.toContain('python:3.12');
+
+    const harnessSpec = JSON.parse(await readFile(join(harnessDir, 'harness.json'), 'utf-8'));
+    expect(harnessSpec.dockerfile).toBe('Dockerfile.custom');
+  });
+});

--- a/src/cli/tui/screens/create/useCreateFlow.ts
+++ b/src/cli/tui/screens/create/useCreateFlow.ts
@@ -654,6 +654,7 @@ export function useCreateFlow(cwd: string): CreateFlowState {
                 skipMemory: addHarnessConfig.skipMemory,
                 containerUri: addHarnessConfig.containerUri,
                 dockerfilePath: addHarnessConfig.dockerfilePath,
+                dockerfileBaseDir: cwd,
                 maxIterations: addHarnessConfig.maxIterations,
                 maxTokens: addHarnessConfig.maxTokens,
                 timeoutSeconds: addHarnessConfig.timeoutSeconds,


### PR DESCRIPTION
## Description

When `agentcore create` adds a harness with a Dockerfile, the project directory is created before the harness is added. Relative Dockerfile paths were resolved from that new project root, so a path supplied from the directory where `agentcore create` was invoked could fail.

This threads the create command's original working directory into the harness add path and uses it as the base for relative Dockerfile paths. Existing harness add behavior still falls back to the project root.

## Related Issue

Closes #1128

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

Additional checks:

- `npx vitest run --project unit src/cli/primitives/__tests__/HarnessPrimitive.test.ts`
- Preview CLI smoke test with `agentcore create --container ./Dockerfile.custom`, verifying the Dockerfile is copied into the generated harness directory and recorded in `harness.json`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.