### PR TITLE
closed

### DIFF
--- a/integ-tests/create-edge-cases.test.ts
+++ b/integ-tests/create-edge-cases.test.ts
@@ -141,12 +141,11 @@ describe.skipIf(!prereqs.npm || !prereqs.git)('integration: create edge cases', 
       expect(json.success).toBe(true);
       expect(json.projectPath).toBeTruthy();
 
-      // No agent-path flags -> create defaults to the harness path.
+      // --defaults is an agent-path flag -> routes to the agent creation path.
       telemetry.assertMetricEmitted({
         command: 'create',
         exit_reason: 'success',
-        agent_environment: 'harness',
-        model_provider: 'bedrock',
+        agent_environment: 'runtime',
         has_agent: 'true',
       });
     });

--- a/src/cli/commands/create/__tests__/create.test.ts
+++ b/src/cli/commands/create/__tests__/create.test.ts
@@ -241,14 +241,15 @@ describe('create command', () => {
   });
 
   describe('--defaults', () => {
-    it('creates project with defaults', async () => {
+    it('creates project with defaults via agent path', async () => {
       const name = `Defaults${Date.now()}`;
       const result = await runCLI(['create', '--name', name, '--defaults', '--json'], testDir);
 
       expect(result.exitCode, `stderr: ${result.stderr}`).toBe(0);
       const json = JSON.parse(result.stdout);
       expect(json.success).toBe(true);
-      expect(await exists(join(testDir, name))).toBeTruthy();
+      expect(json.agentName).toBe(name);
+      expect(await exists(join(json.projectPath, 'app', name))).toBeTruthy();
     });
   });
 

--- a/src/cli/commands/create/command.tsx
+++ b/src/cli/commands/create/command.tsx
@@ -96,6 +96,7 @@ function printCreateSummary(
  * agent-only concept — harnesses use --memory-mode/--no-memory — so it routes to the agent path
  * (and conflicts with harness-only flags) rather than being silently ignored on the harness path. */
 const AGENT_PATH_FLAGS = [
+  'defaults',
   'framework',
   'language',
   'build',


### PR DESCRIPTION
## Description

## Problem
The `agentcore create --name myProj --defaults` command creates a project with a harness, when that command's behavior before v0.21.0 was to create a project with an agent. This is a breaking change.

## Solution
Update the behavior of `--defaults flag` to create a project with an agent, to make it consistent with its functionality before v0.21.0.

## Type of Change

- [x] Bug fix

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.