### PR TITLE
fix(invoke): add bearer-token support to the A2A invoke path for CUSTOM_JWT (#815)

### DIFF
--- a/src/cli/aws/__tests__/agentcore-a2a-bearer.test.ts
+++ b/src/cli/aws/__tests__/agentcore-a2a-bearer.test.ts
@@ -20,9 +20,9 @@ vi.mock('@aws-sdk/client-bedrock-agentcore', () => {
 });
 
 vi.mock('../account.js', () => ({
-  getCredentialProvider: vi.fn().mockReturnValue(() =>
-    Promise.resolve({ accessKeyId: 'test', secretAccessKey: 'test' })
-  ),
+  getCredentialProvider: vi
+    .fn()
+    .mockReturnValue(() => Promise.resolve({ accessKeyId: 'test', secretAccessKey: 'test' })),
 }));
 
 const a2aResultBody = JSON.stringify({

--- a/src/cli/aws/__tests__/agentcore-a2a-bearer.test.ts
+++ b/src/cli/aws/__tests__/agentcore-a2a-bearer.test.ts
@@ -1,0 +1,97 @@
+import { invokeA2ARuntime } from '../agentcore.js';
+import type { A2AInvokeOptions } from '../agentcore.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the SDK so the SigV4 path doesn't need real credentials
+const mockSdkSend = vi.fn();
+vi.mock('@aws-sdk/client-bedrock-agentcore', () => {
+  class MockBedrockAgentCoreClient {
+    send = mockSdkSend;
+    middlewareStack = { add: vi.fn() };
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    constructor(_config: unknown) {}
+  }
+  return {
+    BedrockAgentCoreClient: MockBedrockAgentCoreClient,
+    InvokeAgentRuntimeCommand: vi.fn(),
+    StopRuntimeSessionCommand: vi.fn(),
+    EvaluateCommand: vi.fn(),
+  };
+});
+
+vi.mock('../account.js', () => ({
+  getCredentialProvider: vi.fn().mockReturnValue(() =>
+    Promise.resolve({ accessKeyId: 'test', secretAccessKey: 'test' })
+  ),
+}));
+
+const a2aResultBody = JSON.stringify({
+  jsonrpc: '2.0',
+  id: 1,
+  result: { artifacts: [{ parts: [{ kind: 'text', text: 'Hello from A2A' }] }] },
+});
+
+const baseOpts: A2AInvokeOptions = {
+  region: 'us-east-1',
+  runtimeArn: 'arn:aws:bedrock-agentcore:us-east-1:123456789:runtime/test-runtime',
+  userId: 'test-user',
+};
+
+async function drain(stream: AsyncGenerator<string, void, unknown>): Promise<string> {
+  let out = '';
+  for await (const chunk of stream) out += chunk;
+  return out;
+}
+
+describe('invokeA2ARuntime bearer-token auth path', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  let capturedRequests: { url: string; init: RequestInit }[];
+
+  beforeEach(() => {
+    capturedRequests = [];
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+      capturedRequests.push({ url: input as string, init: init! });
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(a2aResultBody),
+        headers: { get: () => null },
+      } as unknown as Response);
+    });
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  it('uses fetch with Bearer Authorization header and never the SigV4 client', async () => {
+    const result = await invokeA2ARuntime({ ...baseOpts, bearerToken: 'test-jwt-token' }, 'hi');
+    const text = await drain(result.stream);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(mockSdkSend).not.toHaveBeenCalled();
+
+    const headers = capturedRequests[0]!.init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer test-jwt-token');
+
+    // JSON-RPC message/send body is carried in the fetch payload
+    const body = JSON.parse(capturedRequests[0]!.init.body as string);
+    expect(body.method).toBe('message/send');
+    expect(body.params.message.parts[0].text).toBe('hi');
+
+    // Response is still routed through parseA2AResponse
+    expect(text).toBe('Hello from A2A');
+  });
+
+  it('falls back to the SigV4 client when no bearerToken is supplied', async () => {
+    mockSdkSend.mockResolvedValue({
+      response: { transformToByteArray: () => Promise.resolve(new TextEncoder().encode(a2aResultBody)) },
+    });
+
+    await invokeA2ARuntime(baseOpts, 'hi');
+
+    expect(mockSdkSend).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/aws/agentcore.ts
+++ b/src/cli/aws/agentcore.ts
@@ -931,6 +931,8 @@ export interface A2AInvokeOptions {
   logger?: SSELogger;
   /** Custom headers to forward to the agent runtime */
   headers?: Record<string, string>;
+  /** Bearer token for CUSTOM_JWT auth. When provided, uses raw HTTP with Authorization header instead of SigV4. */
+  bearerToken?: string;
 }
 
 let a2aRequestId = 1;
@@ -940,8 +942,6 @@ let a2aRequestId = 1;
  * Streams text parts from the response artifacts.
  */
 export async function invokeA2ARuntime(options: A2AInvokeOptions, message: string): Promise<StreamingInvokeResult> {
-  const client = createAgentCoreClient(options.region, options.headers);
-
   const body = {
     jsonrpc: '2.0',
     id: a2aRequestId++,
@@ -956,6 +956,27 @@ export async function invokeA2ARuntime(options: A2AInvokeOptions, message: strin
   };
 
   options.logger?.logSSEEvent(`A2A request: ${JSON.stringify(body)}`);
+
+  if (options.bearerToken) {
+    const url = buildInvokeUrl(options.region, options.runtimeArn);
+    const headers = buildBearerInvokeHeaders(options, 'application/json, text/event-stream');
+
+    const res = await fetch(url, { method: 'POST', headers, body: JSON.stringify(body) });
+    if (!res.ok) {
+      const errBody = await res.text().catch(() => '');
+      throw new Error(`Invoke failed (${res.status}): ${errBody || res.statusText}`);
+    }
+
+    const text = await res.text();
+    options.logger?.logSSEEvent(`A2A response: ${text}`);
+
+    return {
+      stream: singleValueStream(parseA2AResponse(text)),
+      sessionId: res.headers.get('X-Amzn-Bedrock-AgentCore-Runtime-Session-Id') ?? undefined,
+    };
+  }
+
+  const client = createAgentCoreClient(options.region, options.headers);
 
   const command = new InvokeAgentRuntimeCommand({
     agentRuntimeArn: options.runtimeArn,

--- a/src/cli/commands/invoke/action.ts
+++ b/src/cli/commands/invoke/action.ts
@@ -593,6 +593,7 @@ export async function handleInvoke(context: InvokeContext, options: InvokeOption
           userId: options.userId,
           sessionId: options.sessionId,
           headers: options.headers,
+          bearerToken: options.bearerToken,
         },
         options.prompt
       );

--- a/src/cli/operations/dev/web-ui/handlers/invocations.ts
+++ b/src/cli/operations/dev/web-ui/handlers/invocations.ts
@@ -460,6 +460,7 @@ async function handleDeployedInvocation(
         prompt,
         sessionId,
         userId,
+        bearerToken: resolved.bearerToken,
       });
     } else if (protocol === 'AGUI') {
       await handleDeployedAguiInvocation(ctx, res, origin, {
@@ -555,6 +556,7 @@ async function handleDeployedA2AInvocation(
       runtimeArn: params.runtimeArn,
       userId: params.userId,
       sessionId: params.sessionId,
+      bearerToken: params.bearerToken,
     },
     params.prompt
   );

--- a/src/cli/tui/screens/invoke/useInvokeFlow.ts
+++ b/src/cli/tui/screens/invoke/useInvokeFlow.ts
@@ -783,6 +783,7 @@ export function useInvokeFlow(options: InvokeFlowOptions = {}): InvokeFlowState 
                 sessionId: sessionId ?? undefined,
                 logger,
                 headers,
+                bearerToken: bearerToken || undefined,
               },
               prompt
             )


### PR DESCRIPTION
## Description

**Closes #815 — A2A agents with `CUSTOM_JWT` auth are uninvokable.**

An A2A-protocol agent configured with `CUSTOM_JWT` authorization cannot be invoked. The CLI auto-fetches a bearer token but **silently drops it on the A2A path** and falls back to SigV4, so every invoke fails with a confusing service error:

```
AccessDeniedException: Authorization method mismatch. The agent is configured for a
different authorization method than what was used in your request. (OAuth or SigV4)
```

There is no workaround short of a code change, and no warning at `add` time. The bug affects all three invoke surfaces: `agentcore invoke`, the TUI, and the dev web-UI.

## Fix

Thread the bearer token through the A2A invoke path, mirroring how the HTTP path already works. A2A uses the same `InvokeAgentRuntime` data plane and `/runtimes/{arn}/invocations` endpoint as HTTP, which already supports bearer auth — so when a token is present, the request should be a raw HTTPS POST with an `Authorization: Bearer` header rather than a SigV4-signed SDK call.

| Change | Location |
| --- | --- |
| Add `bearerToken?: string` to `A2AInvokeOptions` | `src/cli/aws/agentcore.ts` |
| In `invokeA2ARuntime`: when `bearerToken` is set, POST the JSON-RPC body with `Authorization: Bearer <token>` (via `buildInvokeUrl` / `buildBearerInvokeHeaders`) and parse via the existing `parseA2AResponse`; otherwise fall back to the SigV4 client unchanged | `src/cli/aws/agentcore.ts` |
| Pass the token through the CLI invoke path | `src/cli/commands/invoke/action.ts` |
| Pass the token through the TUI invoke path | `src/cli/tui/screens/invoke/useInvokeFlow.ts` |
| Pass the token through the dev web-UI path | `src/cli/operations/dev/web-ui/handlers/invocations.ts` |

The no-token path is unchanged, so non-JWT A2A agents keep using SigV4 exactly as before.

## Testing


Validated **end-to-end against a real deployed agent and a real JWT issuer**, not just unit tests.

**Live deploy + invoke (build `0.21.0`, us-east-1):**

1. Stood up a real OIDC issuer — a Cognito user pool with a resource server (`agentcore/invoke` scope) and a client-credentials app client — and confirmed token issuance + OIDC discovery.
2. Created an A2A + CUSTOM_JWT agent (`--protocol A2A --authorizer-type CUSTOM_JWT --discovery-url <cognito-oidc> --allowed-clients <id> ...`) and deployed it. `get-agent-runtime` confirmed `serverProtocol: A2A` with the `customJWTAuthorizer` wired to the Cognito issuer; runtime `READY`.
3. **Invoked with a real bearer token — succeeded:**

   ```
   $ agentcore invoke "What is 21 plus 21? Use the add_numbers tool." \
       --bearer-token <jwt> --session-id <43-char-id>
   21 plus 21 equals **42**.
   ```

4. **Reproduced the pre-fix failure on the same runtime** — a SigV4-signed request returned the exact `AccessDeniedException: Authorization method mismatch` error this fix eliminates on the bearer path. So the bug is confirmed real and the fix confirmed effective on the same deployed agent.

**Automated tests:**

- New `src/cli/aws/__tests__/agentcore-a2a-bearer.test.ts` (2/2) — asserts the bearer path uses `fetch` with `Authorization: Bearer <token>` and **never** the SigV4 client, and that the no-token path still falls back to SigV4.
- 45/45 related regression tests pass (`resolve`, payments, deployed-invocations).
- `build` / `typecheck` / `lint` / `format` all green in CI.

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots — N/A, no `src/assets/` changes

## Related Issue

Closes #815

## Documentation PR

N/A — bug fix; no devguide change required.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
