### PR TITLE
feat: upgrade agent inspector to 0.6.1

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -28,7 +28,7 @@
         "@aws-sdk/client-xray": "^3.1003.0",
         "@aws-sdk/credential-providers": "^3.893.0",
         "@aws-sdk/region-config-resolver": "^3.972.13",
-        "@aws/agent-inspector": "0.6.0",
+        "@aws/agent-inspector": "0.6.1",
         "@commander-js/extra-typings": "^14.0.0",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-metrics-otlp-http": "^0.215.0",
@@ -2835,9 +2835,9 @@
       }
     },
     "node_modules/@aws/agent-inspector": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@aws/agent-inspector/-/agent-inspector-0.6.0.tgz",
-      "integrity": "sha512-WvDies3yLt4ygKRih9a+431pjY8CDTNOR/JpDklq99CVimzDdW2ySd8CTo3pVg8MGl0kJJUFbZNhUr/xUtHTUw==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@aws/agent-inspector/-/agent-inspector-0.6.1.tgz",
+      "integrity": "sha512-+0KJRZe/mK1qenDOGdnCYZdSAt8jZK4tLb8Bc6vbpQqKc3MsRP2ICh0X9mtSAA6iT2KyG7crprsSXZJ3laEijQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ag-ui/core": "^0.0.52",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "@aws-sdk/client-xray": "^3.1003.0",
     "@aws-sdk/credential-providers": "^3.893.0",
     "@aws-sdk/region-config-resolver": "^3.972.13",
-    "@aws/agent-inspector": "0.6.0",
+    "@aws/agent-inspector": "0.6.1",
     "@commander-js/extra-typings": "^14.0.0",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.215.0",


### PR DESCRIPTION
## Description

Updates agent inspector to v0.6.1, which includes the following changes:

- display warning banner in agent inspector if project contains harnesses that have not been deployed

## Related Issue

<!-- Every PR must be associated with an issue. Link it below using #issue-number format. -->

Closes #

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:unit` and `npm run test:integ`
- [ ] I ran `npm run typecheck`
- [ ] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
