### PR TITLE
feat(ci): shard integ tests for faster runs. 

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,7 +43,6 @@ jobs:
         uses: astral-sh/setup-uv@v7
       - run: npm ci
       - run: npm run build --if-present
-      - run: npm run test:integ
       - name: Pack tarball
         if: matrix.node-version == '20.x'
         run: npm pack
@@ -62,6 +61,35 @@ jobs:
         with:
           name: tarball
           path: '*.tgz'
+
+  integ-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          ${{ github.event_name == 'pull_request' && fromJSON('["20.x"]') || fromJSON('["20.x", "22.x", "24.x"]') }}
+        shard: [1/2, 2/2]
+
+    steps:
+      - uses: actions/checkout@v6
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+      - name: Configure git for tests
+        run: |
+          git config --global user.email "bedrock-agentcore-npm+ci@amazon.com"
+          git config --global user.name "CI"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      - run: npm ci
+      - run: npm run build --if-present
+      - name: Run integration tests (shard ${{ matrix.shard }})
+        run: npx vitest run --project integ --shard=${{ matrix.shard }}
 
   unit-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -37,7 +37,7 @@ jobs:
           cache: 'npm'
       - name: Configure git for tests
         run: |
-          git config --global user.email "bedrock-agentcore-npm+ci@amazon.com"
+          git config --global user.email "ci@amazon.com"
           git config --global user.name "CI"
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -71,7 +71,7 @@ jobs:
       matrix:
         node-version:
           ${{ github.event_name == 'pull_request' && fromJSON('["20.x"]') || fromJSON('["20.x", "22.x", "24.x"]') }}
-        shard: [1/2, 2/2]
+        shard: [1/4, 2/4, 3/4, 4/4]
 
     steps:
       - uses: actions/checkout@v6
@@ -82,7 +82,7 @@ jobs:
           cache: 'npm'
       - name: Configure git for tests
         run: |
-          git config --global user.email "bedrock-agentcore-npm+ci@amazon.com"
+          git config --global user.email "ci@amazon.com"
           git config --global user.name "CI"
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -111,7 +111,7 @@ jobs:
           cache: 'npm'
       - name: Configure git for tests
         run: |
-          git config --global user.email "bedrock-agentcore-npm+ci@amazon.com"
+          git config --global user.email "ci@amazon.com"
           git config --global user.name "CI"
       - name: Install uv
         uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
### Problem 
Integ tests have become the bottleneck on PR CI runs. 
https://github.com/aws/agentcore-cli/issues/1487
### Solution
- shard them across 4 runners. 
- also centralize on same git email that e2e tests use. 

### Testing
- see tests on PR. No sharding took 11 min, sharding took: 4 min 50 sec. over 50% reduction. 