### PR TITLE
fix(harness): --no-memory disables managed memory instead of omitting it

### DIFF
--- a/integ-tests/add-remove-harness.test.ts
+++ b/integ-tests/add-remove-harness.test.ts
@@ -139,6 +139,12 @@ describe('integration: harness configuration options', () => {
     const configAfter = await readProjectConfig(project.projectPath);
     const memoriesAfter = (configAfter.memories ?? []).length;
     expect(memoriesAfter).toBe(memoriesBefore);
+
+    // --no-memory must write an explicit `disabled` ref, not omit memory: an omitted memory
+    // config makes the service auto-provision a managed memory the execution role can't read
+    // (AccessDenied on ListEvents at invoke). `disabled` maps to CFN Memory: { Disabled: {} }.
+    const spec = await readHarnessSpec(project.projectPath, name);
+    expect(spec.memory?.mode).toBe('disabled');
   });
 
   it('adds harness with non-bedrock model provider', async () => {

--- a/src/cli/primitives/HarnessPrimitive.ts
+++ b/src/cli/primitives/HarnessPrimitive.ts
@@ -1233,14 +1233,21 @@ export class HarnessPrimitive extends BasePrimitive<AddHarnessOptions, Removable
    * Legacy (gated OFF) memory ref builder — preserves pre-managed-memory behavior exactly.
    * An explicit `--memory-arn`/`--memory-name` references an existing memory; otherwise
    * `autoCreateMemoryName` (when set) points at the `${name}Memory` sibling this command auto-creates.
-   * Returns undefined when there is no memory at all (`--no-memory`).
+   * `--no-memory` emits a `disabled` ref (a true opt-out), never an omitted one.
    */
   private buildLegacyMemoryRef(
     options: AddHarnessOptions,
     autoCreateMemoryName: string | undefined
   ): HarnessMemoryRef | undefined {
     const name = options.memoryName ?? autoCreateMemoryName;
-    if (!options.memoryArn && !name) return undefined;
+    if (!options.memoryArn && !name) {
+      // `--no-memory`: the harness CFN resource now supports an explicit opt-out, so emit a
+      // `disabled` ref instead of omitting memory. An omitted Memory config makes the AgentCore
+      // service auto-provision a managed memory the execution role can't read, so invoke fails
+      // with AccessDenied on bedrock-agentcore:ListEvents. `disabled` maps to CFN Memory:
+      // { Disabled: {} }, so no memory is created and no grant is needed.
+      return options.skipMemory ? { mode: 'disabled' } : undefined;
+    }
     const tuning = this.buildRetrievalConfig(options);
     return {
       mode: 'existing',


### PR DESCRIPTION
## Description

`agentcore add harness --no-memory` (gated-off path) wrote a harness spec that **omitted** the memory config entirely. The AgentCore service treats an omitted memory config as "auto-provision a managed memory", so a "no memory" harness ended up with a managed memory `harness_<physicalName>_<hash>` it never asked for — and the execution role wasn't scoped for it, so invoke failed:

```
AccessDeniedException: not authorized to perform bedrock-agentcore:ListEvents
on resource memory/harness_<name>_<hash>
```

This is a contributing cause of the `harness-custom-jwt` E2E failure (that test uses `--no-memory`).

**Background.** CDK #287 made the harness role grant memory permissions for the *omitted* case (`managedMemory = spec.memory?.mode !== 'disabled'`) — specifically because the CFN `Harness` resource couldn't express a memory opt-out at the time, so "no memory" still got a service-auto-created memory that needed the grant. That CFN limitation is gone: `Memory: { Disabled: {} }` shipped in the CDK (#273, alpha.20+) and the vended project resolves `^0.1.0-alpha.19` → the latest published `0.1.0-alpha.39`, which has it.

**Fix.** `buildLegacyMemoryRef` now returns `{ mode: 'disabled' }` for `--no-memory` instead of `undefined`. That maps to CFN `Memory: { Disabled: {} }` — no memory is provisioned, no `ListEvents` grant is needed, no AccessDenied. CLI-only change; the CFN `disabled` mapping and the schema's `disabled` arm are already live and ungated.

## Related Issue

Closes #1628

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck` (clean)
- [x] I ran `npm run lint` (0 errors; 31 pre-existing warnings)
- [x] `npm run test:integ` — `add-remove-harness.test.ts` **35/35 pass** (strengthened the `--no-memory` test to assert `spec.memory.mode === 'disabled'`)
- [x] Harness primitive unit tests — **283/283 pass**

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
