### PR TITLE
test(e2e): use managed memory for CUSTOM_JWT harness invoke

### DIFF
--- a/e2e-tests/harness-custom-jwt.test.ts
+++ b/e2e-tests/harness-custom-jwt.test.ts
@@ -135,7 +135,9 @@ describe.sequential('e2e: harness with CUSTOM_JWT auth', () => {
         harnessName,
         '--model-provider',
         'bedrock',
-        '--no-memory',
+        // Use the default managed memory (no --no-memory): a disabled-memory harness still
+        // calls bedrock-agentcore:ListEvents at invoke, but the CDK only grants that action on
+        // the execution role when memory is managed — so --no-memory invokes fail with AccessDenied.
         '--authorizer-type',
         'CUSTOM_JWT',
         '--discovery-url',


### PR DESCRIPTION
## Description

`e2e-tests/harness-custom-jwt.test.ts > invokes with bearer token successfully` fails on the full-suite E2E run ([shard 2/5](https://github.com/aws/agentcore-cli/actions/runs/28055245909/job/83056018350)) with:

```
runtimeClientError: AccessDeniedException calling ListEvents:
... is not authorized to perform: bedrock-agentcore:ListEvents
on resource: .../memory/harness_E2eHrnsJwt..._...
because no identity-based policy allows the bedrock-agentcore:ListEvents action
```

This surfaced after #1624 turned that test into a real positive assertion (`exitCode === 0`). The auth flow now works end-to-end — the invoke reaches the runtime and then fails on a missing memory permission.

**Root cause — test fixture, not the CDK.** The CDK already grants `bedrock-agentcore:ListEvents` to the harness execution role, but only when memory is managed:

```ts
// agentcore-l3-cdk-constructs — AgentCoreHarnessEnvironment.ts
const managedMemory = props.spec ? props.spec.memory?.mode !== 'disabled' : harness.managedMemory;
```

The test added the harness with **`--no-memory`**, which the CLI maps to `memory.mode: 'disabled'` → the CDK correctly skips the `ListEvents` grant (disabled memory shouldn't need memory perms). But the harness still calls `ListEvents` on a service-managed memory at invoke time, so it 403s.

The passing harness suites (`harness-bedrock`/`openai`/`gemini` via `harness-e2e-helper`) all run with the **default managed memory**, which gets the grant and invokes successfully. The CUSTOM_JWT test was the only harness E2E using `--no-memory`.

**Fix:** Drop `--no-memory` so the CUSTOM_JWT harness uses managed memory like every other passing harness E2E. Test-only change; no shippable CLI or CDK behavior changes.

## Related Issue

Closes #1626

## Documentation PR

N/A — test-only change.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck` (`tsc --noEmit` — clean)
- [x] I ran `npm run lint` (eslint + prettier `--check` — clean)
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

Also confirmed `vitest list --project e2e` collects all 5 cases. The E2E runs against real AWS (Cognito + harness deploy) in CI on this PR.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
