### PR TITLE
fix: include harness Dockerfiles in deploy hash

### DIFF
--- a/src/cli/operations/deploy/__tests__/change-detection.test.ts
+++ b/src/cli/operations/deploy/__tests__/change-detection.test.ts
@@ -1,14 +1,34 @@
 import { canSkipDeploy, computeProjectDeployHash } from '../change-detection';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockFiles = vi.hoisted(() => ({
+  dockerfile: 'FROM public.ecr.aws/lambda/nodejs:20\n',
+  harnessJson: JSON.stringify({
+    name: 'h1',
+    dockerfile: 'Dockerfile',
+    model: { provider: 'bedrock', modelId: 'anthropic.claude-3' },
+  }),
+  prompt: 'You are a helpful assistant.',
+}));
 
 vi.mock('node:fs/promises', () => ({
   readFile: vi.fn().mockImplementation((path: string) => {
-    if (path.includes('harness.json'))
-      return Promise.resolve('{"name":"h1","model":{"provider":"bedrock","modelId":"anthropic.claude-3"}}');
-    if (path.includes('system-prompt.md')) return Promise.resolve('You are a helpful assistant.');
+    if (path.includes('harness.json')) return Promise.resolve(mockFiles.harnessJson);
+    if (path.includes('system-prompt.md')) return Promise.resolve(mockFiles.prompt);
+    if (path.includes('Dockerfile')) return Promise.resolve(mockFiles.dockerfile);
     return Promise.reject(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
   }),
 }));
+
+beforeEach(() => {
+  mockFiles.dockerfile = 'FROM public.ecr.aws/lambda/nodejs:20\n';
+  mockFiles.harnessJson = JSON.stringify({
+    name: 'h1',
+    dockerfile: 'Dockerfile',
+    model: { provider: 'bedrock', modelId: 'anthropic.claude-3' },
+  });
+  mockFiles.prompt = 'You are a helpful assistant.';
+});
 
 function mockConfigIO(opts: {
   runtimes?: any[];
@@ -50,6 +70,18 @@ describe('computeProjectDeployHash', () => {
     const io2 = mockConfigIO({ awsTargets: [{ name: 'prod', region: 'us-west-2', account: '222' }] });
     const hash1 = await computeProjectDeployHash(io1);
     const hash2 = await computeProjectDeployHash(io2);
+    expect(hash1).not.toBe(hash2);
+  });
+
+  it('returns different hash when harness Dockerfile content changes', async () => {
+    const io = mockConfigIO({});
+
+    mockFiles.dockerfile = 'FROM public.ecr.aws/lambda/nodejs:20\nRUN echo first\n';
+    const hash1 = await computeProjectDeployHash(io);
+
+    mockFiles.dockerfile = 'FROM public.ecr.aws/lambda/nodejs:20\nRUN echo second\n';
+    const hash2 = await computeProjectDeployHash(io);
+
     expect(hash1).not.toBe(hash2);
   });
 });

--- a/src/cli/operations/deploy/change-detection.ts
+++ b/src/cli/operations/deploy/change-detection.ts
@@ -25,6 +25,19 @@ export async function computeProjectDeployHash(configIO: ConfigIO): Promise<stri
     try {
       const harnessJson = await readFile(join(harnessDir, 'harness.json'), 'utf-8');
       hash.update(harnessJson);
+      try {
+        const harnessSpec = JSON.parse(harnessJson) as { dockerfile?: unknown };
+        if (typeof harnessSpec.dockerfile === 'string' && harnessSpec.dockerfile.length > 0) {
+          try {
+            const dockerfileContent = await readFile(join(harnessDir, harnessSpec.dockerfile), 'utf-8');
+            hash.update(dockerfileContent);
+          } catch {
+            // Dockerfile missing — preflight validates existence before deploy.
+          }
+        }
+      } catch {
+        // Invalid harness.json is still represented by the raw content above.
+      }
     } catch {
       // harness.json missing — hash will differ from last deploy
     }


### PR DESCRIPTION
## Summary

Dev-mode deploy skipping currently hashes project and harness config files, but not Dockerfiles referenced by harness specs. That can let `canSkipDeploy` short-circuit the deploy pipeline after a Dockerfile-only change, before the per-harness deployer hash has a chance to notice the update.

Closes #1380

## Changes

This includes the referenced harness Dockerfile content in the project deploy hash, matching the lower-level harness deployer behavior.

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Verification

```bash
npm test -- src/cli/operations/deploy/__tests__/change-detection.test.ts
npm test -- src/cli/operations/deploy
npm run typecheck
npm run lint
npm run format:check
npm run build
```

Note: `npm run lint` currently reports 34 warnings in pre-existing files outside this change; it reports 0 errors.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly, or no documentation update is needed
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
