### PR TITLE
fix(status): exit non-zero on invalid --type/--state filter

### DIFF
--- a/integ-tests/status.test.ts
+++ b/integ-tests/status.test.ts
@@ -69,7 +69,7 @@ describe('status command', () => {
 
   it('emits failure telemetry for invalid --type', async () => {
     const result = await runCLI(['status', '--type', 'bogus'], projectDir, { env: telemetry.env });
-    expect(result.exitCode).toBe(0);
+    expect(result.exitCode).toBe(1);
     telemetry.assertMetricEmitted({
       command: 'status',
       exit_reason: 'failure',
@@ -80,7 +80,7 @@ describe('status command', () => {
 
   it('emits failure telemetry for invalid --state', async () => {
     const result = await runCLI(['status', '--state', 'bogus'], projectDir, { env: telemetry.env });
-    expect(result.exitCode).toBe(0);
+    expect(result.exitCode).toBe(1);
     telemetry.assertMetricEmitted({
       command: 'status',
       exit_reason: 'failure',

--- a/src/cli/commands/status/__tests__/command.test.ts
+++ b/src/cli/commands/status/__tests__/command.test.ts
@@ -1,5 +1,5 @@
-import { registerStatus } from '../command.js';
 import { handleProjectStatus, loadStatusConfig } from '../action.js';
+import { registerStatus } from '../command.js';
 import { Command } from '@commander-js/extra-typings';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 

--- a/src/cli/commands/status/__tests__/command.test.ts
+++ b/src/cli/commands/status/__tests__/command.test.ts
@@ -1,0 +1,77 @@
+import { registerStatus } from '../command.js';
+import { handleProjectStatus, loadStatusConfig } from '../action.js';
+import { Command } from '@commander-js/extra-typings';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockRender } = vi.hoisted(() => ({
+  mockRender: vi.fn(),
+}));
+
+vi.mock('../../../tui/guards', () => ({
+  requireProject: vi.fn(),
+}));
+
+vi.mock('../../../telemetry/cli-command-run.js', () => ({
+  withCommandRunTelemetry: vi.fn((_command, _attrs, run) => run()),
+}));
+
+vi.mock('../../../operations/dataset', () => ({
+  getDatasetStatus: vi.fn(),
+}));
+
+vi.mock('../action.js', () => ({
+  handleProjectStatus: vi.fn(),
+  handleRuntimeLookup: vi.fn(),
+  loadStatusConfig: vi.fn(),
+}));
+
+vi.mock('../../../feature-flags', () => ({
+  isPreviewEnabled: () => false,
+}));
+
+vi.mock('ink', () => ({
+  Box: ({ children }: { children?: unknown }) => children,
+  Text: ({ children }: { children?: unknown }) => children,
+  render: mockRender,
+}));
+
+describe('status command validation', () => {
+  let program: Command;
+  let originalExitCode: typeof process.exitCode;
+
+  beforeEach(() => {
+    originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+    program = new Command();
+    program.exitOverride();
+    registerStatus(program);
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    vi.clearAllMocks();
+  });
+
+  it('sets a non-zero exit code for invalid resource type', async () => {
+    await program.parseAsync(['status', '--type', 'bogus'], { from: 'user' });
+
+    expect(process.exitCode).toBe(1);
+    expect(mockRender).toHaveBeenCalled();
+  });
+
+  it('sets a non-zero exit code for invalid state', async () => {
+    await program.parseAsync(['status', '--state', 'bogus'], { from: 'user' });
+
+    expect(process.exitCode).toBe(1);
+    expect(mockRender).toHaveBeenCalled();
+  });
+
+  it('leaves exit code unset for a valid filter', async () => {
+    vi.mocked(loadStatusConfig).mockResolvedValue({} as never);
+    vi.mocked(handleProjectStatus).mockResolvedValue({ success: true, resources: [] } as never);
+
+    await program.parseAsync(['status', '--type', 'agent'], { from: 'user' });
+
+    expect(process.exitCode).toBeUndefined();
+  });
+});

--- a/src/cli/commands/status/command.tsx
+++ b/src/cli/commands/status/command.tsx
@@ -96,6 +96,7 @@ export const registerStatus = (program: Command) => {
           error: new ValidationError(msg),
         }));
         render(<Text color="red">{msg}</Text>);
+        process.exitCode = 1;
         return;
       }
 
@@ -107,6 +108,7 @@ export const registerStatus = (program: Command) => {
           error: new ValidationError(msg),
         }));
         render(<Text color="red">{msg}</Text>);
+        process.exitCode = 1;
         return;
       }
 


### PR DESCRIPTION
## Description

**#984 — status --type with invalid type prints error but exits 0**

status with an invalid --type/--state prints an error but returns exit code 0, so scripts and CI cannot detect the rejected filter.

### Fix

Set a non-zero exit code on both validation branches. Merge PR #1603 (process.exitCode = 1 before return, adds command.test.ts) — cleaner than a hard process.exit(1) because it lets cli.ts's finally cleanup run. Close PR #1169 (duplicate, uses process.exit(1), diff is stale against pre-#1317 file and will conflict).

## Related Issue

Closes #984

## Documentation PR

N/A — bug fix; no devguide change required.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots — N/A, no `src/assets/` changes

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
