### PR TITLE
chore(policy): ungate guardrail policy form

### DIFF
--- a/integ-tests/dev-server.test.ts
+++ b/integ-tests/dev-server.test.ts
@@ -65,10 +65,12 @@ describe('integration: dev server', () => {
       { skipInstall: false }
     );
 
-    if (result.exitCode === 0) {
-      const json = JSON.parse(result.stdout);
-      projectPath = json.projectPath;
+    if (result.exitCode !== 0) {
+      throw new Error(`Project creation failed (exit ${result.exitCode}): ${result.stderr || result.stdout}`);
     }
+
+    const json = JSON.parse(result.stdout);
+    projectPath = json.projectPath;
   }, 120000);
 
   afterEach(() => {

--- a/src/cli/primitives/PolicyPrimitive.ts
+++ b/src/cli/primitives/PolicyPrimitive.ts
@@ -5,7 +5,6 @@ import { EnforcementModeSchema, PolicySchema, ValidationModeSchema } from '../..
 import { detectRegion } from '../aws';
 import { getPolicyGeneration, startPolicyGeneration } from '../aws/policy-generation';
 import { getErrorMessage } from '../errors';
-import { isGatedFeaturesEnabled } from '../feature-flags';
 import type { RemovalPreview, SchemaChange } from '../operations/remove/types';
 import { runCliCommand, withCommandRunTelemetry } from '../telemetry/cli-command-run.js';
 import { PolicyValidationMode, standardize } from '../telemetry/schemas/common-shapes.js';
@@ -14,7 +13,6 @@ import { type PolicyEffect, authorizationPhaseForEffect, defaultDataPathForEffec
 import { BasePrimitive } from './BasePrimitive';
 import { SOURCE_CODE_NOTE } from './constants';
 import type { AddResult, AddScreenComponent, RemovableResource } from './types';
-import { Option } from '@commander-js/extra-typings';
 import type { Command } from '@commander-js/extra-typings';
 import { existsSync, readFileSync } from 'fs';
 
@@ -287,9 +285,6 @@ export class PolicyPrimitive extends BasePrimitive<AddPolicyOptions, RemovablePo
   }
 
   registerCommands(addCmd: Command, removeCmd: Command): void {
-    // Hide gated options from `--help` unless ENABLE_GATED_FEATURES is set.
-    const gate = <T extends Option>(option: T): T => (isGatedFeaturesEnabled() ? option : option.hideHelp());
-
     addCmd
       .command('policy')
       .description('Add a policy to a policy engine')
@@ -300,34 +295,19 @@ export class PolicyPrimitive extends BasePrimitive<AddPolicyOptions, RemovablePo
       .option('--statement <cedar>', 'Policy statement [non-interactive]')
       .option('-g, --generate <prompt>', 'Generate policy from natural language description [non-interactive]')
       .option('--gateway <name>', 'Deployed gateway name for policy generation [non-interactive]')
-      // Guardrail form flags are gated behind ENABLE_GATED_FEATURES: hidden from help when off.
-      .addOption(gate(new Option('--target <name>', 'Gateway target name for Cedar action scope [non-interactive]')))
-      .addOption(
-        gate(
-          new Option(
-            '--form-category <type>',
-            'Guardrail category: contentFilter, promptAttack, or sensitiveInformation [non-interactive]'
-          )
-        )
+      .option('--target <name>', 'Gateway target name for Cedar action scope [non-interactive]')
+      .option(
+        '--form-category <type>',
+        'Guardrail category: contentFilter, promptAttack, or sensitiveInformation [non-interactive]'
       )
-      .addOption(
-        gate(new Option('--form-filters <list>', 'Comma-separated filters for the chosen category [non-interactive]'))
+      .option('--form-filters <list>', 'Comma-separated filters for the chosen category [non-interactive]')
+      .option(
+        '--form-effect <effect>',
+        'Policy effect: forbid, permit, or suppressOutput (default: forbid) [non-interactive]'
       )
-      .addOption(
-        gate(
-          new Option(
-            '--form-effect <effect>',
-            'Policy effect: forbid, permit, or suppressOutput (default: forbid) [non-interactive]'
-          )
-        )
-      )
-      .addOption(
-        gate(
-          new Option(
-            '--form-data-path <path>',
-            'Data path to evaluate, e.g. context.input.prompt (default: context.input.prompt) [non-interactive]'
-          )
-        )
+      .option(
+        '--form-data-path <path>',
+        'Data path to evaluate, e.g. context.input.prompt (default: context.input.prompt) [non-interactive]'
       )
       .option(
         '--validation-mode <mode>',
@@ -376,11 +356,6 @@ export class PolicyPrimitive extends BasePrimitive<AddPolicyOptions, RemovablePo
               }
               if (!cliOptions.engine) {
                 throw new Error('--engine is required');
-              }
-
-              // Guardrail form path is gated behind ENABLE_GATED_FEATURES.
-              if (cliOptions.formCategory && !isGatedFeaturesEnabled()) {
-                throw new ValidationError('Guardrail policy form is not yet available.');
               }
 
               // Validate mutual exclusion of source flags

--- a/src/cli/tui/screens/policy/AddPolicyScreen.tsx
+++ b/src/cli/tui/screens/policy/AddPolicyScreen.tsx
@@ -1,7 +1,6 @@
 import { PolicyNameSchema } from '../../../../schema';
 import { detectRegion } from '../../../aws';
 import { getPolicyGeneration, startPolicyGeneration } from '../../../aws/policy-generation';
-import { isGatedFeaturesEnabled } from '../../../feature-flags';
 import { policyEnginePrimitive } from '../../../primitives/registry';
 import {
   ConfirmReview,
@@ -76,13 +75,11 @@ export function AddPolicyScreen({
     () =>
       POLICY_SOURCE_METHOD_OPTIONS.map(opt => {
         const isGenerate = opt.id === 'generate';
-        // Guardrail form is gated behind ENABLE_GATED_FEATURES.
-        const gated = opt.id === 'form' && !isGatedFeaturesEnabled();
-        const disabled = gated || (isGenerate && !isEngineDeployed);
+        const disabled = isGenerate && !isEngineDeployed;
         return {
           id: opt.id,
           title: opt.title,
-          description: gated ? 'Coming soon' : disabled ? 'Deploy engine first' : opt.description,
+          description: disabled ? 'Deploy engine first' : opt.description,
           disabled,
         };
       }),


### PR DESCRIPTION
## Summary

Removes the `ENABLE_GATED_FEATURES` gate on the guardrail policy form so it's generally available.

Previously gated behind `isGatedFeaturesEnabled()`:
- **CLI options** (`agentcore add policy`): `--target`, `--form-category`, `--form-filters`, `--form-effect`, `--form-data-path` — hidden from `--help` when the flag was off
- **Runtime guard**: `--form-category` threw `Guardrail policy form is not yet available.`
- **Interactive TUI**: the `form` source method was disabled with a "Coming soon" label

## Changes

- `PolicyPrimitive.ts`: drop the `gate()` helper and the runtime `not yet available` guard; the form options are now plain `.option()` calls. Removed now-unused `isGatedFeaturesEnabled` and `Option` imports.
- `AddPolicyScreen.tsx`: the `form` option is no longer disabled/gated. Removed now-unused `isGatedFeaturesEnabled` import.

Scope is limited to the guardrail form path — the `isGatedFeaturesEnabled` flag itself and its other call sites (harness, knowledge-base, gateway-target, config-bundle, etc.) are untouched.

## Testing

- `npm run typecheck` passes.
- Pre-commit hooks (eslint, prettier, secretlint) pass.