### PR TITLE
feat(agent-inspector): send harness model config to agent inspector

### DIFF
--- a/src/cli/operations/dev/web-ui/api-types.ts
+++ b/src/cli/operations/dev/web-ui/api-types.ts
@@ -8,6 +8,7 @@
  * TODO: Extract these types into a shared package so both repos import
  * from a single source of truth instead of manually duplicating.
  */
+import type { HarnessModel } from '../../../../schema';
 import type { HarnessModelConfiguration, HarnessTool } from '../../../aws/agentcore-harness';
 import type { CloudWatchSpanRecord, CloudWatchTraceRecord } from '../../traces/types';
 
@@ -463,7 +464,9 @@ export interface StatusHarness {
 
 export interface ResourceHarness {
   name: string;
+  /** @deprecated Use modelConfig instead. */
   model: string;
+  modelConfig?: HarnessModel;
   tools: string[];
   deploymentStatus?: ResourceDeploymentStatus;
   deployed?: DeployedHarnessState;

--- a/src/cli/operations/dev/web-ui/handlers/resources.ts
+++ b/src/cli/operations/dev/web-ui/handlers/resources.ts
@@ -119,10 +119,12 @@ export async function handleResources(ctx: RouteContext, res: ServerResponse, or
     const harnesses: ResourceHarness[] = [];
     for (const h of project.harnesses ?? []) {
       let model = '';
+      let modelConfig: ResourceHarness['modelConfig'];
       let tools: string[] = [];
       try {
         const spec = await configIO.readHarnessSpec(h.name);
         model = `${spec.model.provider}/${spec.model.modelId}`;
+        modelConfig = spec.model;
         tools = spec.tools.map(t => t.name);
       } catch {
         // harness spec may be unreadable — show what we can
@@ -131,6 +133,7 @@ export async function handleResources(ctx: RouteContext, res: ServerResponse, or
       harnesses.push({
         name: h.name,
         model,
+        modelConfig,
         tools,
         deploymentStatus: statusByTypeAndName.get(`harness:${h.name}`),
         deployed: deployed ? { harnessId: deployed.harnessId, harnessArn: deployed.harnessArn } : undefined,


### PR DESCRIPTION
## Description

Agent inspector does not prepopulate Harness settings with the agent's selected model, api format, temperature, or other properties. This PR sends the model config in the /resources API so the frontend can populate the settings panel with these values.

## Related Issue

<!-- Every PR must be associated with an issue. Link it below using #issue-number format. -->

Closes #

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:unit` and `npm run test:integ`
- [ ] I ran `npm run typecheck`
- [ ] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
