### PR TITLE
fix(create): use harness-first language when project already exists

### DIFF
--- a/src/cli/tui/screens/create/CreateScreen.tsx
+++ b/src/cli/tui/screens/create/CreateScreen.tsx
@@ -364,9 +364,12 @@ export function CreateScreen({ cwd, isInteractive, onExit, onNavigate }: CreateS
         <Box marginBottom={1} flexDirection="column">
           <Text color="red">A project already exists at this location.</Text>
           {flow.existingProjectPath && <Text dimColor>Found: {flow.existingProjectPath}</Text>}
-          <Box marginTop={1}>
+          <Box marginTop={1} flexDirection="column">
             <Text>
-              Use <Text color="cyan">add agent</Text> to create a new agent in the existing project.
+              Use <Text color="cyan">add harness</Text> to add a harness to the existing project.
+            </Text>
+            <Text dimColor>
+              Or use <Text color="cyan">add agent</Text> to add a code-based agent.
             </Text>
           </Box>
         </Box>


### PR DESCRIPTION
## Problem

When a user runs `agentcore create` inside an existing project, the existing-project-error screen tells them only:

> Use `add agent` to create a new agent in the existing project.

As part of the harness GA cutover, the create experience is harness-first. This message should lead with `add harness`.

## Change

One file — `src/cli/tui/screens/create/CreateScreen.tsx` (the `existing-project-error` phase). The message now reads:

```
A project already exists at this location.
Found: <path>

Use add harness to add a harness to the existing project.
Or use add agent to add a code-based agent.
```

Unconditional — no `isPreviewEnabled()` branch — matching the post-merge GA state where there's a single CLI and harness is a first-class create option. This is consistent with the harness-first voice already used in the create-type picker in the same screen (`Harness (recommended)`).

This is the only place this message exists; the CLI flag path (`validate.ts`) only checks folder-name collisions and has no equivalent message.

Addresses the "harness-first language" action item (#4) in the Harness GA plan.

## ⚠️ Ordering dependency

`add harness` is still preview-gated today:

```ts
// src/cli/primitives/registry.ts
export const harnessPrimitive = isPreviewEnabled() ? new HarnessPrimitive() : undefined;
```

This message is only correct once harness is ungated for all builds — i.e. it must land **with or after** the `__PREVIEW__` / `isPreviewEnabled` removal work. It should **not** ship to the `latest` npm tag before that gating is removed, or a GA build would point users at an `add harness` command that doesn't exist in that build.

## Testing

- `npm run typecheck` ✅
- `eslint` (pre-commit) ✅ / prettier ✅
- `create.test.ts` — 16/16 pass
- Rendered live in the TUI harness on a **preview build** (target state): both lines display correctly when running `create` from inside an existing project.
