### PR TITLE
fix(ci): avoid running pr reviewer on closed prs

### DIFF
--- a/.github/workflows/pr-ai-review.yml
+++ b/.github/workflows/pr-ai-review.yml
@@ -18,7 +18,10 @@ permissions:
 jobs:
   authorize:
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request_target'
+    # explicitly require the PR to be open to avoid old events triggering a review on closed PRs: https://github.com/aws/agentcore-cli/issues/1463
+    if:
+      github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request_target' &&
+      github.event.pull_request.state == 'open')
     outputs:
       authorized: ${{ steps.auth.outputs.authorized }}
     steps:


### PR DESCRIPTION
### Problem 
https://github.com/aws/agentcore-cli/issues/1463

### Solution
- add an explicit gate on the workflow to not continue unless the PR is open. 

### Testing 
```
curl -s https://api.github.com/repos/aws/agentcore-cli/pulls/216 | jq '{state}'
   
  {
    "state": "closed"
  }
```