### PR TITLE
chore: ungate web-search commands

### DIFF
--- a/src/cli/primitives/GatewayTargetPrimitive.ts
+++ b/src/cli/primitives/GatewayTargetPrimitive.ts
@@ -283,12 +283,9 @@ export class GatewayTargetPrimitive extends BasePrimitive<AddGatewayTargetOption
   }
 
   registerCommands(addCmd: Command, removeCmd: Command): void {
-    // Hide gated options from `--help` unless ENABLE_GATED_FEATURES is set.
-    const gate = <T extends Option>(option: T): T => (isGatedFeaturesEnabled() ? option : option.hideHelp());
-
     const typeDescription = isGatedFeaturesEnabled()
       ? 'Target type (required): mcp-server, api-gateway, open-api-schema, smithy-model, lambda-function-arn, http-runtime, connector, passthrough, web-search [non-interactive]'
-      : 'Target type (required): mcp-server, api-gateway, open-api-schema, smithy-model, lambda-function-arn, http-runtime, connector [non-interactive]';
+      : 'Target type (required): mcp-server, api-gateway, open-api-schema, smithy-model, lambda-function-arn, http-runtime, connector, web-search [non-interactive]';
 
     // Reject repeated use of --exclude-domains. Domains must be passed as a
     // single comma-separated value.
@@ -318,13 +315,10 @@ export class GatewayTargetPrimitive extends BasePrimitive<AddGatewayTargetOption
         (val: string, acc: string[]) => [...acc, val],
         [] as string[]
       )
-      .addOption(
-        gate(
-          new Option(
-            '--exclude-domains <list>',
-            'Comma-separated domains to exclude from results (for --type web-search only) [non-interactive]'
-          ).argParser(excludeDomainsCoercer)
-        )
+      .option(
+        '--exclude-domains <list>',
+        'Comma-separated domains to exclude from results (for --type web-search only) [non-interactive]',
+        excludeDomainsCoercer
       )
       .option('--endpoint <endpoint>', 'Server endpoint URL (for mcp-server type) [non-interactive]')
       .option('--language <lang>', 'Language of target code: Python, TypeScript, Other [non-interactive]')
@@ -619,9 +613,6 @@ ${
 
           // Handle Amazon Web Search targets (managed-service backed via gateway IAM role)
           if (cliOptions.type === 'webSearch') {
-            if (!isGatedFeaturesEnabled()) {
-              throw new ValidationError('Web search target type is not yet available.');
-            }
             const excludeDomains =
               typeof cliOptions.excludeDomains === 'string'
                 ? cliOptions.excludeDomains
@@ -911,17 +902,13 @@ ${
     // Top-level shortcuts: agentcore add web-search / remove web-search
     // ──────────────────────────────────────────────────────────────────
     addCmd
-      .command('web-search', { hidden: !isGatedFeaturesEnabled() })
+      .command('web-search')
       .description('Wire the Amazon Web Search managed connector to a gateway as a target.')
       .option('--name <name>', 'Target name (default: web-search) [non-interactive]')
       .option('--gateway <name>', 'Gateway to attach this target to [non-interactive]')
       .option('--exclude-domains <list>', 'Comma-separated domains to exclude from results [non-interactive]')
       .option('--json', 'Output as JSON [non-interactive]')
       .action(async (cliOptions: { name?: string; gateway?: string; excludeDomains?: string; json?: boolean }) => {
-        if (!isGatedFeaturesEnabled()) {
-          console.error('Error: Web search target type is not yet available.');
-          process.exit(1);
-        }
         if (!findConfigRoot()) {
           console.error('No agentcore project found. Run `agentcore create` first.');
           process.exit(1);
@@ -1009,17 +996,13 @@ ${
       });
 
     removeCmd
-      .command('web-search', { hidden: !isGatedFeaturesEnabled() })
+      .command('web-search')
       .description('Remove an Amazon Web Search gateway target from the project')
       .option('--name <name>', 'Name of the web-search target to remove [non-interactive]')
       .option('-y, --yes', 'Skip confirmation prompt [non-interactive]')
       .option('--json', 'Output as JSON [non-interactive]')
       .action(async (cliOptions: { name?: string; yes?: boolean; json?: boolean }) => {
         try {
-          if (!isGatedFeaturesEnabled()) {
-            console.error('Web search target type is not yet available.');
-            process.exit(1);
-          }
           if (!findConfigRoot()) {
             console.error('No agentcore project found. Run `agentcore create` first.');
             process.exit(1);

--- a/src/cli/tui/screens/add/AddScreen.tsx
+++ b/src/cli/tui/screens/add/AddScreen.tsx
@@ -52,7 +52,7 @@ const ADD_RESOURCES: { id: AddResourceType; title: string; description: string }
 ];
 
 const ADD_RESOURCE_ITEMS: SelectableItem[] = ADD_RESOURCES.map(r => {
-  const gated = (r.id === 'knowledge-base' || r.id === 'web-search') && !isGatedFeaturesEnabled();
+  const gated = r.id === 'knowledge-base' && !isGatedFeaturesEnabled();
   return {
     ...r,
     disabled: gated,

--- a/src/cli/tui/screens/add/__tests__/AddScreen.test.tsx
+++ b/src/cli/tui/screens/add/__tests__/AddScreen.test.tsx
@@ -32,15 +32,4 @@ describe('AddScreen', () => {
     expect(lastFrame()).toContain('Payment Manager');
     expect(lastFrame()).toContain('Payment Connector');
   });
-
-  it('Web Search option shows Coming soon when ENABLE_GATED_FEATURES is unset', () => {
-    delete process.env.ENABLE_GATED_FEATURES;
-    const onSelect = vi.fn();
-    const onExit = vi.fn();
-
-    const { lastFrame } = render(<AddScreen onSelect={onSelect} onExit={onExit} />);
-
-    expect(lastFrame()).toContain('Web Search');
-    expect(lastFrame()).toContain('Coming soon');
-  });
 });

--- a/src/cli/tui/screens/mcp/AddGatewayTargetScreen.tsx
+++ b/src/cli/tui/screens/mcp/AddGatewayTargetScreen.tsx
@@ -155,7 +155,7 @@ export function AddGatewayTargetScreen({
   const targetTypeItems: SelectableItem[] = useMemo(
     () =>
       TARGET_TYPE_OPTIONS.map(o => {
-        const gated = (o.id === 'passthrough' || o.id === 'webSearch') && !isGatedFeaturesEnabled();
+        const gated = o.id === 'passthrough' && !isGatedFeaturesEnabled();
         return {
           id: o.id,
           title: o.title,


### PR DESCRIPTION
## Description

Remove all gating logic from web-search feature.

## Related Issue

<!-- Every PR must be associated with an issue. Link it below using #issue-number format. -->

Closes #

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:unit` and `npm run test:integ`
- [ ] I ran `npm run typecheck`
- [ ] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
