### PR TITLE
fix: exit nonzero for invalid status filters

### DIFF
--- a/integ-tests/status.test.ts
+++ b/integ-tests/status.test.ts
@@ -69,7 +69,7 @@ describe('status command', () => {
 
   it('emits failure telemetry for invalid --type', async () => {
     const result = await runCLI(['status', '--type', 'bogus'], projectDir, { env: telemetry.env });
-    expect(result.exitCode).toBe(0);
+    expect(result.exitCode).toBe(1);
     telemetry.assertMetricEmitted({
       command: 'status',
       exit_reason: 'failure',
@@ -80,7 +80,7 @@ describe('status command', () => {
 
   it('emits failure telemetry for invalid --state', async () => {
     const result = await runCLI(['status', '--state', 'bogus'], projectDir, { env: telemetry.env });
-    expect(result.exitCode).toBe(0);
+    expect(result.exitCode).toBe(1);
     telemetry.assertMetricEmitted({
       command: 'status',
       exit_reason: 'failure',

--- a/src/cli/commands/status/__tests__/command.test.ts
+++ b/src/cli/commands/status/__tests__/command.test.ts
@@ -1,0 +1,67 @@
+import { registerStatus } from '../command.js';
+import { Command } from '@commander-js/extra-typings';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockRender } = vi.hoisted(() => ({
+  mockRender: vi.fn(),
+}));
+
+vi.mock('../../../tui/guards', () => ({
+  requireProject: vi.fn(),
+}));
+
+vi.mock('../../../telemetry/cli-command-run.js', () => ({
+  withCommandRunTelemetry: vi.fn((_command, _attrs, run) => run()),
+}));
+
+vi.mock('../../../operations/dataset', () => ({
+  getDatasetStatus: vi.fn(),
+}));
+
+vi.mock('../action.js', () => ({
+  handleProjectStatus: vi.fn(),
+  handleRuntimeLookup: vi.fn(),
+  loadStatusConfig: vi.fn(),
+}));
+
+vi.mock('../../../feature-flags', () => ({
+  isPreviewEnabled: () => false,
+}));
+
+vi.mock('ink', () => ({
+  Box: ({ children }: { children?: unknown }) => children,
+  Text: ({ children }: { children?: unknown }) => children,
+  render: mockRender,
+}));
+
+describe('status command validation', () => {
+  let program: Command;
+  let originalExitCode: typeof process.exitCode;
+
+  beforeEach(() => {
+    originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+    program = new Command();
+    program.exitOverride();
+    registerStatus(program);
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    vi.clearAllMocks();
+  });
+
+  it('sets a non-zero exit code for invalid resource type', async () => {
+    await program.parseAsync(['status', '--type', 'bogus'], { from: 'user' });
+
+    expect(process.exitCode).toBe(1);
+    expect(mockRender).toHaveBeenCalled();
+  });
+
+  it('sets a non-zero exit code for invalid state', async () => {
+    await program.parseAsync(['status', '--state', 'bogus'], { from: 'user' });
+
+    expect(process.exitCode).toBe(1);
+    expect(mockRender).toHaveBeenCalled();
+  });
+});

--- a/src/cli/commands/status/command.tsx
+++ b/src/cli/commands/status/command.tsx
@@ -97,6 +97,7 @@ export const registerStatus = (program: Command) => {
           error: new ValidationError(msg),
         }));
         render(<Text color="red">{msg}</Text>);
+        process.exitCode = 1;
         return;
       }
 
@@ -108,6 +109,7 @@ export const registerStatus = (program: Command) => {
           error: new ValidationError(msg),
         }));
         render(<Text color="red">{msg}</Text>);
+        process.exitCode = 1;
         return;
       }
 


### PR DESCRIPTION
## Summary

- set a non-zero exit code when `agentcore status` rejects an invalid `--type` filter
- do the same for invalid `--state` filters
- add command validation coverage for both cases

Fixes #984

## Testing

- `vitest run --project unit src/cli/commands/status/__tests__/command.test.ts`
- `prettier --check src/cli/commands/status/command.tsx src/cli/commands/status/__tests__/command.test.ts`
- `git diff --check`
