### PR TITLE
feat: ungate AWS skills, managed memory, and read-only harness Version

### DIFF
--- a/e2e-tests/harness-aws-skills.test.ts
+++ b/e2e-tests/harness-aws-skills.test.ts
@@ -1,0 +1,13 @@
+import { createHarnessE2ESuite } from './harness-e2e-helper.js';
+
+// AWS Skills deployed end-to-end: create → add skill --aws-skills → deploy → invoke → confirm the
+// deployed agent actually loaded the skills → teardown. Uses disabled memory so the deploy is fast
+// (no managed-memory provisioning) — this suite is about skills, not memory, which managed-memory
+// e2e covers. The 'loads AWS skills' step asks the agent what skills it has and asserts it references
+// the AWS ones, proving the spec → CFN → runtime path works, not just that the flag parses.
+createHarnessE2ESuite({
+  modelProvider: 'bedrock',
+  awsSkills: 'core-skills/*',
+  skipMemory: true,
+  labelSuffix: 'aws-skills',
+});

--- a/e2e-tests/harness-e2e-helper.ts
+++ b/e2e-tests/harness-e2e-helper.ts
@@ -21,15 +21,31 @@ interface HarnessE2EConfig {
   apiBase?: string;
   /** LiteLLM only: provider-specific params (JSON string), passed as --additional-params. */
   additionalParams?: string;
+  /** Skip memory entirely (`create --no-harness-memory` → disabled). Mutually exclusive with memoryRoundTrip. */
   skipMemory?: boolean;
   skipInvoke?: boolean;
+  /**
+   * After creating the (managed-memory) harness, exercise a 2-turn memory round-trip: state a fact,
+   * then in the SAME session confirm it's recalled. Proves the execution role's memory data-plane
+   * grant actually works at runtime (the AccessDenied-on-ListEvents scenario) — not just that
+   * invoke returns 200. Only meaningful when the harness has managed (or omitted) memory.
+   */
+  memoryRoundTrip?: boolean;
+  /**
+   * AWS Skills to attach to the harness via `add skill --aws-skills <value>` before deploy. Use ''
+   * for all skills, or a comma-separated path filter (e.g. 'core-skills/*'). When set, an extra
+   * step asks the deployed agent what skills it has and asserts the response references them.
+   */
+  awsSkills?: string;
+  /** Suffix for the suite label, so multiple suites with the same provider don't collide in output. */
+  labelSuffix?: string;
 }
 
 export function createHarnessE2ESuite(cfg: HarnessE2EConfig) {
   const hasRequiredVar = !cfg.apiKeyArnEnvVar || !!process.env[cfg.apiKeyArnEnvVar];
   const canRun = baseCanRun && hasRequiredVar;
 
-  const providerLabel =
+  const providerBase =
     cfg.modelProvider === 'open_ai'
       ? 'OpenAI'
       : cfg.modelProvider === 'gemini'
@@ -37,9 +53,10 @@ export function createHarnessE2ESuite(cfg: HarnessE2EConfig) {
         : cfg.modelProvider === 'lite_llm'
           ? 'LiteLLM'
           : 'Bedrock';
+  const providerLabel = providerBase + (cfg.labelSuffix ? `/${cfg.labelSuffix}` : '');
 
   // note: this is created outside of beforeAll since beforeAll is skipped if all tests are skipped.
-  const logger = getLogger(`harness-${providerLabel.toLowerCase()}`);
+  const logger = getLogger(`harness-${providerLabel.toLowerCase().replace('/', '-')}`);
   if (!canRun) {
     logger.warn(
       `tests are skipped due to insufficient conditions. ` +
@@ -98,6 +115,16 @@ export function createHarnessE2ESuite(cfg: HarnessE2EConfig) {
       const json = parseJsonOutput(result.stdout) as { projectPath: string };
       projectPath = json.projectPath;
 
+      // Attach AWS Skills to the harness before deploy, if configured. '' means all skills; a
+      // non-empty value is a comma-separated path filter passed as the --aws-skills argument.
+      if (cfg.awsSkills !== undefined) {
+        const skillArgs = ['add', 'skill', '--harness', harnessName, '--aws-skills'];
+        if (cfg.awsSkills) skillArgs.push(cfg.awsSkills);
+        skillArgs.push('--json');
+        const skillResult = await runAgentCoreCLI(skillArgs, projectPath);
+        expect(skillResult.exitCode, `add skill --aws-skills failed: ${skillResult.stderr}`).toBe(0);
+      }
+
       await writeAwsTargets(projectPath);
       installCdkTarball(projectPath);
     }, 300000);
@@ -115,6 +142,9 @@ export function createHarnessE2ESuite(cfg: HarnessE2EConfig) {
       async () => {
         expect(projectPath, 'Project should have been created').toBeTruthy();
 
+        // Retry the deploy: managed-memory provisioning (3-5 min) can run long, and CFN/global-setup
+        // contention occasionally surfaces a transient non-zero on the first attempt. `deploy` is
+        // idempotent (re-applies the same stack), so a second attempt is safe and lands the stack.
         await retry(
           async () => {
             const result = await runAgentCoreCLI(['deploy', '--yes', '--json'], projectPath);
@@ -124,11 +154,11 @@ export function createHarnessE2ESuite(cfg: HarnessE2EConfig) {
             const json = parseJsonOutput(result.stdout) as { success: boolean };
             expect(json.success, 'Deploy should report success').toBe(true);
           },
-          1,
+          2,
           30000
         );
       },
-      600000
+      900000
     );
 
     it.skipIf(!canRun || !!cfg.skipInvoke)(
@@ -153,6 +183,99 @@ export function createHarnessE2ESuite(cfg: HarnessE2EConfig) {
         );
       },
       180000
+    );
+
+    // Memory round-trip: prove the execution-role memory data-plane grant works at runtime. The
+    // harness must read/write its managed memory without AccessDenied (the bug #286/#287 fixed) —
+    // an invoke that returns 200 isn't enough; the SECOND turn must recall the fact from the FIRST.
+    it.skipIf(!canRun || !cfg.memoryRoundTrip)(
+      'remembers a fact across turns (managed memory round-trip)',
+      async () => {
+        // 33+ char session id (service constraint), no random/Date in the literal source needed —
+        // harnessName already carries a per-run timestamp suffix, which is enough to isolate runs.
+        const sessionId = `e2e-mem-roundtrip-${harnessName}-padding`;
+
+        const turn1 = await runAgentCoreCLI(
+          [
+            'invoke',
+            '--harness',
+            harnessName,
+            '--session-id',
+            sessionId,
+            '--prompt',
+            'My favorite color is teal. Remember it.',
+            '--json',
+          ],
+          projectPath
+        );
+        expect(turn1.exitCode, `Turn 1 failed: stderr=${turn1.stderr}, stdout=${turn1.stdout}`).toBe(0);
+        const t1 = parseJsonOutput(turn1.stdout) as { success: boolean; response?: string };
+        expect(t1.success, 'Turn 1 invoke should succeed (no AccessDenied on memory)').toBe(true);
+
+        // Recall in a fresh invoke on the same session — the harness must read its memory store.
+        const turn2 = await retry(
+          async () => {
+            const result = await runAgentCoreCLI(
+              [
+                'invoke',
+                '--harness',
+                harnessName,
+                '--session-id',
+                sessionId,
+                '--prompt',
+                'What is my favorite color? Answer with just the color.',
+                '--json',
+              ],
+              projectPath
+            );
+            expect(result.exitCode, `Turn 2 failed: stderr=${result.stderr}, stdout=${result.stdout}`).toBe(0);
+            const json = parseJsonOutput(result.stdout) as { success: boolean; response?: string };
+            expect(json.success, 'Turn 2 invoke should succeed').toBe(true);
+            expect(
+              (json.response ?? '').toLowerCase(),
+              `Harness should recall "teal" from memory; got: ${json.response}`
+            ).toContain('teal');
+            return json;
+          },
+          3,
+          15000
+        );
+        expect(turn2.success).toBe(true);
+      },
+      240000
+    );
+
+    // AWS Skills: prove the deployed agent actually loaded the configured skills (not just that the
+    // spec carried them). Ask the agent what skills/tools it has and assert it references AWS ones.
+    it.skipIf(!canRun || cfg.awsSkills === undefined)(
+      'loads AWS skills on the deployed harness',
+      async () => {
+        await retry(
+          async () => {
+            const result = await runAgentCoreCLI(
+              [
+                'invoke',
+                '--harness',
+                harnessName,
+                '--prompt',
+                'List the AWS skills or tools you have access to. Be brief.',
+                '--json',
+              ],
+              projectPath
+            );
+            expect(result.exitCode, `Skills invoke failed: stderr=${result.stderr}, stdout=${result.stdout}`).toBe(0);
+            const json = parseJsonOutput(result.stdout) as { success: boolean; response?: string };
+            expect(json.success, 'Skills invoke should succeed').toBe(true);
+            expect(
+              (json.response ?? '').toLowerCase(),
+              `Agent should reference its loaded AWS skills; got: ${json.response}`
+            ).toContain('aws');
+          },
+          3,
+          15000
+        );
+      },
+      240000
     );
 
     it.skipIf(!canRun)(

--- a/e2e-tests/harness-managed-memory.test.ts
+++ b/e2e-tests/harness-managed-memory.test.ts
@@ -1,0 +1,8 @@
+import { createHarnessE2ESuite } from './harness-e2e-helper.js';
+
+// Managed memory (the default) deployed end-to-end: create → deploy (provisions a dedicated
+// AgentCore Memory) → invoke → memory round-trip → teardown. The round-trip step is the load-bearing
+// assertion: it proves the harness execution role can read/write its managed memory at runtime
+// without AccessDenied on bedrock-agentcore:ListEvents — the regression #286/#287 fixed and that the
+// ungating must not reintroduce.
+createHarnessE2ESuite({ modelProvider: 'bedrock', memoryRoundTrip: true, labelSuffix: 'managed-memory' });

--- a/integ-tests/add-remove-harness.test.ts
+++ b/integ-tests/add-remove-harness.test.ts
@@ -51,11 +51,11 @@ describe('integration: harness add/remove lifecycle', () => {
     expect(await exists(promptPath), 'system-prompt.md should exist').toBe(true);
   });
 
-  it('defaults to managed memory and creates NO sibling memory resource', async () => {
-    // The harness owns its memory internally (managed mode). It must NOT auto-create a
-    // `${name}Memory` sibling in the project (the legacy pre-managed-memory behavior).
+  it('defaults to disabled memory and creates NO sibling memory resource', async () => {
+    // Memory is opt-in: with no memory flag the harness gets `disabled` (no memory). It must also NOT
+    // auto-create a `${name}Memory` sibling in the project (the legacy pre-managed-memory behavior).
     const spec = await readHarnessSpec(project.projectPath, harnessName);
-    expect(spec.memory?.mode, 'default harness memory should be managed').toBe('managed');
+    expect(spec.memory?.mode, 'default harness memory should be disabled (opt-in)').toBe('disabled');
 
     const config = await readProjectConfig(project.projectPath);
     const sibling = (config.memories ?? []).find((m: { name: string }) => m.name === `${harnessName}Memory`);
@@ -472,13 +472,13 @@ describe('integration: harness config shape', () => {
       expect(spec.memory.strategies).toEqual(['SEMANTIC', 'EPISODIC']);
     });
 
-    it('defaults to managed memory when no memory flags are passed', async () => {
+    it('defaults to disabled memory when no memory flags are passed (memory is opt-in)', async () => {
       const name = 'DefaultMemHarness';
       const result = await runCLI(['add', 'harness', '--name', name, '--json'], project.projectPath);
 
       expect(result.exitCode, `stdout: ${result.stdout}, stderr: ${result.stderr}`).toBe(0);
       const spec = await readHarnessSpec(project.projectPath, name);
-      expect(spec.memory.mode).toBe('managed');
+      expect(spec.memory.mode).toBe('disabled');
     });
 
     it('writes disabled memory for --memory-mode disabled (true opt-out, no sibling)', async () => {

--- a/integ-tests/add-remove-harness.test.ts
+++ b/integ-tests/add-remove-harness.test.ts
@@ -51,10 +51,15 @@ describe('integration: harness add/remove lifecycle', () => {
     expect(await exists(promptPath), 'system-prompt.md should exist').toBe(true);
   });
 
-  it('auto-creates memory resource', async () => {
+  it('defaults to managed memory and creates NO sibling memory resource', async () => {
+    // The harness owns its memory internally (managed mode). It must NOT auto-create a
+    // `${name}Memory` sibling in the project (the legacy pre-managed-memory behavior).
+    const spec = await readHarnessSpec(project.projectPath, harnessName);
+    expect(spec.memory?.mode, 'default harness memory should be managed').toBe('managed');
+
     const config = await readProjectConfig(project.projectPath);
-    const memories = config.memories ?? [];
-    expect(memories.length, 'Should have auto-created memory').toBeGreaterThan(0);
+    const sibling = (config.memories ?? []).find((m: { name: string }) => m.name === `${harnessName}Memory`);
+    expect(sibling, 'no `${name}Memory` sibling should be auto-created').toBeFalsy();
   });
 
   it('rejects duplicate harness name', async () => {
@@ -72,12 +77,9 @@ describe('integration: harness add/remove lifecycle', () => {
     const config = await readProjectConfig(project.projectPath);
     const found = config.harnesses?.find((h: { name: string }) => h.name === harnessName);
     expect(found, `Harness "${harnessName}" should be removed`).toBeFalsy();
-
-    const associatedMemory = (config.memories ?? []).find((m: { name: string }) => m.name === `${harnessName}Memory`);
-    expect(associatedMemory, 'Associated memory should be removed with harness').toBeFalsy();
   });
 
-  it('re-adds harness after removal without duplicate memory error', async () => {
+  it('re-adds harness after removal', async () => {
     const result = await runCLI(['add', 'harness', '--name', harnessName, '--json'], project.projectPath);
 
     expect(result.exitCode, `stdout: ${result.stdout}, stderr: ${result.stderr}`).toBe(0);
@@ -236,7 +238,6 @@ describe('integration: create project with harness', () => {
 
 describe('integration: harness config shape', () => {
   let project: TestProject;
-  const gatedEnv = { ENABLE_GATED_FEATURES: '1' };
 
   beforeAll(async () => {
     project = await createTestProject({ noAgent: true });
@@ -420,9 +421,34 @@ describe('integration: harness config shape', () => {
       expect(git.path).toBe('pack');
       expect(git.auth).toEqual({ credentialName: 'gitCred', username: 'git-user' });
     });
+
+    it('adds AWS skills — all paths and a path filter', async () => {
+      await runCLI(['add', 'harness', '--name', 'AwsSkillHarness', '--no-memory', '--json'], project.projectPath);
+
+      const all = await runCLI(
+        ['add', 'skill', '--harness', 'AwsSkillHarness', '--aws-skills', '--json'],
+        project.projectPath
+      );
+      expect(all.exitCode, `stdout: ${all.stdout}, stderr: ${all.stderr}`).toBe(0);
+
+      const filtered = await runCLI(
+        ['add', 'skill', '--harness', 'AwsSkillHarness', '--aws-skills', 'core-skills/*', '--json'],
+        project.projectPath
+      );
+      expect(filtered.exitCode, `stdout: ${filtered.stdout}, stderr: ${filtered.stderr}`).toBe(0);
+
+      const spec = await readHarnessSpec(project.projectPath, 'AwsSkillHarness');
+      // "all" → awsSkills with no paths key; filtered → awsSkills.paths includes the glob.
+      expect(spec.skills.some((s: { awsSkills?: { paths?: string[] } }) => s.awsSkills && !s.awsSkills.paths)).toBe(
+        true
+      );
+      expect(
+        spec.skills.some((s: { awsSkills?: { paths?: string[] } }) => s.awsSkills?.paths?.includes('core-skills/*'))
+      ).toBe(true);
+    });
   });
 
-  describe('memory modes (gated)', () => {
+  describe('memory modes', () => {
     it('adds a managed-memory harness with explicit strategies', async () => {
       const name = 'ManagedMemHarness';
       const result = await runCLI(
@@ -437,14 +463,34 @@ describe('integration: harness config shape', () => {
           'SEMANTIC,EPISODIC',
           '--json',
         ],
-        project.projectPath,
-        { env: gatedEnv }
+        project.projectPath
       );
 
       expect(result.exitCode, `stdout: ${result.stdout}, stderr: ${result.stderr}`).toBe(0);
       const spec = await readHarnessSpec(project.projectPath, name);
       expect(spec.memory.mode).toBe('managed');
       expect(spec.memory.strategies).toEqual(['SEMANTIC', 'EPISODIC']);
+    });
+
+    it('defaults to managed memory when no memory flags are passed', async () => {
+      const name = 'DefaultMemHarness';
+      const result = await runCLI(['add', 'harness', '--name', name, '--json'], project.projectPath);
+
+      expect(result.exitCode, `stdout: ${result.stdout}, stderr: ${result.stderr}`).toBe(0);
+      const spec = await readHarnessSpec(project.projectPath, name);
+      expect(spec.memory.mode).toBe('managed');
+    });
+
+    it('writes disabled memory for --memory-mode disabled (true opt-out, no sibling)', async () => {
+      const name = 'DisabledMemHarness';
+      const result = await runCLI(
+        ['add', 'harness', '--name', name, '--memory-mode', 'disabled', '--json'],
+        project.projectPath
+      );
+
+      expect(result.exitCode, `stdout: ${result.stdout}, stderr: ${result.stderr}`).toBe(0);
+      const spec = await readHarnessSpec(project.projectPath, name);
+      expect(spec.memory.mode).toBe('disabled');
     });
 
     it('adds an existing-memory harness referencing a sibling by name with tuning', async () => {
@@ -465,8 +511,7 @@ describe('integration: harness config shape', () => {
           '5',
           '--json',
         ],
-        project.projectPath,
-        { env: gatedEnv }
+        project.projectPath
       );
 
       expect(result.exitCode, `stdout: ${result.stdout}, stderr: ${result.stderr}`).toBe(0);
@@ -481,26 +526,17 @@ describe('integration: harness config shape', () => {
       {
         label: 'retrievalConfig tuning when memory is referenced by ARN',
         args: ['--memory-mode', 'existing', '--memory-arn', MEMORY_ARN, '--memory-top-k', '5'],
-        env: gatedEnv,
       },
       {
         label: '--memory-mode existing without a memory reference',
         args: ['--memory-mode', 'existing'],
-        env: gatedEnv,
       },
       {
-        label: '--memory-mode when the gated feature is disabled',
-        // Force the gate OFF explicitly: cleanSpawnEnv inherits the host process.env, so a
-        // developer/CI shell with ENABLE_GATED_FEATURES=1 exported would otherwise flip this
-        // case (the CLI would accept --memory-mode and exit 0). An empty string is "off"
-        // because isGatedFeaturesEnabled() checks `=== '1'`.
-        args: ['--memory-mode', 'managed'],
-        env: { ENABLE_GATED_FEATURES: '' },
+        label: '--no-memory combined with managed-only flags (--memory-strategies)',
+        args: ['--no-memory', '--memory-strategies', 'SEMANTIC'],
       },
-    ])('rejects $label', async ({ args, env }) => {
-      const result = await runCLI(['add', 'harness', '--name', 'BadMem', ...args, '--json'], project.projectPath, {
-        env,
-      });
+    ])('rejects $label', async ({ args }) => {
+      const result = await runCLI(['add', 'harness', '--name', 'BadMem', ...args, '--json'], project.projectPath);
       expect(result.exitCode).not.toBe(0);
     });
   });

--- a/src/cli/commands/add/__tests__/harness-privatelink-guard.test.ts
+++ b/src/cli/commands/add/__tests__/harness-privatelink-guard.test.ts
@@ -151,6 +151,40 @@ describe('validateAddHarnessOptions — memory modes', () => {
     if (!r.valid) expect(r.error).toContain('--memory-event-expiry-days');
   });
 
+  it('rejects --memory-mode managed combined with --memory-arn (contradictory)', () => {
+    const r = validateAddHarnessOptions({
+      ...base,
+      memoryMode: 'managed',
+      memoryArn: 'arn:aws:bedrock-agentcore:us-west-2:1:memory/m-aBcD012345',
+    });
+    expect(r.valid).toBe(false);
+    if (!r.valid) expect(r.error).toContain('managed');
+  });
+
+  it('rejects --memory-mode disabled combined with --memory-name (contradictory)', () => {
+    const r = validateAddHarnessOptions({ ...base, memoryMode: 'disabled', memoryName: 'mem' });
+    expect(r.valid).toBe(false);
+    if (!r.valid) expect(r.error).toContain('disabled');
+  });
+
+  it('rejects existing-only tuning flags given without an existing reference', () => {
+    // --memory-top-k alone would otherwise be silently dropped (resolves to disabled).
+    const r = validateAddHarnessOptions({ ...base, memoryTopK: 5 });
+    expect(r.valid).toBe(false);
+    if (!r.valid) expect(r.error).toContain('existing memory');
+  });
+
+  it('accepts existing-only tuning flags WITH an existing reference', () => {
+    const r = validateAddHarnessOptions({ ...base, memoryName: 'mem', memoryTopK: 5, memoryMessagesCount: 10 });
+    expect(r.valid).toBe(true);
+  });
+
+  it('rejects a malformed --memory-arn (not an ARN)', () => {
+    const r = validateAddHarnessOptions({ ...base, memoryArn: 'not-an-arn' });
+    expect(r.valid).toBe(false);
+    if (!r.valid) expect(r.error).toContain('--memory-arn');
+  });
+
   it('rejects an invalid managed strategy', () => {
     const r = validateAddHarnessOptions({ ...base, memoryMode: 'managed', memoryStrategies: 'SEMANTIC,BOGUS' });
     expect(r.valid).toBe(false);

--- a/src/cli/commands/add/__tests__/harness-privatelink-guard.test.ts
+++ b/src/cli/commands/add/__tests__/harness-privatelink-guard.test.ts
@@ -1,6 +1,6 @@
 import type { AddHarnessCliOptions } from '../types';
 import { validateAddHarnessOptions } from '../validate';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 const base: AddHarnessCliOptions = {
   name: 'h1',
@@ -73,6 +73,32 @@ describe('validateAddHarnessOptions — memory flag coupling', () => {
     if (!result.valid) expect(result.error).toContain('--no-memory');
   });
 
+  // --no-memory means disabled memory, so managed-only knobs (strategies/event-expiry/KMS) are
+  // contradictory and must be rejected, not silently dropped. Without an explicit --memory-mode the
+  // earlier `noMemory && memoryMode in {managed,existing}` guard doesn't fire, so this is the case
+  // that guards against silently discarding the flags.
+  it('rejects --no-memory combined with --memory-strategies (managed-only flag)', () => {
+    const result = validateAddHarnessOptions({ ...base, memory: false, memoryStrategies: 'SEMANTIC' });
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.error).toContain('--no-memory');
+  });
+
+  it('rejects --no-memory combined with --memory-event-expiry-days', () => {
+    const result = validateAddHarnessOptions({ ...base, memory: false, memoryEventExpiryDays: 30 });
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.error).toContain('--no-memory');
+  });
+
+  it('rejects --no-memory combined with --memory-encryption-key-arn', () => {
+    const result = validateAddHarnessOptions({
+      ...base,
+      memory: false,
+      memoryEncryptionKeyArn: 'arn:aws:kms:us-west-2:123456789012:key/abc',
+    });
+    expect(result.valid).toBe(false);
+    if (!result.valid) expect(result.error).toContain('--no-memory');
+  });
+
   it('accepts --memory-name alone', () => {
     expect(validateAddHarnessOptions({ ...base, memoryName: 'mem' }).valid).toBe(true);
   });
@@ -103,41 +129,9 @@ describe('validateAddHarnessOptions — gateway oauth flag coupling', () => {
   });
 });
 
-describe('validateAddHarnessOptions — memory modes (gated OFF)', () => {
-  const prev = process.env.ENABLE_GATED_FEATURES;
-  beforeEach(() => {
-    delete process.env.ENABLE_GATED_FEATURES;
-  });
-  afterEach(() => {
-    if (prev === undefined) delete process.env.ENABLE_GATED_FEATURES;
-    else process.env.ENABLE_GATED_FEATURES = prev;
-  });
-
-  it('rejects --memory-mode as not-yet-available', () => {
-    const r = validateAddHarnessOptions({ ...base, memoryMode: 'managed' });
-    expect(r.valid).toBe(false);
-    if (!r.valid) expect(r.error).toContain('not yet available');
-  });
-
-  it('rejects managed-only flags as not-yet-available', () => {
-    const r = validateAddHarnessOptions({ ...base, memoryStrategies: 'SEMANTIC' });
-    expect(r.valid).toBe(false);
-    if (!r.valid) expect(r.error).toContain('not yet available');
-  });
-
-  it('still accepts the legacy --memory-name reference', () => {
+describe('validateAddHarnessOptions — memory modes', () => {
+  it('accepts an existing --memory-name reference', () => {
     expect(validateAddHarnessOptions({ ...base, memoryName: 'mem' }).valid).toBe(true);
-  });
-});
-
-describe('validateAddHarnessOptions — memory modes (gated ON)', () => {
-  const prev = process.env.ENABLE_GATED_FEATURES;
-  beforeEach(() => {
-    process.env.ENABLE_GATED_FEATURES = '1';
-  });
-  afterEach(() => {
-    if (prev === undefined) delete process.env.ENABLE_GATED_FEATURES;
-    else process.env.ENABLE_GATED_FEATURES = prev;
   });
 
   it('rejects --memory-mode existing with neither arn nor name', () => {

--- a/src/cli/commands/add/skill-action.ts
+++ b/src/cli/commands/add/skill-action.ts
@@ -1,6 +1,5 @@
 import { ConfigIO } from '../../../lib';
 import type { HarnessSpec } from '../../../schema';
-import { isGatedFeaturesEnabled } from '@/cli/feature-flags';
 import { getSkillKey, validateGitSkillCredential } from '@/cli/operations/harness/skill-utils';
 import { ValidationError } from '@/lib/errors/types';
 import type { Result } from '@/lib/result';
@@ -34,23 +33,12 @@ export async function handleAddSkill(
     };
   }
 
-  if (options.awsSkills && !isGatedFeaturesEnabled()) {
-    return {
-      success: false,
-      error: new ValidationError('AWS skills are not yet available.'),
-    };
-  }
-
-  const sources = [options.path, options.s3, options.git, ...(isGatedFeaturesEnabled() ? [options.awsSkills] : [])];
+  const sources = [options.path, options.s3, options.git, options.awsSkills];
   const sourceCount = sources.filter(Boolean).length;
   if (sourceCount !== 1) {
     return {
       success: false,
-      error: new ValidationError(
-        isGatedFeaturesEnabled()
-          ? 'Exactly one of --path, --s3, --git, or --aws-skills is required'
-          : 'Exactly one of --path, --s3, or --git is required'
-      ),
+      error: new ValidationError('Exactly one of --path, --s3, --git, or --aws-skills is required'),
     };
   }
 

--- a/src/cli/commands/add/skill-command.ts
+++ b/src/cli/commands/add/skill-command.ts
@@ -1,6 +1,5 @@
 import { findConfigRoot } from '../../../lib';
 import { getErrorMessage } from '../../errors';
-import { isGatedFeaturesEnabled } from '../../feature-flags';
 import { withCommandRunTelemetry } from '../../telemetry/cli-command-run.js';
 import { SkillSourceType, standardize } from '../../telemetry/schemas/common-shapes.js';
 import { handleAddSkill } from './skill-action';
@@ -23,7 +22,7 @@ export function registerAddSkill(addCmd: Command): void {
     .option('--git-path <path>', 'Subdirectory within the git repo (for --git)')
     .option('--credential <name>', 'Name of an API key credential in the project (for git auth)')
     .option('--username <name>', 'Username for git auth (for --git)')
-    .addOption(isGatedFeaturesEnabled() ? awsSkillsOption : awsSkillsOption.hideHelp())
+    .addOption(awsSkillsOption)
     .option('--json', 'Output as JSON')
     .action(async cliOptions => {
       if (!findConfigRoot()) {

--- a/src/cli/commands/add/validate.ts
+++ b/src/cli/commands/add/validate.ts
@@ -1211,6 +1211,9 @@ export function validateAddHarnessOptions(options: AddHarnessCliOptions): Valida
   if (options.memoryArn && options.memoryName) {
     return { valid: false, error: '--memory-arn and --memory-name are mutually exclusive' };
   }
+  if (options.memoryArn && !isValidArn(options.memoryArn)) {
+    return { valid: false, error: `--memory-arn: ${ARN_VALIDATION_MESSAGE}` };
+  }
   if (noMemory && (options.memoryArn || options.memoryName || memoryTuningGiven || managedOnlyFlags)) {
     return {
       valid: false,
@@ -1231,6 +1234,26 @@ export function validateAddHarnessOptions(options: AddHarnessCliOptions): Valida
   }
   if (options.memoryMode === 'existing' && !options.memoryArn && !options.memoryName) {
     return { valid: false, error: '--memory-mode existing requires --memory-arn or --memory-name' };
+  }
+  // A memory reference (--memory-arn/--memory-name) is an `existing` selector. It is contradictory
+  // with an explicit managed or disabled mode — reject rather than silently downgrading to existing.
+  if (
+    (options.memoryArn || options.memoryName) &&
+    (options.memoryMode === 'managed' || options.memoryMode === 'disabled')
+  ) {
+    return {
+      valid: false,
+      error: `--memory-arn/--memory-name reference an existing memory and cannot be combined with --memory-mode ${options.memoryMode}`,
+    };
+  }
+  // Existing-only retrieval tuning (actorId/messagesCount/topK/relevanceScore) only applies to an
+  // existing memory. Given without an existing reference it would be silently dropped — require the ref.
+  if (memoryTuningGiven && !options.memoryArn && !options.memoryName && options.memoryMode !== 'existing') {
+    return {
+      valid: false,
+      error:
+        'memory tuning flags (--memory-actor-id, --memory-messages-count, --memory-top-k, --memory-relevance-score) require an existing memory (--memory-arn, --memory-name, or --memory-mode existing)',
+    };
   }
   if (managedOnlyFlags && options.memoryMode && options.memoryMode !== 'managed') {
     return {

--- a/src/cli/commands/add/validate.ts
+++ b/src/cli/commands/add/validate.ts
@@ -24,7 +24,6 @@ import {
   matchEnumValue,
   validateApiFormat,
 } from '../../../schema';
-import { isGatedFeaturesEnabled } from '../../feature-flags';
 import { ARN_VALIDATION_MESSAGE, isValidArn } from '../shared/arn-utils';
 import { validateHeaderAllowlist } from '../shared/header-utils';
 import { MAX_INDEXED_KEYS, parseIndexedKeyArg } from '../shared/indexed-key-parser';
@@ -1203,62 +1202,54 @@ export function validateAddHarnessOptions(options: AddHarnessCliOptions): Valida
     options.memoryMessagesCount !== undefined ||
     options.memoryTopK !== undefined ||
     options.memoryRelevanceScore !== undefined;
-  if (options.memoryArn && options.memoryName) {
-    return { valid: false, error: '--memory-arn and --memory-name are mutually exclusive' };
-  }
-  if (noMemory && (options.memoryArn || options.memoryName || memoryTuningGiven)) {
-    return {
-      valid: false,
-      error: '--no-memory cannot be combined with --memory-arn, --memory-name, or memory tuning flags',
-    };
-  }
-
-  // Managed-memory mode validation — only when the gated feature is enabled. When gated off, any
-  // --memory-mode / managed-only flag is rejected up front as "not yet available".
+  // Managed-only knobs (strategies/event-expiry/KMS) describe a managed memory; they are meaningless
+  // with --no-memory (which produces disabled memory) and on non-managed modes.
   const managedOnlyFlags =
     options.memoryStrategies !== undefined ||
     options.memoryEventExpiryDays !== undefined ||
     options.memoryEncryptionKeyArn !== undefined;
-  if (!isGatedFeaturesEnabled()) {
-    if (options.memoryMode !== undefined || managedOnlyFlags) {
+  if (options.memoryArn && options.memoryName) {
+    return { valid: false, error: '--memory-arn and --memory-name are mutually exclusive' };
+  }
+  if (noMemory && (options.memoryArn || options.memoryName || memoryTuningGiven || managedOnlyFlags)) {
+    return {
+      valid: false,
+      error:
+        '--no-memory cannot be combined with --memory-arn, --memory-name, memory tuning flags, or managed-memory flags (--memory-strategies, --memory-event-expiry-days, --memory-encryption-key-arn)',
+    };
+  }
+
+  // Managed-memory mode validation.
+  if (options.memoryMode && !VALID_MEMORY_MODES.includes(options.memoryMode as (typeof VALID_MEMORY_MODES)[number])) {
+    return {
+      valid: false,
+      error: `Invalid --memory-mode '${options.memoryMode}'. Use ${VALID_MEMORY_MODES.join(', ')}.`,
+    };
+  }
+  if (noMemory && (options.memoryMode === 'managed' || options.memoryMode === 'existing')) {
+    return { valid: false, error: '--no-memory cannot be combined with --memory-mode managed/existing' };
+  }
+  if (options.memoryMode === 'existing' && !options.memoryArn && !options.memoryName) {
+    return { valid: false, error: '--memory-mode existing requires --memory-arn or --memory-name' };
+  }
+  if (managedOnlyFlags && options.memoryMode && options.memoryMode !== 'managed') {
+    return {
+      valid: false,
+      error:
+        '--memory-strategies, --memory-event-expiry-days, and --memory-encryption-key-arn are only valid with --memory-mode managed',
+    };
+  }
+  if (options.memoryStrategies) {
+    const bad = options.memoryStrategies
+      .split(',')
+      .map(s => s.trim())
+      .filter(Boolean)
+      .filter(s => !VALID_MANAGED_STRATEGIES.includes(s as (typeof VALID_MANAGED_STRATEGIES)[number]));
+    if (bad.length) {
       return {
         valid: false,
-        error:
-          '--memory-mode and managed-memory flags (--memory-strategies, --memory-event-expiry-days, --memory-encryption-key-arn) are not yet available.',
+        error: `Invalid managed memory strateg${bad.length > 1 ? 'ies' : 'y'}: ${bad.join(', ')}. Valid: ${VALID_MANAGED_STRATEGIES.join(', ')}`,
       };
-    }
-  } else {
-    if (options.memoryMode && !VALID_MEMORY_MODES.includes(options.memoryMode as (typeof VALID_MEMORY_MODES)[number])) {
-      return {
-        valid: false,
-        error: `Invalid --memory-mode '${options.memoryMode}'. Use ${VALID_MEMORY_MODES.join(', ')}.`,
-      };
-    }
-    if (noMemory && (options.memoryMode === 'managed' || options.memoryMode === 'existing')) {
-      return { valid: false, error: '--no-memory cannot be combined with --memory-mode managed/existing' };
-    }
-    if (options.memoryMode === 'existing' && !options.memoryArn && !options.memoryName) {
-      return { valid: false, error: '--memory-mode existing requires --memory-arn or --memory-name' };
-    }
-    if (managedOnlyFlags && options.memoryMode && options.memoryMode !== 'managed') {
-      return {
-        valid: false,
-        error:
-          '--memory-strategies, --memory-event-expiry-days, and --memory-encryption-key-arn are only valid with --memory-mode managed',
-      };
-    }
-    if (options.memoryStrategies) {
-      const bad = options.memoryStrategies
-        .split(',')
-        .map(s => s.trim())
-        .filter(Boolean)
-        .filter(s => !VALID_MANAGED_STRATEGIES.includes(s as (typeof VALID_MANAGED_STRATEGIES)[number]));
-      if (bad.length) {
-        return {
-          valid: false,
-          error: `Invalid managed memory strateg${bad.length > 1 ? 'ies' : 'y'}: ${bad.join(', ')}. Valid: ${VALID_MANAGED_STRATEGIES.join(', ')}`,
-        };
-      }
     }
   }
 

--- a/src/cli/commands/create/command.tsx
+++ b/src/cli/commands/create/command.tsx
@@ -192,7 +192,9 @@ async function handleCreateHarnessCLI(options: CreateOptions): Promise<void> {
       agent_environment: 'harness' as const,
       has_agent: true,
       model_provider: standardize(ModelProviderEnum, options.modelProvider ?? 'bedrock'),
-      memory_type: standardize(MemoryType, options.harnessMemory === false ? 'none' : 'longandshortterm'),
+      // Harness memory is opt-in and defaults to disabled; only an explicit managed/existing request
+      // (not modeled by the legacy --harness-memory boolean) would be non-'none'.
+      memory_type: standardize(MemoryType, 'none'),
       network_mode: standardize(NetworkModeEnum, options.networkMode ?? 'public'),
     },
     async () => {

--- a/src/cli/commands/create/command.tsx
+++ b/src/cli/commands/create/command.tsx
@@ -92,8 +92,19 @@ function printCreateSummary(
   console.log('');
 }
 
-/** Flags that trigger the agent/runtime path */
-const AGENT_PATH_FLAGS = ['framework', 'language', 'build', 'protocol', 'type', 'agentId', 'agentAliasId'] as const;
+/** Flags that trigger the agent/runtime path. `memory` (none/shortTerm/longAndShortTerm) is an
+ * agent-only concept — harnesses use --memory-mode/--no-memory — so it routes to the agent path
+ * (and conflicts with harness-only flags) rather than being silently ignored on the harness path. */
+const AGENT_PATH_FLAGS = [
+  'framework',
+  'language',
+  'build',
+  'protocol',
+  'type',
+  'agentId',
+  'agentAliasId',
+  'memory',
+] as const;
 
 /** Flags that are harness-only */
 const HARNESS_ONLY_FLAGS = [
@@ -506,7 +517,7 @@ export const registerCreate = (program: Command) => {
       '--additional-params <json>',
       'Provider-specific harness params as a JSON object (lite_llm) [non-interactive]'
     )
-    .option('--no-harness-memory', 'Skip auto-creating memory for harness [non-interactive]')
+    .option('--no-harness-memory', 'Disable memory for the harness (this is the default) [non-interactive]')
     .option('--max-iterations <n>', 'Max agent loop iterations (harness) [non-interactive]')
     .option('--max-tokens <n>', 'Max tokens per iteration (harness) [non-interactive]')
     .option('--timeout <seconds>', 'Max execution duration in seconds (harness) [non-interactive]')

--- a/src/cli/commands/deploy/actions.ts
+++ b/src/cli/commands/deploy/actions.ts
@@ -23,7 +23,6 @@ import {
   parseRuntimeEndpointOutputs,
 } from '../../cloudformation';
 import { getErrorMessage } from '../../errors';
-import { isGatedFeaturesEnabled } from '../../feature-flags';
 import { ExecLogger } from '../../logging';
 import {
   MANAGED_MEMORY_DEPLOY_NOTICE,
@@ -769,16 +768,14 @@ export async function handleDeploy(options: ValidatedDeployOptions): Promise<Dep
       throw writeErr;
     }
 
-    // Harness config-version drift note (gated): the service increments Version on every successful
+    // Harness config-version drift note: the service increments Version on every successful
     // update, so surface what changed this deploy.
-    if (isGatedFeaturesEnabled()) {
-      for (const drift of computeHarnessVersionDrift(prevHarnessRecords, deployedHarnesses)) {
-        logger.log(
-          drift.from !== undefined
-            ? `Harness ${drift.name}: config updated (v${drift.from} → v${drift.to})`
-            : `Harness ${drift.name}: deployed (v${drift.to})`
-        );
-      }
+    for (const drift of computeHarnessVersionDrift(prevHarnessRecords, deployedHarnesses)) {
+      logger.log(
+        drift.from !== undefined
+          ? `Harness ${drift.name}: config updated (v${drift.from} → v${drift.to})`
+          : `Harness ${drift.name}: deployed (v${drift.to})`
+      );
     }
 
     // Show gateway URLs and target sync status

--- a/src/cli/commands/deploy/command.tsx
+++ b/src/cli/commands/deploy/command.tsx
@@ -106,16 +106,20 @@ async function executeDeploy(options: DeployOptions): Promise<DeployResult> {
     : undefined;
 
   // One-shot user-facing notices (e.g. the managed-memory heads-up before the slow CFN apply).
-  // Always shown, independent of --progress/--verbose. Clear any active spinner line first so the
-  // multi-line notice prints cleanly, then resume the spinner frame on the next onProgress tick.
-  const onNotice = (message: string) => {
-    if (spinner) {
-      clearInterval(spinner);
-      spinner = undefined;
-      process.stdout.write('\r\x1b[K');
-    }
-    console.log(`\n${message}\n`);
-  };
+  // Shown independent of --progress/--verbose, but NEVER under --json: stdout must stay pure
+  // machine-readable JSON there (the notice would corrupt it, breaking `deploy --json` parsing for
+  // any managed-memory harness). The notice is still captured in the deploy log via logger.log.
+  // Clear any active spinner line first so the multi-line notice prints cleanly.
+  const onNotice = options.json
+    ? undefined
+    : (message: string) => {
+        if (spinner) {
+          clearInterval(spinner);
+          spinner = undefined;
+          process.stdout.write('\r\x1b[K');
+        }
+        console.log(`\n${message}\n`);
+      };
 
   const result = await handleDeploy({
     target: options.target!,

--- a/src/cli/commands/status/__tests__/action.test.ts
+++ b/src/cli/commands/status/__tests__/action.test.ts
@@ -25,11 +25,6 @@ vi.mock('../../../aws/bedrock-agent', () => ({
   getLatestIngestionJob: (...args: unknown[]) => mockGetLatestIngestionJob(...args),
 }));
 
-const mockIsGatedFeaturesEnabled = vi.fn(() => true);
-vi.mock('../../../feature-flags', () => ({
-  isGatedFeaturesEnabled: () => mockIsGatedFeaturesEnabled(),
-}));
-
 const loggedLines: string[] = [];
 vi.mock('../../../logging', () => {
   return {
@@ -483,7 +478,7 @@ describe('computeResourceStatuses', () => {
     expect(harnessEntry!.identifier).toBe('arn:aws:bedrock:us-east-1:123456789:harness/h-456');
   });
 
-  it('renders the config version (v{N}) on a deployed harness when gated features are enabled', () => {
+  it('renders the config version (v{N}) on a deployed harness', () => {
     const project = {
       ...baseProject,
       harnesses: [{ name: 'my-harness', path: 'harnesses/my-harness' }],
@@ -503,29 +498,6 @@ describe('computeResourceStatuses', () => {
     const result = computeResourceStatuses(project, resources);
     const harnessEntry = result.find(r => r.resourceType === 'harness' && r.name === 'my-harness');
     expect(harnessEntry!.detail).toBe('v3');
-  });
-
-  it('does not render the config version when gated features are disabled', () => {
-    mockIsGatedFeaturesEnabled.mockReturnValueOnce(false);
-    const project = {
-      ...baseProject,
-      harnesses: [{ name: 'my-harness', path: 'harnesses/my-harness' }],
-    } as unknown as AgentCoreProjectSpec;
-    const resources: DeployedResourceState = {
-      harnesses: {
-        'my-harness': {
-          harnessId: 'h-123',
-          harnessArn: 'arn:aws:bedrock:us-east-1:123456789:harness/h-123',
-          roleArn: 'arn:aws:iam::123456789:role/test',
-          status: 'READY',
-          harnessVersion: 3,
-        },
-      },
-    };
-
-    const result = computeResourceStatuses(project, resources);
-    const harnessEntry = result.find(r => r.resourceType === 'harness' && r.name === 'my-harness');
-    expect(harnessEntry!.detail).toBeUndefined();
   });
 
   it('handles mixed deployed and local-only resources', () => {

--- a/src/cli/commands/status/action.ts
+++ b/src/cli/commands/status/action.ts
@@ -6,7 +6,6 @@ import { getEvaluator, getOnlineEvaluationConfig } from '../../aws/agentcore-con
 import { getPaymentManager } from '../../aws/agentcore-payments';
 import { getKnowledgeBase, getLatestIngestionJob } from '../../aws/bedrock-agent';
 import { getErrorMessage } from '../../errors';
-import { isGatedFeaturesEnabled } from '../../feature-flags';
 import { ExecLogger } from '../../logging';
 import type { ResourceDeploymentState } from './constants';
 import { buildRuntimeInvocationUrl } from './constants';
@@ -318,13 +317,11 @@ export function computeResourceStatuses(
     getLocalDetail: () => undefined,
   });
 
-  // Config version (gated): the harness Version is service-incremented and only known from deployed
+  // Config version: the harness Version is service-incremented and only known from deployed
   // state, so enrich each entry's detail post-pass rather than via getLocalDetail (local spec has none).
-  if (isGatedFeaturesEnabled()) {
-    for (const entry of harnesses) {
-      const version = resources?.harnesses?.[entry.name]?.harnessVersion;
-      if (version !== undefined) entry.detail = entry.detail ? `${entry.detail} v${version}` : `v${version}`;
-    }
+  for (const entry of harnesses) {
+    const version = resources?.harnesses?.[entry.name]?.harnessVersion;
+    if (version !== undefined) entry.detail = entry.detail ? `${entry.detail} v${version}` : `v${version}`;
   }
 
   const payments = diffResourceSet({

--- a/src/cli/operations/deploy/__tests__/managed-memory-notice.test.ts
+++ b/src/cli/operations/deploy/__tests__/managed-memory-notice.test.ts
@@ -4,7 +4,7 @@ import {
   MANAGED_MEMORY_DEPLOY_NOTICE,
   hasManagedMemoryHarness,
 } from '../managed-memory-notice';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 /**
  * Builds a stub ConfigIO whose readHarnessSpec returns the given mode per harness name.
@@ -23,25 +23,8 @@ function stubConfigIO(modes: Record<string, string | undefined>): ConfigIO {
 }
 
 describe('hasManagedMemoryHarness', () => {
-  const originalGate = process.env.ENABLE_GATED_FEATURES;
-
-  beforeEach(() => {
-    process.env.ENABLE_GATED_FEATURES = '1';
-  });
-
   afterEach(() => {
-    if (originalGate === undefined) {
-      delete process.env.ENABLE_GATED_FEATURES;
-    } else {
-      process.env.ENABLE_GATED_FEATURES = originalGate;
-    }
     vi.clearAllMocks();
-  });
-
-  it('returns false when the gate is off, even with a managed harness', async () => {
-    delete process.env.ENABLE_GATED_FEATURES;
-    const configIO = stubConfigIO({ h1: 'managed' });
-    expect(await hasManagedMemoryHarness(configIO, [{ name: 'h1' }])).toBe(false);
   });
 
   it('returns false when there are no harnesses', async () => {
@@ -57,6 +40,12 @@ describe('hasManagedMemoryHarness', () => {
   it('returns false when all harnesses are existing or disabled', async () => {
     const configIO = stubConfigIO({ h1: 'existing', h2: 'disabled' });
     expect(await hasManagedMemoryHarness(configIO, [{ name: 'h1' }, { name: 'h2' }])).toBe(false);
+  });
+
+  it('returns true for a harness whose memory config is OMITTED (service auto-provisions managed)', async () => {
+    // mode undefined → stub resolves { memory: undefined } (omitted), which auto-provisions on deploy.
+    const configIO = stubConfigIO({ h1: undefined });
+    expect(await hasManagedMemoryHarness(configIO, [{ name: 'h1' }])).toBe(true);
   });
 
   it('treats an unreadable harness spec as non-managed (does not throw)', async () => {

--- a/src/cli/operations/deploy/__tests__/managed-memory-notice.test.ts
+++ b/src/cli/operations/deploy/__tests__/managed-memory-notice.test.ts
@@ -62,7 +62,13 @@ describe('managed-memory notice text', () => {
   });
 
   it('add notice is future-tense and points at the next deploy', () => {
-    expect(MANAGED_MEMORY_ADD_NOTICE).toContain('will automatically provision');
+    expect(MANAGED_MEMORY_ADD_NOTICE).toContain('will provision');
     expect(MANAGED_MEMORY_ADD_NOTICE).toContain('on deploy');
+  });
+
+  it('notices reflect opt-in managed (do NOT call managed the default)', () => {
+    expect(MANAGED_MEMORY_DEPLOY_NOTICE).not.toContain('the default');
+    expect(MANAGED_MEMORY_ADD_NOTICE).not.toContain('the default');
+    expect(MANAGED_MEMORY_DEPLOY_NOTICE).toContain('--memory-mode managed');
   });
 });

--- a/src/cli/operations/deploy/__tests__/managed-memory-notice.test.ts
+++ b/src/cli/operations/deploy/__tests__/managed-memory-notice.test.ts
@@ -42,10 +42,11 @@ describe('hasManagedMemoryHarness', () => {
     expect(await hasManagedMemoryHarness(configIO, [{ name: 'h1' }, { name: 'h2' }])).toBe(false);
   });
 
-  it('returns true for a harness whose memory config is OMITTED (service auto-provisions managed)', async () => {
-    // mode undefined → stub resolves { memory: undefined } (omitted), which auto-provisions on deploy.
+  it('returns false for a harness whose memory config is OMITTED (omitted opts out → Disabled, no provisioning)', async () => {
+    // mode undefined → stub resolves { memory: undefined } (omitted). The CDK now synthesizes
+    // Memory: { Disabled: {} } for omitted, so no memory is provisioned and the notice must not fire.
     const configIO = stubConfigIO({ h1: undefined });
-    expect(await hasManagedMemoryHarness(configIO, [{ name: 'h1' }])).toBe(true);
+    expect(await hasManagedMemoryHarness(configIO, [{ name: 'h1' }])).toBe(false);
   });
 
   it('treats an unreadable harness spec as non-managed (does not throw)', async () => {

--- a/src/cli/operations/deploy/__tests__/preflight-utils.test.ts
+++ b/src/cli/operations/deploy/__tests__/preflight-utils.test.ts
@@ -18,13 +18,24 @@ describe('formatError', () => {
     expect(formatError(err)).toBe('something failed');
   });
 
-  it('includes stack trace when available', () => {
+  it('omits the stack trace by default (no raw JS frames for users)', () => {
     const err = new Error('with stack');
 
     const result = formatError(err);
 
     expect(result).toContain('with stack');
-    expect(result).toContain('Stack trace:');
+    expect(result).not.toContain('Stack trace:');
+  });
+
+  it('includes the stack trace when AGENTCORE_DEBUG is set', () => {
+    const prev = process.env.AGENTCORE_DEBUG;
+    process.env.AGENTCORE_DEBUG = '1';
+    try {
+      expect(formatError(new Error('with stack'))).toContain('Stack trace:');
+    } finally {
+      if (prev === undefined) delete process.env.AGENTCORE_DEBUG;
+      else process.env.AGENTCORE_DEBUG = prev;
+    }
   });
 
   it('formats nested cause', () => {

--- a/src/cli/operations/deploy/__tests__/preflight.test.ts
+++ b/src/cli/operations/deploy/__tests__/preflight.test.ts
@@ -202,11 +202,19 @@ describe('formatError', () => {
     expect(result).toContain('Something went wrong');
   });
 
-  it('includes stack trace when present', () => {
+  it('omits the stack trace by default but includes it under AGENTCORE_DEBUG', () => {
     const err = new Error('oops');
-    const result = formatError(err);
-    expect(result).toContain('Stack trace:');
-    expect(result).toContain('oops');
+    expect(formatError(err)).not.toContain('Stack trace:');
+    expect(formatError(err)).toContain('oops');
+
+    const prev = process.env.AGENTCORE_DEBUG;
+    process.env.AGENTCORE_DEBUG = '1';
+    try {
+      expect(formatError(new Error('oops'))).toContain('Stack trace:');
+    } finally {
+      if (prev === undefined) delete process.env.AGENTCORE_DEBUG;
+      else process.env.AGENTCORE_DEBUG = prev;
+    }
   });
 
   it('formats nested cause errors', () => {

--- a/src/cli/operations/deploy/managed-memory-notice.ts
+++ b/src/cli/operations/deploy/managed-memory-notice.ts
@@ -1,5 +1,4 @@
 import type { ConfigIO } from '../../../lib';
-import { isGatedFeaturesEnabled } from '../../feature-flags';
 
 /**
  * One-shot heads-up shown before the CFN apply when a harness uses managed memory.
@@ -26,7 +25,13 @@ export const MANAGED_MEMORY_ADD_NOTICE =
   'provisioning time. To skip it, recreate the harness with --memory-mode disabled.';
 
 /**
- * Returns true when the gate is on and at least one harness in the project uses managed memory.
+ * Returns true when at least one harness in the project will provision a NEW managed memory on
+ * deploy (the slow 3-5 min step the notice explains). That happens for an explicit `managed` mode
+ * AND for an omitted memory config — the service auto-provisions a managed memory whenever the
+ * harness is not explicitly `disabled` or pointed at an `existing` memory (mirrors the CDK
+ * derivation in AgentCoreHarnessEnvironment). `existing` references a pre-existing memory (no
+ * provisioning) and `disabled` opts out, so neither triggers the notice.
+ *
  * The memory mode lives in each harness's harness.json (not the agentcore.json pointer list), so
  * the per-harness specs are read to detect it.
  */
@@ -34,12 +39,11 @@ export async function hasManagedMemoryHarness(
   configIO: ConfigIO,
   harnesses: { name: string }[] | undefined
 ): Promise<boolean> {
-  if (!isGatedFeaturesEnabled()) {
-    return false;
-  }
   for (const h of harnesses ?? []) {
     const harnessSpec = await configIO.readHarnessSpec(h.name).catch(() => undefined);
-    if (harnessSpec?.memory?.mode === 'managed') {
+    // Only a successfully-loaded spec counts: an explicit `managed` mode, or an omitted memory
+    // config (auto-provisions). An unreadable spec stays unknown and does not trigger the notice.
+    if (harnessSpec && (harnessSpec.memory?.mode === 'managed' || harnessSpec.memory === undefined)) {
       return true;
     }
   }

--- a/src/cli/operations/deploy/managed-memory-notice.ts
+++ b/src/cli/operations/deploy/managed-memory-notice.ts
@@ -9,8 +9,8 @@ import type { ConfigIO } from '../../../lib';
  * wording can't drift between them.
  */
 export const MANAGED_MEMORY_DEPLOY_NOTICE =
-  'Managed memory: this harness automatically provisions a dedicated AgentCore Memory resource ' +
-  '(the default unless you set --memory-mode existing or disabled).\n\n' +
+  'Managed memory: this harness provisions a dedicated AgentCore Memory resource on deploy ' +
+  '(you requested --memory-mode managed).\n\n' +
   'Memory provisioning can take 3-5 minutes. We know this is slow, and we will be reducing this ' +
   'provisioning time. To skip it, redeploy with --memory-mode disabled.';
 
@@ -19,8 +19,8 @@ export const MANAGED_MEMORY_DEPLOY_NOTICE =
  * what the next deploy will do and how to opt out before deploying.
  */
 export const MANAGED_MEMORY_ADD_NOTICE =
-  'Managed memory: this harness will automatically provision a dedicated AgentCore Memory resource ' +
-  'on deploy (the default unless you set --memory-mode existing or disabled).\n\n' +
+  'Managed memory: this harness will provision a dedicated AgentCore Memory resource on deploy ' +
+  '(you requested --memory-mode managed).\n\n' +
   'Memory provisioning can take 3-5 minutes. We know this is slow, and we will be reducing this ' +
   'provisioning time. To skip it, recreate the harness with --memory-mode disabled.';
 

--- a/src/cli/operations/deploy/managed-memory-notice.ts
+++ b/src/cli/operations/deploy/managed-memory-notice.ts
@@ -26,11 +26,9 @@ export const MANAGED_MEMORY_ADD_NOTICE =
 
 /**
  * Returns true when at least one harness in the project will provision a NEW managed memory on
- * deploy (the slow 3-5 min step the notice explains). That happens for an explicit `managed` mode
- * AND for an omitted memory config — the service auto-provisions a managed memory whenever the
- * harness is not explicitly `disabled` or pointed at an `existing` memory (mirrors the CDK
- * derivation in AgentCoreHarnessEnvironment). `existing` references a pre-existing memory (no
- * provisioning) and `disabled` opts out, so neither triggers the notice.
+ * deploy (the slow 3-5 min step the notice explains) — i.e. an explicit `managed` mode. Every other
+ * shape skips provisioning: `disabled` and omitted both synthesize Memory: { Disabled: {} } (no
+ * memory), and `existing` references a pre-existing memory.
  *
  * The memory mode lives in each harness's harness.json (not the agentcore.json pointer list), so
  * the per-harness specs are read to detect it.
@@ -41,9 +39,7 @@ export async function hasManagedMemoryHarness(
 ): Promise<boolean> {
   for (const h of harnesses ?? []) {
     const harnessSpec = await configIO.readHarnessSpec(h.name).catch(() => undefined);
-    // Only a successfully-loaded spec counts: an explicit `managed` mode, or an omitted memory
-    // config (auto-provisions). An unreadable spec stays unknown and does not trigger the notice.
-    if (harnessSpec && (harnessSpec.memory?.mode === 'managed' || harnessSpec.memory === undefined)) {
+    if (harnessSpec?.memory?.mode === 'managed') {
       return true;
     }
   }

--- a/src/cli/operations/deploy/preflight.ts
+++ b/src/cli/operations/deploy/preflight.ts
@@ -40,12 +40,14 @@ export interface StackStatusCheckResult {
 }
 
 /**
- * Format an error for user display, including stack trace if available.
+ * Format an error for user display. Shows the message and the cause chain, but NOT the raw JS stack
+ * trace — dumping `err.stack` (minified dist/cli/index.mjs frames) to users is noise for the common
+ * case (config/validation errors). Set AGENTCORE_DEBUG=1 to include the stack trace for debugging.
  */
 export function formatError(err: unknown): string {
   if (err instanceof Error) {
     const lines = [err.message];
-    if (err.stack) {
+    if (err.stack && process.env.AGENTCORE_DEBUG) {
       lines.push('', 'Stack trace:', err.stack);
     }
     if (err.cause) {

--- a/src/cli/primitives/HarnessPrimitive.ts
+++ b/src/cli/primitives/HarnessPrimitive.ts
@@ -1154,8 +1154,12 @@ export class HarnessPrimitive extends BasePrimitive<AddHarnessOptions, Removable
   /**
    * Build the mode-tagged memory ref for the harness.
    * Precedence: an explicit existing reference (--memory-arn/--memory-name or --memory-mode existing)
-   * → existing; --no-memory or --memory-mode disabled → disabled; otherwise (the default) → managed,
-   * with strategies written explicitly so the config is auditable.
+   * → existing; an explicit managed request (--memory-mode managed or a managed-tuning flag) →
+   * managed, with strategies written explicitly so the config is auditable; everything else →
+   * disabled. Memory is OPT-IN: a user who says nothing about memory gets `disabled`, which maps to
+   * CFN `Memory: { Disabled: {} }`. This is deliberate — an omitted CFN Memory block makes the
+   * service auto-provision managed memory, so the CLI always emits an explicit mode to avoid that
+   * surprise (silence must mean "no memory", not "managed").
    */
   private buildMemoryRef(options: AddHarnessOptions): HarnessMemoryRef | undefined {
     if (options.memoryArn || options.memoryName || options.memoryMode === 'existing') {
@@ -1169,20 +1173,26 @@ export class HarnessPrimitive extends BasePrimitive<AddHarnessOptions, Removable
         ...(tuning && { retrievalConfig: tuning }),
       };
     }
-    if (options.skipMemory || options.memoryMode === 'disabled') {
-      return { mode: 'disabled' };
+    // Managed is opt-in: only when the user explicitly asks for it via --memory-mode managed or any
+    // managed-tuning flag. Strategies are written ONLY when the user tuned them; omitted otherwise so
+    // the service applies its own default rather than the CLI pinning one.
+    const managedRequested =
+      options.memoryMode === 'managed' ||
+      (options.memoryStrategies?.length ?? 0) > 0 ||
+      options.memoryEventExpiryDays !== undefined ||
+      options.memoryEncryptionKeyArn !== undefined;
+    if (managedRequested) {
+      return {
+        mode: 'managed',
+        ...(options.memoryStrategies?.length && {
+          strategies: options.memoryStrategies as ManagedMemoryStrategy[],
+        }),
+        ...(options.memoryEventExpiryDays !== undefined && { eventExpiryDuration: options.memoryEventExpiryDays }),
+        ...(options.memoryEncryptionKeyArn && { encryptionKeyArn: options.memoryEncryptionKeyArn }),
+      };
     }
-    // Default (and explicit --memory-mode managed): managed memory. Strategies are written ONLY when
-    // the user tuned them (--memory-strategies); omitted otherwise so the harness/service applies its
-    // own default rather than the CLI pinning one.
-    return {
-      mode: 'managed',
-      ...(options.memoryStrategies?.length && {
-        strategies: options.memoryStrategies as ManagedMemoryStrategy[],
-      }),
-      ...(options.memoryEventExpiryDays !== undefined && { eventExpiryDuration: options.memoryEventExpiryDays }),
-      ...(options.memoryEncryptionKeyArn && { encryptionKeyArn: options.memoryEncryptionKeyArn }),
-    };
+    // Default (and --no-memory / --memory-mode disabled): no memory.
+    return { mode: 'disabled' };
   }
 
   private buildRetrievalConfig(options: AddHarnessOptions) {

--- a/src/cli/primitives/HarnessPrimitive.ts
+++ b/src/cli/primitives/HarnessPrimitive.ts
@@ -8,16 +8,13 @@ import type {
   HarnessModelProvider,
   HarnessSpec,
   ManagedMemoryStrategy,
-  MemoryStrategy,
-  MemoryStrategyType,
   NetworkMode,
   PrivateEndpoint,
   RuntimeAuthorizerType,
 } from '../../schema';
-import { DEFAULT_EPISODIC_REFLECTION_NAMESPACES, DEFAULT_STRATEGY_NAMESPACES, HarnessSpecSchema } from '../../schema';
+import { HarnessSpecSchema } from '../../schema';
 import { deleteHarness, isHarnessNotFoundError } from '../aws/agentcore-harness';
 import { getErrorMessage } from '../errors';
-import { isGatedFeaturesEnabled } from '../feature-flags';
 import { MANAGED_MEMORY_ADD_NOTICE } from '../operations/deploy';
 import { findOrphanHarnesses } from '../operations/harness/orphan';
 import type { OrphanHarness } from '../operations/harness/orphan';
@@ -26,7 +23,6 @@ import { withCommandRunTelemetry } from '../telemetry/cli-command-run.js';
 import type { SubCommand } from '../telemetry/schemas/command-run.js';
 import { getTemplatePath } from '../templates/templateRoot';
 import { requireTTY } from '../tui/guards/tty';
-import { DEFAULT_MEMORY_EXPIRY_DAYS } from '../tui/screens/generate/defaults';
 import { BasePrimitive } from './BasePrimitive';
 import { buildAuthorizerConfigFromJwtConfig, createManagedOAuthCredential } from './auth-utils';
 import type { JwtConfigOptions } from './auth-utils';
@@ -73,15 +69,6 @@ function strictFloat(label: string): (value: string) => number {
   };
 }
 
-/**
- * Hide a gated option from `--help` when ENABLE_GATED_FEATURES is off. The option still PARSES
- * (so explicit use is caught by validation with a clean "not yet available" message) but does not
- * advertise itself. Mirrors the AWS Skills gating pattern (skill-command.ts).
- */
-function gatedOption<T extends Option>(option: T): T {
-  return isGatedFeaturesEnabled() ? option : option.hideHelp();
-}
-
 /** Commander accumulator for repeatable `--env`/`--tag` KEY=VALUE flags. Last write wins per key. */
 function collectKeyValue(value: string, previous: Record<string, string>): Record<string, string> {
   const eq = value.indexOf('=');
@@ -125,13 +112,13 @@ export interface AddHarnessOptions {
   modelMaxTokens?: number;
   systemPrompt?: string;
   skipMemory?: boolean;
-  /** Memory mode (gated). managed = harness owns its memory; existing = BYO; disabled = none. */
+  /** Memory mode. managed = harness owns its memory; existing = BYO; disabled = none. */
   memoryMode?: 'managed' | 'existing' | 'disabled';
-  /** Managed-memory strategies (gated). Subset of SEMANTIC/SUMMARIZATION/USER_PREFERENCE/EPISODIC. */
+  /** Managed-memory strategies. Subset of SEMANTIC/SUMMARIZATION/USER_PREFERENCE/EPISODIC. */
   memoryStrategies?: string[];
-  /** Managed-memory event retention in days, 3-365 (gated). */
+  /** Managed-memory event retention in days, 3-365. */
   memoryEventExpiryDays?: number;
-  /** Managed-memory KMS CMK ARN, create-only (gated). */
+  /** Managed-memory KMS CMK ARN, create-only. */
   memoryEncryptionKeyArn?: string;
   /** Reference an existing memory by name or ARN instead of auto-creating one. */
   memoryName?: string;
@@ -226,17 +213,11 @@ export class HarnessPrimitive extends BasePrimitive<AddHarnessOptions, Removable
       const harnesses = project.harnesses ?? [];
       this.checkDuplicate(harnesses, options.name);
 
-      // Memory resolution. Two regimes, gated by ENABLE_GATED_FEATURES:
-      //  - Gated ON (managed-memory feature): the harness owns its memory internally (managed
-      //    default). No sibling `${name}Memory` is ever auto-created; buildMemoryRef emits the
-      //    mode-tagged union (managed | existing | disabled).
-      //  - Gated OFF (today's behavior): an explicit --memory-arn/--memory-name reference is used
-      //    as-is; otherwise (unless --no-memory) a dedicated `${name}Memory` sibling is auto-created.
-      const gated = isGatedFeaturesEnabled();
-      const referencesExistingMemory = options.memoryArn !== undefined || options.memoryName !== undefined;
-      const autoCreateMemoryName =
-        gated || options.skipMemory || referencesExistingMemory ? undefined : `${options.name}Memory`;
-      const memoryRef = gated ? this.buildMemoryRef(options) : this.buildLegacyMemoryRef(options, autoCreateMemoryName);
+      // Memory resolution: the harness owns its memory internally. buildMemoryRef emits the
+      // mode-tagged union (managed | existing | disabled). No sibling `${name}Memory` is ever
+      // auto-created — managed is the default, and --no-memory/--memory-mode disabled emits
+      // `{ mode: 'disabled' }`, which maps to CFN `Memory: { Disabled: {} }` (a true opt-out).
+      const memoryRef = this.buildMemoryRef(options);
 
       let dockerfile: string | undefined;
       if (options.dockerfilePath) {
@@ -403,21 +384,6 @@ export class HarnessPrimitive extends BasePrimitive<AddHarnessOptions, Removable
         template = template.replace('{{HARNESS_ARN}}', '<your-harness-arn>');
         template = template.replace('{{REGION}}', '<your-region>');
         await writeFile(invokeScriptPath, template, 'utf-8');
-      }
-
-      if (autoCreateMemoryName) {
-        const strategyTypes: MemoryStrategyType[] = ['SEMANTIC', 'USER_PREFERENCE', 'SUMMARIZATION', 'EPISODIC'];
-        const strategies: MemoryStrategy[] = strategyTypes.map(type => ({
-          type,
-          ...(DEFAULT_STRATEGY_NAMESPACES[type] && { namespaces: DEFAULT_STRATEGY_NAMESPACES[type] }),
-          ...(type === 'EPISODIC' && { reflectionNamespaces: DEFAULT_EPISODIC_REFLECTION_NAMESPACES }),
-        }));
-
-        project.memories.push({
-          name: autoCreateMemoryName,
-          eventExpiryDuration: DEFAULT_MEMORY_EXPIRY_DAYS,
-          strategies,
-        });
       }
 
       project.harnesses = [
@@ -685,30 +651,20 @@ export class HarnessPrimitive extends BasePrimitive<AddHarnessOptions, Removable
         'Memory retrieval: minimum relevance score (0-1)',
         strictFloat('--memory-relevance-score')
       )
-      // Managed-memory flags — gated behind ENABLE_GATED_FEATURES. When off they still PARSE
-      // (so explicit use returns a clean "not yet available" error in validation) but are hidden
-      // from --help, mirroring the AWS Skills gating pattern.
+      // Managed-memory flags.
+      .addOption(new Option('--memory-mode <mode>', 'Memory mode: managed (default), existing, or disabled'))
       .addOption(
-        gatedOption(new Option('--memory-mode <mode>', 'Memory mode: managed (default), existing, or disabled'))
-      )
-      .addOption(
-        gatedOption(
-          new Option(
-            '--memory-strategies <list>',
-            'Managed memory strategies (comma-separated): SEMANTIC,SUMMARIZATION,USER_PREFERENCE,EPISODIC'
-          )
+        new Option(
+          '--memory-strategies <list>',
+          'Managed memory strategies (comma-separated): SEMANTIC,SUMMARIZATION,USER_PREFERENCE,EPISODIC'
         )
       )
       .addOption(
-        gatedOption(
-          new Option('--memory-event-expiry-days <n>', 'Managed memory event retention in days (3-365)').argParser(
-            strictInt('--memory-event-expiry-days')
-          )
+        new Option('--memory-event-expiry-days <n>', 'Managed memory event retention in days (3-365)').argParser(
+          strictInt('--memory-event-expiry-days')
         )
       )
-      .addOption(
-        gatedOption(new Option('--memory-encryption-key-arn <arn>', 'Managed memory KMS CMK ARN (create-only)'))
-      )
+      .addOption(new Option('--memory-encryption-key-arn <arn>', 'Managed memory KMS CMK ARN (create-only)'))
       .option('--max-iterations <n>', 'Max iterations', strictInt('--max-iterations'))
       .option('--max-tokens <n>', 'Max execution tokens per invocation (harness loop cap)', strictInt('--max-tokens'))
       .option('--timeout <seconds>', 'Timeout in seconds', strictInt('--timeout'))
@@ -1196,7 +1152,7 @@ export class HarnessPrimitive extends BasePrimitive<AddHarnessOptions, Removable
   }
 
   /**
-   * Build the mode-tagged memory ref for the managed-memory feature (gated ON).
+   * Build the mode-tagged memory ref for the harness.
    * Precedence: an explicit existing reference (--memory-arn/--memory-name or --memory-mode existing)
    * → existing; --no-memory or --memory-mode disabled → disabled; otherwise (the default) → managed,
    * with strategies written explicitly so the config is auditable.
@@ -1226,29 +1182,6 @@ export class HarnessPrimitive extends BasePrimitive<AddHarnessOptions, Removable
       }),
       ...(options.memoryEventExpiryDays !== undefined && { eventExpiryDuration: options.memoryEventExpiryDays }),
       ...(options.memoryEncryptionKeyArn && { encryptionKeyArn: options.memoryEncryptionKeyArn }),
-    };
-  }
-
-  /**
-   * Legacy (gated OFF) memory ref builder — preserves pre-managed-memory behavior exactly.
-   * An explicit `--memory-arn`/`--memory-name` references an existing memory; otherwise
-   * `autoCreateMemoryName` (when set) points at the `${name}Memory` sibling this command auto-creates.
-   * Returns undefined when there is no memory at all (`--no-memory`).
-   */
-  private buildLegacyMemoryRef(
-    options: AddHarnessOptions,
-    autoCreateMemoryName: string | undefined
-  ): HarnessMemoryRef | undefined {
-    const name = options.memoryName ?? autoCreateMemoryName;
-    if (!options.memoryArn && !name) return undefined;
-    const tuning = this.buildRetrievalConfig(options);
-    return {
-      mode: 'existing',
-      ...(name && { name }),
-      ...(options.memoryArn && { arn: options.memoryArn }),
-      ...(options.memoryActorId && { actorId: options.memoryActorId }),
-      ...(options.messagesCount !== undefined && { messagesCount: options.messagesCount }),
-      ...(tuning && { retrievalConfig: tuning }),
     };
   }
 

--- a/src/cli/primitives/HarnessPrimitive.ts
+++ b/src/cli/primitives/HarnessPrimitive.ts
@@ -120,7 +120,7 @@ export interface AddHarnessOptions {
   memoryEventExpiryDays?: number;
   /** Managed-memory KMS CMK ARN, create-only. */
   memoryEncryptionKeyArn?: string;
-  /** Reference an existing memory by name or ARN instead of auto-creating one. */
+  /** Reference an existing memory by name or ARN (sets memory mode to existing). */
   memoryName?: string;
   memoryArn?: string;
   /** Deploy-time ActorId for the referenced memory (CFN Memory.ActorId). */
@@ -215,8 +215,8 @@ export class HarnessPrimitive extends BasePrimitive<AddHarnessOptions, Removable
 
       // Memory resolution: the harness owns its memory internally. buildMemoryRef emits the
       // mode-tagged union (managed | existing | disabled). No sibling `${name}Memory` is ever
-      // auto-created — managed is the default, and --no-memory/--memory-mode disabled emits
-      // `{ mode: 'disabled' }`, which maps to CFN `Memory: { Disabled: {} }` (a true opt-out).
+      // auto-created. Memory is opt-in: with no memory flag (or --no-memory / --memory-mode disabled)
+      // it emits `{ mode: 'disabled' }`, which maps to CFN `Memory: { Disabled: {} }` (a true opt-out).
       const memoryRef = this.buildMemoryRef(options);
 
       let dockerfile: string | undefined;
@@ -636,9 +636,9 @@ export class HarnessPrimitive extends BasePrimitive<AddHarnessOptions, Removable
         strictInt('--model-max-tokens')
       )
       .option('--container <uri-or-path>', 'Container image URI or path to a Dockerfile')
-      .option('--no-memory', 'Skip auto-creating memory')
-      .option('--memory-name <name>', 'Reference an existing memory by name instead of auto-creating one')
-      .option('--memory-arn <arn>', 'Reference an existing memory by ARN instead of auto-creating one')
+      .option('--no-memory', 'Disable memory for this harness (this is the default)')
+      .option('--memory-name <name>', 'Use an existing memory by name')
+      .option('--memory-arn <arn>', 'Use an existing memory by ARN')
       .option('--memory-actor-id <id>', 'Deploy-time ActorId scoping memory access for the harness')
       .option(
         '--memory-messages-count <n>',
@@ -652,7 +652,7 @@ export class HarnessPrimitive extends BasePrimitive<AddHarnessOptions, Removable
         strictFloat('--memory-relevance-score')
       )
       // Managed-memory flags.
-      .addOption(new Option('--memory-mode <mode>', 'Memory mode: managed (default), existing, or disabled'))
+      .addOption(new Option('--memory-mode <mode>', 'Memory mode: disabled (default), managed, or existing'))
       .addOption(
         new Option(
           '--memory-strategies <list>',

--- a/src/cli/primitives/__tests__/HarnessPrimitive.add.memory.test.ts
+++ b/src/cli/primitives/__tests__/HarnessPrimitive.add.memory.test.ts
@@ -52,16 +52,24 @@ async function memoryWrittenFor(options: Record<string, unknown>) {
 describe('HarnessPrimitive.add — memory mode resolution', () => {
   afterEach(() => vi.clearAllMocks());
 
-  it('defaults to managed when no memory flags are passed', async () => {
-    expect(await memoryWrittenFor({})).toEqual({ mode: 'managed' });
+  it('defaults to disabled when no memory flags are passed (memory is opt-in)', async () => {
+    expect(await memoryWrittenFor({})).toEqual({ mode: 'disabled' });
   });
 
-  it('writes { mode: "disabled" } for --no-memory (skipMemory) — true opt-out, not omitted', async () => {
+  it('writes { mode: "disabled" } for --no-memory (skipMemory)', async () => {
     expect(await memoryWrittenFor({ skipMemory: true })).toEqual({ mode: 'disabled' });
   });
 
   it('writes { mode: "disabled" } for --memory-mode disabled', async () => {
     expect(await memoryWrittenFor({ memoryMode: 'disabled' })).toEqual({ mode: 'disabled' });
+  });
+
+  it('writes managed only when explicitly requested via --memory-mode managed', async () => {
+    expect(await memoryWrittenFor({ memoryMode: 'managed' })).toEqual({ mode: 'managed' });
+  });
+
+  it('writes managed when a managed-tuning flag is given (implies managed)', async () => {
+    expect(await memoryWrittenFor({ memoryEventExpiryDays: 30 })).toEqual({ mode: 'managed', eventExpiryDuration: 30 });
   });
 
   it('writes managed with explicit strategies when tuned', async () => {

--- a/src/cli/primitives/__tests__/HarnessPrimitive.add.memory.test.ts
+++ b/src/cli/primitives/__tests__/HarnessPrimitive.add.memory.test.ts
@@ -1,0 +1,91 @@
+import { HarnessPrimitive } from '../HarnessPrimitive';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Memory-mode resolution is the load-bearing behavior of the managed-memory ungating: the harness
+// owns its memory internally (no sibling `${name}Memory` is ever auto-created), and "no memory"
+// must write `{ mode: 'disabled' }` — which the CDK maps to CFN `Memory: { Disabled: {} }`, a true
+// opt-out — rather than omitting memory (which the service would silently auto-provision).
+
+const mockReadProjectSpec = vi.fn();
+const mockWriteProjectSpec = vi.fn();
+const mockWriteHarnessSpec = vi.fn();
+
+vi.mock('../../../lib', () => ({
+  APP_DIR: 'app',
+  ConfigIO: class {
+    readProjectSpec = mockReadProjectSpec;
+    writeProjectSpec = mockWriteProjectSpec;
+    writeHarnessSpec = mockWriteHarnessSpec;
+    getPathResolver = () => ({ getHarnessDir: (name: string) => `/fake/root/app/${name}` });
+  },
+  findConfigRoot: () => '/fake/root',
+}));
+
+vi.mock('fs/promises', () => ({
+  access: vi.fn(),
+  copyFile: vi.fn(),
+  mkdir: vi.fn(),
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+}));
+
+function baseProject() {
+  return { name: 'proj', harnesses: [], memories: [], runtimes: [] };
+}
+
+/** Runs add() with the given options and returns the memory ref written to harness.json. */
+async function memoryWrittenFor(options: Record<string, unknown>) {
+  mockReadProjectSpec.mockResolvedValue(baseProject());
+  const primitive = new HarnessPrimitive();
+  const result = await primitive.add({
+    name: 'support',
+    modelProvider: 'bedrock',
+    modelId: 'anthropic.claude-3',
+    configBaseDir: '/fake/root',
+    ...options,
+  } as never);
+  expect(result.success).toBe(true);
+  const [, spec] = mockWriteHarnessSpec.mock.calls.at(-1)!;
+  return (spec as { memory?: { mode: string } }).memory;
+}
+
+describe('HarnessPrimitive.add — memory mode resolution', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('defaults to managed when no memory flags are passed', async () => {
+    expect(await memoryWrittenFor({})).toEqual({ mode: 'managed' });
+  });
+
+  it('writes { mode: "disabled" } for --no-memory (skipMemory) — true opt-out, not omitted', async () => {
+    expect(await memoryWrittenFor({ skipMemory: true })).toEqual({ mode: 'disabled' });
+  });
+
+  it('writes { mode: "disabled" } for --memory-mode disabled', async () => {
+    expect(await memoryWrittenFor({ memoryMode: 'disabled' })).toEqual({ mode: 'disabled' });
+  });
+
+  it('writes managed with explicit strategies when tuned', async () => {
+    expect(await memoryWrittenFor({ memoryMode: 'managed', memoryStrategies: ['SEMANTIC', 'SUMMARIZATION'] })).toEqual({
+      mode: 'managed',
+      strategies: ['SEMANTIC', 'SUMMARIZATION'],
+    });
+  });
+
+  it('writes existing when a memory ARN is referenced', async () => {
+    const arn = 'arn:aws:bedrock-agentcore:us-west-2:111122223333:memory/m-aBcD012345';
+    expect(await memoryWrittenFor({ memoryArn: arn })).toEqual({ mode: 'existing', arn });
+  });
+
+  it('never auto-creates a sibling `${name}Memory` resource in the project', async () => {
+    mockReadProjectSpec.mockResolvedValue(baseProject());
+    const primitive = new HarnessPrimitive();
+    await primitive.add({
+      name: 'support',
+      modelProvider: 'bedrock',
+      modelId: 'anthropic.claude-3',
+      configBaseDir: '/fake/root',
+    } as never);
+    const writtenProject = mockWriteProjectSpec.mock.calls.at(-1)![0] as { memories: unknown[] };
+    expect(writtenProject.memories).toHaveLength(0);
+  });
+});

--- a/src/cli/tui/hooks/useMultiSelectNavigation.ts
+++ b/src/cli/tui/hooks/useMultiSelectNavigation.ts
@@ -108,12 +108,17 @@ export function useMultiSelectNavigation<T>({
         return;
       }
 
-      // Handle Enter confirm
+      // Handle Enter confirm. Only return selections that are still VISIBLE in `items`: a selection
+      // can go stale if the option set changes after a toggle (e.g. the mode-scoped "memory tuning"
+      // option is filtered out when the user switches memory mode). Returning a stale id pushes a
+      // step that isn't in the wizard's step list, corrupting navigation — so reconcile here.
       if (key.return) {
-        if (requireSelection && selectedIds.size === 0) {
-          return; // Don't confirm if selection required but none selected
+        const visibleIds = new Set(items.map(getId));
+        const confirmed = Array.from(selectedIds).filter(id => visibleIds.has(id));
+        if (requireSelection && confirmed.length === 0) {
+          return; // Don't confirm if selection required but none (visible) selected
         }
-        onConfirm?.(Array.from(selectedIds));
+        onConfirm?.(confirmed);
       }
     },
     { isActive }

--- a/src/cli/tui/screens/create/useCreateFlow.ts
+++ b/src/cli/tui/screens/create/useCreateFlow.ts
@@ -44,6 +44,7 @@ import { withMinDuration } from '../../utils';
 import { mapByoConfigToAgent } from '../agent';
 import type { AddAgentConfig } from '../agent/types';
 import type { GenerateConfig } from '../generate/types';
+import { toMemoryAddOptions } from '../harness/memory-options';
 import type { AddHarnessConfig } from '../harness/types';
 import { DescribeSubnetsCommand, EC2Client } from '@aws-sdk/client-ec2';
 import { mkdir } from 'fs/promises';
@@ -249,7 +250,11 @@ export function useCreateFlow(cwd: string): CreateFlowState {
       ),
       memory_type: standardize(
         MemoryEnum,
-        isHarness ? (addHarnessConfig?.skipMemory ? 'none' : 'longandshortterm') : (addAgentConfig?.memory ?? 'none')
+        isHarness
+          ? addHarnessConfig?.memory?.mode === 'disabled'
+            ? 'none'
+            : 'longandshortterm'
+          : (addAgentConfig?.memory ?? 'none')
       ),
       build_type: isHarness ? undefined : standardize(BuildType, addAgentConfig?.buildType ?? 'CodeZip'),
       network_mode: standardize(
@@ -621,13 +626,14 @@ export function useCreateFlow(cwd: string): CreateFlowState {
             await withMinDuration(async () => {
               logger.logSubStep(`Adding harness: ${addHarnessConfig.name}`);
               const { harnessPrimitive: hp } = await import('../../../primitives/registry');
+              const memoryOptions = toMemoryAddOptions(addHarnessConfig.memory);
               const result = await hp.add({
                 name: addHarnessConfig.name,
                 modelProvider: addHarnessConfig.modelProvider,
                 modelId: addHarnessConfig.modelId,
                 apiFormat: addHarnessConfig.apiFormat,
                 apiKeyArn: addHarnessConfig.apiKeyArn,
-                skipMemory: addHarnessConfig.skipMemory,
+                ...memoryOptions,
                 containerUri: addHarnessConfig.containerUri,
                 dockerfilePath: addHarnessConfig.dockerfilePath,
                 maxIterations: addHarnessConfig.maxIterations,

--- a/src/cli/tui/screens/harness/AddHarnessFlow.tsx
+++ b/src/cli/tui/screens/harness/AddHarnessFlow.tsx
@@ -3,6 +3,7 @@ import { ErrorPrompt } from '../../components';
 import { AddSuccessScreen } from '../add/AddSuccessScreen';
 import { useExistingCredentials } from '../identity/useCreateIdentity';
 import { AddHarnessScreen } from './AddHarnessScreen';
+import { toMemoryAddOptions } from './memory-options';
 import type { AddHarnessConfig } from './types';
 import { Box, Text } from 'ink';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
@@ -55,6 +56,7 @@ export function AddHarnessFlow({ isInteractive = true, onExit, onBack, onDev, on
     setFlow({ name: 'create-success', harnessName: config.name, loading: true, loadingMessage: 'Creating harness...' });
     try {
       const { harnessPrimitive } = await import('../../../primitives/registry');
+      const memoryOptions = toMemoryAddOptions(config.memory);
       const result = await harnessPrimitive.add({
         name: config.name,
         modelProvider: config.modelProvider,
@@ -63,33 +65,7 @@ export function AddHarnessFlow({ isInteractive = true, onExit, onBack, onDev, on
         apiKeyArn: config.apiKeyArn,
         apiBase: config.apiBase,
         additionalParams: config.additionalParams,
-        // Memory: when the mode-tagged union is present (gated ON), translate it to the primitive's
-        // memory-mode options; otherwise fall back to the legacy skipMemory + flat tuning fields.
-        ...(config.memory
-          ? config.memory.mode === 'managed'
-            ? {
-                memoryMode: 'managed' as const,
-                memoryStrategies: config.memory.strategies,
-                memoryEventExpiryDays: config.memory.eventExpiryDuration,
-                memoryEncryptionKeyArn: config.memory.encryptionKeyArn,
-              }
-            : config.memory.mode === 'existing'
-              ? {
-                  memoryMode: 'existing' as const,
-                  memoryName: config.memory.name,
-                  memoryArn: config.memory.arn,
-                  memoryActorId: config.memory.actorId,
-                  messagesCount: config.memory.messagesCount,
-                  memoryTopK: config.memory.topK,
-                  memoryRelevanceScore: config.memory.relevanceScore,
-                }
-              : { memoryMode: 'disabled' as const, skipMemory: true }
-          : {
-              skipMemory: config.skipMemory,
-              messagesCount: config.messagesCount,
-              memoryTopK: config.memoryTopK,
-              memoryRelevanceScore: config.memoryRelevanceScore,
-            }),
+        ...memoryOptions,
         containerUri: config.containerUri,
         dockerfilePath: config.dockerfilePath,
         maxIterations: config.maxIterations,

--- a/src/cli/tui/screens/harness/AddHarnessScreen.tsx
+++ b/src/cli/tui/screens/harness/AddHarnessScreen.tsx
@@ -41,7 +41,6 @@ import {
   HARNESS_STEP_LABELS,
   MANAGED_STRATEGY_OPTIONS,
   MEMORY_MODE_OPTIONS,
-  MEMORY_OPTIONS,
   MODEL_PROVIDER_OPTIONS,
   NETWORK_MODE_OPTIONS,
   OPENAI_API_FORMAT_OPTIONS,
@@ -50,7 +49,6 @@ import {
   TRUNCATION_STRATEGY_OPTIONS,
 } from './types';
 import { useAddHarnessWizard } from './useAddHarnessWizard';
-import { isGatedFeaturesEnabled } from '@/cli/feature-flags';
 import { Text } from 'ink';
 import React, { useEffect, useMemo } from 'react';
 
@@ -114,24 +112,17 @@ export function AddHarnessScreen({
         // and managed/existing have disjoint knob sets (per the harness API). Disabled shows none.
         //  - memory-managed-tuning  → only when mode === 'managed'  (strategies/event-expiry/KMS)
         //  - memory-existing-tuning → only when mode === 'existing' (actorId/messagesCount/topK/relevance)
-        //  - memory-tuning (legacy) → only in the gated-off model, when memory isn't skipped
         .filter(opt => {
           if (opt.id === 'memory-managed-tuning') return wizard.config.memory?.mode === 'managed';
           if (opt.id === 'memory-existing-tuning') return wizard.config.memory?.mode === 'existing';
-          if (opt.id === 'memory-tuning') return !wizard.config.memory && wizard.config.skipMemory !== true;
           return true;
         })
         .map(opt => ({ id: opt.id, title: opt.title, description: opt.description })),
-    [wizard.config.skipMemory, wizard.config.memory]
+    [wizard.config.memory]
   );
 
   const toolSelectItems: SelectableItem[] = useMemo(
     () => TOOL_SELECT_OPTIONS.map(opt => ({ id: opt.id, title: opt.title, description: opt.description })),
-    []
-  );
-
-  const memoryItems: SelectableItem[] = useMemo(
-    () => MEMORY_OPTIONS.map(opt => ({ id: opt.id, title: opt.title, description: opt.description })),
     []
   );
 
@@ -182,7 +173,6 @@ export function AddHarnessScreen({
   const isGatewayOutboundAuthStep = wizard.step === 'gateway-outbound-auth';
   const isGatewayProviderArnStep = wizard.step === 'gateway-provider-arn';
   const isGatewayScopesStep = wizard.step === 'gateway-scopes';
-  const isMemoryStep = wizard.step === 'memory';
   const isMemoryModeStep = wizard.step === 'memory-mode';
   const isMemoryStrategiesStep = wizard.step === 'memory-strategies';
   const isMemoryEventExpiryStep = wizard.step === 'memory-event-expiry';
@@ -264,13 +254,6 @@ export function AddHarnessScreen({
     requireSelection: false,
   });
 
-  const memoryNav = useListNavigation({
-    items: memoryItems,
-    onSelect: item => wizard.setMemoryEnabled(item.id === 'enabled'),
-    onExit: () => wizard.goBack(),
-    isActive: isMemoryStep,
-  });
-
   const memoryModeNav = useListNavigation({
     items: memoryModeItems,
     onSelect: item => wizard.setMemoryMode(item.id as 'managed' | 'existing' | 'disabled'),
@@ -328,8 +311,7 @@ export function AddHarnessScreen({
       SKILL_SOURCE_TYPE_OPTIONS.map(opt => ({
         id: opt.id,
         title: opt.title,
-        description: opt.id === 'aws_skills' && !isGatedFeaturesEnabled() ? 'Coming soon' : opt.description,
-        disabled: opt.id === 'aws_skills' && !isGatedFeaturesEnabled(),
+        description: opt.description,
       })),
     []
   );
@@ -409,7 +391,6 @@ export function AddHarnessScreen({
       ? 'Space toggle · Enter confirm · Esc back'
       : isModelProviderStep ||
           isApiFormatStep ||
-          isMemoryStep ||
           isMemoryModeStep ||
           isContainerStep ||
           isNetworkModeStep ||
@@ -451,7 +432,6 @@ export function AddHarnessScreen({
 
     const mem = wizard.config.memory;
     if (mem) {
-      // Mode-tagged memory (gated ON).
       if (mem.mode === 'managed') {
         const titled = mem.strategies?.length
           ? mem.strategies.map(s => s.charAt(0) + s.slice(1).toLowerCase().replace('_', ' ')).join(', ')
@@ -465,22 +445,18 @@ export function AddHarnessScreen({
         }
       } else if (mem.mode === 'existing') {
         fields.push({ label: 'Memory', value: `Existing (${mem.arn ?? mem.name ?? '—'})` });
+        if (mem.messagesCount !== undefined) {
+          fields.push({ label: 'Memory Messages Count', value: String(mem.messagesCount) });
+        }
+        if (mem.topK !== undefined) {
+          fields.push({ label: 'Memory Retrieval Top K', value: String(mem.topK) });
+        }
+        if (mem.relevanceScore !== undefined) {
+          fields.push({ label: 'Memory Relevance Score', value: String(mem.relevanceScore) });
+        }
       } else {
         fields.push({ label: 'Memory', value: 'Disabled' });
       }
-    } else if (wizard.config.skipMemory !== undefined) {
-      // Legacy enabled/disabled (gated OFF).
-      fields.push({ label: 'Memory', value: wizard.config.skipMemory ? 'Disabled' : 'Enabled' });
-    }
-
-    if (wizard.config.messagesCount !== undefined) {
-      fields.push({ label: 'Memory Messages Count', value: String(wizard.config.messagesCount) });
-    }
-    if (wizard.config.memoryTopK !== undefined) {
-      fields.push({ label: 'Memory Retrieval Top K', value: String(wizard.config.memoryTopK) });
-    }
-    if (wizard.config.memoryRelevanceScore !== undefined) {
-      fields.push({ label: 'Memory Relevance Score', value: String(wizard.config.memoryRelevanceScore) });
     }
 
     if (wizard.config.allowedTools?.length) {
@@ -568,7 +544,10 @@ export function AddHarnessScreen({
 
     if (wizard.config.skills?.length) {
       for (const [i, skill] of wizard.config.skills.entries()) {
-        const label = skill.s3Uri ?? skill.gitUrl ?? skill.path ?? 'unknown';
+        const awsSkillsLabel = skill.awsSkills
+          ? `aws-skills (${skill.awsSkills.length > 0 ? skill.awsSkills.join(', ') : 'all'})`
+          : undefined;
+        const label = skill.s3Uri ?? skill.gitUrl ?? skill.path ?? awsSkillsLabel ?? 'unknown';
         fields.push({ label: `Skill ${i + 1}`, value: label });
       }
     }
@@ -1021,15 +1000,6 @@ export function AddHarnessScreen({
             description={`${(wizard.config.skills ?? []).length} skill(s) configured`}
             items={skillAddAnotherItems}
             selectedIndex={skillAddAnotherNav.selectedIndex}
-          />
-        )}
-
-        {isMemoryStep && (
-          <WizardSelect
-            title="Memory"
-            description="Persistent memory lets the harness remember context across sessions"
-            items={memoryItems}
-            selectedIndex={memoryNav.selectedIndex}
           />
         )}
 

--- a/src/cli/tui/screens/harness/__tests__/memory-options.test.ts
+++ b/src/cli/tui/screens/harness/__tests__/memory-options.test.ts
@@ -67,12 +67,7 @@ describe('toMemoryAddOptions', () => {
     expect(toMemoryAddOptions({ mode: 'disabled' })).toEqual({ memoryMode: 'disabled' });
   });
 
-  it('falls through to managed when memory is undefined (wizard always seeds, but be safe)', () => {
-    expect(toMemoryAddOptions(undefined)).toEqual({
-      memoryMode: 'managed',
-      memoryStrategies: undefined,
-      memoryEventExpiryDays: undefined,
-      memoryEncryptionKeyArn: undefined,
-    });
+  it('falls through to disabled when memory is undefined (opt-in: silence means no memory)', () => {
+    expect(toMemoryAddOptions(undefined)).toEqual({ memoryMode: 'disabled' });
   });
 });

--- a/src/cli/tui/screens/harness/__tests__/memory-options.test.ts
+++ b/src/cli/tui/screens/harness/__tests__/memory-options.test.ts
@@ -1,0 +1,78 @@
+import { toMemoryAddOptions } from '../memory-options';
+import type { AddHarnessConfig } from '../types';
+import { describe, expect, it } from 'vitest';
+
+// Regression guard: the wizard's existing-tuning setters write into the `existing` union arm, and
+// this translation must READ them from the same arm. A prior drift (setters wrote flat fields, the
+// translation read the union) silently dropped messagesCount/topK/relevanceScore entered in the TUI.
+
+describe('toMemoryAddOptions', () => {
+  it('maps managed (with tuning) to managed add-options', () => {
+    const memory: AddHarnessConfig['memory'] = {
+      mode: 'managed',
+      strategies: ['SEMANTIC', 'SUMMARIZATION'],
+      eventExpiryDuration: 45,
+      encryptionKeyArn: 'arn:aws:kms:us-west-2:1:key/abc',
+    };
+    expect(toMemoryAddOptions(memory)).toEqual({
+      memoryMode: 'managed',
+      memoryStrategies: ['SEMANTIC', 'SUMMARIZATION'],
+      memoryEventExpiryDays: 45,
+      memoryEncryptionKeyArn: 'arn:aws:kms:us-west-2:1:key/abc',
+    });
+  });
+
+  it('maps bare managed to managed with undefined tuning (service defaults)', () => {
+    expect(toMemoryAddOptions({ mode: 'managed' })).toEqual({
+      memoryMode: 'managed',
+      memoryStrategies: undefined,
+      memoryEventExpiryDays: undefined,
+      memoryEncryptionKeyArn: undefined,
+    });
+  });
+
+  it('maps existing WITH retrieval tuning — tuning must NOT be dropped', () => {
+    const memory: AddHarnessConfig['memory'] = {
+      mode: 'existing',
+      arn: 'arn:aws:bedrock-agentcore:us-west-2:1:memory/m-aBcD012345',
+      actorId: 'actor-1',
+      messagesCount: 20,
+      topK: 5,
+      relevanceScore: 0.7,
+    };
+    expect(toMemoryAddOptions(memory)).toEqual({
+      memoryMode: 'existing',
+      memoryName: undefined,
+      memoryArn: 'arn:aws:bedrock-agentcore:us-west-2:1:memory/m-aBcD012345',
+      memoryActorId: 'actor-1',
+      messagesCount: 20,
+      memoryTopK: 5,
+      memoryRelevanceScore: 0.7,
+    });
+  });
+
+  it('maps existing by name with no tuning', () => {
+    expect(toMemoryAddOptions({ mode: 'existing', name: 'myMem' })).toEqual({
+      memoryMode: 'existing',
+      memoryName: 'myMem',
+      memoryArn: undefined,
+      memoryActorId: undefined,
+      messagesCount: undefined,
+      memoryTopK: undefined,
+      memoryRelevanceScore: undefined,
+    });
+  });
+
+  it('maps disabled to a bare disabled option', () => {
+    expect(toMemoryAddOptions({ mode: 'disabled' })).toEqual({ memoryMode: 'disabled' });
+  });
+
+  it('falls through to managed when memory is undefined (wizard always seeds, but be safe)', () => {
+    expect(toMemoryAddOptions(undefined)).toEqual({
+      memoryMode: 'managed',
+      memoryStrategies: undefined,
+      memoryEventExpiryDays: undefined,
+      memoryEncryptionKeyArn: undefined,
+    });
+  });
+});

--- a/src/cli/tui/screens/harness/memory-options.ts
+++ b/src/cli/tui/screens/harness/memory-options.ts
@@ -1,0 +1,50 @@
+import type { AddHarnessConfig } from './types';
+
+/**
+ * The subset of `HarnessPrimitive.add` options that describe memory. Returned by
+ * {@link toMemoryAddOptions} and spread into the primitive's `add()` call.
+ */
+export interface MemoryAddOptions {
+  memoryMode: 'managed' | 'existing' | 'disabled';
+  memoryName?: string;
+  memoryArn?: string;
+  memoryActorId?: string;
+  messagesCount?: number;
+  memoryTopK?: number;
+  memoryRelevanceScore?: number;
+  memoryStrategies?: string[];
+  memoryEventExpiryDays?: number;
+  memoryEncryptionKeyArn?: string;
+}
+
+/**
+ * Translate the wizard's mode-tagged memory union (`AddHarnessConfig['memory']`) into the flat
+ * `HarnessPrimitive.add` memory options. Single source of truth shared by the add-harness flow and
+ * the create flow so the two can't drift — a past drift silently dropped existing-mode retrieval
+ * tuning because one reader pulled tuning from the union while the wizard wrote it to flat fields.
+ *
+ * The wizard always seeds a memory mode (managed default), so an absent/unknown mode falls through
+ * to managed.
+ */
+export function toMemoryAddOptions(memory: AddHarnessConfig['memory']): MemoryAddOptions {
+  if (memory?.mode === 'existing') {
+    return {
+      memoryMode: 'existing',
+      memoryName: memory.name,
+      memoryArn: memory.arn,
+      memoryActorId: memory.actorId,
+      messagesCount: memory.messagesCount,
+      memoryTopK: memory.topK,
+      memoryRelevanceScore: memory.relevanceScore,
+    };
+  }
+  if (memory?.mode === 'disabled') {
+    return { memoryMode: 'disabled' };
+  }
+  return {
+    memoryMode: 'managed',
+    memoryStrategies: memory?.mode === 'managed' ? memory.strategies : undefined,
+    memoryEventExpiryDays: memory?.mode === 'managed' ? memory.eventExpiryDuration : undefined,
+    memoryEncryptionKeyArn: memory?.mode === 'managed' ? memory.encryptionKeyArn : undefined,
+  };
+}

--- a/src/cli/tui/screens/harness/memory-options.ts
+++ b/src/cli/tui/screens/harness/memory-options.ts
@@ -38,13 +38,15 @@ export function toMemoryAddOptions(memory: AddHarnessConfig['memory']): MemoryAd
       memoryRelevanceScore: memory.relevanceScore,
     };
   }
-  if (memory?.mode === 'disabled') {
-    return { memoryMode: 'disabled' };
+  if (memory?.mode === 'managed') {
+    return {
+      memoryMode: 'managed',
+      memoryStrategies: memory.strategies,
+      memoryEventExpiryDays: memory.eventExpiryDuration,
+      memoryEncryptionKeyArn: memory.encryptionKeyArn,
+    };
   }
-  return {
-    memoryMode: 'managed',
-    memoryStrategies: memory?.mode === 'managed' ? memory.strategies : undefined,
-    memoryEventExpiryDays: memory?.mode === 'managed' ? memory.eventExpiryDuration : undefined,
-    memoryEncryptionKeyArn: memory?.mode === 'managed' ? memory.encryptionKeyArn : undefined,
-  };
+  // disabled, or absent (the wizard always seeds a mode, but default to disabled to match the
+  // opt-in model: silence means no memory).
+  return { memoryMode: 'disabled' };
 }

--- a/src/cli/tui/screens/harness/types.ts
+++ b/src/cli/tui/screens/harness/types.ts
@@ -299,13 +299,15 @@ export type AdvancedSetting = (typeof ADVANCED_SETTING_OPTIONS)[number]['id'];
 
 /** Mode-first memory options. Mirrors the schema's 3-mode union. */
 export const MEMORY_MODE_OPTIONS = [
+  // Disabled is first so it is the highlighted default (the picker selects index 0). Memory is
+  // opt-in: a harness has no memory unless the user picks Managed or Existing here.
+  { id: 'disabled' as const, title: 'Disabled', description: 'No memory (default)' },
   {
     id: 'managed' as const,
     title: 'Managed',
-    description: 'AgentCore creates and manages memory for this harness (default)',
+    description: 'AgentCore creates and manages memory for this harness',
   },
   { id: 'existing' as const, title: 'Existing', description: 'Reference an existing memory by name or ARN' },
-  { id: 'disabled' as const, title: 'Disabled', description: 'No memory' },
 ] as const;
 
 /** Managed-memory strategy choices (the four CFN ManagedMemoryConfiguration.Strategies values). */

--- a/src/cli/tui/screens/harness/types.ts
+++ b/src/cli/tui/screens/harness/types.ts
@@ -30,7 +30,6 @@ export type AddHarnessStep =
   | 'skill-git-username'
   | 'skill-aws-skills-paths'
   | 'skill-add-another'
-  | 'memory'
   | 'memory-mode'
   | 'memory-strategies'
   | 'memory-event-expiry'
@@ -83,10 +82,8 @@ export interface AddHarnessConfig {
   topP?: number;
   topK?: number;
   modelMaxTokens?: number;
-  /** Legacy enabled/disabled memory toggle — used only when gated features are OFF. */
-  skipMemory?: boolean;
   /**
-   * Mode-tagged memory ref — used when gated features are ON. Mirrors the schema union.
+   * Mode-tagged memory ref. Mirrors the schema union.
    * `managed` owns memory internally; `existing` references a memory by name/arn; `disabled` opts out.
    */
   memory?:
@@ -101,9 +98,6 @@ export interface AddHarnessConfig {
         relevanceScore?: number;
       }
     | { mode: 'disabled' };
-  messagesCount?: number;
-  memoryTopK?: number;
-  memoryRelevanceScore?: number;
   mcpHeaders?: Record<string, string>;
   allowedTools?: string[];
   truncationStrategy?: 'sliding_window' | 'summarization' | 'none';
@@ -166,7 +160,6 @@ export const HARNESS_STEP_LABELS: Record<AddHarnessStep, string> = {
   'skill-git-username': 'Username',
   'skill-aws-skills-paths': 'AWS Skills paths',
   'skill-add-another': 'Add skill',
-  memory: 'Memory',
   'memory-mode': 'Memory mode',
   'memory-strategies': 'Memory strategies',
   'memory-event-expiry': 'Memory event expiry (days)',
@@ -274,12 +267,7 @@ export const ADVANCED_SETTING_OPTIONS = [
   { id: 'skills', title: 'Skills', description: 'Add agent skills' },
   // Two mode-scoped memory-tuning options: only the one matching the chosen memory mode is shown in
   // the advanced list (see AddHarnessScreen's filter). Managed and existing have disjoint knob sets
-  // per the harness API, so they never both appear. Legacy (gated-off) uses 'memory-tuning'.
-  {
-    id: 'memory-tuning',
-    title: 'Memory tuning',
-    description: 'Tune messages count and retrieval (topK, relevance score)',
-  },
+  // per the harness API, so they never both appear.
   {
     id: 'memory-managed-tuning',
     title: 'Memory tuning',
@@ -309,16 +297,7 @@ export const ADVANCED_SETTING_OPTIONS = [
 
 export type AdvancedSetting = (typeof ADVANCED_SETTING_OPTIONS)[number]['id'];
 
-export const MEMORY_OPTIONS = [
-  {
-    id: 'disabled' as const,
-    title: 'No persistent memory',
-    description: 'Harness does not retain context across sessions',
-  },
-  { id: 'enabled' as const, title: 'Enabled', description: 'Create persistent memory for this harness' },
-] as const;
-
-/** Mode-first memory options (gated features ON). Mirrors the schema's 3-mode union. */
+/** Mode-first memory options. Mirrors the schema's 3-mode union. */
 export const MEMORY_MODE_OPTIONS = [
   {
     id: 'managed' as const,

--- a/src/cli/tui/screens/harness/useAddHarnessWizard.ts
+++ b/src/cli/tui/screens/harness/useAddHarnessWizard.ts
@@ -1,5 +1,4 @@
 import type { HarnessApiFormat, HarnessModelProvider, NetworkMode, RuntimeAuthorizerType } from '../../../../schema';
-import { isGatedFeaturesEnabled } from '../../../feature-flags';
 import type { JwtConfig } from '../../components/jwt-config';
 import { HARNESS_FILESYSTEM_STEP_NAMES, useFilesystemMountState } from '../../hooks/useFilesystemMountState';
 import type { AddHarnessConfig, AddHarnessStep, AdvancedSetting, ContainerMode } from './types';
@@ -9,7 +8,6 @@ import { useCallback, useMemo, useState } from 'react';
 const ADVANCED_SETTING_ORDER: AdvancedSetting[] = [
   'tools',
   'skills',
-  'memory-tuning',
   'memory-managed-tuning',
   'memory-existing-tuning',
   'allowed-tools',
@@ -24,7 +22,6 @@ const ADVANCED_SETTING_ORDER: AdvancedSetting[] = [
 const SETTING_TO_FIRST_STEP: Record<AdvancedSetting, AddHarnessStep> = {
   tools: 'tools-select',
   skills: 'skills-source-type',
-  'memory-tuning': 'memory-messages-count',
   'memory-managed-tuning': 'memory-strategies',
   'memory-existing-tuning': 'memory-messages-count',
   'allowed-tools': 'allowed-tools',
@@ -57,12 +54,9 @@ function getDefaultConfig(): AddHarnessConfig {
     name: '',
     modelProvider: 'bedrock',
     modelId: DEFAULT_MODEL_IDS.bedrock,
-    // Managed memory is the default for new harnesses when the gated feature is on (strategies left
-    // absent → service default; tunable under Advanced). When off, the legacy enabled/disabled
-    // `memory` step drives skipMemory instead and this stays undefined.
-    ...(isGatedFeaturesEnabled() && {
-      memory: { mode: 'managed' as const },
-    }),
+    // Managed memory is the default for new harnesses (strategies left absent → service default;
+    // tunable under Advanced).
+    memory: { mode: 'managed' as const },
   };
 }
 
@@ -93,17 +87,12 @@ export function useAddHarnessWizard() {
       steps.push('container-dockerfile');
     }
 
-    if (isGatedFeaturesEnabled()) {
-      // Main path is just the mode pick. Managed defaults to the service's own strategy set (nothing
-      // more to ask); existing REQUIRES a name/ARN so it's collected here; disabled needs nothing.
-      // All other knobs (managed strategies/expiry/KMS, existing tuning) live under Advanced → Memory tuning.
-      steps.push('memory-mode');
-      if (config.memory?.mode === 'existing') {
-        steps.push('memory-existing-ref');
-      }
-    } else {
-      // Legacy enabled/disabled memory step.
-      steps.push('memory');
+    // Main path is just the mode pick. Managed defaults to the service's own strategy set (nothing
+    // more to ask); existing REQUIRES a name/ARN so it's collected here; disabled needs nothing.
+    // All other knobs (managed strategies/expiry/KMS, existing tuning) live under Advanced → Memory tuning.
+    steps.push('memory-mode');
+    if (config.memory?.mode === 'existing') {
+      steps.push('memory-existing-ref');
     }
 
     steps.push('advanced');
@@ -157,10 +146,6 @@ export function useAddHarnessWizard() {
       steps.push('memory-strategies', 'memory-event-expiry', 'memory-kms');
     }
     if (advancedSettings.includes('memory-existing-tuning') && config.memory?.mode === 'existing') {
-      steps.push('memory-messages-count', 'memory-retrieval-top-k', 'memory-relevance-score');
-    }
-    // Legacy tuning (gated off): the old flat topK/relevance/messages knobs.
-    if (advancedSettings.includes('memory-tuning') && !isGatedFeaturesEnabled()) {
       steps.push('memory-messages-count', 'memory-retrieval-top-k', 'memory-relevance-score');
     }
 
@@ -418,8 +403,8 @@ export function useAddHarnessWizard() {
     } else if (containerMode === 'dockerfile') {
       setStep('container-dockerfile');
     } else {
-      // Route to the first memory step: the mode picker (gated on) or the legacy toggle (gated off).
-      setStep(isGatedFeaturesEnabled() ? 'memory-mode' : 'memory');
+      // Route to the first memory step: the mode picker.
+      setStep('memory-mode');
     }
   }, []);
 
@@ -533,12 +518,7 @@ export function useAddHarnessWizard() {
     [advancedSettings]
   );
 
-  const setMemoryEnabled = useCallback((enabled: boolean) => {
-    setConfig(c => ({ ...c, skipMemory: !enabled }));
-    setStep('advanced');
-  }, []);
-
-  // --- Mode-first memory sub-flow setters (gated features ON) ---
+  // --- Mode-first memory sub-flow setters ---
 
   const setMemoryMode = useCallback((mode: 'managed' | 'existing' | 'disabled') => {
     // Managed seeds nothing beyond the mode — strategies/expiry/KMS are opt-in under Advanced, and an
@@ -748,10 +728,13 @@ export function useAddHarnessWizard() {
     [nextStep]
   );
 
+  // Existing-memory retrieval tuning. These steps appear only in existing mode, so the value is
+  // written into the existing union arm (mirroring the managed setters above) — AddHarnessFlow reads
+  // tuning from config.memory, not from flat fields.
   const setMessagesCount = useCallback(
     (raw: string) => {
       const messagesCount = raw.trim() === '' ? undefined : parseInt(raw, 10);
-      setConfig(c => ({ ...c, messagesCount }));
+      setConfig(c => (c.memory?.mode === 'existing' ? { ...c, memory: { ...c.memory, messagesCount } } : c));
       const next = nextStep('memory-messages-count');
       if (next) setStep(next);
     },
@@ -760,8 +743,8 @@ export function useAddHarnessWizard() {
 
   const setMemoryTopK = useCallback(
     (raw: string) => {
-      const memoryTopK = raw.trim() === '' ? undefined : parseInt(raw, 10);
-      setConfig(c => ({ ...c, memoryTopK }));
+      const topK = raw.trim() === '' ? undefined : parseInt(raw, 10);
+      setConfig(c => (c.memory?.mode === 'existing' ? { ...c, memory: { ...c.memory, topK } } : c));
       const next = nextStep('memory-retrieval-top-k');
       if (next) setStep(next);
     },
@@ -770,8 +753,8 @@ export function useAddHarnessWizard() {
 
   const setMemoryRelevanceScore = useCallback(
     (raw: string) => {
-      const memoryRelevanceScore = raw.trim() === '' ? undefined : parseFloat(raw);
-      setConfig(c => ({ ...c, memoryRelevanceScore }));
+      const relevanceScore = raw.trim() === '' ? undefined : parseFloat(raw);
+      setConfig(c => (c.memory?.mode === 'existing' ? { ...c, memory: { ...c.memory, relevanceScore } } : c));
       const next = nextStep('memory-relevance-score');
       if (next) setStep(next);
     },
@@ -938,7 +921,6 @@ export function useAddHarnessWizard() {
     setGatewayOutboundAuth,
     setGatewayProviderArn,
     setGatewayScopes,
-    setMemoryEnabled,
     setMemoryMode,
     setMemoryStrategies,
     setMemoryEventExpiry,

--- a/src/cli/tui/screens/harness/useAddHarnessWizard.ts
+++ b/src/cli/tui/screens/harness/useAddHarnessWizard.ts
@@ -54,9 +54,10 @@ function getDefaultConfig(): AddHarnessConfig {
     name: '',
     modelProvider: 'bedrock',
     modelId: DEFAULT_MODEL_IDS.bedrock,
-    // Managed memory is the default for new harnesses (strategies left absent → service default;
-    // tunable under Advanced).
-    memory: { mode: 'managed' as const },
+    // Memory is opt-in: a new harness defaults to disabled (no memory). The user picks Managed or
+    // Existing on the memory-mode step if they want it. Seeding disabled keeps the confirm summary
+    // accurate when the user accepts the default.
+    memory: { mode: 'disabled' as const },
   };
 }
 


### PR DESCRIPTION
## Description

The NY-Summit `AWS::BedrockAgentCore::Harness` CFN type is now public in all regions, so the harness summit-preview features can be ungated. This removes the `ENABLE_GATED_FEATURES` gate **at the in-scope call sites only** — knowledge-base, gateway passthrough, and config-bundle branch intentionally **stay gated** (not part of this ungating; verified still hidden without the flag).

### Ungated
- **AWS Skills** — `--aws-skills` source on `add skill` and the TUI skill-source picker (no longer "Coming soon").
- **Managed memory** — the `managed`/`existing`/`disabled` memory-mode union and the managed-tuning flags. The legacy "No persistent memory" enabled/disabled TUI screen is removed, and the auto-created `${name}Memory` sibling is gone. **"No memory"** (`--no-memory` / `--memory-mode disabled`) now writes `{ mode: 'disabled' }` → CFN `Memory: { Disabled: {} }` (a true opt-out, instead of silently getting a service-auto-created memory).
- **Harness Version** — `status` and the deploy drift note show the config version unconditionally.

### Fixes found while testing (in-scope)
- Reject `--no-memory` combined with managed-only flags (`--memory-strategies` / `--memory-event-expiry-days` / `--memory-encryption-key-arn`) instead of silently dropping them.
- TUI existing-memory retrieval tuning (messages count / topK / relevance) was silently dropped — the wizard setters now write into the memory union and the add/create flows share one `toMemoryAddOptions()` translation helper.
- `deploy --json` no longer emits the managed-memory heads-up notice to stdout (it corrupted the JSON output); the notice is suppressed under `--json` and still recorded in the deploy log.

## Related Issue

Closes #1628

## Documentation PR

<!-- link agent-docs PR if applicable -->

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots — N/A (no asset changes)

Added/updated: corrected the integ memory-mode coverage (removed legacy auto-memory assertions, ungated the memory-modes describe); added unit coverage for memory-mode resolution (`HarnessPrimitive.add.memory.test.ts`) and the TUI translation helper (`memory-options.test.ts`); added `harness-managed-memory` and `harness-aws-skills` e2e suites (deploy → invoke → memory round-trip / skills-loaded → teardown), **verified against a real account**. 5425 unit tests pass; typecheck + lint clean.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published — **depends on aws/agentcore-l3-cdk-constructs#289 (merge + publish CDK first)**

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.