### PR TITLE
fix: dont show deploy screen when deploy is skipped

### DIFF
--- a/src/cli/commands/dev/browser-mode.ts
+++ b/src/cli/commands/dev/browser-mode.ts
@@ -2,6 +2,7 @@ import { ConfigIO, findConfigRoot, getWorkingDirectory } from '../../../lib';
 import type { AgentCoreProjectSpec } from '../../../schema';
 import { ANSI } from '../../constants';
 import { isPreviewEnabled } from '../../feature-flags';
+import { isDeploySkippable } from '../../operations/deploy/change-detection';
 import { getDevConfig, getDevSupportedAgents, loadDevEnv, loadProjectConfig } from '../../operations/dev';
 import { type OtelCollector, startOtelCollector } from '../../operations/dev/otel';
 import {
@@ -133,7 +134,8 @@ export async function launchBrowserDev(): Promise<void> {
     process.exit(1);
   }
 
-  if (hasHarnesses) {
+  // Only auto-deploy for harness-only projects, and skip if no CDK changes
+  if (hasHarnesses && !hasRuntimes && !(await isDeploySkippable())) {
     await runCliDeploy();
   }
 

--- a/src/cli/commands/dev/command.tsx
+++ b/src/cli/commands/dev/command.tsx
@@ -12,6 +12,7 @@ import { getErrorMessage } from '../../errors';
 import { detectContainerRuntime } from '../../external-requirements';
 import { isPreviewEnabled } from '../../feature-flags';
 import { ExecLogger } from '../../logging';
+import { isDeploySkippable } from '../../operations/deploy/change-detection';
 import {
   callMcpTool,
   createDevServer,
@@ -509,28 +510,54 @@ export const registerDev = (program: Command) => {
               };
             }
 
-            // Preview: show TUI deploy progress, then launch Agent Inspector in the browser
+            // Preview browser mode: check if deploy is needed BEFORE entering the TUI.
+            // This avoids an alt-screen flash when there's nothing to deploy.
+            // The TUI (launchTuiDevScreenWithPicker) is only used to show deploy progress.
             if (isPreviewEnabled()) {
-              const pickerResult = await launchTuiDevScreenWithPicker(workingDir, {
-                skipDeploy: opts.skipDeploy,
-              });
+              const isHarnessOnly = hasHarnesses && supportedAgents.length === 0;
+              let needsTuiDeploy = false;
 
-              if (pickerResult != null) {
-                recorder.set({ ui_mode: 'browser' as const });
-                return {
-                  success: true as const,
-                  blockingPromise: runBrowserMode({
-                    workingDir,
-                    project,
-                    port,
-                    agentName: pickerResult.agentName,
-                    harnessName: pickerResult.harnessName,
-                    otelEnvVars,
-                    collector,
-                  }),
-                };
+              if (isHarnessOnly && !opts.skipDeploy) {
+                needsTuiDeploy = !(await isDeploySkippable());
               }
-              return { success: true as const, blockingPromise: Promise.resolve() };
+
+              if (needsTuiDeploy) {
+                // Deploy is needed — show TUI deploy progress, then launch browser
+                const pickerResult = await launchTuiDevScreenWithPicker(workingDir, {
+                  skipDeploy: opts.skipDeploy,
+                });
+
+                if (pickerResult != null) {
+                  recorder.set({ ui_mode: 'browser' as const });
+                  return {
+                    success: true as const,
+                    blockingPromise: runBrowserMode({
+                      workingDir,
+                      project,
+                      port,
+                      agentName: pickerResult.agentName,
+                      harnessName: pickerResult.harnessName,
+                      otelEnvVars,
+                      collector,
+                    }),
+                  };
+                }
+                return { success: true as const, blockingPromise: Promise.resolve() };
+              }
+
+              // No deploy needed — skip TUI entirely, go straight to browser
+              recorder.set({ ui_mode: 'browser' as const });
+              return {
+                success: true as const,
+                blockingPromise: runBrowserMode({
+                  workingDir,
+                  project,
+                  port,
+                  agentName: opts.runtime,
+                  otelEnvVars,
+                  collector,
+                }),
+              };
             }
 
             // Default: browser mode (blocks forever)

--- a/src/cli/operations/deploy/change-detection.ts
+++ b/src/cli/operations/deploy/change-detection.ts
@@ -1,4 +1,5 @@
 import { ConfigIO } from '../../../lib';
+import { ensureDefaultDeploymentTarget } from './ensure-target';
 import { createHash } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
@@ -69,6 +70,25 @@ export async function canSkipDeploy(configIO: ConfigIO): Promise<boolean> {
     }
 
     return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Checks whether a deploy is needed, handling target auto-population.
+ * Returns true if deploy can be safely skipped (no changes detected).
+ * Returns false if deploy is needed or if the check itself fails.
+ *
+ * This is the high-level entry point used by both the browser-mode gate
+ * (command.tsx) and the terminal-mode gate (DevScreen) to avoid showing
+ * deploy UI when there's nothing to deploy.
+ */
+export async function isDeploySkippable(): Promise<boolean> {
+  try {
+    const configIO = new ConfigIO();
+    await ensureDefaultDeploymentTarget(configIO);
+    return await canSkipDeploy(configIO);
   } catch {
     return false;
   }

--- a/src/cli/tui/screens/dev/DevScreen.tsx
+++ b/src/cli/tui/screens/dev/DevScreen.tsx
@@ -1,5 +1,6 @@
 import type { AgentEnvSpec } from '../../../../schema';
 import { isPreviewEnabled } from '../../../feature-flags';
+import { isDeploySkippable } from '../../../operations/deploy/change-detection';
 import { getDevSupportedAgents, getEndpointUrl, loadProjectConfig } from '../../../operations/dev';
 import {
   DeployStatus,
@@ -185,19 +186,35 @@ export function DevScreen(props: DevScreenProps) {
       } else if (agents.length === 1 && harnesses.length === 0 && agents[0]) {
         setSelectedAgentName(agents[0].name);
         if (!onLaunchBrowser) setMode('chat');
-      } else if (harnesses.length === 1 && agents.length === 0) {
-        setSelectedHarness(harnesses[0]);
-        setMode('deploying');
+      } else if (harnesses.length > 0 && agents.length === 0) {
+        // Harness-only projects: check if deploy is needed before showing deploy UI.
+        // This covers terminal mode (--no-browser). Browser mode is gated earlier in command.tsx.
+        if (harnesses.length === 1) setSelectedHarness(harnesses[0]);
+
+        const skipDeploy = props.skipDeploy === true || (await isDeploySkippable());
+
+        if (skipDeploy) {
+          if (onLaunchBrowser) {
+            queueMicrotask(() => onLaunchBrowser({ harnessName: harnesses.length === 1 ? harnesses[0] : undefined }));
+          } else if (harnesses.length === 1) {
+            setMode('harness');
+          }
+          // Multiple harnesses + terminal: stays in 'select-agent' (chooser)
+        } else {
+          setMode('deploying');
+        }
       } else if (agents.length === 0 && harnesses.length === 0) {
         setNoAgentsError(true);
       }
 
       setAgentsLoaded(true);
 
-      // If onLaunchBrowser is set and only agents (no harnesses), auto-select immediately.
-      // Harness projects need deploy first — handled after deploy completes.
-      if (onLaunchBrowser && agents.length === 1 && harnesses.length === 0) {
-        queueMicrotask(() => onLaunchBrowser({ agentName: agents[0]?.name }));
+      // Browser mode: skip the terminal chooser and launch browser immediately.
+      // The web UI handles agent/harness selection.
+      // Harness-only projects need deploy first — handled after deploy completes.
+      if (onLaunchBrowser && agents.length > 0) {
+        const resolvedName = props.agentName ?? (agents.length === 1 ? agents[0]?.name : undefined);
+        queueMicrotask(() => onLaunchBrowser({ agentName: resolvedName }));
       }
     };
     void load();
@@ -255,8 +272,11 @@ export function DevScreen(props: DevScreenProps) {
     queueMicrotask(() => {
       if (onLaunchBrowser) {
         onLaunchBrowser({ harnessName: selectedHarness });
-      } else {
+      } else if (selectedHarness) {
         setMode('harness');
+      } else {
+        // Multiple harnesses: show the chooser after deploy completes
+        setMode('select-agent');
       }
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Problems

1. **`agentcore dev --skip-deploy` still shows "Deploying project resources..." TUI** — The `--skip-deploy` flag was passed to the deploy hook, which skipped the actual deploy but still rendered the deploy screen for a frame before resolving.

2. **`agentcore dev` on an already-deployed harness project briefly flashes the TUI** — Browser mode always entered the alt-screen TUI (`launchTuiDevScreenWithPicker`) even when there was nothing to deploy, causing a visible terminal flicker before the browser opened.

3. **Mixed projects (agent + harness) auto-deployed on `agentcore dev`** — The `launchBrowserDev()` path (TUI → dev) unconditionally called `runCliDeploy()` whenever harnesses existed, regardless of whether the project also had agents.

4. **Terminal harness chooser appeared in browser mode** — When a project had multiple agents or harnesses, the terminal selection list appeared even in browser mode (default `agentcore dev`), where the web UI should handle selection.

5. **Multi-harness projects only supported single-harness auto-deploy** — The harness-only branch in DevScreen required exactly 1 harness (`harnesses.length === 1`), so projects with 2+ harnesses fell through to the chooser without deploying.

## Solutions

1. **Check `isDeploySkippable()` before entering deploy mode** — Both `command.tsx` (browser mode) and `DevScreen.tsx` (terminal mode) now call `isDeploySkippable()` before setting `mode = 'deploying'`. If the flag is set or no CDK changes exist, deploy UI is never rendered.

2. **Gate TUI entry on whether deploy is actually needed** — In `command.tsx`, the preview browser path now checks `isDeploySkippable()` first. Only when deploy is genuinely needed does it enter `launchTuiDevScreenWithPicker`. Otherwise it goes straight to `runBrowserMode()` — no alt-screen, no flicker.

3. **Only auto-deploy for harness-only projects** — `launchBrowserDev()` now checks `hasHarnesses && !hasRuntimes` before deploying. Mixed projects skip deploy entirely and let the web UI handle everything.

4. **Browser mode skips the terminal chooser for all project types** — The `onLaunchBrowser` auto-launch condition is widened from `agents.length === 1` to `agents.length > 0`. Multi-agent and mixed projects immediately launch the browser, passing no pre-selection so the web UI shows the picker.

5. **Harness-only branch handles any number of harnesses** — Changed from `harnesses.length === 1 && agents.length === 0` to `harnesses.length > 0 && agents.length === 0`. Single-harness is pre-selected; multi-harness defers selection to post-deploy (terminal chooser or web UI).

## Shared utility: `isDeploySkippable()`

Extracted to `src/cli/operations/deploy/change-detection.ts`. Bundles the repeated pattern of `new ConfigIO()` → `ensureDefaultDeploymentTarget()` → `canSkipDeploy()`. Used by:
- `command.tsx` — gates whether to enter the TUI at all (browser mode)
- `DevScreen.tsx` — gates whether to show deploy UI (terminal mode)
- `browser-mode.ts` — gates whether `launchBrowserDev()` (TUI → dev) runs deploy

## Before / After

### Browser mode (`agentcore dev`) on deployed harness project (no changes)

**Before:** Alt-screen enters → "Deploying project resources..." flashes → resolves instantly → exits → browser opens

**After:** Browser opens immediately. No terminal flicker.

### `agentcore dev --skip-deploy` on harness project

**Before:** Alt-screen enters → "Deploying project resources..." appears for one frame → skips → exits → browser opens

**After:** Browser opens immediately. No deploy UI rendered at all.

### `agentcore dev` on mixed project (agent + harness)

**Before:** TUI chooser appears in terminal, user must select before browser opens. If harness selected, deploy runs.

**After:** Browser opens immediately with no chooser. Web UI shows both agent and harness options. No auto-deploy.

### `agentcore dev --no-browser` on multi-harness project (needs deploy)

**Before:** Chooser appeared immediately (user had to pick before deploy started, only single-harness was supported)

**After:** Deploy runs first (for all harnesses), then chooser appears so user can pick which to invoke.

## Test Plan

- [x] One agent project: `agentcore dev` opens browser immediately, no flash
- [x] Mixed project: `agentcore dev` opens browser, no deploy, no chooser
- [x] Deployed harness: `agentcore dev` opens browser, no flash, no "Deploying" UI
- [x] Fresh harness (first deploy): `agentcore dev` shows deploy progress, then opens browser
- [x] `--skip-deploy` on any harness project: no deploy UI ever rendered
- [x] `--no-browser` on multi-harness: deploys first, then shows terminal chooser
- [x] TUI → dev on mixed project: no auto-deploy