### PR TITLE
Ungate passthrough gateway targets

### DIFF
--- a/src/cli/commands/add/__tests__/validate.test.ts
+++ b/src/cli/commands/add/__tests__/validate.test.ts
@@ -469,8 +469,8 @@ describe('validate', () => {
       expect(result.valid).toBe(true);
     });
 
-    // Passthrough is gated behind ENABLE_GATED_FEATURES
-    describe('passthrough feature flag', () => {
+    // Passthrough is generally available (no longer gated)
+    describe('passthrough target type', () => {
       const passthroughOpts: AddGatewayTargetOptions = {
         name: 'pt-target',
         type: 'passthrough',
@@ -478,31 +478,20 @@ describe('validate', () => {
         passthroughEndpoint: 'https://api.example.com',
       } as AddGatewayTargetOptions;
 
-      afterEach(() => {
-        delete process.env.ENABLE_GATED_FEATURES;
-      });
-
-      it('rejects passthrough when the flag is off', async () => {
+      it('allows passthrough without any feature flag', async () => {
         delete process.env.ENABLE_GATED_FEATURES;
         const result = await validateAddGatewayTargetOptions({ ...passthroughOpts });
-        expect(result.valid).toBe(false);
-        expect(result.error).toBe('Passthrough targets are not yet available.');
+        expect(result.valid).toBe(true);
       });
 
-      it('omits passthrough from the invalid-type error when the flag is off', async () => {
+      it('lists passthrough in the invalid-type error', async () => {
         delete process.env.ENABLE_GATED_FEATURES;
         const result = await validateAddGatewayTargetOptions({
           ...validGatewayTargetOptions,
           type: 'bogus-type',
         } as AddGatewayTargetOptions);
         expect(result.valid).toBe(false);
-        expect(result.error).not.toContain('passthrough');
-      });
-
-      it('allows passthrough when the flag is on', async () => {
-        process.env.ENABLE_GATED_FEATURES = '1';
-        const result = await validateAddGatewayTargetOptions({ ...passthroughOpts });
-        expect(result.valid).toBe(true);
+        expect(result.error).toContain('passthrough');
       });
     });
     // AC20: type validation

--- a/src/cli/commands/add/__tests__/validate.test.ts
+++ b/src/cli/commands/add/__tests__/validate.test.ts
@@ -469,7 +469,6 @@ describe('validate', () => {
       expect(result.valid).toBe(true);
     });
 
-    // Passthrough is generally available (no longer gated)
     describe('passthrough target type', () => {
       const passthroughOpts: AddGatewayTargetOptions = {
         name: 'pt-target',
@@ -478,14 +477,12 @@ describe('validate', () => {
         passthroughEndpoint: 'https://api.example.com',
       } as AddGatewayTargetOptions;
 
-      it('allows passthrough without any feature flag', async () => {
-        delete process.env.ENABLE_GATED_FEATURES;
+      it('accepts a valid passthrough target', async () => {
         const result = await validateAddGatewayTargetOptions({ ...passthroughOpts });
         expect(result.valid).toBe(true);
       });
 
       it('lists passthrough in the invalid-type error', async () => {
-        delete process.env.ENABLE_GATED_FEATURES;
         const result = await validateAddGatewayTargetOptions({
           ...validGatewayTargetOptions,
           type: 'bogus-type',

--- a/src/cli/commands/add/validate.ts
+++ b/src/cli/commands/add/validate.ts
@@ -399,7 +399,6 @@ export async function validateAddGatewayTargetOptions(options: AddGatewayTargetO
     return { valid: false, error: '--name is required' };
   }
 
-  // passthrough is gated; omit it from advertised type lists when the flag is off.
   const validTypeList = [
     'mcp-server',
     'api-gateway',
@@ -408,7 +407,7 @@ export async function validateAddGatewayTargetOptions(options: AddGatewayTargetO
     'lambda-function-arn',
     'http-runtime',
     'connector',
-    ...(isGatedFeaturesEnabled() ? ['passthrough'] : []),
+    'passthrough',
     'web-search',
   ].join(', ');
 
@@ -727,9 +726,6 @@ export async function validateAddGatewayTargetOptions(options: AddGatewayTargetO
 
   // Passthrough targets: validate early and return
   if (mappedType === 'passthrough') {
-    if (!isGatedFeaturesEnabled()) {
-      return { valid: false, error: 'Passthrough targets are not yet available.' };
-    }
     const passthroughEndpoint = (options as Record<string, string | undefined>).passthroughEndpoint;
     if (!passthroughEndpoint) {
       return { valid: false, error: '--passthrough-endpoint is required for passthrough type' };

--- a/src/cli/primitives/GatewayTargetPrimitive.ts
+++ b/src/cli/primitives/GatewayTargetPrimitive.ts
@@ -63,14 +63,6 @@ import { dirname, join } from 'path';
 const MCP_DEFS_FILE = 'mcp-defs.json';
 
 /**
- * Passthrough-only CLI option. Kept as a pass-through wrapper so the six call sites
- * read consistently; passthrough targets are no longer gated.
- */
-function gatePassthroughOption(option: Option): Option {
-  return option;
-}
-
-/**
  * Options for adding a gateway target (CLI-level).
  */
 export interface AddGatewayTargetOptions {
@@ -355,47 +347,35 @@ export class GatewayTargetPrimitive extends BasePrimitive<AddGatewayTargetOption
       )
       .option('--runtime <name>', 'Runtime from your project (for http-runtime type) [non-interactive]')
       .option('--runtime-endpoint <name>', 'Runtime endpoint / version alias (for http-runtime type) [non-interactive]')
-      // Passthrough-only flags are gated behind ENABLE_GATED_FEATURES — hidden from help when off.
+      // Passthrough-only flags.
       .addOption(
-        gatePassthroughOption(
-          new Option('--passthrough-endpoint <url>', 'HTTPS endpoint URL for passthrough targets [non-interactive]')
+        new Option('--passthrough-endpoint <url>', 'HTTPS endpoint URL for passthrough targets [non-interactive]')
+      )
+      .addOption(
+        new Option(
+          '--passthrough-protocol <type>',
+          'Passthrough protocol: MCP | A2A | INFERENCE | CUSTOM (default: CUSTOM) [non-interactive]'
         )
       )
       .addOption(
-        gatePassthroughOption(
-          new Option(
-            '--passthrough-protocol <type>',
-            'Passthrough protocol: MCP | A2A | INFERENCE | CUSTOM (default: CUSTOM) [non-interactive]'
-          )
+        new Option(
+          '--stickiness-identifier <expr>',
+          'Session routing expression for passthrough targets [non-interactive]'
         )
       )
       .addOption(
-        gatePassthroughOption(
-          new Option(
-            '--stickiness-identifier <expr>',
-            'Session routing expression for passthrough targets [non-interactive]'
-          )
+        new Option('--stickiness-timeout <seconds>', 'Sticky session timeout in seconds (1-86400) [non-interactive]')
+      )
+      .addOption(
+        new Option(
+          '--signing-service <name>',
+          'SigV4 signing service name for passthrough GATEWAY_IAM_ROLE auth [non-interactive]'
         )
       )
       .addOption(
-        gatePassthroughOption(
-          new Option('--stickiness-timeout <seconds>', 'Sticky session timeout in seconds (1-86400) [non-interactive]')
-        )
-      )
-      .addOption(
-        gatePassthroughOption(
-          new Option(
-            '--signing-service <name>',
-            'SigV4 signing service name for passthrough GATEWAY_IAM_ROLE auth [non-interactive]'
-          )
-        )
-      )
-      .addOption(
-        gatePassthroughOption(
-          new Option(
-            '--signing-region <region>',
-            'SigV4 signing region for passthrough (defaults to project region) [non-interactive]'
-          )
+        new Option(
+          '--signing-region <region>',
+          'SigV4 signing region for passthrough (defaults to project region) [non-interactive]'
         )
       )
       .option('--json', 'Output as JSON [non-interactive]')

--- a/src/cli/primitives/GatewayTargetPrimitive.ts
+++ b/src/cli/primitives/GatewayTargetPrimitive.ts
@@ -29,7 +29,6 @@ import {
 import type { AddGatewayTargetOptions as CLIAddGatewayTargetOptions } from '../commands/add/types';
 import { validateAddGatewayTargetOptions } from '../commands/add/validate';
 import { getErrorMessage } from '../errors';
-import { isGatedFeaturesEnabled } from '../feature-flags';
 import { upsertAgenticRetrieveTarget } from '../operations/knowledge-base/agentic-retrieve-upsert';
 import type { RemovableGatewayTarget } from '../operations/remove/remove-gateway-target';
 import type { RemovalPreview, SchemaChange } from '../operations/remove/types';
@@ -64,11 +63,11 @@ import { dirname, join } from 'path';
 const MCP_DEFS_FILE = 'mcp-defs.json';
 
 /**
- * Hide a passthrough-only CLI option from --help unless gated features are enabled.
- * The option is still parsed if passed; the runtime guard in validate.ts rejects it.
+ * Passthrough-only CLI option. Kept as a pass-through wrapper so the six call sites
+ * read consistently; passthrough targets are no longer gated.
  */
 function gatePassthroughOption(option: Option): Option {
-  return isGatedFeaturesEnabled() ? option : option.hideHelp();
+  return option;
 }
 
 /**
@@ -283,9 +282,8 @@ export class GatewayTargetPrimitive extends BasePrimitive<AddGatewayTargetOption
   }
 
   registerCommands(addCmd: Command, removeCmd: Command): void {
-    const typeDescription = isGatedFeaturesEnabled()
-      ? 'Target type (required): mcp-server, api-gateway, open-api-schema, smithy-model, lambda-function-arn, http-runtime, connector, passthrough, web-search [non-interactive]'
-      : 'Target type (required): mcp-server, api-gateway, open-api-schema, smithy-model, lambda-function-arn, http-runtime, connector, web-search [non-interactive]';
+    const typeDescription =
+      'Target type (required): mcp-server, api-gateway, open-api-schema, smithy-model, lambda-function-arn, http-runtime, connector, passthrough, web-search [non-interactive]';
 
     // Reject repeated use of --exclude-domains. Domains must be passed as a
     // single comma-separated value.
@@ -430,17 +428,13 @@ Target types and their options:
   connector — Wire a managed AWS connector (Bedrock KB, agentic-retrieve)
     --connector <id>               bedrock-knowledge-bases or bedrock-agentic-retrieve
     --knowledge-base-id <id>       Project KB name or 10-char external KB id (repeatable for agentic-retrieve)
-${
-  isGatedFeaturesEnabled()
-    ? `
+
   passthrough — Route to an external HTTPS endpoint
     --passthrough-endpoint <url>   HTTPS endpoint URL
     --stickiness-identifier <expr> Session routing expression (optional)
     --stickiness-timeout <seconds> Sticky session timeout in seconds (optional)
-`
-    : ''
-}
-  Auth (mcp-server, open-api-schema, smithy-model, lambda-function-arn${isGatedFeaturesEnabled() ? ', passthrough' : ''}):
+
+  Auth (mcp-server, open-api-schema, smithy-model, lambda-function-arn, passthrough):
     --outbound-auth <type>         oauth, api-key, or none
     --credential-name <name>       Existing credential name
 `

--- a/src/cli/tui/screens/mcp/AddGatewayTargetScreen.tsx
+++ b/src/cli/tui/screens/mcp/AddGatewayTargetScreen.tsx
@@ -1,6 +1,5 @@
 import type { ApiGatewayHttpMethod, GatewayTargetType, PassthroughProtocolType } from '../../../../schema';
 import { REAL_KB_ID_PATTERN, ToolNameSchema } from '../../../../schema';
-import { isGatedFeaturesEnabled } from '../../../feature-flags';
 import { ConfirmReview, Panel, Screen, StepIndicator, TextInput, WizardSelect } from '../../components';
 import type { SelectableItem } from '../../components';
 import { HELP_TEXT } from '../../constants';
@@ -154,15 +153,11 @@ export function AddGatewayTargetScreen({
   );
   const targetTypeItems: SelectableItem[] = useMemo(
     () =>
-      TARGET_TYPE_OPTIONS.map(o => {
-        const gated = o.id === 'passthrough' && !isGatedFeaturesEnabled();
-        return {
-          id: o.id,
-          title: o.title,
-          description: gated ? 'Coming soon' : o.description,
-          disabled: gated,
-        };
-      }),
+      TARGET_TYPE_OPTIONS.map(o => ({
+        id: o.id,
+        title: o.title,
+        description: o.description,
+      })),
     []
   );
   const outboundAuthItems: SelectableItem[] = useMemo(


### PR DESCRIPTION
## What

Makes **passthrough gateway targets** generally available by removing the `isGatedFeaturesEnabled()` (ENABLE_GATED_FEATURES) checks that hid them.

## Changes
- `add/validate.ts` — always include `passthrough` in the valid target-type list; drop the `Passthrough targets are not yet available.` early return.
- `primitives/GatewayTargetPrimitive.ts` — always advertise passthrough options/description in `--help`; `gatePassthroughOption()` is now a pass-through (kept so the six call sites read consistently).
- `tui/screens/mcp/AddGatewayTargetScreen.tsx` — passthrough row is always selectable (no more "Coming soon").
- `add/__tests__/validate.test.ts` — assert passthrough is accepted **without** the flag, and that it appears in the invalid-type error.

Other gated features (knowledge-base, managed memory, aws-skills, previews) are intentionally untouched.

## Testing
- `npm run typecheck`, eslint, prettier, secretlint — pass (pre-commit hooks).
- `npm test src/cli/commands/add src/cli/primitives` — pass.
- `npm run bundle` + installed the local build globally.
- Non-interactive: `agentcore add gateway-target --type passthrough --passthrough-endpoint https://... --outbound-auth gateway-iam-role --signing-service execute-api` → `{"success":true}` **without** `ENABLE_GATED_FEATURES`.
- TUI (via tui-harness): `add → Gateway Target → Target Type` shows **Passthrough — Route to external HTTPS endpoint** (no "Coming soon"), selectable, and the wizard advances through Endpoint → Protocol → Stickiness → Gateway → Outbound Auth → Signing Service → Signing Region → Confirm.