### PR TITLE
fix(config-bundle): ungate custom branchName feature

### DIFF
--- a/integ-tests/add-remove-config-bundle.test.ts
+++ b/integ-tests/add-remove-config-bundle.test.ts
@@ -109,9 +109,7 @@ describe('integration: add and remove config-bundle', () => {
       const bundle = config.configBundles.find(b => b.name === 'FullOptsBundle');
       expect(bundle).toBeDefined();
       expect(bundle!.description).toBe('A bundle with all optional fields');
-      // --branch is gated behind ENABLE_GATED_FEATURES; when off, silently defaults to mainline
-      const expectedBranch = process.env.ENABLE_GATED_FEATURES === '1' ? 'feature-branch' : 'mainline';
-      expect(bundle!.branchName).toBe(expectedBranch);
+      expect(bundle!.branchName).toBe('feature-branch');
       expect(bundle!.commitMessage).toBe('initial config');
     });
 

--- a/src/cli/commands/config-bundle/command.tsx
+++ b/src/cli/commands/config-bundle/command.tsx
@@ -8,7 +8,6 @@ import type {
   ListConfigurationBundleVersionsFilter,
 } from '../../aws/agentcore-config-bundles';
 import { getErrorMessage } from '../../errors';
-import { isGatedFeaturesEnabled } from '../../feature-flags';
 import { deepDiff } from '../../operations/config-bundle/diff-versions';
 import { resolveBundleByName } from '../../operations/config-bundle/resolve-bundle';
 import { requireProject } from '../../tui/guards';
@@ -259,8 +258,7 @@ export const registerConfigBundle = (program: Command) => {
       }
     });
 
-  // --- create-branch: gated until upstream CFN read-back bug is fixed for non-default branches ---
-  if (!isGatedFeaturesEnabled()) return cmd;
+  // --- create-branch ---
   cmd
     .command('create-branch')
     .description('Create a new branch on an existing configuration bundle')

--- a/src/cli/primitives/ConfigBundlePrimitive.ts
+++ b/src/cli/primitives/ConfigBundlePrimitive.ts
@@ -3,11 +3,9 @@ import type { Result } from '../../lib/result';
 import type { ConfigBundle } from '../../schema';
 import { ConfigBundleSchema } from '../../schema';
 import { getErrorMessage } from '../errors';
-import { isGatedFeaturesEnabled } from '../feature-flags';
 import type { RemovalPreview, SchemaChange } from '../operations/remove/types';
 import { BasePrimitive } from './BasePrimitive';
 import type { AddResult, AddScreenComponent, RemovableResource } from './types';
-import { Option } from '@commander-js/extra-typings';
 import type { Command } from '@commander-js/extra-typings';
 import { readFileSync } from 'fs';
 
@@ -116,12 +114,7 @@ export class ConfigBundlePrimitive extends BasePrimitive<AddConfigBundleOptions,
         'Components map as inline JSON. Keys are ARNs or placeholders: {{runtime:<name>}}, {{gateway:<name>}}. Placeholders resolve to real ARNs at deploy time.'
       )
       .option('--components-file <path>', 'Path to components JSON file (same format as --components)')
-      // Gated: custom branches blocked by upstream CFN read-back bug. Remove gate when service fixes GetConfigurationBundle.
-      .addOption(
-        isGatedFeaturesEnabled()
-          ? new Option('--branch <name>', 'Branch name for versioning')
-          : new Option('--branch <name>', 'Branch name for versioning').hideHelp()
-      )
+      .option('--branch <name>', 'Branch name for versioning')
       .option('--commit-message <text>', 'Commit message for this version')
       .option('--json', 'Output as JSON')
       .action(
@@ -173,7 +166,7 @@ export class ConfigBundlePrimitive extends BasePrimitive<AddConfigBundleOptions,
                 name: cliOptions.name!,
                 description: cliOptions.description,
                 components,
-                branchName: isGatedFeaturesEnabled() ? cliOptions.branch : undefined,
+                branchName: cliOptions.branch,
                 commitMessage: cliOptions.commitMessage,
               });
 

--- a/src/cli/tui/screens/config-bundle/__tests__/useAddConfigBundleWizard.test.tsx
+++ b/src/cli/tui/screens/config-bundle/__tests__/useAddConfigBundleWizard.test.tsx
@@ -74,14 +74,11 @@ describe('useAddConfigBundleWizard — add-another back-navigation (BUG TUI-B)',
     const { ref } = setup();
     advanceToAddAnother(ref);
     act(() => ref.current!.wizard.doneAddingComponents());
-    // When ENABLE_GATED_FEATURES is off, branchName is skipped (defaults to mainline)
-    const expectedStep = process.env.ENABLE_GATED_FEATURES === '1' ? 'branchName' : 'commitMessage';
-    expect(ref.current!.wizard.step).toBe(expectedStep);
+    expect(ref.current!.wizard.step).toBe('branchName');
 
     // Back from the current step follows the linear order, not the loop guard.
     act(() => ref.current!.wizard.goBack());
-    const expectedBackStep = process.env.ENABLE_GATED_FEATURES === '1' ? 'addAnother' : 'branchName';
-    expect(ref.current!.wizard.step).toBe(expectedBackStep);
+    expect(ref.current!.wizard.step).toBe('addAnother');
   });
 
   it('first-pass back-navigation is unaffected (componentType → description)', () => {

--- a/src/cli/tui/screens/config-bundle/useAddConfigBundleWizard.ts
+++ b/src/cli/tui/screens/config-bundle/useAddConfigBundleWizard.ts
@@ -1,5 +1,4 @@
 import type { ComponentConfigurationMap } from '../../../../schema';
-import { isGatedFeaturesEnabled } from '../../../feature-flags';
 import type { AddConfigBundleConfig, AddConfigBundleStep, ComponentType } from './types';
 import { useCallback, useState } from 'react';
 
@@ -103,11 +102,7 @@ export function useAddConfigBundleWizard() {
 
   const doneAddingComponents = useCallback(() => {
     setInAddAnotherLoop(false);
-    if (isGatedFeaturesEnabled()) {
-      setStep('branchName');
-    } else {
-      setStep('commitMessage');
-    }
+    setStep('branchName');
   }, []);
 
   const setBranchName = useCallback((branchName: string) => {


### PR DESCRIPTION
This PR removes `ENABLE_GATED_FEATURES` gate from config-bundle custom branch support (CLI `--branch`, TUI branch step, `create-branch` subcommand). Service bug in `GetConfigurationBundle` for non-default branches has been fixed and deployed
