### PR TITLE
test(e2e): fix harness CUSTOM_JWT auth to validate allowedClients

### DIFF
--- a/e2e-tests/harness-custom-jwt.test.ts
+++ b/e2e-tests/harness-custom-jwt.test.ts
@@ -5,8 +5,8 @@
  * CUSTOM_JWT authorizer (added via `add harness` with the JWT + OAuth-credential flags, so
  * the managed OAuth credential is registered the way a real user would), and verifies that:
  * - Deploy embeds AuthorizerConfiguration in the CloudFormation template
- * - A default SigV4 invocation is rejected (auth method mismatch)
- * - A bearer-token invocation is not rejected for auth reasons
+ * - A default (non-bearer) invocation auto-fetches a CUSTOM_JWT token via the managed credential
+ * - A bearer-token invocation succeeds (not rejected for auth reasons)
  * - `fetch access --type harness` mints a CUSTOM_JWT bearer token via the managed credential
  * - Status reports the harness as deployed
  *
@@ -140,7 +140,9 @@ describe.sequential('e2e: harness with CUSTOM_JWT auth', () => {
         'CUSTOM_JWT',
         '--discovery-url',
         discoveryUrl,
-        '--allowed-audience',
+        // Cognito client_credentials (M2M) tokens carry a `client_id` claim, not `aud`,
+        // so the authorizer must validate allowedClients — allowedAudience would 403 every token.
+        '--allowed-clients',
         clientId,
         '--client-id',
         clientId,
@@ -220,19 +222,23 @@ describe.sequential('e2e: harness with CUSTOM_JWT auth', () => {
       expect(harnessResource, 'Template should contain a Harness resource').toBeDefined();
 
       const authConfig = harnessResource!.Properties.AuthorizerConfiguration as {
-        CustomJWTAuthorizer: { DiscoveryUrl: string; AllowedAudience: string[] };
+        CustomJWTAuthorizer: { DiscoveryUrl: string; AllowedClients: string[] };
       };
       expect(authConfig, 'Harness should have AuthorizerConfiguration').toBeDefined();
       expect(authConfig.CustomJWTAuthorizer.DiscoveryUrl).toBe(discoveryUrl);
-      expect(authConfig.CustomJWTAuthorizer.AllowedAudience).toContain(clientId);
+      expect(authConfig.CustomJWTAuthorizer.AllowedClients).toContain(clientId);
     },
     600000
   );
 
   it.skipIf(!canRun)(
-    'rejects SigV4 invocation (auth method mismatch)',
+    'auto-fetches a JWT for a default (non-bearer) invocation',
     async () => {
-      // The CLI uses SigV4 by default — a CUSTOM_JWT harness should reject it.
+      // This harness was added with --client-id/--client-secret, so the managed OAuth
+      // credential is registered. A default `invoke` (no --bearer-token) must therefore
+      // auto-fetch a CUSTOM_JWT bearer token rather than fall back to SigV4 — and that
+      // token must be accepted (it carries `client_id`, which the authorizer validates via
+      // allowedClients). So the invoke must NOT be rejected for an auth/audience reason.
       const result = await runCLI(
         ['invoke', '--harness', harnessName, '--prompt', 'Say hello', '--json'],
         projectPath,
@@ -240,8 +246,10 @@ describe.sequential('e2e: harness with CUSTOM_JWT auth', () => {
       );
 
       const output = stripAnsi(result.stdout + result.stderr);
-      expect(result.exitCode, `failure: stderr=${result.stderr}\n\nstdout=${result.stdout}`).not.toBe(0);
-      expect(output).toMatch(customJWTRejectMsgRegex);
+      expect(output, `auth-method rejection: ${output}`).not.toMatch(customJWTRejectMsgRegex);
+      expect(output, `audience rejection (allowedClients misconfigured?): ${output}`).not.toMatch(
+        /missing required audience claim/i
+      );
     },
     180000
   );
@@ -258,8 +266,13 @@ describe.sequential('e2e: harness with CUSTOM_JWT auth', () => {
       );
 
       const output = stripAnsi(result.stdout + result.stderr);
-      // May still fail for unrelated reasons, but NOT with an auth-method mismatch.
-      expect(output).not.toMatch(customJWTRejectMsgRegex);
+      // Must NOT be rejected for an auth reason — neither a client-side auth-method mismatch
+      // nor a service-side audience rejection (which would mean allowedClients is misconfigured).
+      expect(output, `auth-method rejection: ${output}`).not.toMatch(customJWTRejectMsgRegex);
+      expect(output, `audience rejection (allowedClients misconfigured?): ${output}`).not.toMatch(
+        /missing required audience claim/i
+      );
+      expect(result.exitCode, `bearer-token invoke failed: ${output}`).toBe(0);
     },
     180000
   );


### PR DESCRIPTION
## Description

The `harness-custom-jwt` E2E test (added in #1609) fails on the full-suite run ([shard 2/5](https://github.com/aws/agentcore-cli/actions/runs/28051685327/job/83043643825)) at `rejects SigV4 invocation (auth method mismatch)`.

**Root cause — a test fixture bug, surfaced by the main+preview merge (#1598, #1611):**

1. The harness was deployed with `--allowed-audience <clientId>`, so the service validates the token's `aud` claim.
2. But the test authenticates via Cognito **client_credentials (M2M)**, whose tokens carry a `client_id` claim and **no `aud`**.
3. The fixture also registers a managed OAuth credential (`--client-id`/`--client-secret`), so the post-merge auto-fetch path kicks in: a default `invoke` (no `--bearer-token`) now auto-fetches a JWT instead of doing SigV4 (`canFetchHarnessToken()` → `true`).
4. The service rejects the fetched token with `403 "*** missing required audience claim."`, which doesn't match the test's expected client-side `customJWTRejectMsgRegex` → assertion fails.

The sibling `byo-custom-jwt.test.ts` passes only because it patches `agentcore.json` with **no** credential, so it hits the client-side SigV4 fast-fail the regex expects. The same `aud` misconfiguration is latent there, hidden by a weak `not.toMatch` assertion.

**Fix (test-only — no shippable CLI behavior changes):**

- Deploy the authorizer with `--allowed-clients` (the claim Cognito M2M tokens actually carry) instead of `--allowed-audience`.
- Assert `AllowedClients` in the CFN template check.
- Reframe the invoke tests to the real post-merge behavior: a default invoke **auto-fetches a JWT and is accepted** (renamed `auto-fetches a JWT for a default (non-bearer) invocation`), and the bearer-token invoke now asserts `exitCode === 0` (a real positive, replacing the weak `not.toMatch`). Both also assert no `missing required audience claim` 403, so a future `allowedClients` regression is caught.

## Related Issue

Closes #1623

## Documentation PR

N/A — test-only change.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck` (`tsc --noEmit` — clean)
- [x] I ran `npm run lint` (eslint + prettier `--check` — clean)
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

Also confirmed `vitest list --project e2e` collects all 5 cases including the renamed test. The E2E itself runs against real AWS (Cognito deploy) and will execute in CI on this PR.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
