### PR TITLE
fix(e2e): wire up payments env vars for full test suite

### DIFF
--- a/.github/workflows/e2e-tests-full.yml
+++ b/.github/workflows/e2e-tests-full.yml
@@ -92,6 +92,10 @@ jobs:
           E2E_FILESYSTEM_SUBNET_ID: ${{ env.E2E_FILESYSTEM_SUBNET_ID }}
           E2E_FILESYSTEM_SECURITY_GROUP_ID: ${{ env.E2E_FILESYSTEM_SECURITY_GROUP_ID }}
           CDK_TARBALL: ${{ env.CDK_TARBALL }}
+          CDP_API_KEY_ID: ${{ env.E2E_CDP_API_KEY_ID }}
+          CDP_API_KEY_SECRET: ${{ env.E2E_CDP_API_KEY_SECRET }}
+          CDP_WALLET_SECRET: ${{ env.E2E_CDP_WALLET_SECRET }}
+
         run: npx vitest run --project e2e --shard=${{ matrix.shard }}
   browser-tests:
     runs-on: ubuntu-latest

--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -42,6 +42,8 @@ Attach this to every IAM user or role that will run AgentCore CLI commands. The 
 - `bedrock-agentcore:Invoke*`, `bedrock-agentcore:Get*`, `bedrock-agentcore:List*` for invoking agents and checking
   status
 - Credential provider and token vault actions for `deploy` when the project uses identity features
+- Payment credential provider and payment session actions for `deploy`, `status`, and `invoke` when the project uses
+  payment connectors
 - CloudWatch Logs, X-Ray, and Application Signals actions for `logs`, `traces`, and observability setup
 - Bedrock actions for agent import and AI-assisted code generation (optional, see
   [Scoping down by feature](#scoping-down-by-feature))
@@ -172,6 +174,7 @@ safely removed:
 | Filesystem mounts (EFS/S3)      | `FilesystemNetworkValidation`                                        | _(no change)_                                                                                          |
 | AI-assisted code generation     | `BedrockModelInvocation`                                             | _(no change)_                                                                                          |
 | Identity/credential providers   | `IdentityCredentialManagement`, `TokenVaultKmsKeyCreation`           | `SecretsManagerForCredentials`                                                                         |
+| Payment connectors              | `PaymentCredentialManagement`, `PaymentCredentialSecrets`            | _(no change)_                                                                                          |
 | Policy engine                   | `PolicyGeneration`                                                   | Remove `*PolicyEngine*` and `*Policy` actions from `BedrockAgentCoreResources`                         |
 | Online evaluations              | Remove `UpdateOnlineEvaluationConfig` from `AgentCoreResourceStatus` | Remove `*OnlineEvaluationConfig*` actions from `BedrockAgentCoreResources`                             |
 
@@ -383,6 +386,36 @@ These EC2 and EFS `Describe*` actions do not support resource-level scoping, so 
 | `bedrock-agentcore:SetTokenVaultCMK`               | `deploy`     | Configure KMS encryption for token vault  |
 | `kms:CreateKey`                                    | `deploy`     | Create KMS key for token vault encryption |
 | `kms:TagResource`                                  | `deploy`     | Tag the created KMS key                   |
+
+### Payment credential management
+
+Required only when the project defines payment managers and connectors (the `payments` block in the project spec). The
+CLI calls the Payment control-plane and data-plane APIs directly with the developer's credentials; both are signed under
+the `bedrock-agentcore` service.
+
+| Action                                              | CLI Commands | Purpose                                                              |
+| --------------------------------------------------- | ------------ | -------------------------------------------------------------------- |
+| `bedrock-agentcore:GetPaymentCredentialProvider`    | `deploy`     | Check if a payment credential provider already exists                |
+| `bedrock-agentcore:CreatePaymentCredentialProvider` | `deploy`     | Create a payment credential provider from connector secrets          |
+| `bedrock-agentcore:UpdatePaymentCredentialProvider` | `deploy`     | Update a payment credential provider with new secret values          |
+| `bedrock-agentcore:DeletePaymentCredentialProvider` | `deploy`     | Remove a payment credential provider when a connector is removed     |
+| `bedrock-agentcore:GetPaymentManager`               | `status`     | Look up payment manager status                                       |
+| `bedrock-agentcore:ListPaymentSessions`             | `invoke`     | Find an existing active payment session before creating a new one    |
+| `bedrock-agentcore:CreatePaymentSession`            | `invoke`     | Create a payment session with a default budget for `invoke` auto-pay |
+
+Creating or updating a payment credential provider also writes the connector secrets into a service-managed Secrets
+Manager secret (named `bedrock-agentcore-identity!default/payment/*`). Unlike API key and OAuth2 providers, the Payment
+API performs these Secrets Manager operations with the **caller's** credentials, so the developer policy must allow them
+directly. These actions are scoped to the managed payment secret prefix.
+
+| Action                          | CLI Commands | Purpose                                                         |
+| ------------------------------- | ------------ | --------------------------------------------------------------- |
+| `secretsmanager:CreateSecret`   | `deploy`     | Create the managed secret backing a new payment credential      |
+| `secretsmanager:PutSecretValue` | `deploy`     | Write updated connector secret values when a credential changes |
+| `secretsmanager:GetSecretValue` | `deploy`     | Read the managed secret during provider create/update           |
+| `secretsmanager:DescribeSecret` | `deploy`     | Inspect the managed secret metadata                             |
+| `secretsmanager:TagResource`    | `deploy`     | Tag the managed secret on creation                              |
+| `secretsmanager:DeleteSecret`   | `deploy`     | Remove the managed secret when a payment connector is removed   |
 
 ### Policy generation
 

--- a/docs/policies/iam-policy-user.json
+++ b/docs/policies/iam-policy-user.json
@@ -88,6 +88,33 @@
       "Resource": "*"
     },
     {
+      "Sid": "PaymentCredentialManagement",
+      "Effect": "Allow",
+      "Action": [
+        "bedrock-agentcore:GetPaymentCredentialProvider",
+        "bedrock-agentcore:CreatePaymentCredentialProvider",
+        "bedrock-agentcore:UpdatePaymentCredentialProvider",
+        "bedrock-agentcore:DeletePaymentCredentialProvider",
+        "bedrock-agentcore:GetPaymentManager",
+        "bedrock-agentcore:ListPaymentSessions",
+        "bedrock-agentcore:CreatePaymentSession"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "PaymentCredentialSecrets",
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:CreateSecret",
+        "secretsmanager:PutSecretValue",
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:DescribeSecret",
+        "secretsmanager:TagResource",
+        "secretsmanager:DeleteSecret"
+      ],
+      "Resource": "arn:aws:secretsmanager:*:ACCOUNT_ID:secret:bedrock-agentcore-identity!default/payment/*"
+    },
+    {
       "Sid": "PolicyGeneration",
       "Effect": "Allow",
       "Action": [

--- a/e2e-tests/payment-strands-bedrock.test.ts
+++ b/e2e-tests/payment-strands-bedrock.test.ts
@@ -201,7 +201,6 @@ describe.sequential('e2e: payments — create → add payment → deploy → sta
     expect(managerState.managerArn).toBeTruthy();
     expect(managerState.processPaymentRoleArn).toBeTruthy();
     expect(managerState.resourceRetrievalRoleArn).toBeTruthy();
-    expect(managerState.roleCreatedByCli).toBe(true);
 
     // Connector info
     const connectors = managerState.connectors as Record<string, Record<string, unknown>>;

--- a/e2e-tests/payment-strands-bedrock.test.ts
+++ b/e2e-tests/payment-strands-bedrock.test.ts
@@ -11,6 +11,7 @@
  */
 import { hasAwsCredentials, parseJsonOutput, prereqs, retry } from '../src/test-utils/index.js';
 import { installCdkTarball, runAgentCoreCLI, teardownE2EProject, writeAwsTargets } from './e2e-helper.js';
+import { type Logger, getLogger } from './utils/logger.js';
 import { randomUUID } from 'node:crypto';
 import { mkdir, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -25,12 +26,16 @@ describe.sequential('e2e: payments — create → add payment → deploy → sta
   let testDir: string;
   let projectPath: string;
   let agentName: string;
+  let logger: Logger;
   const managerName = 'E2ePayMgr';
   const connectorName = 'E2ePayConn';
 
   beforeAll(async () => {
-    if (!canRun) return;
-
+    logger = getLogger('payments-strands-bedrock');
+    if (!canRun) {
+      logger.warn(`tests are skipped due to insufficient conditions. hasCdpCreds=${hasCdpCreds}, hasAws=${hasAws}`);
+      return;
+    }
     testDir = join(tmpdir(), `agentcore-e2e-pay-${randomUUID()}`);
     await mkdir(testDir, { recursive: true });
 
@@ -146,8 +151,8 @@ describe.sequential('e2e: payments — create → add payment → deploy → sta
           const result = await runAgentCoreCLI(['deploy', '--yes', '--json'], projectPath);
 
           if (result.exitCode !== 0) {
-            console.log('Deploy stdout:', result.stdout);
-            console.log('Deploy stderr:', result.stderr);
+            logger.error(`deploy stdout=${result.stdout}`);
+            logger.error(`deploy stderr=${result.stderr}`);
           }
 
           expect(result.exitCode, `Deploy failed: ${result.stderr}`).toBe(0);

--- a/scripts/run-e2e-local.sh
+++ b/scripts/run-e2e-local.sh
@@ -3,7 +3,8 @@
 #
 # Required env vars:
 #   E2E_ROLE_ARN    — IAM role ARN to assume (grants access to the test account)
-#   E2E_SECRET_ARN  — Secrets Manager ARN containing ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY
+#   E2E_SECRET_ARN  — Secrets Manager ARN containing ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY,
+#                     and (for payments tests) CDP_API_KEY_ID, CDP_API_KEY_SECRET, CDP_WALLET_SECRET
 #
 # Optional env vars:
 #   AWS_REGION      — defaults to us-east-1
@@ -81,6 +82,11 @@ export E2E_EFS_ACCESS_POINT_ARN=$(echo "$SECRET_JSON" | jq -r '.EFS_ACCESS_POINT
 export E2E_S3_ACCESS_POINT_ARN=$(echo "$SECRET_JSON" | jq -r '.S3_ACCESS_POINT_ARN // empty')
 export E2E_FILESYSTEM_SUBNET_ID=$(echo "$SECRET_JSON" | jq -r '.FILESYSTEM_SUBNET_ID // empty')
 export E2E_FILESYSTEM_SECURITY_GROUP_ID=$(echo "$SECRET_JSON" | jq -r '.FILESYSTEM_SECURITY_GROUP_ID // empty')
+
+# Payments (CDP) test inputs — required by payment-strands-bedrock.test.ts.
+export CDP_API_KEY_ID=$(echo "$SECRET_JSON" | jq -r '.CDP_API_KEY_ID // empty')
+export CDP_API_KEY_SECRET=$(echo "$SECRET_JSON" | jq -r '.CDP_API_KEY_SECRET // empty')
+export CDP_WALLET_SECRET=$(echo "$SECRET_JSON" | jq -r '.CDP_WALLET_SECRET // empty')
 
 echo "✅ Secrets loaded (keys present: $(echo "$SECRET_JSON" | jq -r 'keys | join(", ")')"
 


### PR DESCRIPTION
### Problem 
Payments tests are silently skipped on full e2e test runs and may fail.
https://github.com/aws/agentcore-cli/issues/1504

The permissions are also missing from the e2e test role and documentation. 


### Solution
- wire up the necessary env vars to get payments to run. copying what was done here: https://github.com/aws/agentcore-cli/blob/9966e9d26fadeb04b6932c850582bd9a0f8d6847/.github/workflows/e2e-tests.yml#L161-L164. 
- add a clear logging message to make it clear when test is skipped. 
- update local testing script. 
- update ci role and documentation. 

### Testing 
ran e2e tests locally. 

```
More information can be found at: https://a.co/c895JFp
(Use `node --trace-warnings ...` to show where the warning was created)
[global-setup:stack-cleanup]:found 2 stacks
[global-setup:stack-cleanup]:deleting 2 stacks with names=AgentCore-E2eVercBedr99070720-default,AgentCore-E2eStraBedr98918939-default
[global-setup:stack-cleanup]:deleting stack with name AgentCore-E2eVercBedr99070720-default
[global-setup:stack-cleanup]:deleting stack with name AgentCore-E2eStraBedr98918939-default
[global-setup:stack-cleanup]:finished deleting stack in 15.072 seconds
[global-setup:stack-cleanup]:finished deleting stack in 37.354 seconds
[global-setup:stack-cleanup]:deleted 2 of 2 remaining stacks
[global-setup]:done cleaning up stacks after 37.667 seconds
[global-setup]:cleaning up stale credential providers...
[global-setup]:setup finished in 37.743 seconds
 ✓  e2e  e2e-tests/payment-strands-bedrock.test.ts > e2e: payments — create → add payment → deploy → status > has correct agentcore.json structure 2ms
 ✓  e2e  e2e-tests/payment-strands-bedrock.test.ts > e2e: payments — create → add payment → deploy → status > has payment capability code in agent 1ms
 ✓  e2e  e2e-tests/payment-strands-bedrock.test.ts > e2e: payments — create → add payment → deploy → status > deploys to AWS successfully 107518ms
 ✓  e2e  e2e-tests/payment-strands-bedrock.test.ts > e2e: payments — create → add payment → deploy → status > status shows payment manager 9655ms
 ✓  e2e  e2e-tests/payment-strands-bedrock.test.ts > e2e: payments — create → add payment → deploy → status > deployed-state.json has payment manager and connector info 1ms

 Test Files  1 passed (1)
      Tests  5 passed (5)
   Start at  16:50:15
   Duration  237.47s (transform 145ms, setup 0ms, import 1.24s, tests 196.37s, environment 0ms)
```