### PR TITLE
fix(invoke): adjust redaction regex to allow words following bearer

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/agentcore",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/agentcore",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -81,6 +81,7 @@
         "eslint-plugin-security": "^4.0.0",
         "husky": "^9.1.7",
         "ink-testing-library": "^4.0.0",
+        "jose": "^6.2.3",
         "lint-staged": "^16.2.7",
         "node-pty": "^1.1.0",
         "prettier": "^3.7.4",
@@ -10904,9 +10905,9 @@
       "license": "MIT"
     },
     "node_modules/jose": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
-      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "eslint-plugin-security": "^4.0.0",
     "husky": "^9.1.7",
     "ink-testing-library": "^4.0.0",
+    "jose": "^6.2.3",
     "lint-staged": "^16.2.7",
     "node-pty": "^1.1.0",
     "prettier": "^3.7.4",

--- a/src/cli/commands/invoke/__tests__/redact-sensitive-text.test.ts
+++ b/src/cli/commands/invoke/__tests__/redact-sensitive-text.test.ts
@@ -1,17 +1,34 @@
 import { redactSensitiveText } from '../command.js';
-import { describe, expect, it } from 'vitest';
+import { SignJWT } from 'jose';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+const TEST_SIGNING_SECRET = new TextEncoder().encode('redaction-unit-test-signing-secret-0123456789');
+
+async function makeJwt(claims: Record<string, unknown> = { sub: '1234567890', aud: 'client-abc' }): Promise<string> {
+  return new SignJWT(claims)
+    .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
+    .setIssuedAt()
+    .setExpirationTime('1h')
+    .sign(TEST_SIGNING_SECRET);
+}
 
 describe('redactSensitiveText', () => {
+  let jwt: string;
+
+  beforeAll(async () => {
+    jwt = await makeJwt();
+  });
+
   it('redacts Bearer tokens', () => {
-    expect(redactSensitiveText('Authorization: Bearer eyJhbGciOiJSUzI1NiJ9.payload.sig')).toBe(
-      'Authorization: Bearer [REDACTED]'
-    );
+    expect(redactSensitiveText(`Authorization: Bearer ${jwt}`)).toBe('Authorization: Bearer [REDACTED]');
   });
 
   it('redacts Bearer tokens in JSON', () => {
-    expect(redactSensitiveText('{"header":"Bearer eyJhbGciOiJSUzI1NiJ9.payload.sig"}')).toBe(
-      '{"header":"Bearer [REDACTED]"}'
-    );
+    expect(redactSensitiveText(`{"header":"Bearer ${jwt}"}`)).toBe('{"header":"Bearer [REDACTED]"}');
+  });
+
+  it('redacts a JWT by shape even without a "bearer"/key prefix', () => {
+    expect(redactSensitiveText(`agent response: ${jwt}`)).toBe('agent response: [REDACTED]');
   });
 
   it('redacts client_secret in key=value form', () => {
@@ -38,13 +55,24 @@ describe('redactSensitiveText', () => {
     expect(redactSensitiveText('client-secret=mysecret')).toBe('client-secret=[REDACTED]');
   });
 
+  it('handles multiple sensitive values in one string', () => {
+    expect(redactSensitiveText(`Bearer ${jwt} and client_secret=xyz789`)).toBe(
+      'Bearer [REDACTED] and client_secret=[REDACTED]'
+    );
+  });
+
   it('does not modify text without sensitive content', () => {
     const input = 'Agent responded successfully with 200 OK';
     expect(redactSensitiveText(input)).toBe(input);
   });
 
-  it('handles multiple sensitive values in one string', () => {
-    const input = 'Bearer abc123 and client_secret=xyz789';
-    expect(redactSensitiveText(input)).toBe('Bearer [REDACTED] and client_secret=[REDACTED]');
+  it('does not redact the literal word "token" after "bearer"', () => {
+    const input = "Agent 'E2eJwt123' is configured for CUSTOM_JWT but no bearer token is available.";
+    expect(redactSensitiveText(input)).toBe(input);
+  });
+
+  it('does not redact prose like "Invalid Bearer Token"', () => {
+    const input = 'Invalid Bearer Token';
+    expect(redactSensitiveText(input)).toBe(input);
   });
 });

--- a/src/cli/commands/invoke/command.tsx
+++ b/src/cli/commands/invoke/command.tsx
@@ -82,10 +82,16 @@ async function handleInvokeCLI(options: InvokeOptions, preloadedContext?: Invoke
 }
 
 export function redactSensitiveText(value: string): string {
-  return value
-    .replace(/(bearer\s+)[a-z0-9\-._~+/]+=*/gi, '$1[REDACTED]')
-    .replace(/(client[_-]?secret["']?\s*[:=]\s*["']?)([^"',\s}]+)/gi, '$1[REDACTED]')
-    .replace(/((?:access[_-]?)?token["']?\s*[:=]\s*["']?)([^"',\s}]+)/gi, '$1[REDACTED]');
+  return (
+    value
+      // AgentCore inbound bearer tokens are always CUSTOM_JWT/OIDC JWTs, and a JWT always begins
+      // with `eyJ` (base64url of `{"`, the start of its header/payload JSON). Matching by shape
+      // redacts the token wherever it appears and never touches prose like "bearer token".
+      // See https://stackoverflow.com/a/74181595 (why JWTs start with `eyJ`).
+      .replace(/eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g, '[REDACTED]')
+      .replace(/(client[_-]?secret["']?\s*[:=]\s*["']?)([^"',\s}]+)/gi, '$1[REDACTED]')
+      .replace(/((?:access[_-]?)?token["']?\s*[:=]\s*["']?)([^"',\s}]+)/gi, '$1[REDACTED]')
+  );
 }
 
 function printInvokeResult(result: InvokeResult, options: InvokeOptions): void {


### PR DESCRIPTION
## Description

See https://github.com/aws/agentcore-cli/issues/1479. The fix is to leverage the shape of JWT instead of a bearer prefix for redaction. 

This relies on AgentCore inbound auth only accepting JWT, and not arbitrary bearer tokens. 

Tests create an actual JWT (pull in jose as dev dependency) to verify the pattern matching is working as expected. 
## Related Issue

<!-- Every PR must be associated with an issue. Link it below using #issue-number format. -->

Closes #

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Check all that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:unit` and `npm run test:integ`
- [ ] I ran `npm run typecheck`
- [ ] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
