### PR TITLE
fix(run-insights): TUI wizard state, inline name validation, job history

### DIFF
--- a/src/cli/tui/screens/insights-jobs/InsightsJobsScreen.tsx
+++ b/src/cli/tui/screens/insights-jobs/InsightsJobsScreen.tsx
@@ -1,7 +1,8 @@
 import type { FailureAnalysisResult, GetBatchEvaluationResult } from '../../../aws/agentcore-batch-evaluation';
 import { getBatchEvaluation } from '../../../aws/agentcore-batch-evaluation';
-import type { InsightsRunRecord } from '../../../operations/insights';
-import { listInsightsRuns } from '../../../operations/insights';
+import { regionFromArn } from '../../../operations/jobs';
+import { listRecords } from '../../../operations/jobs/shared/storage';
+import type { InsightsJobRecord } from '../../../operations/jobs/shared/types';
 import { Panel, Screen } from '../../components';
 import { HELP_TEXT } from '../../constants';
 import { useListNavigation } from '../../hooks';
@@ -44,8 +45,8 @@ function InsightsJobsListView({
   onExit,
   availableHeight,
 }: {
-  records: InsightsRunRecord[];
-  onSelect: (record: InsightsRunRecord) => void;
+  records: InsightsJobRecord[];
+  onSelect: (record: InsightsJobRecord) => void;
   onExit: () => void;
   availableHeight: number;
 }) {
@@ -79,11 +80,11 @@ function InsightsJobsListView({
             const date = rec.createdAt ? formatShortDate(rec.createdAt) : 'unknown';
 
             return (
-              <Text key={rec.batchEvaluationId} wrap="truncate-end">
+              <Text key={rec.id} wrap="truncate-end">
                 <Text color={selected ? 'cyan' : undefined}>{selected ? '>' : ' '} </Text>
                 <Text dimColor>{date.padEnd(16)}</Text>
                 <Text color={statusColor(rec.status)}>{rec.status.padEnd(12)}</Text>
-                <Text dimColor>{rec.name || rec.batchEvaluationId}</Text>
+                <Text dimColor>{rec.name || rec.id}</Text>
               </Text>
             );
           })}
@@ -100,19 +101,21 @@ function InsightsJobsListView({
 // Results view
 // ─────────────────────────────────────────────────────────────────────────────
 
-function InsightsResultsView({ record, onBack }: { record: InsightsRunRecord; onBack: () => void }) {
+function InsightsResultsView({ record, onBack }: { record: InsightsJobRecord; onBack: () => void }) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [failureAnalysis, setFailureAnalysis] = useState<FailureAnalysisResult | undefined>(undefined);
   const [totalSessions, setTotalSessions] = useState(0);
+
+  const region = regionFromArn(record.arn) ?? '';
 
   useEffect(() => {
     let cancelled = false;
     void (async () => {
       try {
         const result: GetBatchEvaluationResult = await getBatchEvaluation({
-          region: record.region,
-          batchEvaluationId: record.batchEvaluationId,
+          region,
+          batchEvaluationId: record.id,
         });
         if (cancelled) return;
         if (result.status !== 'COMPLETED' && result.status !== 'COMPLETEDWITHERRORS') {
@@ -132,7 +135,7 @@ function InsightsResultsView({ record, onBack }: { record: InsightsRunRecord; on
     return () => {
       cancelled = true;
     };
-  }, [record.batchEvaluationId, record.region]);
+  }, [record.id, region]);
 
   useInput((input, key) => {
     if (key.escape || input === 'b') {
@@ -179,7 +182,7 @@ function InsightsResultsView({ record, onBack }: { record: InsightsRunRecord; on
   return (
     <Panel fullWidth>
       <Box flexDirection="column">
-        <Text bold>Insights Results: {record.name || record.batchEvaluationId}</Text>
+        <Text bold>Insights Results: {record.name || record.id}</Text>
         <Text dimColor>
           Sessions: {totalSessions} | Clusters: {categories.length}
         </Text>
@@ -236,7 +239,7 @@ function InsightsJobDetailView({
   onBack,
   onViewResults,
 }: {
-  record: InsightsRunRecord;
+  record: InsightsJobRecord;
   onBack: () => void;
   onViewResults: () => void;
 }) {
@@ -255,7 +258,7 @@ function InsightsJobDetailView({
     <Panel fullWidth>
       <Box flexDirection="column">
         <Text>
-          <Text bold>ID:</Text> {record.batchEvaluationId}
+          <Text bold>ID:</Text> {record.id}
         </Text>
         <Text>
           <Text bold>Status:</Text> <Text color={statusColor(record.status)}>{record.status}</Text>
@@ -282,18 +285,19 @@ function InsightsJobDetailView({
         <Box marginTop={1} flexDirection="column">
           <Text bold>Sessions:</Text>
           <Text>
-            {'  '}total: {record.sessionCount ?? 'N/A'}
-            {record.sessionsCompleted != null && <Text>, completed: {record.sessionsCompleted}</Text>}
-            {record.sessionsFailed != null && record.sessionsFailed > 0 && (
-              <Text color="red">, failed: {record.sessionsFailed}</Text>
+            {'  '}total: {record.evaluationResults?.totalNumberOfSessions ?? 'N/A'}
+            {record.evaluationResults?.numberOfSessionsCompleted != null && (
+              <Text>, completed: {record.evaluationResults.numberOfSessionsCompleted}</Text>
             )}
+            {record.evaluationResults?.numberOfSessionsFailed != null &&
+              record.evaluationResults.numberOfSessionsFailed > 0 && (
+                <Text color="red">, failed: {record.evaluationResults.numberOfSessionsFailed}</Text>
+              )}
           </Text>
         </Box>
 
         <Box marginTop={1}>
-          <Text dimColor>
-            To generate a recommendation: agentcore run recommendation --from-insights {record.batchEvaluationId}
-          </Text>
+          <Text dimColor>To generate a recommendation: agentcore run recommendation --from-insights {record.id}</Text>
         </Box>
 
         <Box marginTop={1}>
@@ -317,14 +321,14 @@ export function InsightsJobsScreen({ onExit }: InsightsJobsScreenProps) {
   const terminalHeight = stdout?.rows ?? 24;
   const availableHeight = Math.max(6, terminalHeight - CHROME_LINES);
 
-  const [selectedRecord, setSelectedRecord] = useState<InsightsRunRecord | null>(null);
+  const [selectedRecord, setSelectedRecord] = useState<InsightsJobRecord | null>(null);
   const [viewingResults, setViewingResults] = useState(false);
 
   const [records, loaded, error] = useMemo(() => {
     try {
-      return [listInsightsRuns(), true, null] as const;
+      return [listRecords('insights'), true, null] as const;
     } catch (err) {
-      return [[] as InsightsRunRecord[], true, err instanceof Error ? err.message : String(err)] as const;
+      return [[] as InsightsJobRecord[], true, err instanceof Error ? err.message : String(err)] as const;
     }
   }, []);
 

--- a/src/cli/tui/screens/run-insights/RunInsightsFlow.tsx
+++ b/src/cli/tui/screens/run-insights/RunInsightsFlow.tsx
@@ -1,8 +1,6 @@
 import { ConfigIO } from '../../../../lib';
 import type { DeployedState } from '../../../../schema';
-import { detectRegion } from '../../../aws/region';
 import { getErrorMessage } from '../../../errors';
-import { saveInsightsRun } from '../../../operations/insights';
 import { createJobEngine } from '../../../operations/jobs';
 import type { InsightsJobRecord } from '../../../operations/jobs/shared/types';
 import { withCommandRunTelemetry } from '../../../telemetry/cli-command-run.js';
@@ -96,13 +94,6 @@ export function RunInsightsFlow({ isInteractive = true, onExit, onBack, onViewJo
             throw startResult.error ?? new Error('Failed to start insights job');
           }
 
-          // Mirror the new job to the legacy insights store so `view insights`
-          // (InsightsJobsScreen) finds it. Without this, the post-launch screen
-          // shows "No insights runs found" right after creating the job.
-          await persistToLegacyStore(startResult.record).catch(() => {
-            // Non-fatal — the job started successfully; storage failures shouldn't surface.
-          });
-
           setFlow({ name: 'success', record: startResult.record });
         } catch (err) {
           setFlow({
@@ -167,31 +158,6 @@ export function RunInsightsFlow({ isInteractive = true, onExit, onBack, onViewJo
       onExit={onExit}
     />
   );
-}
-
-async function persistToLegacyStore(record: InsightsJobRecord): Promise<void> {
-  // The job engine record uses `id`/`arn`; the legacy storage uses
-  // `batchEvaluationId`/`batchEvaluationArn`. Translate so InsightsJobsScreen
-  // (which reads from the legacy store) sees the new run.
-  const region = regionFromArn(record.arn) ?? (await detectRegion()).region;
-  saveInsightsRun({
-    batchEvaluationId: record.id,
-    batchEvaluationArn: record.arn,
-    name: record.name,
-    status: record.status,
-    region,
-    createdAt: record.createdAt,
-    completedAt: record.completedAt,
-    insights: record.insights,
-    agent: record.agent,
-  });
-}
-
-function regionFromArn(arn: string | undefined): string | undefined {
-  if (!arn) return undefined;
-  const region = arn.split(':')[3];
-  if (!region) return undefined;
-  return region;
 }
 
 function extractOnlineEvalConfigArns(deployedState: DeployedState): string[] {

--- a/src/cli/tui/screens/run-insights/RunInsightsFlow.tsx
+++ b/src/cli/tui/screens/run-insights/RunInsightsFlow.tsx
@@ -1,20 +1,27 @@
 import { ConfigIO } from '../../../../lib';
 import type { DeployedState } from '../../../../schema';
+import { detectRegion } from '../../../aws/region';
 import { getErrorMessage } from '../../../errors';
+import { saveInsightsRun } from '../../../operations/insights';
 import { createJobEngine } from '../../../operations/jobs';
 import type { InsightsJobRecord } from '../../../operations/jobs/shared/types';
 import { withCommandRunTelemetry } from '../../../telemetry/cli-command-run.js';
 import { ErrorPrompt, GradientText, SuccessPrompt } from '../../components';
 import { RunInsightsScreen } from './RunInsightsScreen';
-import type { RunInsightsConfig } from './types';
+import type { RunInsightsConfig, RunInsightsStep } from './types';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+
+interface ProjectData {
+  agentNames: string[];
+  onlineEvalConfigArns: string[];
+}
 
 type FlowState =
   | { name: 'loading' }
-  | { name: 'wizard'; agentNames: string[]; onlineEvalConfigArns: string[] }
+  | { name: 'wizard'; project: ProjectData; resume?: { config: RunInsightsConfig; step: RunInsightsStep } }
   | { name: 'submitting' }
   | { name: 'success'; record: InsightsJobRecord }
-  | { name: 'error'; message: string };
+  | { name: 'error'; message: string; project?: ProjectData; failedConfig?: RunInsightsConfig };
 
 interface RunInsightsFlowProps {
   isInteractive?: boolean;
@@ -51,7 +58,7 @@ export function RunInsightsFlow({ isInteractive = true, onExit, onBack, onViewJo
 
         const onlineEvalConfigArns = extractOnlineEvalConfigArns(deployedState);
 
-        setFlow({ name: 'wizard', agentNames, onlineEvalConfigArns });
+        setFlow({ name: 'wizard', project: { agentNames, onlineEvalConfigArns } });
       } catch (err) {
         if (!cancelled) setFlow({ name: 'error', message: getErrorMessage(err) });
       }
@@ -69,7 +76,7 @@ export function RunInsightsFlow({ isInteractive = true, onExit, onBack, onViewJo
   }, [isInteractive, flow.name, onExit]);
 
   const handleComplete = useCallback(
-    (config: RunInsightsConfig) => {
+    (config: RunInsightsConfig, project: ProjectData) => {
       setFlow({ name: 'submitting' });
 
       void (async () => {
@@ -88,9 +95,22 @@ export function RunInsightsFlow({ isInteractive = true, onExit, onBack, onViewJo
           if (!startResult.success) {
             throw startResult.error ?? new Error('Failed to start insights job');
           }
+
+          // Mirror the new job to the legacy insights store so `view insights`
+          // (InsightsJobsScreen) finds it. Without this, the post-launch screen
+          // shows "No insights runs found" right after creating the job.
+          await persistToLegacyStore(startResult.record).catch(() => {
+            // Non-fatal — the job started successfully; storage failures shouldn't surface.
+          });
+
           setFlow({ name: 'success', record: startResult.record });
         } catch (err) {
-          setFlow({ name: 'error', message: getErrorMessage(err) });
+          setFlow({
+            name: 'error',
+            message: getErrorMessage(err),
+            project,
+            failedConfig: config,
+          });
         }
       })();
     },
@@ -104,10 +124,12 @@ export function RunInsightsFlow({ isInteractive = true, onExit, onBack, onViewJo
   if (flow.name === 'wizard') {
     return (
       <RunInsightsScreen
-        agentNames={flow.agentNames}
-        onlineEvalConfigArns={flow.onlineEvalConfigArns}
-        onComplete={handleComplete}
+        agentNames={flow.project.agentNames}
+        onlineEvalConfigArns={flow.project.onlineEvalConfigArns}
+        onComplete={cfg => handleComplete(cfg, flow.project)}
         onExit={onBack}
+        initialConfig={flow.resume?.config}
+        initialStep={flow.resume?.step}
       />
     );
   }
@@ -124,14 +146,52 @@ export function RunInsightsFlow({ isInteractive = true, onExit, onBack, onViewJo
     );
   }
 
+  // Error: if we still have project data + the user's prior input, jump back
+  // into the wizard at the Name step with their config preserved. Otherwise
+  // (catastrophic load failure) fall back to the loading→error cycle.
   return (
     <ErrorPrompt
       message="Failed to start insights job"
       detail={flow.message}
-      onBack={() => setFlow({ name: 'loading' })}
+      onBack={() => {
+        if (flow.project && flow.failedConfig) {
+          setFlow({
+            name: 'wizard',
+            project: flow.project,
+            resume: { config: flow.failedConfig, step: 'name' },
+          });
+        } else {
+          setFlow({ name: 'loading' });
+        }
+      }}
       onExit={onExit}
     />
   );
+}
+
+async function persistToLegacyStore(record: InsightsJobRecord): Promise<void> {
+  // The job engine record uses `id`/`arn`; the legacy storage uses
+  // `batchEvaluationId`/`batchEvaluationArn`. Translate so InsightsJobsScreen
+  // (which reads from the legacy store) sees the new run.
+  const region = regionFromArn(record.arn) ?? (await detectRegion()).region;
+  saveInsightsRun({
+    batchEvaluationId: record.id,
+    batchEvaluationArn: record.arn,
+    name: record.name,
+    status: record.status,
+    region,
+    createdAt: record.createdAt,
+    completedAt: record.completedAt,
+    insights: record.insights,
+    agent: record.agent,
+  });
+}
+
+function regionFromArn(arn: string | undefined): string | undefined {
+  if (!arn) return undefined;
+  const region = arn.split(':')[3];
+  if (!region) return undefined;
+  return region;
 }
 
 function extractOnlineEvalConfigArns(deployedState: DeployedState): string[] {

--- a/src/cli/tui/screens/run-insights/RunInsightsScreen.tsx
+++ b/src/cli/tui/screens/run-insights/RunInsightsScreen.tsx
@@ -10,20 +10,59 @@ import {
 import type { SelectableItem } from '../../components';
 import { HELP_TEXT } from '../../constants';
 import { useListNavigation, useMultiSelectNavigation } from '../../hooks';
-import { AVAILABLE_INSIGHTS, RUN_INSIGHTS_STEP_LABELS, SESSION_MODE_OPTIONS, SOURCE_OPTIONS } from './types';
-import type { RunInsightsConfig } from './types';
+import {
+  AVAILABLE_INSIGHTS,
+  JOB_NAME_PATTERN,
+  RUN_INSIGHTS_STEP_LABELS,
+  SESSION_MODE_OPTIONS,
+  SOURCE_OPTIONS,
+} from './types';
+import type { RunInsightsConfig, RunInsightsStep } from './types';
 import { useRunInsightsWizard } from './useRunInsightsWizard';
-import React, { useMemo } from 'react';
+import React, { forwardRef, useImperativeHandle, useMemo } from 'react';
+
+export interface RunInsightsScreenHandle {
+  jumpToStep: (step: RunInsightsStep) => void;
+}
 
 interface RunInsightsScreenProps {
   agentNames: string[];
   onlineEvalConfigArns: string[];
   onComplete: (config: RunInsightsConfig) => void;
   onExit: () => void;
+  /** Pre-seed wizard state, e.g. when returning from a validation/API error. */
+  initialConfig?: RunInsightsConfig;
+  /** Step to land on at mount (default: 'source'). */
+  initialStep?: RunInsightsStep;
 }
 
-export function RunInsightsScreen({ agentNames, onlineEvalConfigArns, onComplete, onExit }: RunInsightsScreenProps) {
-  const wizard = useRunInsightsWizard(agentNames.length);
+function validateJobName(value: string): true | string {
+  // Empty is allowed — the CLI auto-generates a name when omitted.
+  if (!value) return true;
+  if (!JOB_NAME_PATTERN.test(value)) {
+    return 'Name must start with a letter and contain only letters, numbers, and underscores (max 48 chars).';
+  }
+  return true;
+}
+
+function validateLookbackInput(value: string): true | string {
+  if (!value) return true;
+  const days = parseInt(value, 10);
+  if (!Number.isInteger(days) || String(days) !== value.trim()) {
+    return 'Lookback must be a whole number.';
+  }
+  if (days < 1 || days > 90) {
+    return 'Lookback must be between 1 and 90 days.';
+  }
+  return true;
+}
+
+export const RunInsightsScreen = forwardRef<RunInsightsScreenHandle, RunInsightsScreenProps>(function RunInsightsScreen(
+  { agentNames, onlineEvalConfigArns, onComplete, onExit, initialConfig, initialStep },
+  ref
+) {
+  const wizard = useRunInsightsWizard(agentNames, initialConfig, initialStep);
+  useImperativeHandle(ref, () => ({ jumpToStep: wizard.jumpToStep }), [wizard.jumpToStep]);
 
   const isSourceStep = wizard.step === 'source';
   const isAgentStep = wizard.step === 'agent';
@@ -157,10 +196,8 @@ export function RunInsightsScreen({ agentNames, onlineEvalConfigArns, onComplete
             key="lookback"
             prompt="Lookback window (days)"
             initialValue="7"
-            onSubmit={value => {
-              const days = parseInt(value, 10);
-              wizard.setLookbackDays(isNaN(days) || days <= 0 ? 7 : days);
-            }}
+            customValidation={validateLookbackInput}
+            onSubmit={value => wizard.setLookbackDays(parseInt(value, 10))}
             onCancel={() => wizard.goBack()}
           />
         )}
@@ -187,6 +224,8 @@ export function RunInsightsScreen({ agentNames, onlineEvalConfigArns, onComplete
           <TextInput
             key="name"
             prompt="Job name (leave blank for auto-generated)"
+            allowEmpty
+            customValidation={validateJobName}
             onSubmit={value => wizard.setName(value)}
             onCancel={() => wizard.goBack()}
           />
@@ -197,7 +236,7 @@ export function RunInsightsScreen({ agentNames, onlineEvalConfigArns, onComplete
             fields={
               wizard.config.source === 'agent'
                 ? [
-                    { label: 'Agent', value: wizard.config.agent ?? agentNames[0] ?? '' },
+                    { label: 'Agent', value: wizard.config.agent !== '' ? wizard.config.agent : (agentNames[0] ?? '') },
                     {
                       label: 'Insights',
                       value: wizard.config.insights
@@ -218,4 +257,4 @@ export function RunInsightsScreen({ agentNames, onlineEvalConfigArns, onComplete
       </Panel>
     </Screen>
   );
-}
+});

--- a/src/cli/tui/screens/run-insights/RunInsightsScreen.tsx
+++ b/src/cli/tui/screens/run-insights/RunInsightsScreen.tsx
@@ -19,11 +19,7 @@ import {
 } from './types';
 import type { RunInsightsConfig, RunInsightsStep } from './types';
 import { useRunInsightsWizard } from './useRunInsightsWizard';
-import React, { forwardRef, useImperativeHandle, useMemo } from 'react';
-
-export interface RunInsightsScreenHandle {
-  jumpToStep: (step: RunInsightsStep) => void;
-}
+import React, { useMemo } from 'react';
 
 interface RunInsightsScreenProps {
   agentNames: string[];
@@ -57,12 +53,15 @@ function validateLookbackInput(value: string): true | string {
   return true;
 }
 
-export const RunInsightsScreen = forwardRef<RunInsightsScreenHandle, RunInsightsScreenProps>(function RunInsightsScreen(
-  { agentNames, onlineEvalConfigArns, onComplete, onExit, initialConfig, initialStep },
-  ref
-) {
+export function RunInsightsScreen({
+  agentNames,
+  onlineEvalConfigArns,
+  onComplete,
+  onExit,
+  initialConfig,
+  initialStep,
+}: RunInsightsScreenProps) {
   const wizard = useRunInsightsWizard(agentNames, initialConfig, initialStep);
-  useImperativeHandle(ref, () => ({ jumpToStep: wizard.jumpToStep }), [wizard.jumpToStep]);
 
   const isSourceStep = wizard.step === 'source';
   const isAgentStep = wizard.step === 'agent';
@@ -257,4 +256,4 @@ export const RunInsightsScreen = forwardRef<RunInsightsScreenHandle, RunInsights
       </Panel>
     </Screen>
   );
-});
+}

--- a/src/cli/tui/screens/run-insights/types.ts
+++ b/src/cli/tui/screens/run-insights/types.ts
@@ -36,6 +36,13 @@ export const RUN_INSIGHTS_STEP_LABELS: Record<RunInsightsStep, string> = {
 
 export const DEFAULT_LOOKBACK_DAYS = 7;
 
+/**
+ * Validation pattern for job names. Mirrors the service-side BatchEvaluationName
+ * shape (`^[a-zA-Z][a-zA-Z0-9_]{0,47}$`) so we reject locally instead of
+ * surfacing a 400 from startBatchEvaluation.
+ */
+export const JOB_NAME_PATTERN = /^[a-zA-Z][a-zA-Z0-9_]{0,47}$/;
+
 export const AVAILABLE_INSIGHTS = [
   {
     id: 'Builtin.Insight.FailureAnalysis',

--- a/src/cli/tui/screens/run-insights/useRunInsightsWizard.ts
+++ b/src/cli/tui/screens/run-insights/useRunInsightsWizard.ts
@@ -12,10 +12,12 @@ function getStepsForSource(source: RunInsightsSource, agentCount: number): RunIn
   return ['source', 'agent', 'insights', 'sessions', 'lookbackDays', 'name', 'confirm'];
 }
 
-function getDefaultConfig(): RunInsightsConfig {
+function getDefaultConfig(soleAgent: string): RunInsightsConfig {
   return {
     source: 'agent',
-    agent: '',
+    // Pre-populate when only one agent exists so the confirm screen shows it
+    // even though the agent selection step is skipped.
+    agent: soleAgent,
     insights: [],
     sessionMode: 'lookback',
     lookbackDays: DEFAULT_LOOKBACK_DAYS,
@@ -25,9 +27,15 @@ function getDefaultConfig(): RunInsightsConfig {
   };
 }
 
-export function useRunInsightsWizard(agentCount: number) {
-  const [config, setConfig] = useState<RunInsightsConfig>(getDefaultConfig);
-  const [step, setStep] = useState<RunInsightsStep>('source');
+export function useRunInsightsWizard(
+  agentNames: string[],
+  initialConfig?: RunInsightsConfig,
+  initialStep: RunInsightsStep = 'source'
+) {
+  const agentCount = agentNames.length;
+  const soleAgent = agentCount === 1 ? (agentNames[0] ?? '') : '';
+  const [config, setConfig] = useState<RunInsightsConfig>(() => initialConfig ?? getDefaultConfig(soleAgent));
+  const [step, setStep] = useState<RunInsightsStep>(initialStep);
 
   const allSteps = useMemo(() => getStepsForSource(config.source, agentCount), [config.source, agentCount]);
   const currentIndex = allSteps.indexOf(step);
@@ -49,6 +57,16 @@ export function useRunInsightsWizard(agentCount: number) {
       setStep(allSteps[currentIndex - 1]!);
     }
   }, [allSteps, currentIndex]);
+
+  /** Jump to an arbitrary step in the current flow without resetting config. */
+  const jumpToStep = useCallback(
+    (target: RunInsightsStep) => {
+      if (allSteps.includes(target)) {
+        setStep(target);
+      }
+    },
+    [allSteps]
+  );
 
   const setSource = useCallback(
     (source: RunInsightsSource) => {
@@ -80,13 +98,8 @@ export function useRunInsightsWizard(agentCount: number) {
   const setSessionMode = useCallback(
     (sessionMode: RunInsightsSessionMode) => {
       setConfig(c => ({ ...c, sessionMode }));
-      if (sessionMode === 'lookback') {
-        const next = nextStep('sessions');
-        if (next) setStep(next);
-      } else {
-        const next = nextStep('sessions');
-        if (next) setStep(next);
-      }
+      const next = nextStep('sessions');
+      if (next) setStep(next);
     },
     [nextStep]
   );
@@ -128,9 +141,9 @@ export function useRunInsightsWizard(agentCount: number) {
   );
 
   const reset = useCallback(() => {
-    setConfig(getDefaultConfig());
+    setConfig(getDefaultConfig(soleAgent));
     setStep('source');
-  }, []);
+  }, [soleAgent]);
 
   return {
     config,
@@ -138,6 +151,7 @@ export function useRunInsightsWizard(agentCount: number) {
     steps: allSteps,
     currentIndex,
     goBack,
+    jumpToStep,
     setSource,
     setAgent,
     setInsights,

--- a/src/cli/tui/screens/run-insights/useRunInsightsWizard.ts
+++ b/src/cli/tui/screens/run-insights/useRunInsightsWizard.ts
@@ -58,16 +58,6 @@ export function useRunInsightsWizard(
     }
   }, [allSteps, currentIndex]);
 
-  /** Jump to an arbitrary step in the current flow without resetting config. */
-  const jumpToStep = useCallback(
-    (target: RunInsightsStep) => {
-      if (allSteps.includes(target)) {
-        setStep(target);
-      }
-    },
-    [allSteps]
-  );
-
   const setSource = useCallback(
     (source: RunInsightsSource) => {
       setConfig(c => ({ ...c, source }));
@@ -151,7 +141,6 @@ export function useRunInsightsWizard(
     steps: allSteps,
     currentIndex,
     goBack,
-    jumpToStep,
     setSource,
     setAgent,
     setInsights,


### PR DESCRIPTION
## Summary

Four fixes to the `agentcore run insights` interactive wizard, from the Lens-in-CLI bug bash:

- Single-agent flow leaves Confirm blank. When the project has exactly one agent, the wizard skipped the agent step but never populated `config.agent`, so the Confirm screen showed an empty `Agent:` line. The default config now pre-populates the sole agent so it threads through to confirm and the API call.

- Inline name validation. The Name step accepted spaces / hyphens / leading digits and only blew up after submit with a service 400. We now validate inline using the service-side `BatchEvaluationName` shape (`^[a-zA-Z][a-zA-Z0-9_]{0,47}$`) from `AgentCoreEvaluationCommonModel`. Lookback days also validate inline (1-90, integer only) instead of silently coercing 0 → 7.

-  Preserve config on error. Hitting \"Go back\" from a launch error reset the entire wizard. The failed config is now stashed in flow state and the wizard re-opens at the Name step with all prior selections intact.

-  Post-launch \"No insights runs found\". The wizard wrote to the job-engine store, but the post-launch \"View Insights Jobs\" screen reads from the legacy `.cli/insights/*.json` store. We now mirror successful starts to the legacy store after launch so the new job appears immediately.
