### PR TITLE
feat(e2e): enable gemini tests

### DIFF
--- a/e2e-tests/googleadk-gemini.test.ts
+++ b/e2e-tests/googleadk-gemini.test.ts
@@ -1,3 +1,3 @@
 import { createE2ESuite } from './e2e-helper.js';
 
-createE2ESuite({ framework: 'GoogleADK', modelProvider: 'Gemini', apiKeyEnvVar: 'GEMINI_API_KEY', skipInvoke: true });
+createE2ESuite({ framework: 'GoogleADK', modelProvider: 'Gemini', apiKeyEnvVar: 'GEMINI_API_KEY' });

--- a/e2e-tests/harness-gemini.test.ts
+++ b/e2e-tests/harness-gemini.test.ts
@@ -4,5 +4,4 @@ createHarnessE2ESuite({
   modelProvider: 'gemini',
   apiKeyEnvVar: 'GEMINI_API_KEY_ARN',
   skipMemory: true,
-  skipInvoke: true,
 });

--- a/e2e-tests/langgraph-gemini.test.ts
+++ b/e2e-tests/langgraph-gemini.test.ts
@@ -4,5 +4,4 @@ createE2ESuite({
   framework: 'LangChain_LangGraph',
   modelProvider: 'Gemini',
   apiKeyEnvVar: 'GEMINI_API_KEY',
-  skipInvoke: true,
 });

--- a/e2e-tests/strands-gemini.test.ts
+++ b/e2e-tests/strands-gemini.test.ts
@@ -1,3 +1,3 @@
 import { createE2ESuite } from './e2e-helper.js';
 
-createE2ESuite({ framework: 'Strands', modelProvider: 'Gemini', apiKeyEnvVar: 'GEMINI_API_KEY', skipInvoke: true });
+createE2ESuite({ framework: 'Strands', modelProvider: 'Gemini', apiKeyEnvVar: 'GEMINI_API_KEY' });


### PR DESCRIPTION
### Problem 
https://github.com/aws/agentcore-cli/issues/1435
Billing issue has since been fixed, we can re-enable. 

### Solution
- re-enable gemini invokes by removing the skipInvoke flag. 

### Testing 
Ran a smoke test with the key: https://ai.google.dev/api/models#models_list-SHELL, and its now working. 
