### PR TITLE
fix(e2e): address failing byo e2e tests. 

### DIFF
--- a/e2e-tests/byo-custom-jwt.test.ts
+++ b/e2e-tests/byo-custom-jwt.test.ts
@@ -38,6 +38,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 const hasAws = hasAwsCredentials();
 const canRun = prereqs.npm && prereqs.git && prereqs.uv && hasAws;
 const region = process.env.AWS_REGION ?? 'us-east-1';
+const customJWTRejectMsgRegex = /configured for CUSTOM_JWT|[Aa]uthoriz(ation|er).*mismatch|different.*authorization/i;
 
 /**
  * Run the local CLI build without skipping install (needed for deploy).
@@ -61,8 +62,6 @@ describe.sequential('e2e: BYO agent with CUSTOM_JWT auth', () => {
 
   const cognitoClient = new CognitoIdentityProviderClient({ region });
   const cfnClient = new CloudFormationClient({ region });
-
-  const customJWTRejectMsgRegex = /configured for CUSTOM_JWT/i;
 
   /** Fetch a Cognito access token via client_credentials flow. */
   async function fetchCognitoAccessToken(): Promise<string> {

--- a/e2e-tests/byo-custom-jwt.test.ts
+++ b/e2e-tests/byo-custom-jwt.test.ts
@@ -7,11 +7,7 @@
  * - SigV4 invocation is rejected (auth method mismatch)
  * - Status reports the agent as deployed
  *
- * Unlike other E2E tests that use the globally installed CLI, this test uses
- * the local build (`runCLI`) because it exercises unreleased schema and CDK
- * changes. Set CDK_TARBALL to a path to the modified CDK package tarball.
- *
- * Requires: AWS credentials, npm, git, uv, CDK_TARBALL env var.
+ * Requires: AWS credentials, npm, git, uv
  */
 import {
   type RunResult,
@@ -21,6 +17,7 @@ import {
   runCLI,
   stripAnsi,
 } from '../src/test-utils/index.js';
+import { installCdkTarball, writeAwsTargets } from './e2e-helper.js';
 import { CloudFormationClient, GetTemplateCommand } from '@aws-sdk/client-cloudformation';
 import {
   CognitoIdentityProviderClient,
@@ -32,7 +29,6 @@ import {
   DeleteUserPoolCommand,
   DeleteUserPoolDomainCommand,
 } from '@aws-sdk/client-cognito-identity-provider';
-import { execSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -40,8 +36,7 @@ import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 const hasAws = hasAwsCredentials();
-const hasCdkTarball = !!process.env.CDK_TARBALL;
-const canRun = prereqs.npm && prereqs.git && prereqs.uv && hasAws && hasCdkTarball;
+const canRun = prereqs.npm && prereqs.git && prereqs.uv && hasAws;
 const region = process.env.AWS_REGION ?? 'us-east-1';
 
 /**
@@ -66,6 +61,8 @@ describe.sequential('e2e: BYO agent with CUSTOM_JWT auth', () => {
 
   const cognitoClient = new CognitoIdentityProviderClient({ region });
   const cfnClient = new CloudFormationClient({ region });
+
+  const customJWTRejectMsgRegex = /configured for CUSTOM_JWT/i;
 
   /** Fetch a Cognito access token via client_credentials flow. */
   async function fetchCognitoAccessToken(): Promise<string> {
@@ -149,19 +146,8 @@ describe.sequential('e2e: BYO agent with CUSTOM_JWT auth', () => {
     projectPath = createJson.projectPath;
 
     // Write AWS targets
-    const account =
-      process.env.AWS_ACCOUNT_ID ??
-      execSync('aws sts get-caller-identity --query Account --output text').toString().trim();
-    await writeFile(
-      join(projectPath, 'agentcore', 'aws-targets.json'),
-      JSON.stringify([{ name: 'default', account, region }])
-    );
-
-    // Install modified CDK tarball (required for auth fields support)
-    execSync(`npm install -f ${process.env.CDK_TARBALL}`, {
-      cwd: join(projectPath, 'agentcore', 'cdk'),
-      stdio: 'pipe',
-    });
+    await writeAwsTargets(projectPath);
+    installCdkTarball(projectPath);
 
     // ── Add an MCP protocol agent to the same project ──
     mcpAgentName = `E2eMcp${String(Date.now()).slice(-8)}`;
@@ -274,9 +260,9 @@ describe.sequential('e2e: BYO agent with CUSTOM_JWT auth', () => {
 
       // Expect failure due to auth method mismatch (client-side fast-fail or server-side rejection)
       const output = stripAnsi(result.stdout + result.stderr);
-      expect(output).toMatch(
-        /configured for CUSTOM_JWT but no bearer token|[Aa]uthoriz(ation|er).*mismatch|different.*authorization/i
-      );
+
+      expect(result.exitCode, `failure: stderr=${result.stderr}\n\nstdout=${result.stdout}`).not.toBe(0);
+      expect(output).toMatch(customJWTRejectMsgRegex);
     },
     180000
   );
@@ -296,9 +282,7 @@ describe.sequential('e2e: BYO agent with CUSTOM_JWT auth', () => {
 
       const output = stripAnsi(result.stdout + result.stderr);
       // The invoke may fail for other reasons (agent logic), but it should NOT fail with auth mismatch
-      expect(output).not.toMatch(
-        /configured for CUSTOM_JWT but no bearer token|[Aa]uthoriz(ation|er).*mismatch|different.*authorization/i
-      );
+      expect(output).not.toMatch(customJWTRejectMsgRegex);
     },
     180000
   );
@@ -311,9 +295,8 @@ describe.sequential('e2e: BYO agent with CUSTOM_JWT auth', () => {
       const result = await runLocalCLI(['invoke', '--runtime', mcpAgentName, 'list-tools', '--json'], projectPath);
 
       const output = stripAnsi(result.stdout + result.stderr);
-      expect(output).toMatch(
-        /configured for CUSTOM_JWT but no bearer token|[Aa]uthoriz(ation|er).*mismatch|different.*authorization/i
-      );
+      expect(result.exitCode, `failure: stderr=${result.stderr}\n\nstdout=${result.stdout}`).not.toBe(0);
+      expect(output).toMatch(customJWTRejectMsgRegex);
     },
     180000
   );
@@ -331,9 +314,7 @@ describe.sequential('e2e: BYO agent with CUSTOM_JWT auth', () => {
       );
 
       const output = stripAnsi(result.stdout + result.stderr);
-      expect(output).not.toMatch(
-        /configured for CUSTOM_JWT but no bearer token|[Aa]uthoriz(ation|er).*mismatch|different.*authorization/i
-      );
+      expect(output).not.toMatch(customJWTRejectMsgRegex);
     },
     180000
   );
@@ -363,9 +344,7 @@ describe.sequential('e2e: BYO agent with CUSTOM_JWT auth', () => {
       );
 
       const output = stripAnsi(result.stdout + result.stderr);
-      expect(output).not.toMatch(
-        /configured for CUSTOM_JWT but no bearer token|[Aa]uthoriz(ation|er).*mismatch|different.*authorization/i
-      );
+      expect(output).not.toMatch(customJWTRejectMsgRegex);
     },
     180000
   );

--- a/e2e-tests/e2e-helper.ts
+++ b/e2e-tests/e2e-helper.ts
@@ -127,7 +127,7 @@ export function createE2ESuite(cfg: E2EConfig) {
 
       const result = await runAgentCoreCLI(createArgs, testDir);
 
-      expect(result.exitCode, `Create failed: ${result.stderr}`).toBe(0);
+      expect(result.exitCode, `Create failed: stderr=${result.stderr}\n\nstdout=${result.stdout}`).toBe(0);
       const json = parseJsonOutput(result.stdout) as { projectPath: string };
       projectPath = json.projectPath;
 


### PR DESCRIPTION
### Problem 
See https://github.com/aws/agentcore-cli/issues/1441 for failing test information. 

### Solution
- loosen regex and add result assertions. 
- add more detailed logging on failures. 
- avoid always using cdk main for byo tests. 

### Testing 
ran e2e tests via scripts/run-e2e-local.sh. 
```
 ✓  e2e  e2e-tests/strands-bedrock-byo-filesystem.test.ts > e2e: Strands/Bedrock — create → deploy → invoke > deplo
ys to AWS successfully 92511ms
 ✓  e2e  e2e-tests/strands-bedrock-byo-filesystem.test.ts > e2e: Strands/Bedrock — create → deploy → invoke > invok
es the deployed agent 27705ms
 ✓  e2e  e2e-tests/strands-bedrock-byo-filesystem.test.ts > e2e: Strands/Bedrock — create → deploy → invoke > statu
s shows the deployed agent 9672ms
 ✓  e2e  e2e-tests/strands-bedrock-byo-filesystem.test.ts > e2e: Strands/Bedrock — create → deploy → invoke > statu
s looks up agent runtime by ID 8923ms
 ✓  e2e  e2e-tests/strands-bedrock-byo-filesystem.test.ts > e2e: Strands/Bedrock — create → deploy → invoke > logs 
returns entries from the invocation 9960ms
 ✓  e2e  e2e-tests/strands-bedrock-byo-filesystem.test.ts > e2e: Strands/Bedrock — create → deploy → invoke > logs 
supports level filtering 9988ms
 ✓  e2e  e2e-tests/strands-bedrock-byo-filesystem.test.ts > e2e: Strands/Bedrock — create → deploy → invoke > trace
s list succeeds after invocation 2642ms
 ✓  e2e  e2e-tests/byo-custom-jwt.test.ts > e2e: BYO agent with CUSTOM_JWT auth > deploys with CUSTOM_JWT authorize
r configuration 244869ms
 ✓  e2e  e2e-tests/byo-custom-jwt.test.ts > e2e: BYO agent with CUSTOM_JWT auth > rejects SigV4 invocation (auth me
thod mismatch) 6352ms
 ✓  e2e  e2e-tests/byo-custom-jwt.test.ts > e2e: BYO agent with CUSTOM_JWT auth > invokes with bearer token success
fully 6982ms
 ✓  e2e  e2e-tests/byo-custom-jwt.test.ts > e2e: BYO agent with CUSTOM_JWT auth > MCP agent: rejects SigV4 invocati
on (auth method mismatch) 6363ms
 ✓  e2e  e2e-tests/byo-custom-jwt.test.ts > e2e: BYO agent with CUSTOM_JWT auth > MCP agent: lists tools with beare
r token 6535ms
 ✓  e2e  e2e-tests/byo-custom-jwt.test.ts > e2e: BYO agent with CUSTOM_JWT auth > MCP agent: calls tool with bearer
 token 6561ms
 ✓  e2e  e2e-tests/byo-custom-jwt.test.ts > e2e: BYO agent with CUSTOM_JWT auth > status shows the deployed agent 9
435ms

 Test Files  2 passed (2)
      Tests  14 passed (14)
   Start at  17:21:53
   Duration  413.64s (transform 274ms, setup 0ms, import 2.27s, tests 680.94s, environment 0ms)
```