### PR TITLE
fix: stop web-search TUI early exit when no gateway

### DIFF
--- a/src/cli/tui/screens/web-search/AddWebSearchScreen.tsx
+++ b/src/cli/tui/screens/web-search/AddWebSearchScreen.tsx
@@ -92,7 +92,7 @@ export function AddWebSearchScreen({
       onExit={onExit}
       helpText={helpText}
       headerContent={headerContent}
-      exitEnabled={isNameStep}
+      exitEnabled={isNameStep || (isGatewayStep && noGatewaysAvailable)}
     >
       <Panel>
         {isNameStep && (

--- a/src/cli/tui/screens/web-search/__tests__/AddWebSearchScreen.test.tsx
+++ b/src/cli/tui/screens/web-search/__tests__/AddWebSearchScreen.test.tsx
@@ -1,0 +1,107 @@
+import { AddWebSearchScreen } from '../AddWebSearchScreen';
+import type { AddWebSearchConfig } from '../types';
+import { render } from 'ink-testing-library';
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const ENTER = '\r';
+const ESCAPE = '\x1B';
+const BACKSPACE = '\x7f';
+const delay = (ms = 50) => new Promise(resolve => setTimeout(resolve, ms));
+
+function makeProps(overrides: Partial<React.ComponentProps<typeof AddWebSearchScreen>> = {}) {
+  return {
+    onComplete: vi.fn<(config: AddWebSearchConfig) => void>(),
+    onExit: vi.fn(),
+    existingGatewayNames: [],
+    existingToolNames: [],
+    ...overrides,
+  };
+}
+
+// Walk past the name step by accepting the default and pressing Enter.
+async function submitName(stdin: ReturnType<typeof render>['stdin']) {
+  stdin.write(ENTER);
+  await delay();
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('AddWebSearchScreen — Escape navigation', () => {
+  it('Escape on the no-gateways view calls onExit (the only step where Screen owns Esc)', async () => {
+    const props = makeProps({ existingGatewayNames: [] });
+    const { lastFrame, stdin } = render(<AddWebSearchScreen {...props} />);
+
+    await submitName(stdin);
+    expect(lastFrame() ?? '').toContain('No gateways found');
+
+    stdin.write(ESCAPE);
+    await delay();
+
+    expect(props.onExit).toHaveBeenCalledTimes(1);
+  });
+
+  it('Escape on the gateway step (with gateways) goes back to name, does NOT call onExit', async () => {
+    const props = makeProps({ existingGatewayNames: ['gw1'] });
+    const { lastFrame, stdin } = render(<AddWebSearchScreen {...props} />);
+
+    await submitName(stdin);
+    expect(lastFrame() ?? '').toContain('Attach to which gateway?');
+
+    stdin.write(ESCAPE);
+    await delay();
+
+    expect(props.onExit).not.toHaveBeenCalled();
+    // Back at the name step: the name input is mounted again.
+    expect(lastFrame() ?? '').toContain('Web search target name');
+  });
+
+  it('Escape on the exclude-domains step goes back to gateway, does NOT call onExit', async () => {
+    const props = makeProps({ existingGatewayNames: ['gw1'] });
+    const { lastFrame, stdin } = render(<AddWebSearchScreen {...props} />);
+
+    await submitName(stdin);
+    // Pick gw1 (single item, already selected), advance to exclude-domains.
+    stdin.write(ENTER);
+    await delay();
+    expect(lastFrame() ?? '').toContain('Exclude domains');
+
+    stdin.write(ESCAPE);
+    await delay();
+
+    expect(props.onExit).not.toHaveBeenCalled();
+    expect(lastFrame() ?? '').toContain('Attach to which gateway?');
+  });
+
+  it('Escape on the confirm step goes back to exclude-domains, does NOT call onExit', async () => {
+    const props = makeProps({ existingGatewayNames: ['gw1'] });
+    const { lastFrame, stdin } = render(<AddWebSearchScreen {...props} />);
+
+    await submitName(stdin);
+    stdin.write(ENTER); // pick gw1
+    await delay();
+    stdin.write(ENTER); // submit empty exclude-domains, advance to confirm
+    await delay();
+    expect(lastFrame() ?? '').toContain('Confirm');
+
+    stdin.write(ESCAPE);
+    await delay();
+
+    expect(props.onExit).not.toHaveBeenCalled();
+    expect(lastFrame() ?? '').toContain('Exclude domains');
+  });
+
+  it('Escape on the name step calls onExit', async () => {
+    const props = makeProps({ existingGatewayNames: ['gw1'] });
+    const { stdin } = render(<AddWebSearchScreen {...props} />);
+
+    // Clear the default value first so TextInput's onCancel fires onExit
+    // rather than just clearing input.
+    for (let i = 0; i < 30; i++) stdin.write(BACKSPACE);
+    await delay();
+    stdin.write(ESCAPE);
+    await delay();
+
+    expect(props.onExit).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Description

Fix for issue causing the web-search interactive flow to kill the TUI process early if no gateway is present. Tested via installing tarball, process now stays alive and `NoGatewayMessage` renders as expected.


<img width="426" height="211" alt="image" src="https://github.com/user-attachments/assets/2d099615-a9d3-4ede-b835-065f71ecbf3c" />


## Related Issue

<!-- Every PR must be associated with an issue. Link it below using #issue-number format. -->

Closes #

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Check all that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
