### PR TITLE
fix(deploy): resolve online-eval step on re-deploys with no new configs

### DIFF
--- a/src/cli/tui/screens/deploy/useDeployFlow.ts
+++ b/src/cli/tui/screens/deploy/useDeployFlow.ts
@@ -656,6 +656,10 @@ export function useDeployFlow(options: DeployFlowOptions = {}): DeployFlowState 
         logger.endStep('error', message);
         setOnlineEvalStep(prev => ({ ...prev, status: 'error', error: message }));
       }
+    } else if (onlineEvalFullSpecs.length > 0) {
+      // Step is rendered whenever onlineEvalConfigs is non-empty, but only runs for newly
+      // deployed configs. With nothing new to enable, mark it terminal so the deploy completes.
+      setOnlineEvalStep(prev => ({ ...prev, status: 'success' }));
     }
 
     // Config bundles are now managed via CloudFormation; their state is parsed


### PR DESCRIPTION
## Summary

Fixes #1614.

TLDR if you have online eval configs (enabled) in your project and you deploy it, then deploy again without changing the state of online eval config, the TUI would freeze on this step `Enable online evaluation`.

I made a fix for this step in the codebase but I believe a larger refactor is needed here