### PR TITLE
fix(ci): avoid formatting lock file

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 CHANGELOG.md
+npm-shrinkwrap.json
 src/assets/**/*.md
 .github/scripts/prompts/
 src/assets/**/*.ts


### PR DESCRIPTION
### Problem 
See https://github.com/aws/agentcore-cli/issues/1488, formatter is running on generated file causing dependabot PRs to fail CI. Since the file is generated, this check will always fail on updating, causing noise in CI and pre-commit. 

### Solution
- add shrinkwrap to prettier ignore file. 

### Testing 
```
# regenerated the file
npm shrinkwrap
npm run format:check 
# I see the failure here. 
# update the .prettierignore
npm run format:check
# now it passes
```