### PR TITLE
fix(tui): use "No memory" instead of "Disabled" in harness memory picker

### DIFF
--- a/src/cli/tui/screens/harness/AddHarnessScreen.tsx
+++ b/src/cli/tui/screens/harness/AddHarnessScreen.tsx
@@ -455,7 +455,7 @@ export function AddHarnessScreen({
           fields.push({ label: 'Memory Relevance Score', value: String(mem.relevanceScore) });
         }
       } else {
-        fields.push({ label: 'Memory', value: 'Disabled' });
+        fields.push({ label: 'Memory', value: 'No memory' });
       }
     }
 

--- a/src/cli/tui/screens/harness/types.ts
+++ b/src/cli/tui/screens/harness/types.ts
@@ -299,9 +299,10 @@ export type AdvancedSetting = (typeof ADVANCED_SETTING_OPTIONS)[number]['id'];
 
 /** Mode-first memory options. Mirrors the schema's 3-mode union. */
 export const MEMORY_MODE_OPTIONS = [
-  // Disabled is first so it is the highlighted default (the picker selects index 0). Memory is
-  // opt-in: a harness has no memory unless the user picks Managed or Existing here.
-  { id: 'disabled' as const, title: 'Disabled', description: 'No memory (default)' },
+  // "No memory" is first so it is the highlighted default (the picker selects index 0). Memory is
+  // opt-in: a harness has no memory unless the user picks Managed or Existing here. The id stays
+  // 'disabled' — it is the schema/CFN contract token; only the displayed title is reworded.
+  { id: 'disabled' as const, title: 'No memory', description: 'Default' },
   {
     id: 'managed' as const,
     title: 'Managed',


### PR DESCRIPTION
## Description

In the harness add/create TUI wizard, the memory-mode picker presented its opt-out option with the label **`Disabled`**, and the confirm-review summary showed **`Memory: Disabled`**. 

This PR changes the **displayed label only** to **`No memory`**, matching the agent/generate wizard which already uses `None` / "No memory".

**Changes:**
- `src/cli/tui/screens/harness/types.ts` — `MEMORY_MODE_OPTIONS` opt-out option `title: 'Disabled'` → `'No memory'`; description trimmed to `'Default'` (was `'No memory (default)'`) to avoid duplicating the new title.
- `src/cli/tui/screens/harness/AddHarnessScreen.tsx` — confirm-review summary value `'Disabled'` → `'No memory'`.

**Deliberately NOT changed (wire/API contracts):** the option `id: 'disabled'`, the config union `{ mode: 'disabled' }`, the Zod `z.literal('disabled')`, the `--memory-mode disabled` flag value and its help text / `VALID_MEMORY_MODES` allow-list, the deploy notices that instruct users to type `--memory-mode disabled`, and the CDK `Memory: { Disabled: {} }` CFN mapping. Renaming any of these would break deployments or the schema shared with `@aws/agentcore-cdk`.

The picker's `onSelect` consumes only `item.id` (never `item.title`), so the title is pure presentation and is never parsed back — which is why this rename is safe.

## Related Issue

Closes #1634

## Documentation PR

N/A — no doc changes. `docs/memory.md` already describes the agent `--memory none` shorthand as "No memory resource created"; no harness `--memory-mode` prose references a "Disabled" display label.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe): user-facing wording (display-only)

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` (harness suite: `src/cli/tui/screens/harness` — 6/6 passed, including the contract test `maps disabled to a bare disabled option`)
- [x] I ran `npm run typecheck` (exit 0)
- [x] I ran `npm run lint` (0 errors on the changed files; 2 pre-existing warnings unrelated to this change)
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots (N/A — no asset changes)

No test or snapshot asserts the changed display strings, so none required updating. The contract value `{ mode: 'disabled' }` remains covered and green.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works (existing contract test confirms behavior is unchanged; the edit is a display string with no test coverage to add)
- [x] I have updated the documentation accordingly (no doc changes needed)
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.