### PR TITLE
fix(ci): limit e2e tests to cdk mainline

### DIFF
--- a/.github/workflows/e2e-tests-full.yml
+++ b/.github/workflows/e2e-tests-full.yml
@@ -29,7 +29,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cdk-source: [npm, main]
         shard: ['1/6', '2/6', '3/6', '4/6', '5/6', '6/6']
     steps:
       - uses: actions/checkout@v6
@@ -61,7 +60,6 @@ jobs:
       - run: npm ci
       - run: npm run build
       - name: Generate GitHub App Token
-        if: matrix.cdk-source == 'main'
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
@@ -69,7 +67,6 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: aws
       - name: Build CDK package from main
-        if: matrix.cdk-source == 'main'
         run: |
           git clone --depth 1 "https://x-access-token:${CDK_REPO_TOKEN}@github.com/${CDK_REPO}.git" /tmp/cdk-repo
           cd /tmp/cdk-repo
@@ -82,7 +79,7 @@ jobs:
           CDK_REPO: ${{ secrets.CDK_REPO_NAME }}
       - name: Install CLI globally
         run: npm install -g "$(npm pack | tail -1)"
-      - name: Run E2E tests (${{ matrix.cdk-source }}, shard ${{ matrix.shard }})
+      - name: Run E2E tests (shard ${{ matrix.shard }})
         env:
           AWS_ACCOUNT_ID: ${{ steps.aws.outputs.account_id }}
           AWS_REGION: ${{ inputs.aws_region || 'us-east-1' }}


### PR DESCRIPTION
### Problem 
https://github.com/aws/agentcore-cli/issues/1494

We receive intermittent 403s on control plane calls. The clients do not retry, since 403 is treated as non-retryable and the tests fail. Usually retrying fixes the issue. 

Looking deeper, we don't see these request in CloudTrail, suggesting they are getting rejected before hitting the service at the edge. Given that we have both added significantly more tests recently, and run it across 12 runners, means we could be hammering those APIs, and get rate limited. The current evidence suggests this is the most likely cause. 

### Solution
- remove 6 runners by only testing against main.  The primary use case for testing against npm is for knowing if the current CLI requires the newer CDK changes, which isn't very useful since we always release the CDK first. If we determine we still need this functionality, we can consider adding an optional workflow dispatch override for testing against non-main branch, allowing us to test on latest release manually.  
- This cuts are API reqs in half and should significantly reduce the amount of API calls we make, and hopefully reduce the throttling. If this does not reduce the 403s, we can revert this and continue to investigate. 

