### PR TITLE
fix(harness): surface managed-memory heads-up on dev deploy + validate session storage path in TUI

### DIFF
--- a/src/cli/tui/hooks/__tests__/useDevDeploy.test.tsx
+++ b/src/cli/tui/hooks/__tests__/useDevDeploy.test.tsx
@@ -36,10 +36,11 @@ vi.mock('../../../operations/deploy/change-detection', () => ({
 }));
 
 function Harness({ skip }: { skip?: boolean }) {
-  const { steps, isComplete, error } = useDevDeploy({ skip });
+  const { steps, isComplete, error, managedMemoryNotice } = useDevDeploy({ skip });
   return (
     <Text>
-      steps:{steps.length} isComplete:{String(isComplete)} error:{error ?? 'null'}
+      steps:{steps.length} isComplete:{String(isComplete)} error:{error ?? 'null'} notice:
+      {managedMemoryNotice ?? 'null'}
     </Text>
   );
 }
@@ -106,6 +107,31 @@ describe('useDevDeploy', () => {
       expect(lastFrame()).toContain('isComplete:true');
       expect(lastFrame()).toContain('error:Network error');
     });
+  });
+
+  it('surfaces the managed-memory heads-up from the onNotice callback', async () => {
+    mockHandleDeploy.mockImplementation((opts: { onNotice?: (message: string) => void }) => {
+      opts.onNotice?.('Managed memory: this harness automatically provisions a dedicated AgentCore Memory resource');
+      return Promise.resolve({ success: true });
+    });
+
+    const { lastFrame } = render(<Harness />);
+
+    await vi.waitFor(() => {
+      expect(lastFrame()).toContain('notice:Managed memory:');
+      expect(lastFrame()).toContain('isComplete:true');
+    });
+  });
+
+  it('leaves the managed-memory heads-up null when onNotice is not called', async () => {
+    mockHandleDeploy.mockResolvedValue({ success: true });
+
+    const { lastFrame } = render(<Harness />);
+
+    await vi.waitFor(() => {
+      expect(lastFrame()).toContain('isComplete:true');
+    });
+    expect(lastFrame()).toContain('notice:null');
   });
 
   it('populates steps from onProgress callback', async () => {

--- a/src/cli/tui/hooks/useDevDeploy.ts
+++ b/src/cli/tui/hooks/useDevDeploy.ts
@@ -18,6 +18,8 @@ export interface UseDevDeployResult {
   isComplete: boolean;
   error: string | undefined;
   logPath: string | undefined;
+  /** Managed-memory heads-up surfaced by handleDeploy (null when not applicable) */
+  managedMemoryNotice: string | null;
 }
 
 export function useDevDeploy({ skip, ready = true }: UseDevDeployOptions = {}): UseDevDeployResult {
@@ -26,6 +28,7 @@ export function useDevDeploy({ skip, ready = true }: UseDevDeployOptions = {}): 
   const [deployDone, setDeployDone] = useState(false);
   const [error, setError] = useState<string | undefined>();
   const [logPath, setLogPath] = useState<string | undefined>();
+  const [managedMemoryNotice, setManagedMemoryNotice] = useState<string | null>(null);
   const hasStarted = useRef(false);
 
   const onProgress = useCallback((stepName: string, status: 'start' | 'success' | 'error') => {
@@ -39,6 +42,10 @@ export function useDevDeploy({ skip, ready = true }: UseDevDeployOptions = {}): 
 
   const onDeployMessage = useCallback((msg: DeployMessage) => {
     setDeployMessages(prev => [...prev, msg]);
+  }, []);
+
+  const onNotice = useCallback((message: string) => {
+    setManagedMemoryNotice(message);
   }, []);
 
   useEffect(() => {
@@ -78,6 +85,7 @@ export function useDevDeploy({ skip, ready = true }: UseDevDeployOptions = {}): 
           verbose: true,
           onProgress,
           onDeployMessage,
+          onNotice,
         });
 
         if (result.logPath) {
@@ -95,10 +103,10 @@ export function useDevDeploy({ skip, ready = true }: UseDevDeployOptions = {}): 
     };
 
     void run();
-  }, [skip, ready, onProgress, onDeployMessage]);
+  }, [skip, ready, onProgress, onDeployMessage, onNotice]);
 
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- skip is boolean, not nullable; || is the correct operator here
   const isComplete = skip || deployDone;
 
-  return { steps, deployMessages, isComplete, error, logPath };
+  return { steps, deployMessages, isComplete, error, logPath, managedMemoryNotice };
 }

--- a/src/cli/tui/screens/dev/DevScreen.tsx
+++ b/src/cli/tui/screens/dev/DevScreen.tsx
@@ -245,6 +245,7 @@ export function DevScreen(props: DevScreenProps) {
     isComplete: deployComplete,
     error: deployError,
     logPath: deployLogPath,
+    managedMemoryNotice,
   } = useDevDeploy({ skip: props.skipDeploy, ready: mode === 'deploying' });
 
   const hasTransitionedFromDeployRef = useRef(false);
@@ -527,6 +528,11 @@ export function DevScreen(props: DevScreenProps) {
           <Box marginTop={1}>
             <StepProgress steps={displaySteps} />
           </Box>
+          {managedMemoryNotice && !deployComplete && (
+            <Box marginTop={1}>
+              <Text dimColor>Note: {managedMemoryNotice}</Text>
+            </Box>
+          )}
           {hasStartedCfn && (
             <Box marginTop={1}>
               <DeployStatus messages={deployMessages} isComplete={deployComplete} hasError={!!deployError} />

--- a/src/cli/tui/screens/harness/AddHarnessScreen.tsx
+++ b/src/cli/tui/screens/harness/AddHarnessScreen.tsx
@@ -1423,7 +1423,10 @@ export function AddHarnessScreen({
             initialValue="/mnt/data/"
             onSubmit={wizard.setSessionStoragePath}
             onCancel={() => wizard.goBack()}
-            customValidation={value => (value.startsWith('/') ? true : 'Must be an absolute path')}
+            customValidation={value => {
+              const r = validateBYOMountPath(value);
+              return r === true ? true : r;
+            }}
           />
         )}
 


### PR DESCRIPTION
## Description

Fixes two bugs in the gated managed-memory / harness TUI flows (both gated behind `ENABLE_GATED_FEATURES`).

### 1. Managed-memory heads-up missing on `agentcore dev` deploys

The regular `deploy` path shows a heads-up when a harness uses managed memory ("this harness automatically provisions a dedicated AgentCore Memory resource… provisioning can take 3-5 minutes…"). The **dev** deploy path did not: `useDevDeploy` called `handleDeploy` without an `onNotice` callback, so the notice (emitted via `onNotice`) was dropped.

Fix: thread `onNotice` through `useDevDeploy` into a `managedMemoryNotice` state, and render it in `DevScreen`'s "Deploying project resources…" view as a plain dim `Note:` (matching the deploy-screen convention). Verified live: the note now appears as the CFN apply starts and stays pinned through memory provisioning.

### 2. Session-storage mount path not validated in the add-harness wizard

The session-storage step only checked `value.startsWith('/')`, so a nested path like `/mnt/data/workplace/` passed Enter and then failed later at schema-write/deploy. The other mount-path steps (EFS, S3 Files) already validate with `validateBYOMountPath`.

I confirmed the constraint against the API: the smithy `MountPath` shape (`com.amazonaws.bedrockagentcorecontrol#MountPath`) is `pattern: ^/mnt/[a-zA-Z0-9._-]+/?$`, length 6-200 — exactly one segment under `/mnt` — and the `AWS::BedrockAgentCore::Harness` CFN resource schema mirrors it. So nested paths are genuinely invalid at the API; the CLI regex is correct, the TUI step just wasn't using it.

Fix: use `validateBYOMountPath` in the session-storage step's `customValidation`. `TextInput` already blocks Enter and renders a red error/✗ when validation fails. Verified live: `/mnt/data/workplace/` now shows a red error and Enter is blocked; `/mnt/data` shows ✓.

## Related Issue

Closes #

## Type of Change

- [x] Bug fix

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` (added `useDevDeploy` tests for the `onNotice` → `managedMemoryNotice` wiring, set + unset; the mount-path validator already has direct coverage incl. nested-path rejection)
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint` (no new warnings; the 2 remaining in `AddHarnessScreen.tsx` are pre-existing and outside the changed lines)
- [ ] If I modified `src/assets/` — n/a, no asset changes

Also verified **end-to-end live** (account 603141041947, ap-southeast-2, preview build) via the TUI harness:
- `agentcore dev` on a managed-memory harness now shows the `Note:` heads-up during the deploy phase (pinned through `CREATE_IN_PROGRESS`).
- `add harness` session-storage step: `/mnt/data/workplace/` → red error + Enter blocked; `/mnt/data` → ✓.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective
- [ ] I have updated the documentation accordingly — n/a (gated/unreleased surface)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published
