### PR TITLE
fix(create): make --defaults create a harness project

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -30,8 +30,11 @@ Create a new AgentCore project.
 # Interactive wizard
 agentcore create
 
-# Fully non-interactive with defaults
-agentcore create --name MyProject --defaults
+# Non-interactive harness project (this is the default)
+agentcore create --name MyProject
+
+# Non-interactive agent project
+agentcore create --name MyProject --framework Strands --model-provider Bedrock
 
 # Custom configuration
 agentcore create \
@@ -44,7 +47,8 @@ agentcore create \
 # With networking
 agentcore create \
   --name MyProject \
-  --defaults \
+  --framework Strands \
+  --model-provider Bedrock \
   --network-mode VPC \
   --subnets subnet-abc,subnet-def \
   --security-groups sg-123
@@ -60,7 +64,7 @@ agentcore create \
   --model-provider Bedrock
 
 # Preview without creating
-agentcore create --name MyProject --defaults --dry-run
+agentcore create --name MyProject --framework Strands --model-provider Bedrock --dry-run
 
 # Import from Bedrock Agents
 agentcore create \
@@ -77,7 +81,7 @@ agentcore create \
 | ------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
 | `--name <name>`                       | Agent (resource) name; also used as project directory name when `--project-name` is omitted                    |
 | `--project-name <name>`               | Project directory name (alphanumeric, starts with letter, max 23 chars)                                        |
-| `--defaults`                          | Use defaults (Python, Strands, Bedrock, no memory)                                                             |
+| `--defaults`                          | Create a harness project with default settings (this is the default)                                           |
 | `--no-agent`                          | Skip agent creation                                                                                            |
 | `--type <type>`                       | `create` (default) or `import`                                                                                 |
 | `--language <lang>`                   | `Python` (default) or `TypeScript` (Strands-only; see [Frameworks](frameworks.md#supported-languages))         |
@@ -1492,7 +1496,7 @@ agentcore deploy -y --json            # Deploy with auto-confirm
 ### Scripted Project Setup
 
 ```bash
-agentcore create --name MyProject --defaults
+agentcore create --name MyProject --framework Strands --model-provider Bedrock
 cd MyProject
 agentcore add memory --name SharedMemory --strategies SEMANTIC
 agentcore deploy -y

--- a/docs/config-bundles.md
+++ b/docs/config-bundles.md
@@ -20,7 +20,7 @@ invocation time from whichever bundle version is active.
 Create an agent with a pre-wired config bundle that injects system prompt and tool descriptions at runtime:
 
 ```bash
-agentcore create --name MyProject --defaults --with-config-bundle
+agentcore create --name MyProject --framework Strands --model-provider Bedrock --with-config-bundle
 ```
 
 This creates a `{AgentName}Config` bundle with smart defaults and generates a template that uses

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -10,7 +10,7 @@ the gateway client code.
 
 ```bash
 # 1. Create a project
-agentcore create --name MyProject --defaults
+agentcore create --name MyProject --framework Strands --model-provider Bedrock
 cd MyProject
 
 # 2. Add a gateway

--- a/docs/knowledge-bases.md
+++ b/docs/knowledge-bases.md
@@ -11,7 +11,7 @@ code is wired to call `retrieve` against the KB through the gateway.
 
 ```bash
 # 1. Create a project
-agentcore create --name MyProject --defaults
+agentcore create --name MyProject --framework Strands --model-provider Bedrock
 cd MyProject
 
 # 2. Add a gateway

--- a/docs/payments.md
+++ b/docs/payments.md
@@ -12,7 +12,7 @@ guide.
 
 ```bash
 # 1. Create a project with payments capability
-agentcore create --name MyProject --defaults
+agentcore create --name MyProject --framework Strands --model-provider Bedrock
 cd MyProject
 
 # 2. Add a payment manager
@@ -367,7 +367,7 @@ The complete path from a fresh project to a settled on-chain payment. Steps 1–
 
 ```bash
 # 1. Create a project and add the payment manager + connector
-agentcore create --name MyProject --defaults && cd MyProject
+agentcore create --name MyProject --framework Strands --model-provider Bedrock && cd MyProject
 agentcore add payment-manager --name MyManager
 agentcore add payment-connector --manager MyManager --name MyCDPConnector --provider CoinbaseCDP \
   --api-key-id "$CDP_API_KEY_ID" --api-key-secret "$CDP_API_KEY_SECRET" --wallet-secret "$CDP_WALLET_SECRET"

--- a/docs/recommendations.md
+++ b/docs/recommendations.md
@@ -129,7 +129,7 @@ When using `--bundle-name`, the completed result also includes `configurationBun
 1. Create agent with config bundle:
 
    ```bash
-   agentcore create --name MyAgent --defaults --with-config-bundle
+   agentcore create --name MyAgent --framework Strands --model-provider Bedrock --with-config-bundle
    agentcore deploy
    ```
 

--- a/src/cli/commands/create/__tests__/create.test.ts
+++ b/src/cli/commands/create/__tests__/create.test.ts
@@ -241,14 +241,17 @@ describe('create command', () => {
   });
 
   describe('--defaults', () => {
-    it('creates project with defaults', async () => {
-      const name = `Defaults${Date.now()}`;
+    // --defaults creates a harness project (the default), identical to passing no routing flags.
+    // The harness path returns `harnessName` and writes app/<name>/harness.json.
+    it('creates a harness project', async () => {
+      const name = `Def${Date.now().toString().slice(-6)}`;
       const result = await runCLI(['create', '--name', name, '--defaults', '--json'], testDir);
 
       expect(result.exitCode, `stderr: ${result.stderr}`).toBe(0);
       const json = JSON.parse(result.stdout);
       expect(json.success).toBe(true);
-      expect(await exists(join(testDir, name))).toBeTruthy();
+      expect(json.harnessName).toBe(name);
+      expect(await exists(join(json.projectPath, 'app', name, 'harness.json'))).toBeTruthy();
     });
   });
 

--- a/src/cli/commands/create/command.tsx
+++ b/src/cli/commands/create/command.tsx
@@ -447,7 +447,7 @@ export const registerCreate = (program: Command) => {
       'Project name (start with letter, alphanumeric only, max 23 chars) [non-interactive]'
     )
     .option('--no-agent', 'Skip agent creation [non-interactive]')
-    .option('--defaults', 'Use defaults (Python, Strands, Bedrock, no memory) [non-interactive]')
+    .option('--defaults', 'Create a harness project with default settings (this is the default) [non-interactive]')
     .option('--build <type>', 'Build type: CodeZip or Container (default: CodeZip) [non-interactive]')
     .option('--language <language>', 'Target language: Python or TypeScript (default: Python) [non-interactive]')
     .option(
@@ -633,13 +633,6 @@ export const registerCreate = (program: Command) => {
 
       // Agent path: any agent-specific flag triggers it
       if (isAgentPath(opts)) {
-        if (opts.defaults) {
-          opts.language = opts.language ?? 'Python';
-          opts.build = opts.build ?? 'CodeZip';
-          opts.framework = opts.framework ?? 'Strands';
-          opts.modelProvider = opts.modelProvider ?? 'Bedrock';
-          opts.memory = opts.memory ?? 'none';
-        }
         opts.language = opts.language ?? 'Python';
         await handleCreateCLI(opts);
         return;


### PR DESCRIPTION
## Description

Harness is now the default for `agentcore create`, so `--defaults` no longer creates a Python/Strands/Bedrock agent — it produces a harness project, identical to passing no routing flags.

This PR makes the code and docs reflect that:

- **`command.tsx`** — drop the agent-default backfill block that ran when `--defaults` was combined with an agent-path flag (e.g. `--defaults --framework Strands`). The flag is now purely "create with default (harness) settings." Update the help text from *"Use defaults (Python, Strands, Bedrock, no memory)"* to *"Create a harness project with default settings (this is the default)."*
- **Docs** — every `--defaults` usage is corrected:
  - Standalone harness quick-starts drop the flag (harness is implicit) and add an explicit agent example where useful (`docs/commands.md`).
  - Agent-oriented flows (`gateway.md`, `knowledge-bases.md`, `payments.md`, `config-bundles.md`, `recommendations.md`) now use the explicit `--framework Strands --model-provider Bedrock` agent path. This also **fixes** the two `--defaults --with-config-bundle` examples, which were silently broken — the harness path ignores `--with-config-bundle`, so they previously produced a harness with no bundle.
- **Tests** — strengthen the `--defaults` unit test to assert the harness contract (`harnessName` + `app/<name>/harness.json`) so the routing can't silently regress.

## Related Issue

Closes #

## Documentation PR

N/A — docs in this repo are updated in-line.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ` (ran the affected `create` unit + `create-edge-cases` integ suites — all pass)
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots (no asset changes)

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
