### PR TITLE
fix(policy): correct INSULTS content-filter enum and validate --form-filters

### DIFF
--- a/src/cli/primitives/PolicyPrimitive.ts
+++ b/src/cli/primitives/PolicyPrimitive.ts
@@ -9,7 +9,14 @@ import type { RemovalPreview, SchemaChange } from '../operations/remove/types';
 import { runCliCommand, withCommandRunTelemetry } from '../telemetry/cli-command-run.js';
 import { PolicyValidationMode, standardize } from '../telemetry/schemas/common-shapes.js';
 import { requireTTY } from '../tui/guards/tty';
-import { type PolicyEffect, authorizationPhaseForEffect, defaultDataPathForEffect } from '../tui/screens/policy/types';
+import {
+  FILTERS_BY_CATEGORY,
+  type GuardrailCategoryType,
+  type PolicyEffect,
+  authorizationPhaseForEffect,
+  defaultDataPathForEffect,
+  invalidFiltersForCategory,
+} from '../tui/screens/policy/types';
 import { BasePrimitive } from './BasePrimitive';
 import { SOURCE_CODE_NOTE } from './constants';
 import type { AddResult, AddScreenComponent, RemovableResource } from './types';
@@ -408,6 +415,15 @@ export class PolicyPrimitive extends BasePrimitive<AddPolicyOptions, RemovablePo
                 const policyEffect = effect as PolicyEffect;
                 const filters = cliOptions.formFilters.split(',').map(s => s.trim());
 
+                const category = cliOptions.formCategory as GuardrailCategoryType;
+                const invalidFilters = invalidFiltersForCategory(category, filters);
+                if (invalidFilters.length > 0) {
+                  throw new ValidationError(
+                    `Invalid filter(s) for category '${category}': ${invalidFilters.join(', ')}. ` +
+                      `Allowed: ${FILTERS_BY_CATEGORY[category].join(', ')}`
+                  );
+                }
+
                 let resolvedGatewayArn: string | undefined;
                 let resolvedTargetName: string | undefined = cliOptions.target;
                 if (cliOptions.gateway) {
@@ -446,7 +462,7 @@ export class PolicyPrimitive extends BasePrimitive<AddPolicyOptions, RemovablePo
 
                 const statement = synthesizeCedar(
                   {
-                    category: cliOptions.formCategory as 'contentFilter' | 'promptAttack' | 'sensitiveInformation',
+                    category,
                     filters,
                     effect: policyEffect,
                     dataPath: cliOptions.formDataPath ?? defaultDataPathForEffect(policyEffect),

--- a/src/cli/tui/screens/policy/__tests__/synthesize-cedar.test.ts
+++ b/src/cli/tui/screens/policy/__tests__/synthesize-cedar.test.ts
@@ -30,6 +30,12 @@ describe('synthesizeCedar', () => {
     expect(result).toContain('[context.input.prompt]');
   });
 
+  it('generates a policy with the INSULTS content filter (canonical plural name)', () => {
+    const form: GuardrailFormConfig = { ...baseForm, filters: ['INSULTS'] };
+    const result = synthesizeCedar(form);
+    expect(result).toContain('["INSULTS"]');
+  });
+
   it('generates permit policy with single filter using lessThanOrEqual', () => {
     const form: GuardrailFormConfig = { ...baseForm, effect: 'permit' };
     const result = synthesizeCedar(form);

--- a/src/cli/tui/screens/policy/__tests__/types.test.ts
+++ b/src/cli/tui/screens/policy/__tests__/types.test.ts
@@ -1,12 +1,5 @@
-import { CONTENT_FILTER_FILTERS, FILTERS_BY_CATEGORY, invalidFiltersForCategory } from '../types.js';
+import { invalidFiltersForCategory } from '../types.js';
 import { describe, expect, it } from 'vitest';
-
-describe('CONTENT_FILTER_FILTERS', () => {
-  it('uses the canonical plural INSULTS, not the singular INSULT', () => {
-    expect(CONTENT_FILTER_FILTERS).toContain('INSULTS');
-    expect(CONTENT_FILTER_FILTERS).not.toContain('INSULT');
-  });
-});
 
 describe('invalidFiltersForCategory', () => {
   it('returns an empty array when every filter is valid for the category', () => {
@@ -22,16 +15,5 @@ describe('invalidFiltersForCategory', () => {
   it('rejects the legacy singular INSULT (regression guard for #1571)', () => {
     expect(invalidFiltersForCategory('contentFilter', ['INSULT'])).toEqual(['INSULT']);
     expect(invalidFiltersForCategory('contentFilter', ['INSULTS'])).toEqual([]);
-  });
-
-  it('rejects a filter from a different category', () => {
-    // JAILBREAK is valid for promptAttack but not for contentFilter
-    expect(invalidFiltersForCategory('contentFilter', ['JAILBREAK'])).toEqual(['JAILBREAK']);
-  });
-
-  it('exposes the allowed filters per category', () => {
-    expect(FILTERS_BY_CATEGORY.contentFilter).toBe(CONTENT_FILTER_FILTERS);
-    expect(FILTERS_BY_CATEGORY.promptAttack.length).toBeGreaterThan(0);
-    expect(FILTERS_BY_CATEGORY.sensitiveInformation.length).toBeGreaterThan(0);
   });
 });

--- a/src/cli/tui/screens/policy/__tests__/types.test.ts
+++ b/src/cli/tui/screens/policy/__tests__/types.test.ts
@@ -1,0 +1,37 @@
+import { CONTENT_FILTER_FILTERS, FILTERS_BY_CATEGORY, invalidFiltersForCategory } from '../types.js';
+import { describe, expect, it } from 'vitest';
+
+describe('CONTENT_FILTER_FILTERS', () => {
+  it('uses the canonical plural INSULTS, not the singular INSULT', () => {
+    expect(CONTENT_FILTER_FILTERS).toContain('INSULTS');
+    expect(CONTENT_FILTER_FILTERS).not.toContain('INSULT');
+  });
+});
+
+describe('invalidFiltersForCategory', () => {
+  it('returns an empty array when every filter is valid for the category', () => {
+    expect(invalidFiltersForCategory('contentFilter', ['VIOLENCE', 'INSULTS'])).toEqual([]);
+    expect(invalidFiltersForCategory('promptAttack', ['JAILBREAK'])).toEqual([]);
+    expect(invalidFiltersForCategory('sensitiveInformation', ['EMAIL', 'PHONE'])).toEqual([]);
+  });
+
+  it('rejects an unknown filter value', () => {
+    expect(invalidFiltersForCategory('contentFilter', ['VIOLENCE', 'NOTAREAL'])).toEqual(['NOTAREAL']);
+  });
+
+  it('rejects the legacy singular INSULT (regression guard for #1571)', () => {
+    expect(invalidFiltersForCategory('contentFilter', ['INSULT'])).toEqual(['INSULT']);
+    expect(invalidFiltersForCategory('contentFilter', ['INSULTS'])).toEqual([]);
+  });
+
+  it('rejects a filter from a different category', () => {
+    // JAILBREAK is valid for promptAttack but not for contentFilter
+    expect(invalidFiltersForCategory('contentFilter', ['JAILBREAK'])).toEqual(['JAILBREAK']);
+  });
+
+  it('exposes the allowed filters per category', () => {
+    expect(FILTERS_BY_CATEGORY.contentFilter).toBe(CONTENT_FILTER_FILTERS);
+    expect(FILTERS_BY_CATEGORY.promptAttack.length).toBeGreaterThan(0);
+    expect(FILTERS_BY_CATEGORY.sensitiveInformation.length).toBeGreaterThan(0);
+  });
+});

--- a/src/cli/tui/screens/policy/types.ts
+++ b/src/cli/tui/screens/policy/types.ts
@@ -12,7 +12,7 @@ export type PolicySourceMethod = 'file' | 'inline' | 'generate' | 'form';
 
 export type GuardrailCategoryType = 'contentFilter' | 'promptAttack' | 'sensitiveInformation';
 
-export const CONTENT_FILTER_FILTERS = ['VIOLENCE', 'HATE', 'SEXUAL', 'MISCONDUCT', 'INSULT'] as const;
+export const CONTENT_FILTER_FILTERS = ['VIOLENCE', 'HATE', 'SEXUAL', 'MISCONDUCT', 'INSULTS'] as const;
 export type ContentFilterCategory = (typeof CONTENT_FILTER_FILTERS)[number];
 
 export const PROMPT_ATTACK_FILTERS = ['JAILBREAK', 'PROMPT_INJECTION', 'PROMPT_LEAKAGE'] as const;
@@ -80,6 +80,25 @@ export const GUARDRAIL_CATEGORY_OPTIONS: {
     filters: SENSITIVE_INFO_FILTERS,
   },
 ];
+
+/**
+ * Valid filters per guardrail category. Single source of truth for both the TUI options
+ * and client-side validation of the non-interactive `--form-filters` flag.
+ */
+export const FILTERS_BY_CATEGORY: Record<GuardrailCategoryType, readonly string[]> = {
+  contentFilter: CONTENT_FILTER_FILTERS,
+  promptAttack: PROMPT_ATTACK_FILTERS,
+  sensitiveInformation: SENSITIVE_INFO_FILTERS,
+};
+
+/**
+ * Returns the filter values that are not valid for the given category.
+ * An empty array means every supplied filter is valid.
+ */
+export function invalidFiltersForCategory(category: GuardrailCategoryType, filters: string[]): string[] {
+  const allowed = FILTERS_BY_CATEGORY[category];
+  return filters.filter(f => !allowed.includes(f));
+}
 
 export type PolicyEffect = 'permit' | 'forbid' | 'suppressOutput';
 


### PR DESCRIPTION
## Description

`agentcore add policy --form-category contentFilter --form-filters INSULT` succeeded locally but `agentcore deploy` failed at the CFN service with an opaque `ValidationException` (`Valid categories: VIOLENCE, HATE, SEXUAL, MISCONDUCT, INSULTS`).

Two root causes, both fixed here:

1. **Enum typo.** `CONTENT_FILTER_FILTERS` listed `'INSULT'` (singular); the service enum is `'INSULTS'` (plural). The TUI offered the bad value because its options derive from this constant. Fixed in `src/cli/tui/screens/policy/types.ts` — one-word change that also fixes the TUI.
2. **No client-side validation of `--form-filters`.** The non-interactive path split the flag and passed raw values straight to `synthesizeCedar`, so any string (e.g. `NOTAREAL`) was accepted and only failed at deploy. Added `FILTERS_BY_CATEGORY` + `invalidFiltersForCategory()` helpers in `types.ts` (reusing the per-category enums already defined there as the single source of truth) and wired validation into `PolicyPrimitive`, throwing a `ValidationError` with a clear message listing the invalid filter(s) and the allowed set.

Per maintainer guidance on the issue, validation is scoped to the form-filter enums the TUI/CLI already offers — not a blanket validation of every flag.

## Related Issue

Closes #1571

## Type of Change

- [x] Bug fix

## Testing

- [x] I ran `npm run test:unit` (24 policy tests pass, incl. new regression coverage)
- [x] I ran `npm run typecheck` (zero errors)
- [x] I ran `npm run lint` (passes via pre-commit hooks)

New tests:
- `types.test.ts` — valid filters per category pass; unknown filter rejected; cross-category filter rejected; regression guard that `INSULTS` is accepted while `INSULT` is rejected.
- `synthesize-cedar.test.ts` — added an `INSULTS` case to lock in the canonical name.

## Checklist

- [x] I have added any necessary tests that prove my fix is effective
- [x] My changes generate no new warnings
- [ ] Docs update — N/A (no user-facing doc changes; valid filter list unchanged in count)