### PR TITLE
fix(e2e): add harness tests to e2e workflow

### DIFF
--- a/.github/workflows/e2e-tests-full.yml
+++ b/.github/workflows/e2e-tests-full.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         cli-build: [preview, ga]
-        shard: ['1/6', '2/6', '3/6', '4/6', '5/6', '6/6']
+        shard: ['1/5', '2/5', '3/5', '4/5', '5/5']
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/e2e-tests-full.yml
+++ b/.github/workflows/e2e-tests-full.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cdk-source: [npm, main]
+        cli-build: [preview, ga]
         shard: ['1/6', '2/6', '3/6', '4/6', '5/6', '6/6']
     steps:
       - uses: actions/checkout@v6
@@ -57,9 +57,11 @@ jobs:
             E2E,${{ secrets.E2E_SECRET_ARN }}
           parse-json-secrets: true
       - run: npm ci
-      - run: npm run build
+      - name: Build CLI (${{ matrix.cli-build }})
+        run: npm run build
+        env:
+          BUILD_PREVIEW: ${{ matrix.cli-build == 'preview' && '1' || '0' }}
       - name: Generate GitHub App Token
-        if: matrix.cdk-source == 'main'
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
@@ -67,7 +69,6 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: aws
       - name: Build CDK package from main
-        if: matrix.cdk-source == 'main'
         run: |
           git clone --depth 1 "https://x-access-token:${CDK_REPO_TOKEN}@github.com/${CDK_REPO}.git" /tmp/cdk-repo
           cd /tmp/cdk-repo
@@ -80,7 +81,7 @@ jobs:
           CDK_REPO: ${{ secrets.CDK_REPO_NAME }}
       - name: Install CLI globally
         run: npm install -g "$(npm pack | tail -1)"
-      - name: Run E2E tests (${{ matrix.cdk-source }}, shard ${{ matrix.shard }})
+      - name: Run E2E tests (${{ matrix.cli-build }}, shard ${{ matrix.shard }})
         env:
           AWS_ACCOUNT_ID: ${{ steps.aws.outputs.account_id }}
           AWS_REGION: ${{ inputs.aws_region || 'us-east-1' }}
@@ -95,6 +96,7 @@ jobs:
           CDP_API_KEY_ID: ${{ env.E2E_CDP_API_KEY_ID }}
           CDP_API_KEY_SECRET: ${{ env.E2E_CDP_API_KEY_SECRET }}
           CDP_WALLET_SECRET: ${{ env.E2E_CDP_WALLET_SECRET }}
+          BUILD_PREVIEW: ${{ matrix.cli-build == 'preview' && '1' || '0' }}
 
         run: npx vitest run --project e2e --shard=${{ matrix.shard }}
   browser-tests:

--- a/e2e-tests/harness-e2e-helper.ts
+++ b/e2e-tests/harness-e2e-helper.ts
@@ -15,13 +15,14 @@ const baseCanRun = prereqs.npm && prereqs.git && hasAws && isPreviewBuild;
 
 interface HarnessE2EConfig {
   modelProvider: 'bedrock' | 'open_ai' | 'gemini';
-  apiKeyEnvVar?: string;
+  /** Env var holding the API key ARN — its value is passed as --api-key-arn. */
+  apiKeyArnEnvVar?: string;
   skipMemory?: boolean;
   skipInvoke?: boolean;
 }
 
 export function createHarnessE2ESuite(cfg: HarnessE2EConfig) {
-  const hasRequiredVar = !cfg.apiKeyEnvVar || !!process.env[cfg.apiKeyEnvVar];
+  const hasRequiredVar = !cfg.apiKeyArnEnvVar || !!process.env[cfg.apiKeyArnEnvVar];
   const canRun = baseCanRun && hasRequiredVar;
 
   const providerLabel =
@@ -62,8 +63,8 @@ export function createHarnessE2ESuite(cfg: HarnessE2EConfig) {
         '--skip-git',
       ];
 
-      if (cfg.apiKeyEnvVar && process.env[cfg.apiKeyEnvVar]) {
-        createArgs.push('--api-key-arn', process.env[cfg.apiKeyEnvVar]!);
+      if (cfg.apiKeyArnEnvVar && process.env[cfg.apiKeyArnEnvVar]) {
+        createArgs.push('--api-key-arn', process.env[cfg.apiKeyArnEnvVar]!);
       }
 
       if (cfg.skipMemory) {

--- a/e2e-tests/harness-e2e-helper.ts
+++ b/e2e-tests/harness-e2e-helper.ts
@@ -27,8 +27,7 @@ export function createHarnessE2ESuite(cfg: HarnessE2EConfig) {
   const providerLabel =
     cfg.modelProvider === 'open_ai' ? 'OpenAI' : cfg.modelProvider === 'gemini' ? 'Gemini' : 'Bedrock';
 
-  // Logged at collection time (not in beforeAll, which Vitest skips when every test in the
-  // suite is skipped) so the skip reason is always surfaced.
+  // note: this is created outside of beforeAll since beforeAll is skipped if all tests are skipped.
   const logger = getLogger(`harness-${providerLabel.toLowerCase()}`);
   if (!canRun) {
     logger.warn(
@@ -98,12 +97,7 @@ export function createHarnessE2ESuite(cfg: HarnessE2EConfig) {
           async () => {
             const result = await runAgentCoreCLI(['deploy', '--yes', '--json'], projectPath);
 
-            if (result.exitCode !== 0) {
-              console.log('Deploy stdout:', result.stdout);
-              console.log('Deploy stderr:', result.stderr);
-            }
-
-            expect(result.exitCode, `Deploy failed (stderr: ${result.stderr}, stdout: ${result.stdout})`).toBe(0);
+            expect(result.exitCode, `Deploy failed stderr=${result.stderr}, stdout=${result.stdout}`).toBe(0);
 
             const json = parseJsonOutput(result.stdout) as { success: boolean };
             expect(json.success, 'Deploy should report success').toBe(true);
@@ -127,12 +121,7 @@ export function createHarnessE2ESuite(cfg: HarnessE2EConfig) {
               projectPath
             );
 
-            if (result.exitCode !== 0) {
-              console.log('Invoke stdout:', result.stdout);
-              console.log('Invoke stderr:', result.stderr);
-            }
-
-            expect(result.exitCode, `Invoke failed: ${result.stderr}`).toBe(0);
+            expect(result.exitCode, `Invoke failed: stderr=${result.stderr}, stdout=${result.stdout}`).toBe(0);
 
             const json = parseJsonOutput(result.stdout) as { success: boolean };
             expect(json.success, 'Invoke should report success').toBe(true);

--- a/e2e-tests/harness-e2e-helper.ts
+++ b/e2e-tests/harness-e2e-helper.ts
@@ -1,6 +1,7 @@
 import { getHarness } from '../src/cli/aws/agentcore-harness.js';
 import { hasAwsCredentials, parseJsonOutput, prereqs, retry, spawnAndCollect } from '../src/test-utils/index.js';
 import { installCdkTarball, runAgentCoreCLI, teardownE2EProject, writeAwsTargets } from './e2e-helper.js';
+import { getLogger } from './utils/logger.js';
 import { randomUUID } from 'node:crypto';
 import { mkdir, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -25,6 +26,17 @@ export function createHarnessE2ESuite(cfg: HarnessE2EConfig) {
 
   const providerLabel =
     cfg.modelProvider === 'open_ai' ? 'OpenAI' : cfg.modelProvider === 'gemini' ? 'Gemini' : 'Bedrock';
+
+  // Logged at collection time (not in beforeAll, which Vitest skips when every test in the
+  // suite is skipped) so the skip reason is always surfaced.
+  const logger = getLogger(`harness-${providerLabel.toLowerCase()}`);
+  if (!canRun) {
+    logger.warn(
+      `tests are skipped due to insufficient conditions. ` +
+        `npm=${prereqs.npm}, git=${prereqs.git}, hasAws=${hasAws}, ` +
+        `isPreviewBuild=${isPreviewBuild}, hasRequiredVar=${hasRequiredVar}`
+    );
+  }
 
   describe.sequential(`e2e: harness/${providerLabel} — create → deploy → invoke → teardown`, () => {
     let testDir: string;

--- a/e2e-tests/harness-gemini.test.ts
+++ b/e2e-tests/harness-gemini.test.ts
@@ -2,6 +2,6 @@ import { createHarnessE2ESuite } from './harness-e2e-helper.js';
 
 createHarnessE2ESuite({
   modelProvider: 'gemini',
-  apiKeyEnvVar: 'GEMINI_API_KEY',
+  apiKeyArnEnvVar: 'GEMINI_API_KEY_ARN',
   skipMemory: true,
 });

--- a/e2e-tests/harness-gemini.test.ts
+++ b/e2e-tests/harness-gemini.test.ts
@@ -2,6 +2,6 @@ import { createHarnessE2ESuite } from './harness-e2e-helper.js';
 
 createHarnessE2ESuite({
   modelProvider: 'gemini',
-  apiKeyEnvVar: 'GEMINI_API_KEY_ARN',
+  apiKeyEnvVar: 'GEMINI_API_KEY',
   skipMemory: true,
 });

--- a/e2e-tests/harness-openai.test.ts
+++ b/e2e-tests/harness-openai.test.ts
@@ -1,3 +1,3 @@
 import { createHarnessE2ESuite } from './harness-e2e-helper.js';
 
-createHarnessE2ESuite({ modelProvider: 'open_ai', apiKeyEnvVar: 'OPENAI_API_KEY_ARN', skipMemory: true });
+createHarnessE2ESuite({ modelProvider: 'open_ai', apiKeyEnvVar: 'OPENAI_API_KEY', skipMemory: true });

--- a/e2e-tests/harness-openai.test.ts
+++ b/e2e-tests/harness-openai.test.ts
@@ -1,3 +1,3 @@
 import { createHarnessE2ESuite } from './harness-e2e-helper.js';
 
-createHarnessE2ESuite({ modelProvider: 'open_ai', apiKeyEnvVar: 'OPENAI_API_KEY', skipMemory: true });
+createHarnessE2ESuite({ modelProvider: 'open_ai', apiKeyArnEnvVar: 'OPENAI_API_KEY_ARN', skipMemory: true });

--- a/scripts/run-e2e-local.sh
+++ b/scripts/run-e2e-local.sh
@@ -8,13 +8,18 @@
 #
 # Optional env vars:
 #   AWS_REGION      — defaults to us-east-1
+#   BUILD_PREVIEW   — set to 1 to build a preview CLI and run the harness e2e tests
+#                     (e2e-tests/harness-*.test.ts). Harness features are gated to preview
+#                     builds; without this they self-skip. The var is read at build time
+#                     (esbuild bakes __PREVIEW__=true) and at test runtime (skip gate).
 #
 # Usage:
 #   export E2E_ROLE_ARN=arn:aws:iam::<account>:role/<role>
 #   export E2E_SECRET_ARN=arn:aws:secretsmanager:<region>:<account>:secret:<name>
-#   ./scripts/run-e2e-local.sh                          # runs strands-bedrock.test.ts (CI default)
-#   ./scripts/run-e2e-local.sh --all                    # runs the full e2e suite
-#   ./scripts/run-e2e-local.sh e2e-tests/foo.test.ts    # runs a specific test file
+#   ./scripts/run-e2e-local.sh                                  # runs strands-bedrock.test.ts (CI default)
+#   ./scripts/run-e2e-local.sh --all                            # runs the full e2e suite
+#   ./scripts/run-e2e-local.sh e2e-tests/foo.test.ts            # runs a specific test file
+#   BUILD_PREVIEW=1 ./scripts/run-e2e-local.sh e2e-tests/harness-bedrock.test.ts  # runs harness tests
 #
 # Prerequisites: aws CLI, node >=20.19, npm, git, uv, jq
 


### PR DESCRIPTION
### Problem
Harness tests do not run on every push to main, and we don't e2e test the harness artifact. 
https://github.com/aws/agentcore-cli/issues/1506

we are also potentially getting throttled due to the sharding setup. 
### Solution
#### replace the npm tests with harness tests in the dimensions. 
- these tests were low value since we already test against mainline, and always release the CDK package first.
- avoids adding another 6 runners blasting the bedrock apis. 

#### drop shards to 5 instead of 6
- this is an attempt to reduce the load in the e2e tests with the idea that https://github.com/aws/agentcore-cli/issues/1494 could be due to our high concurrency. 

#### add more logging
- make it clear when tests are skipped. vitests down arrows are not sufficient. 


### Notes
As part of ripping out the feature flag, these test dimensions will need to be combined. 

### Testing
Ran the harness tests: via `BUILD_PREVIEW=1 ~/scripts/run-cli-e2e.sh e2e-tests/harness-bedrock.test.ts`
```
✓  e2e  e2e-tests/harness-bedrock.test.ts > e2e: harness/Bedrock — create → deploy → invoke → teardown > deploys to AWS successfully 225885ms
 ✓  e2e  e2e-tests/harness-bedrock.test.ts > e2e: harness/Bedrock — create → deploy → invoke → teardown > invokes the deployed harness 32260ms
 ✓  e2e  e2e-tests/harness-bedrock.test.ts > e2e: harness/Bedrock — create → deploy → invoke → teardown > status shows the deployed harness 10039ms
 ✓  e2e  e2e-tests/harness-bedrock.test.ts > e2e: harness/Bedrock — create → deploy → invoke → teardown > remove all and deploy tears down harness 69147ms
 ✓  e2e  e2e-tests/harness-bedrock.test.ts > e2e: harness/Bedrock — create → deploy → invoke → teardown > verifies harness is deleted from AWS 109ms
stdout | e2e-tests/harness-bedrock.test.ts > e2e: harness/Bedrock — create → deploy → invoke → teardown
Teardown stdout: {"success":false,"logPath":"agentcore/.cli/logs/deploy/deploy-20260610-185008.log","error":"No resources defined in project. Add at least one resource (agent, memory, evaluator, or gateway) before deploying."}
Teardown stderr: (node:1627601) Warning: NodeVersionSupportWarning: The AWS SDK for JavaScript (v3)
```
That noisy teardown error will go away once harness i migrate to use CDK which is an active effort so not worth addressing. 

Ran the non-harness tests with flag: via ` BUILD_PREVIEW=1 ~/scripts/run-cli-e2e.sh e2e-tests/strands-bedrock.test.ts`
```
[global-setup]:starting global setup in region: us-east-1
[global-setup]:cleaning up stale stacks...
[global-setup:stack-cleanup]:listing stacks with cutoff=2026-06-10T15:54:02.381Z, prefix=AgentCore-E2e
(node:1629682) Warning: NodeVersionSupportWarning: The AWS SDK for JavaScript (v3)
versions published after the first week of January 2027
will require node >=22. You are running node v20.20.2.

To continue receiving updates to AWS services, bug fixes,
and security updates please upgrade to node >=22.

More information can be found at: https://a.co/c895JFp
(Use `node --trace-warnings ...` to show where the warning was created)
[global-setup:stack-cleanup]:found 0 stacks
[global-setup:stack-cleanup]:no stacks found!
[global-setup]:done cleaning up stacks after 0.146 seconds
[global-setup]:cleaning up stale credential providers...
[global-setup]:setup finished in 0.225 seconds
 ✓  e2e  e2e-tests/strands-bedrock.test.ts > e2e: Strands/Bedrock — create → deploy → invoke > deploys to AWS successfully 82206ms
 ✓  e2e  e2e-tests/strands-bedrock.test.ts > e2e: Strands/Bedrock — create → deploy → invoke > invokes the deployed agent 15467ms
 ✓  e2e  e2e-tests/strands-bedrock.test.ts > e2e: Strands/Bedrock — create → deploy → invoke > status shows the deployed agent 10252ms
 ✓  e2e  e2e-tests/strands-bedrock.test.ts > e2e: Strands/Bedrock — create → deploy → invoke > status looks up agent runtime by ID 9586ms
 ✓  e2e  e2e-tests/strands-bedrock.test.ts > e2e: Strands/Bedrock — create → deploy → invoke > logs returns entries from the invocation 8822ms
 ✓  e2e  e2e-tests/strands-bedrock.test.ts > e2e: Strands/Bedrock — create → deploy → invoke > logs supports level filtering 9621ms
 ✓  e2e  e2e-tests/strands-bedrock.test.ts > e2e: Strands/Bedrock — create → deploy → invoke > traces list succeeds after invocation 2617ms
```

