### PR TITLE
fix: select deployed target's stack at Persist instead of stackNames[0]

### DIFF
--- a/src/cli/commands/deploy/__tests__/deploy.test.ts
+++ b/src/cli/commands/deploy/__tests__/deploy.test.ts
@@ -1,5 +1,5 @@
 import { runCLI } from '../../../../test-utils/index.js';
-import { runDeploy, runDiff } from '../actions.js';
+import { runDeploy, runDiff, selectTargetStack } from '../actions.js';
 import { StackSelectionStrategy } from '@aws-cdk/toolkit-lib';
 import { randomUUID } from 'node:crypto';
 import { mkdir, rm, writeFile } from 'node:fs/promises';
@@ -56,6 +56,42 @@ describe('deploy without agents', () => {
     expect(json.success).toBe(false);
     expect(json.error).toBeDefined();
     expect(json.error.toLowerCase()).toContain('no resources defined');
+  });
+});
+
+describe('selectTargetStack', () => {
+  // Multi-target projects synth one stack per target in aws-targets.json. The deploy flow
+  // must persist/describe the stack for the *deployed* target — not blindly stackNames[0].
+  // Regression guard for: `deploy --target qa` failing at Persist because the CLI described
+  // the first target's stack (e.g. AgentCore-myapp-default) instead of the qa stack.
+  it('selects the deployed target stack, not the first synthesized stack', () => {
+    const result = selectTargetStack(['AgentCore-myapp-default', 'AgentCore-myapp-qa'], 'myapp', 'qa');
+    expect(result).toEqual({ success: true, stackName: 'AgentCore-myapp-qa' });
+  });
+
+  it('selects the target stack regardless of ordering in the assembly', () => {
+    const result = selectTargetStack(['AgentCore-myapp-qa', 'AgentCore-myapp-default'], 'myapp', 'default');
+    expect(result).toEqual({ success: true, stackName: 'AgentCore-myapp-default' });
+  });
+
+  it('handles single-target projects', () => {
+    const result = selectTargetStack(['AgentCore-myapp-default'], 'myapp', 'default');
+    expect(result).toEqual({ success: true, stackName: 'AgentCore-myapp-default' });
+  });
+
+  it('normalizes underscores in project and target names to match synthesized names', () => {
+    const result = selectTargetStack(['AgentCore-my-app-qa-east'], 'my_app', 'qa_east');
+    expect(result).toEqual({ success: true, stackName: 'AgentCore-my-app-qa-east' });
+  });
+
+  it('fails when no stacks were synthesized', () => {
+    const result = selectTargetStack([], 'myapp', 'qa');
+    expect(result.success).toBe(false);
+  });
+
+  it('fails when the deployed target has no matching synthesized stack', () => {
+    const result = selectTargetStack(['AgentCore-myapp-default'], 'myapp', 'qa');
+    expect(result.success).toBe(false);
   });
 });
 

--- a/src/cli/commands/deploy/actions.ts
+++ b/src/cli/commands/deploy/actions.ts
@@ -1,4 +1,5 @@
 import { ConfigIO, ResourceNotFoundError, SecureCredentials, ValidationError, toError } from '../../../lib';
+import type { Result } from '../../../lib/result';
 import type { AgentCoreMcpSpec, DeployedState } from '../../../schema';
 import { applyTargetRegionToEnv } from '../../aws';
 import { validateAwsCredentials } from '../../aws/account';
@@ -92,6 +93,36 @@ export function computeHarnessVersionDrift(
     if (from !== rec.harnessVersion) notes.push({ name, from, to: rec.harnessVersion });
   }
   return notes;
+}
+
+/**
+ * Pick the synthesized stack for the target being deployed.
+ *
+ * The vended CDK app synthesizes one stack per target in aws-targets.json, so a multi-target
+ * project's assembly contains every target's stack. Selecting `stackNames[0]` would describe/persist
+ * the *first* target's stack rather than the deployed one — for `deploy --target qa` that meant the
+ * Persist step ran `DescribeStacks` on a different (often undeployed) stack and failed. Matching on the
+ * deterministic `toStackName(project, target)` keeps the choice correct regardless of target ordering.
+ */
+export function selectTargetStack(
+  stackNames: string[],
+  projectName: string,
+  targetName: string
+): Result<{ stackName: string }, ValidationError> {
+  if (stackNames.length === 0) {
+    return { success: false, error: new ValidationError('No stacks found to deploy') };
+  }
+  const expected = toStackName(projectName, targetName);
+  if (!stackNames.includes(expected)) {
+    return {
+      success: false,
+      error: new ValidationError(
+        `Synthesized stacks [${stackNames.join(', ')}] do not include the stack for target ` +
+          `"${targetName}" (expected "${expected}").`
+      ),
+    };
+  }
+  return { success: true, stackName: expected };
 }
 
 export async function runDiff(
@@ -387,20 +418,21 @@ export async function handleDeploy(options: ValidatedDeployOptions): Promise<Dep
       region: target.region,
     });
     toolkitWrapper = synthResult.toolkitWrapper;
-    const stackNames = synthResult.stackNames;
-    if (stackNames.length === 0) {
-      endStep('error', 'No stacks found');
+    // The assembly holds one stack per target in aws-targets.json. Select the deployed target's
+    // stack so every downstream step (deployability check, deploy, Persist/describe) acts on it
+    // rather than blindly on stackNames[0] — see selectTargetStack.
+    const stackSelection = selectTargetStack(synthResult.stackNames, context.projectSpec.name, target.name);
+    if (!stackSelection.success) {
+      endStep('error', stackSelection.error.message);
       logger.finalize(false);
       return {
         success: false,
-        error: new ValidationError('No stacks found to deploy'),
+        error: stackSelection.error,
         logPath: logger.getRelativeLogPath(),
       };
     }
-    const stackName = stackNames[0]!;
+    const stackName = stackSelection.stackName;
     endStep('success');
-
-    const targetStackName = toStackName(context.projectSpec.name, target.name);
 
     // Check if bootstrap needed
     startStep('Check bootstrap status');
@@ -421,9 +453,10 @@ export async function handleDeploy(options: ValidatedDeployOptions): Promise<Dep
     }
     endStep('success');
 
-    // Check stack deployability
+    // Check stack deployability — scope to the deployed target's stack only, not every
+    // synthesized target, so a sibling target's in-progress/failed stack can't block this deploy.
     startStep('Check stack status');
-    const deployabilityCheck = await checkStackDeployability(target.region, stackNames);
+    const deployabilityCheck = await checkStackDeployability(target.region, [stackName]);
     if (!deployabilityCheck.canDeploy) {
       endStep('error', deployabilityCheck.message);
       logger.finalize(false);
@@ -451,7 +484,7 @@ export async function handleDeploy(options: ValidatedDeployOptions): Promise<Dep
     // Diff mode: run cdk diff and exit without deploying
     if (options.diff) {
       startStep('Run CDK diff');
-      await runDiff(toolkitWrapper, targetStackName, switchableIoHost);
+      await runDiff(toolkitWrapper, stackName, switchableIoHost);
       endStep('success');
 
       logger.finalize(true);
@@ -491,7 +524,7 @@ export async function handleDeploy(options: ValidatedDeployOptions): Promise<Dep
       switchableIoHost.setVerbose(true);
     }
 
-    await runDeploy(toolkitWrapper, targetStackName);
+    await runDeploy(toolkitWrapper, stackName);
 
     // Disable verbose output
     if (switchableIoHost) {


### PR DESCRIPTION
## Description

`agentcore deploy --target <name>` failed at the **Persist deployment state** step when the
target was not the first entry in `aws-targets.json`, erroring with `Stack <first-target> does
not exist` — even though the requested target's stack deployed successfully. AWS resources were
left running while `deployed-state.json` was never written (orphaned infrastructure with no local
pointer for teardown/status).

**Root cause.** The vended CDK app (`src/assets/cdk/bin/cdk.ts`) synthesizes **one stack per
target** in `aws-targets.json`, so `synthResult.stackNames` contains every target's stack. The
deploy flow used `stackNames[0]` for the deployability check and the Persist step
(`getStackOutputs` / `buildDeployedState`), while the deploy and diff steps correctly used
`toStackName(project, target)`. When the deployed `--target` wasn't first in the file,
`stackNames[0]` pointed at a different (usually undeployed) stack, so `DescribeStacks` at Persist
threw.

**Fix.** Introduce a pure `selectTargetStack(stackNames, projectName, targetName)` that matches the
deterministic `toStackName(project, target)` against the synthesized stacks — making selection
**ordering-independent** — and returns a clear `ValidationError` (naming the synthesized stacks and
the expected one) if the target's stack is absent. That selected stack name is now authoritative for
the deployability check (scoped to the single stack instead of looping `DescribeStacks` over every
target), diff, deploy, and Persist. The redundant `targetStackName` local is removed.

Single-target projects are unaffected (where `stackNames[0]` happened to already be the right stack).

### Scope note (for reviewers)
This fixes the **CLI** deploy path (`handleDeploy`). The **TUI** deploy path (`useDeployFlow.ts`)
has a *separate, related* multi-target limitation — it has no `--target` selector (the `--target`
flag always routes to the CLI path), always uses `awsTargets[0]`/`stackNames[0]` (which are mutually
consistent, so it is **not** the same cross-mismatch bug), and persists state for only the first of N
deployed targets. That is intentionally **out of scope** here and should be tracked as a follow-up;
the new `selectTargetStack` is exported so it can be reused there.

## Related Issue

No existing GitHub issue. Reported via internal feedback:
- Aperture: `9013745d-b4aa-4b20-a1ca-e03fa712ffbf`
- SIM: `V2260713830`

## Documentation PR

N/A — bug fix, no user-facing documentation change.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [x] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots — N/A, `src/assets/` not modified

**Unit (`selectTargetStack`)** — 6 cases: ordering (`--target qa` with qa first vs. second),
single-target, underscore normalization, empty assembly, and target-with-no-matching-stack. Verified
red→green by reintroducing `stackNames[0]` (the ordering tests fail) and reverting (they pass).
Full suites: **unit 5415 passed, integ 310 passed**, typecheck clean, lint 0 errors.

**End-to-end on live CloudFormation** (us-east-1) with a 2-target project
(`default` first, `qa` second):

| Build | Command | Result |
|-------|---------|--------|
| `main` (before) | `deploy --target qa --yes --json` | ❌ Deploy step ✓ (qa stack `CREATE_COMPLETE`) → **Persist** → `Stack with id AgentCore-<project>-default does not exist`; `deployed-state.json` left `{"targets":{}}` |
| this branch (after) | `deploy --target qa --yes --json` | ✅ `{"success":true,"targetName":"qa","stackName":"AgentCore-<project>-qa", ...}`; Persist SUCCESS; `deployed-state.json` keyed under `qa`; only the qa stack created/described |

All test CloudFormation stacks and resources were torn down after verification.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly — N/A
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
