### PR TITLE
test(e2e): use real key formats in payment-validation CDP fixtures

### DIFF
--- a/e2e-tests/payment-validation.test.ts
+++ b/e2e-tests/payment-validation.test.ts
@@ -7,13 +7,24 @@
  */
 import { parseJsonOutput, prereqs } from '../src/test-utils/index.js';
 import { runAgentCoreCLI } from './e2e-helper.js';
-import { randomUUID } from 'node:crypto';
+import { generateKeyPairSync, randomUUID } from 'node:crypto';
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 const canRun = prereqs.npm && prereqs.git && prereqs.uv;
+
+// The CLI validates CDP secret formats at add time: apiKeySecret must be a
+// base64-encoded Ed25519 private key and walletSecret a base64-encoded EC P-256
+// private key. Use real keys so add/remove lifecycle tests exercise their intent
+// rather than tripping the format check.
+const CDP_API_KEY_SECRET = generateKeyPairSync('ed25519')
+  .privateKey.export({ type: 'pkcs8', format: 'der' })
+  .toString('base64');
+const CDP_WALLET_SECRET = generateKeyPairSync('ec', { namedCurve: 'P-256' })
+  .privateKey.export({ type: 'pkcs8', format: 'der' })
+  .toString('base64');
 
 describe.sequential('e2e: payments — validation, config, and remove lifecycle', () => {
   let testDir: string;
@@ -91,9 +102,9 @@ describe.sequential('e2e: payments — validation, config, and remove lifecycle'
         '--api-key-id',
         'key-id',
         '--api-key-secret',
-        'key-secret',
+        CDP_API_KEY_SECRET,
         '--wallet-secret',
-        'wallet-secret',
+        CDP_WALLET_SECRET,
         '--json',
       ],
       projectPath
@@ -253,9 +264,9 @@ describe.sequential('e2e: payments — validation, config, and remove lifecycle'
         '--api-key-id',
         'a',
         '--api-key-secret',
-        'b',
+        CDP_API_KEY_SECRET,
         '--wallet-secret',
-        'c',
+        CDP_WALLET_SECRET,
         '--json',
       ],
       projectPath
@@ -281,9 +292,9 @@ describe.sequential('e2e: payments — validation, config, and remove lifecycle'
         '--api-key-id',
         'key-id',
         '--api-key-secret',
-        'key-secret',
+        CDP_API_KEY_SECRET,
         '--wallet-secret',
-        'wallet-secret',
+        CDP_WALLET_SECRET,
         '--json',
       ],
       projectPath


### PR DESCRIPTION
## Description

Fixes the **E2E Tests (Full Suite)** failure on `main` introduced by #1573.

#1573 added client-side validation that requires the CoinbaseCDP `apiKeySecret` to be a base64-encoded Ed25519 private key and `walletSecret` a base64-encoded EC P-256 private key. The full E2E suite runs only on push to `main` (it needs AWS secrets unavailable to PRs), so its `e2e-tests/payment-validation.test.ts` fixtures — which seeded those fields with dummy strings like `key-secret` / `wallet-secret` / `b` / `c` — weren't exercised by #1573's PR CI and started failing post-merge: the add/remove lifecycle tests tripped the new format check instead of testing their intent (e.g. "rejects connector on non-existent manager" returned the apiKeySecret format error instead of "not found").

This generates real Ed25519 / P-256 keys for the CDP secret fields in the four affected tests. The `integ-tests/` equivalent was already updated in #1573; this applies the same fix to the `e2e-tests/` file.

The whitespace-rejection test (asserts "Missing required options" — the missing-check runs before format validation) and the StripePrivy format tests (assert rejection of non-base64 / too-short keys) are unchanged and still pass.

## Related Issue

Follow-up to #1573 (which closed #1564). No separate issue.

Closes #

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [x] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

Notes:
- Only `e2e-tests/payment-validation.test.ts` changed. `typecheck` and `prettier` pass.
- Ran the affected e2e file against the freshly-built, globally-installed CLI: **all 11 tests pass**, including the 4 that were failing in the CI run, the whitespace-rejection test, and the StripePrivy format tests.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
