### PR TITLE
fix(scripts): avoid overwriting git local config in e2e script

### DIFF
--- a/scripts/run-e2e-local.sh
+++ b/scripts/run-e2e-local.sh
@@ -88,11 +88,21 @@ echo "=== Setting AWS account env var ==="
 export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 echo "✅ AWS_ACCOUNT_ID=$AWS_ACCOUNT_ID  AWS_REGION=$AWS_REGION"
 
-echo "=== Configuring git (required for agentcore create) ==="
-git config --global user.email "ci@local" 2>/dev/null || true
-git config --global user.name "Local E2E" 2>/dev/null || true
-
 cd "$REPO_ROOT"
+
+echo "=== Verifying git is configured (required for agentcore create) ==="
+git_email="$(git config --global user.email || true)"
+git_name="$(git config --global user.name || true)"
+
+if [ -z "$git_email" ] || [ -z "$git_name" ]; then
+  echo "ERROR: git is not configured. 'agentcore create' requires a global git identity." >&2
+  echo "Set it with:" >&2
+  echo "  git config --global user.email \"you@example.com\"" >&2
+  echo "  git config --global user.name \"Your Name\"" >&2
+  exit 1
+fi
+
+echo "git configured as: $git_name <$git_email>"
 
 echo "=== Installing dependencies ==="
 npm ci


### PR DESCRIPTION
### Problem 
The local e2e test script overwrites my git config, adding a testing name for `user.name` and `user.email`. This persists after running the script and causes commits to be coauthored by local e2e. 

Example: https://github.com/aws/agentcore-cli/commit/6c57e789915c8455b0976b6f3bb17b19ad63c211

### Solution
Remove the git config override and replace it with a warning if git is not configured. Any engineer running this would likely have git configured, but just in case we fail early. 

### Testing 
Ran locally:
```
=== Assuming IAM role ===
✅ Assumed role successfully
=== Fetching API keys from Secrets Manager ===
✅ Secrets loaded (keys present: ANTHROPIC_API_KEY, CDP_API_KEY_ID, CDP_API_KEY_SECRET, CDP_WALLET_SECRET, EFS_ACCESS_POINT_ARN, FILESYSTEM_SECURITY_GROUP_ID, FILESYSTEM_SUB
NET_ID, GEMINI_API_KEY, OPENAI_API_KEY, S3_ACCESS_POINT_ARN
=== Setting AWS account env var ===
✅ AWS_ACCOUNT_ID=685197708687  AWS_REGION=us-east-1
=== Verifying git is configured (required for agentcore create) ===
git configured as: Hweinstock <hkobew@amazon.com>
=== Installing dependencies ===
```