### PR TITLE
chore(ci): add longer timeout and retries for deploying memory

### DIFF
--- a/e2e-tests/e2e-helper.ts
+++ b/e2e-tests/e2e-helper.ts
@@ -143,9 +143,10 @@ export function createE2ESuite(cfg: E2EConfig) {
     }, 600000);
 
     // Container builds go through CodeBuild which is slower and more prone to transient failures.
+    // Memory deployment time can be flaky and take at least 3-5 minutes.
     const isContainerBuild = cfg.build === 'Container';
-    const deployRetries = isContainerBuild ? 3 : 1;
-    const deployTimeout = isContainerBuild ? 900000 : 600000;
+    const deployRetries = isContainerBuild || cfg.memory ? 3 : 1;
+    const deployTimeout = isContainerBuild || cfg.memory ? 900000 : 600000;
 
     it.skipIf(!canRun)(
       'deploys to AWS successfully',


### PR DESCRIPTION
### Problem 
https://github.com/aws/agentcore-cli/issues/1490

Flaky test failure, since it passed on the next run. 

```
 ×  e2e  e2e-tests/strands-bedrock-memory.test.ts > e2e: Strands/Bedrock — create → deploy → invoke > deploys to AWS successfully 600106ms
   → Test timed out in 600000ms.
```

### Solution
- bump the timeout and retries for memory, using the same mechanism as container. 