### PR TITLE
test(e2e): fix shard 4/5 stale paths and missing --wait

### DIFF
--- a/e2e-tests/archive-lifecycle.test.ts
+++ b/e2e-tests/archive-lifecycle.test.ts
@@ -151,7 +151,14 @@ describe.sequential('e2e: archive command lifecycle', () => {
     'local .cli/batch-eval-results contains the run record',
     () => {
       expect(batchEvaluationId, 'batchEvaluationId should have been captured').toBeTruthy();
-      const filePath = join(projectPath, 'agentcore', '.cli', 'batch-eval-results', `${batchEvaluationId}.json`);
+      const filePath = join(
+        projectPath,
+        'agentcore',
+        '.cli',
+        'jobs',
+        'batch-eval-results',
+        `${batchEvaluationId}.json`
+      );
       expect(existsSync(filePath), `Expected local record at ${filePath}`).toBe(true);
     },
     30000
@@ -196,7 +203,7 @@ describe.sequential('e2e: archive command lifecycle', () => {
     'local .cli/recommendations contains the run record',
     () => {
       expect(recommendationId, 'recommendationId should have been captured').toBeTruthy();
-      const filePath = join(projectPath, 'agentcore', '.cli', 'recommendations', `${recommendationId}.json`);
+      const filePath = join(projectPath, 'agentcore', '.cli', 'jobs', 'recommendations', `${recommendationId}.json`);
       expect(existsSync(filePath), `Expected local record at ${filePath}`).toBe(true);
     },
     30000
@@ -233,7 +240,14 @@ describe.sequential('e2e: archive command lifecycle', () => {
   it.skipIf(!canRun)(
     'local .cli/batch-eval-results no longer contains the archived record',
     () => {
-      const filePath = join(projectPath, 'agentcore', '.cli', 'batch-eval-results', `${batchEvaluationId}.json`);
+      const filePath = join(
+        projectPath,
+        'agentcore',
+        '.cli',
+        'jobs',
+        'batch-eval-results',
+        `${batchEvaluationId}.json`
+      );
       expect(existsSync(filePath), `Local record should have been deleted from ${filePath}`).toBe(false);
     },
     30000
@@ -297,7 +311,7 @@ describe.sequential('e2e: archive command lifecycle', () => {
   it.skipIf(!canRun)(
     'local .cli/recommendations no longer contains the archived record',
     () => {
-      const filePath = join(projectPath, 'agentcore', '.cli', 'recommendations', `${recommendationId}.json`);
+      const filePath = join(projectPath, 'agentcore', '.cli', 'jobs', 'recommendations', `${recommendationId}.json`);
       expect(existsSync(filePath), `Local record should have been deleted from ${filePath}`).toBe(false);
     },
     30000

--- a/e2e-tests/config-bundle-eval-rec.test.ts
+++ b/e2e-tests/config-bundle-eval-rec.test.ts
@@ -491,6 +491,7 @@ describe.sequential('e2e: config bundles, batch evaluation, and recommendations'
             'You are a helpful assistant for testing.',
             '--lookback',
             '1',
+            '--wait',
             '--json',
           ]);
 


### PR DESCRIPTION
there are 3 failures in e2e shard 4. they are based on stale assumptions.

2 of them have the same root cause: path migration to a common jobs/ dir. those tests are looking at the wrong place for the run results file.

the other one is expecting json.result to be defined but since that was made async recently, the user has to pass --wait, otherwise it works async.

this PR aims to fix all of those 3 tests.

note: no CLI code is being touched here, only text fixes