### PR TITLE
fix(deploy): scope TUI deploy to the picker-selected targets (#1267)

### DIFF
--- a/src/cli/tui/screens/deploy/DeployScreen.tsx
+++ b/src/cli/tui/screens/deploy/DeployScreen.tsx
@@ -59,6 +59,12 @@ export function DeployScreen({
 }: DeployScreenProps) {
   const { stdout } = useStdout();
   const awsConfig = useAwsTargetConfig();
+  // Targets the user picked in the multi-select. Drives both the header and the deploy scope so a
+  // single-target selection no longer deploys to every configured account/region (issue #1267).
+  const selectedTargets = useMemo(
+    () => awsConfig.selectedTargetIndices.map(i => awsConfig.availableTargets[i]).filter(t => t !== undefined),
+    [awsConfig.selectedTargetIndices, awsConfig.availableTargets]
+  );
   const [showInvoke, setShowInvoke] = useState(false);
   const [showResourceGraph, setShowResourceGraph] = useState(false);
   const [showDiff, setShowDiff] = useState(diffMode ?? false);
@@ -98,7 +104,7 @@ export function DeployScreen({
     useEnvLocalCredentials,
     useManualCredentials,
     skipCredentials,
-  } = useDeployFlow({ preSynthesized, isInteractive, diffMode });
+  } = useDeployFlow({ preSynthesized, isInteractive, diffMode, selectedTargets });
   const allSuccess = !hasError && isComplete;
   const skipPreflight = !!preSynthesized;
 
@@ -276,7 +282,10 @@ export function DeployScreen({
     );
   }
 
-  const targetDisplay = context?.awsTargets.map(t => `${t.region}:${t.account}`).join(', ');
+  // Show the target(s) the user actually picked, not the full configured list. Fall back to the
+  // resolved context targets for the plan path (no picker) or when nothing was selected.
+  const displayTargets = selectedTargets.length > 0 ? selectedTargets : (context?.awsTargets ?? []);
+  const targetDisplay = context && displayTargets.map(t => `${t.region}:${t.account}`).join(', ');
 
   // Show deploy status box once CloudFormation has started (after asset publishing)
   const showDeployStatus = !diffMode && (hasStartedCfn || isComplete);

--- a/src/cli/tui/screens/deploy/__tests__/useDeployFlow.targets.test.tsx
+++ b/src/cli/tui/screens/deploy/__tests__/useDeployFlow.targets.test.tsx
@@ -1,0 +1,217 @@
+/**
+ * Regression test for issue #1267.
+ *
+ * In the TUI deploy flow a multi-target project synthesizes one stack per configured target.
+ * The deploy was calling `cdkToolkitWrapper.deploy()` with no stacks selector, which the wrapper
+ * forwards as `{ stacks: undefined }` — toolkit-lib defaults that to ALL_STACKS and provisions
+ * infrastructure to EVERY configured account/region, ignoring the picker selection.
+ *
+ * These tests render `useDeployFlow` with a mocked preflight + CDK wrapper and assert the deploy
+ * is scoped to ONLY the selected target's stack name via PATTERN_MUST_MATCH.
+ */
+import { toStackName } from '../../../../commands/import/import-utils';
+import { useDeployFlow } from '../useDeployFlow';
+import { StackSelectionStrategy } from '@aws-cdk/toolkit-lib';
+import { render } from 'ink-testing-library';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---- Module mocks -----------------------------------------------------------
+
+const deploySpy = vi.fn().mockResolvedValue(undefined);
+const diffSpy = vi.fn().mockResolvedValue(undefined);
+const disposeSpy = vi.fn().mockResolvedValue(undefined);
+
+const fakeWrapper = {
+  deploy: deploySpy,
+  diff: diffSpy,
+  dispose: disposeSpy,
+};
+
+// switchableIoHost: noop setters so the deploy effect can wire callbacks without crashing.
+const fakeIoHost = {
+  setOnRawMessage: vi.fn(),
+  setOnMessage: vi.fn(),
+  setVerbose: vi.fn(),
+};
+
+// preflightState is mutated per-test before render so the same mock can vary phase/context.
+let preflightState: any;
+
+vi.mock('../../../hooks', async () => {
+  const actual = await vi.importActual<any>('../../../hooks');
+  return {
+    ...actual,
+    useCdkPreflight: () => preflightState,
+  };
+});
+
+// Telemetry wrapper: just run the deploy closure so deploy() actually fires.
+vi.mock('../../../../telemetry/cli-command-run.js', () => ({
+  withCommandRunTelemetry: async (_cmd: string, _attrs: unknown, fn: () => Promise<unknown>) => fn(),
+}));
+
+// persistDeployedState polls getStackOutputs; make it throw fast so the (caught) post-deploy path
+// resolves immediately instead of polling for 15s. The deploy() call has already happened by then.
+vi.mock('../../../../cloudformation', async () => {
+  const actual = await vi.importActual<any>('../../../../cloudformation');
+  return {
+    ...actual,
+    getStackOutputs: vi.fn().mockRejectedValue(new Error('test: skip persist')),
+  };
+});
+
+// Managed-memory notice does a config read; short-circuit it.
+vi.mock('../../../../operations/deploy', async () => {
+  const actual = await vi.importActual<any>('../../../../operations/deploy');
+  return {
+    ...actual,
+    hasManagedMemoryHarness: vi.fn().mockResolvedValue(false),
+    setupTransactionSearch: vi.fn().mockResolvedValue({ success: true }),
+  };
+});
+
+// ---- Fixtures ---------------------------------------------------------------
+
+const TARGET_A = { name: 'prod-east', account: '111111111111', region: 'us-east-1' as const };
+const TARGET_B = { name: 'prod-west', account: '222222222222', region: 'us-west-2' as const };
+const PROJECT_NAME = 'myproj';
+
+function makePreflight(opts: { awsTargets: any[]; projectName?: string }) {
+  const stackNames = opts.awsTargets.map(t => toStackName(opts.projectName ?? PROJECT_NAME, t.name));
+  return {
+    phase: 'complete',
+    steps: [],
+    context: {
+      projectSpec: { name: opts.projectName ?? PROJECT_NAME, runtimes: [] },
+      awsTargets: opts.awsTargets,
+      isTeardownDeploy: false,
+      isFirstDeploy: true, // skip the pre-deploy diff branch
+    },
+    cdkToolkitWrapper: fakeWrapper,
+    stackNames,
+    switchableIoHost: fakeIoHost,
+    hasTokenExpiredError: false,
+    hasCredentialsError: false,
+    missingCredentials: [],
+    allCredentials: {},
+    identityKmsKeyArn: undefined,
+    startPreflight: vi.fn().mockResolvedValue(undefined),
+    confirmTeardown: vi.fn(),
+    cancelTeardown: vi.fn(),
+    confirmBootstrap: vi.fn(),
+    skipBootstrap: vi.fn(),
+    clearTokenExpiredError: vi.fn(),
+    clearCredentialsError: vi.fn(),
+    useEnvLocalCredentials: vi.fn(),
+    useManualCredentials: vi.fn(),
+    skipCredentials: vi.fn(),
+  };
+}
+
+// Harness component: mounts the hook so its effects fire under ink-testing-library.
+function Harness({ selectedTargets }: { selectedTargets?: any[] }) {
+  useDeployFlow({ isInteractive: true, selectedTargets });
+  return null as unknown as React.ReactElement;
+}
+
+async function flush() {
+  // Let queued microtasks + effect timers settle.
+  for (let i = 0; i < 10; i += 1) {
+    await new Promise(resolve => setTimeout(resolve, 5));
+  }
+}
+
+// ---- Tests ------------------------------------------------------------------
+
+describe('useDeployFlow target scoping (issue #1267)', () => {
+  beforeEach(() => {
+    deploySpy.mockClear();
+    diffSpy.mockClear();
+    disposeSpy.mockClear();
+    fakeIoHost.setOnRawMessage.mockClear();
+    fakeIoHost.setOnMessage.mockClear();
+    fakeIoHost.setVerbose.mockClear();
+  });
+  afterEach(() => {
+    vi.clearAllTimers();
+  });
+
+  it('scopes deploy to ONLY the single selected target stack (not ALL_STACKS)', async () => {
+    preflightState = makePreflight({ awsTargets: [TARGET_A, TARGET_B] });
+
+    const { unmount } = render(<Harness selectedTargets={[TARGET_B]} />);
+    await flush();
+    unmount();
+
+    expect(deploySpy).toHaveBeenCalledTimes(1);
+    const arg = deploySpy.mock.calls[0][0];
+
+    // Must NOT be called with stacks undefined (the pre-fix behavior → ALL_STACKS).
+    expect(arg).toBeDefined();
+    expect(arg.stacks).toBeDefined();
+    expect(arg.stacks.strategy).toBe(StackSelectionStrategy.PATTERN_MUST_MATCH);
+    expect(arg.stacks.patterns).toEqual([toStackName(PROJECT_NAME, TARGET_B.name)]);
+
+    // Regression: selecting B must never produce a pattern for A.
+    expect(arg.stacks.patterns).not.toContain(toStackName(PROJECT_NAME, TARGET_A.name));
+  });
+
+  it('selecting target A produces only A’s stack (no cross-leak to B)', async () => {
+    preflightState = makePreflight({ awsTargets: [TARGET_A, TARGET_B] });
+
+    const { unmount } = render(<Harness selectedTargets={[TARGET_A]} />);
+    await flush();
+    unmount();
+
+    expect(deploySpy).toHaveBeenCalledTimes(1);
+    const arg = deploySpy.mock.calls[0][0];
+    expect(arg.stacks.patterns).toEqual([toStackName(PROJECT_NAME, TARGET_A.name)]);
+    expect(arg.stacks.patterns).not.toContain(toStackName(PROJECT_NAME, TARGET_B.name));
+  });
+
+  it('selecting ALL targets yields a selector covering every target stack', async () => {
+    preflightState = makePreflight({ awsTargets: [TARGET_A, TARGET_B] });
+
+    const { unmount } = render(<Harness selectedTargets={[TARGET_A, TARGET_B]} />);
+    await flush();
+    unmount();
+
+    expect(deploySpy).toHaveBeenCalledTimes(1);
+    const arg = deploySpy.mock.calls[0][0];
+    expect(arg.stacks.strategy).toBe(StackSelectionStrategy.PATTERN_MUST_MATCH);
+    expect(arg.stacks.patterns).toEqual([
+      toStackName(PROJECT_NAME, TARGET_A.name),
+      toStackName(PROJECT_NAME, TARGET_B.name),
+    ]);
+  });
+
+  it('single-target project still deploys (unscoped → the lone synthesized stack)', async () => {
+    preflightState = makePreflight({ awsTargets: [TARGET_A] });
+
+    // Single-target picker selects the one target.
+    const { unmount } = render(<Harness selectedTargets={[TARGET_A]} />);
+    await flush();
+    unmount();
+
+    expect(deploySpy).toHaveBeenCalledTimes(1);
+    const arg = deploySpy.mock.calls[0][0];
+    // Either a pattern selector for the single stack, or undefined (assembly's lone stack) — both
+    // deploy exactly one stack. Must never resolve to a broader set.
+    if (arg.stacks) {
+      expect(arg.stacks.patterns).toEqual([toStackName(PROJECT_NAME, TARGET_A.name)]);
+    }
+  });
+
+  it('no picker selection falls back to the unscoped assembly (undefined selector)', async () => {
+    preflightState = makePreflight({ awsTargets: [TARGET_A, TARGET_B] });
+
+    const { unmount } = render(<Harness selectedTargets={[]} />);
+    await flush();
+    unmount();
+
+    expect(deploySpy).toHaveBeenCalledTimes(1);
+    const arg = deploySpy.mock.calls[0][0];
+    expect(arg.stacks).toBeUndefined();
+  });
+});

--- a/src/cli/tui/screens/deploy/__tests__/useDeployFlow.targets.test.tsx
+++ b/src/cli/tui/screens/deploy/__tests__/useDeployFlow.targets.test.tsx
@@ -35,6 +35,12 @@ const fakeIoHost = {
   setVerbose: vi.fn(),
 };
 
+// Hoisted so the vi.mock factory below (hoisted above module init) can reference it, while the
+// test bodies keep a handle to assert the persist path polls the SELECTED target's stack/region.
+const { getStackOutputsSpy } = vi.hoisted(() => ({
+  getStackOutputsSpy: vi.fn().mockRejectedValue(new Error('test: skip persist')),
+}));
+
 // preflightState is mutated per-test before render so the same mock can vary phase/context.
 let preflightState: any;
 
@@ -57,7 +63,7 @@ vi.mock('../../../../cloudformation', async () => {
   const actual = await vi.importActual<any>('../../../../cloudformation');
   return {
     ...actual,
-    getStackOutputs: vi.fn().mockRejectedValue(new Error('test: skip persist')),
+    getStackOutputs: getStackOutputsSpy,
   };
 });
 
@@ -77,7 +83,7 @@ const TARGET_A = { name: 'prod-east', account: '111111111111', region: 'us-east-
 const TARGET_B = { name: 'prod-west', account: '222222222222', region: 'us-west-2' as const };
 const PROJECT_NAME = 'myproj';
 
-function makePreflight(opts: { awsTargets: any[]; projectName?: string }) {
+function makePreflight(opts: { awsTargets: any[]; projectName?: string; isFirstDeploy?: boolean }) {
   const stackNames = opts.awsTargets.map(t => toStackName(opts.projectName ?? PROJECT_NAME, t.name));
   return {
     phase: 'complete',
@@ -86,7 +92,8 @@ function makePreflight(opts: { awsTargets: any[]; projectName?: string }) {
       projectSpec: { name: opts.projectName ?? PROJECT_NAME, runtimes: [] },
       awsTargets: opts.awsTargets,
       isTeardownDeploy: false,
-      isFirstDeploy: true, // skip the pre-deploy diff branch
+      // First-deploy skips the pre-deploy diff branch; flip it off to exercise diff scoping.
+      isFirstDeploy: opts.isFirstDeploy ?? true,
     },
     cdkToolkitWrapper: fakeWrapper,
     stackNames,
@@ -132,6 +139,8 @@ describe('useDeployFlow target scoping (issue #1267)', () => {
     fakeIoHost.setOnRawMessage.mockClear();
     fakeIoHost.setOnMessage.mockClear();
     fakeIoHost.setVerbose.mockClear();
+    getStackOutputsSpy.mockClear();
+    getStackOutputsSpy.mockRejectedValue(new Error('test: skip persist'));
   });
   afterEach(() => {
     vi.clearAllTimers();
@@ -213,5 +222,41 @@ describe('useDeployFlow target scoping (issue #1267)', () => {
     expect(deploySpy).toHaveBeenCalledTimes(1);
     const arg = deploySpy.mock.calls[0]![0];
     expect(arg.stacks).toBeUndefined();
+  });
+
+  it('persist polls the SELECTED target stack/region, not awsTargets[0]/stackNames[0]', async () => {
+    // [A, B] project, user picks B (the non-first target). The persist step must resolve outputs
+    // from B's stack in B's region — pre-fix it polled A's stack in A's region (never deployed),
+    // failing the poll and writing deployed-state under the wrong target name.
+    preflightState = makePreflight({ awsTargets: [TARGET_A, TARGET_B] });
+
+    const { unmount } = render(<Harness selectedTargets={[TARGET_B]} />);
+    await flush();
+    unmount();
+
+    expect(getStackOutputsSpy).toHaveBeenCalled();
+    const [region, stackName] = getStackOutputsSpy.mock.calls[0]!;
+    expect(region).toBe(TARGET_B.region);
+    expect(stackName).toBe(toStackName(PROJECT_NAME, TARGET_B.name));
+    // Regression: must never poll A's (the first configured target's) stack/region.
+    expect(region).not.toBe(TARGET_A.region);
+    expect(stackName).not.toBe(toStackName(PROJECT_NAME, TARGET_A.name));
+  });
+
+  it('scopes the pre-deploy diff to the selected target stack (not ALL_STACKS)', async () => {
+    // isFirstDeploy=false enables the pre-deploy diff branch. Picking B must diff only B's stack.
+    preflightState = makePreflight({ awsTargets: [TARGET_A, TARGET_B], isFirstDeploy: false });
+
+    const { unmount } = render(<Harness selectedTargets={[TARGET_B]} />);
+    await flush();
+    unmount();
+
+    expect(diffSpy).toHaveBeenCalled();
+    const diffArg = diffSpy.mock.calls[0]![0];
+    expect(diffArg).toBeDefined();
+    expect(diffArg.stacks).toBeDefined();
+    expect(diffArg.stacks.strategy).toBe(StackSelectionStrategy.PATTERN_MUST_MATCH);
+    expect(diffArg.stacks.patterns).toEqual([toStackName(PROJECT_NAME, TARGET_B.name)]);
+    expect(diffArg.stacks.patterns).not.toContain(toStackName(PROJECT_NAME, TARGET_A.name));
   });
 });

--- a/src/cli/tui/screens/deploy/__tests__/useDeployFlow.targets.test.tsx
+++ b/src/cli/tui/screens/deploy/__tests__/useDeployFlow.targets.test.tsx
@@ -116,9 +116,12 @@ function makePreflight(opts: { awsTargets: any[]; projectName?: string; isFirstD
   };
 }
 
-// Harness component: mounts the hook so its effects fire under ink-testing-library.
-function Harness({ selectedTargets }: { selectedTargets?: any[] }) {
-  useDeployFlow({ isInteractive: true, selectedTargets });
+// Harness component: mounts the hook so its effects fire under ink-testing-library. onState (when
+// provided) captures the latest hook state each render so tests can assert user-facing output
+// (deployOutput / deployNotes) after the flow settles.
+function Harness({ selectedTargets, onState }: { selectedTargets?: any[]; onState?: (state: any) => void }) {
+  const state = useDeployFlow({ isInteractive: true, selectedTargets });
+  onState?.(state);
   return null as unknown as React.ReactElement;
 }
 
@@ -212,7 +215,25 @@ describe('useDeployFlow target scoping (issue #1267)', () => {
     }
   });
 
-  it('no picker selection falls back to the unscoped assembly (undefined selector)', async () => {
+  it('no picker provided (undefined) falls back to the unscoped assembly', async () => {
+    // Programmatic / non-interactive callers pass no selection at all — keep prior behavior
+    // (undefined selector → the assembly's lone stack deploys).
+    preflightState = makePreflight({ awsTargets: [TARGET_A] });
+
+    const { unmount } = render(<Harness />);
+    await flush();
+    unmount();
+
+    expect(deploySpy).toHaveBeenCalledTimes(1);
+    const arg = deploySpy.mock.calls[0]![0];
+    expect(arg.stacks).toBeUndefined();
+  });
+
+  it('empty picker selection fails safe (scoped to nothing), never ALL_STACKS (#1267)', async () => {
+    // A picker that yields an empty selection must NOT resolve to undefined (→ toolkit ALL_STACKS).
+    // It scopes to an empty PATTERN_MUST_MATCH set, which makes toolkit-lib throw NoStacksMatched
+    // rather than deploy every configured target — so the #1267 bug can't re-latent if the picker's
+    // empty-selection guard ever changes.
     preflightState = makePreflight({ awsTargets: [TARGET_A, TARGET_B] });
 
     const { unmount } = render(<Harness selectedTargets={[]} />);
@@ -221,7 +242,72 @@ describe('useDeployFlow target scoping (issue #1267)', () => {
 
     expect(deploySpy).toHaveBeenCalledTimes(1);
     const arg = deploySpy.mock.calls[0]![0];
-    expect(arg.stacks).toBeUndefined();
+    expect(arg.stacks).toBeDefined();
+    expect(arg.stacks.strategy).toBe(StackSelectionStrategy.PATTERN_MUST_MATCH);
+    expect(arg.stacks.patterns).toEqual([]);
+  });
+
+  it('deploy summary reports only the picker-scoped stacks, not the full synthesized set (#1267)', async () => {
+    // [A, B] project, user picks B. The success message must say "1 stack" naming only B's stack —
+    // pre-fix it read the full stackNames set and claimed both A and B were deployed.
+    preflightState = makePreflight({ awsTargets: [TARGET_A, TARGET_B] });
+
+    let latest: any;
+    const { unmount } = render(
+      <Harness
+        selectedTargets={[TARGET_B]}
+        onState={s => {
+          latest = s;
+        }}
+      />
+    );
+    await flush();
+    unmount();
+
+    expect(latest.deployOutput).toBe(`Deployed 1 stack(s): ${toStackName(PROJECT_NAME, TARGET_B.name)}`);
+    expect(latest.deployOutput).not.toContain(toStackName(PROJECT_NAME, TARGET_A.name));
+  });
+
+  it('warns that only the first selected target is bookkept on a multi-target pick (#1267)', async () => {
+    // Picking A + B deploys both stacks, but persist + transaction search only cover activeTarget
+    // (A, the first selected). Surface a note so B isn't silently left without recorded state.
+    preflightState = makePreflight({ awsTargets: [TARGET_A, TARGET_B] });
+
+    let latest: any;
+    const { unmount } = render(
+      <Harness
+        selectedTargets={[TARGET_A, TARGET_B]}
+        onState={s => {
+          latest = s;
+        }}
+      />
+    );
+    await flush();
+    unmount();
+
+    const warned = (latest.deployNotes ?? []).some(
+      (n: string) => n.includes('recorded only for') && n.includes(TARGET_A.name)
+    );
+    expect(warned).toBe(true);
+  });
+
+  it('single-target pick adds no multi-target bookkeeping warning', async () => {
+    preflightState = makePreflight({ awsTargets: [TARGET_A, TARGET_B] });
+
+    let latest: any;
+    const { unmount } = render(
+      <Harness
+        selectedTargets={[TARGET_B]}
+        onState={s => {
+          latest = s;
+        }}
+      />
+    );
+    await flush();
+    unmount();
+
+    const warned = (latest.deployNotes ?? []).some((n: string) => n.includes('recorded only for'));
+    expect(warned).toBe(false);
   });
 
   it('persist polls the SELECTED target stack/region, not awsTargets[0]/stackNames[0]', async () => {

--- a/src/cli/tui/screens/deploy/__tests__/useDeployFlow.targets.test.tsx
+++ b/src/cli/tui/screens/deploy/__tests__/useDeployFlow.targets.test.tsx
@@ -145,7 +145,7 @@ describe('useDeployFlow target scoping (issue #1267)', () => {
     unmount();
 
     expect(deploySpy).toHaveBeenCalledTimes(1);
-    const arg = deploySpy.mock.calls[0][0];
+    const arg = deploySpy.mock.calls[0]![0];
 
     // Must NOT be called with stacks undefined (the pre-fix behavior → ALL_STACKS).
     expect(arg).toBeDefined();
@@ -165,7 +165,7 @@ describe('useDeployFlow target scoping (issue #1267)', () => {
     unmount();
 
     expect(deploySpy).toHaveBeenCalledTimes(1);
-    const arg = deploySpy.mock.calls[0][0];
+    const arg = deploySpy.mock.calls[0]![0];
     expect(arg.stacks.patterns).toEqual([toStackName(PROJECT_NAME, TARGET_A.name)]);
     expect(arg.stacks.patterns).not.toContain(toStackName(PROJECT_NAME, TARGET_B.name));
   });
@@ -178,7 +178,7 @@ describe('useDeployFlow target scoping (issue #1267)', () => {
     unmount();
 
     expect(deploySpy).toHaveBeenCalledTimes(1);
-    const arg = deploySpy.mock.calls[0][0];
+    const arg = deploySpy.mock.calls[0]![0];
     expect(arg.stacks.strategy).toBe(StackSelectionStrategy.PATTERN_MUST_MATCH);
     expect(arg.stacks.patterns).toEqual([
       toStackName(PROJECT_NAME, TARGET_A.name),
@@ -195,7 +195,7 @@ describe('useDeployFlow target scoping (issue #1267)', () => {
     unmount();
 
     expect(deploySpy).toHaveBeenCalledTimes(1);
-    const arg = deploySpy.mock.calls[0][0];
+    const arg = deploySpy.mock.calls[0]![0];
     // Either a pattern selector for the single stack, or undefined (assembly's lone stack) — both
     // deploy exactly one stack. Must never resolve to a broader set.
     if (arg.stacks) {
@@ -211,7 +211,7 @@ describe('useDeployFlow target scoping (issue #1267)', () => {
     unmount();
 
     expect(deploySpy).toHaveBeenCalledTimes(1);
-    const arg = deploySpy.mock.calls[0][0];
+    const arg = deploySpy.mock.calls[0]![0];
     expect(arg.stacks).toBeUndefined();
   });
 });

--- a/src/cli/tui/screens/deploy/useDeployFlow.ts
+++ b/src/cli/tui/screens/deploy/useDeployFlow.ts
@@ -1,5 +1,7 @@
 import { ConfigIO } from '../../../../lib';
+import type { AwsDeploymentTarget } from '../../../../schema';
 import type { CdkToolkitWrapper, DeployMessage, SwitchableIoHost } from '../../../cdk/toolkit-lib';
+import { toStackName } from '../../../commands/import/import-utils';
 import {
   buildDeployedState,
   getStackOutputs,
@@ -43,6 +45,7 @@ import {
   parseStackDiff,
 } from '../../components';
 import { type MissingCredential, type PreflightContext, useCdkPreflight } from '../../hooks';
+import { StackSelectionStrategy } from '@aws-cdk/toolkit-lib';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 type DeployPhase =
@@ -75,6 +78,13 @@ interface DeployFlowOptions {
   isInteractive?: boolean;
   /** Run CDK diff instead of deploy */
   diffMode?: boolean;
+  /**
+   * Targets the user chose in the multi-select picker. The vended CDK app synthesizes one stack
+   * per configured target, so without scoping the deploy runs against ALL_STACKS (every target).
+   * When set, the deploy is restricted to these targets' stacks. Empty/undefined falls back to the
+   * full assembly (single-target projects, and the pre-synthesized plan path).
+   */
+  selectedTargets?: AwsDeploymentTarget[];
 }
 
 interface DeployFlowState {
@@ -130,7 +140,7 @@ interface DeployFlowState {
 }
 
 export function useDeployFlow(options: DeployFlowOptions = {}): DeployFlowState {
-  const { preSynthesized, isInteractive = false, diffMode = false } = options;
+  const { preSynthesized, isInteractive = false, diffMode = false, selectedTargets } = options;
   const skipPreflight = !!preSynthesized;
 
   // Create logger once for the entire deploy flow
@@ -146,6 +156,21 @@ export function useDeployFlow(options: DeployFlowOptions = {}): DeployFlowState 
   const switchableIoHost = preSynthesized?.switchableIoHost ?? preflight.switchableIoHost;
   const identityKmsKeyArn = preSynthesized?.identityKmsKeyArn ?? preflight.identityKmsKeyArn;
   const allCredentials = preSynthesized?.allCredentials ?? preflight.allCredentials;
+
+  // Scope the deploy to the picker's selected targets. The vended CDK app synthesizes one stack
+  // per target, so an unscoped deploy resolves to ALL_STACKS and provisions every configured
+  // account/region — even the ones the user did not pick (see issue #1267). Mirrors CLI mode
+  // (commands/deploy/actions.ts), which patterns deploy() by toStackName(project, target).
+  // Skipped on the pre-synthesized plan path, which already targets a single stack.
+  const deployStacks = useMemo(() => {
+    if (skipPreflight) return undefined;
+    const projectName = context?.projectSpec.name;
+    if (!projectName || !selectedTargets || selectedTargets.length === 0) return undefined;
+    return {
+      strategy: StackSelectionStrategy.PATTERN_MUST_MATCH,
+      patterns: selectedTargets.map(t => toStackName(projectName, t.name)),
+    };
+  }, [skipPreflight, context?.projectSpec.name, selectedTargets]);
 
   const [preDeployDiffStep, setPreDeployDiffStep] = useState<Step>({
     label: 'Computing diff changes...',
@@ -779,8 +804,10 @@ export function useDeployFlow(options: DeployFlowOptions = {}): DeployFlowState 
 
       try {
         // Run deploy - toolkit-lib handles CloudFormation orchestration
-        // Output goes to stdout via the switchable ioHost
-        await cdkToolkitWrapper.deploy();
+        // Output goes to stdout via the switchable ioHost.
+        // deployStacks restricts the deploy to the picker's selected targets; undefined (single
+        // target or plan path) lets the assembly's lone stack deploy as before.
+        await cdkToolkitWrapper.deploy({ stacks: deployStacks });
 
         // CDK deploy itself is done. Mark "Deploy to AWS" success and let post-deploy
         // phases (persist, hydrate KBs, auto-ingest, dataset sync, online evals,
@@ -934,6 +961,7 @@ export function useDeployFlow(options: DeployFlowOptions = {}): DeployFlowState 
     context?.awsTargets,
     context?.projectSpec.runtimes,
     diffMode,
+    deployStacks,
   ]);
 
   // Start diff when preflight completes (diff mode only)

--- a/src/cli/tui/screens/deploy/useDeployFlow.ts
+++ b/src/cli/tui/screens/deploy/useDeployFlow.ts
@@ -165,7 +165,15 @@ export function useDeployFlow(options: DeployFlowOptions = {}): DeployFlowState 
   const deployStacks = useMemo(() => {
     if (skipPreflight) return undefined;
     const projectName = context?.projectSpec.name;
-    if (!projectName || !selectedTargets || selectedTargets.length === 0) return undefined;
+    if (!projectName) return undefined;
+    // No picker selection provided at all (programmatic / non-interactive callers): keep the
+    // unscoped assembly, matching prior behavior for single-target and CLI-parity paths.
+    if (selectedTargets === undefined) return undefined;
+    // A picker selection is present — scope to exactly those stacks. An EMPTY selection must NOT
+    // silently fall through to ALL_STACKS (that would re-latent the #1267 bug): PATTERN_MUST_MATCH
+    // with no patterns makes toolkit-lib throw NoStacksMatched, so an unexpected empty pick fails
+    // safe (deploys nothing) instead of provisioning every configured target. The picker blocks
+    // empty selections today, so this is defense-in-depth rather than a reachable path.
     return {
       strategy: StackSelectionStrategy.PATTERN_MUST_MATCH,
       patterns: selectedTargets.map(t => toStackName(projectName, t.name)),
@@ -924,7 +932,22 @@ export function useDeployFlow(options: DeployFlowOptions = {}): DeployFlowState 
         // their own start/end pairs, so this usually no-ops).
         logger.endStep('success');
         logger.finalize(true);
-        setDeployOutput(`Deployed ${stackNames.length} stack(s): ${stackNames.join(', ')}`);
+        // Report the stacks that were actually deployed — the picker-scoped set, not the full
+        // synthesized list (issue #1267). deployStacks is undefined on the single-target / plan
+        // path, where the lone synthesized stack in stackNames is exactly what deployed.
+        const deployedStackNames = deployStacks?.patterns ?? stackNames;
+        setDeployOutput(`Deployed ${deployedStackNames.length} stack(s): ${deployedStackNames.join(', ')}`);
+
+        // A multi-target pick deploys every selected stack, but the post-deploy bookkeeping above
+        // (persist state, transaction search) only covers `activeTarget` — the first selected
+        // target — so the other targets would silently have no recorded state or traces. Warn
+        // until full per-target bookkeeping lands as a follow-up (issue #1267).
+        if ((deployStacks?.patterns?.length ?? 0) > 1) {
+          setDeployNotes(prev => [
+            ...prev,
+            `Deployed ${deployStacks!.patterns.length} targets, but deployed-state and transaction search were recorded only for "${activeTarget?.name}". Re-run deploy selecting each remaining target to record its state and enable transaction search there.`,
+          ]);
+        }
         return { success: true } as const;
       } catch (err) {
         const errorMsg = getErrorMessage(err);

--- a/src/cli/tui/screens/deploy/useDeployFlow.ts
+++ b/src/cli/tui/screens/deploy/useDeployFlow.ts
@@ -1,7 +1,6 @@
 import { ConfigIO } from '../../../../lib';
 import type { AwsDeploymentTarget } from '../../../../schema';
 import type { CdkToolkitWrapper, DeployMessage, SwitchableIoHost } from '../../../cdk/toolkit-lib';
-import { toStackName } from '../../../commands/import/import-utils';
 import {
   buildDeployedState,
   getStackOutputs,
@@ -20,6 +19,7 @@ import {
   parseRuntimeEndpointOutputs,
 } from '../../../cloudformation';
 import { DEFAULT_DEPLOY_ATTRS, computeDeployAttrs } from '../../../commands/deploy/utils.js';
+import { toStackName } from '../../../commands/import/import-utils';
 import { getErrorMessage, isChangesetInProgressError, isExpiredTokenError } from '../../../errors';
 import { ExecLogger } from '../../../logging';
 import {

--- a/src/cli/tui/screens/deploy/useDeployFlow.ts
+++ b/src/cli/tui/screens/deploy/useDeployFlow.ts
@@ -172,6 +172,19 @@ export function useDeployFlow(options: DeployFlowOptions = {}): DeployFlowState 
     };
   }, [skipPreflight, context?.projectSpec.name, selectedTargets]);
 
+  // The target whose stack the post-deploy bookkeeping (persist state, teardown, transaction
+  // search) operates on. The deploy is now scoped to the picker selection, so this MUST track the
+  // deployed target rather than blindly using `awsTargets[0]`: when a multi-target project's user
+  // picks a non-first target, `awsTargets[0]`/`stackNames[0]` point at a stack that was never
+  // deployed, so persist would poll the wrong stack and write deployed-state under the wrong target
+  // (see issue #1267). Falls back to the resolved context target for the plan path (no picker) and
+  // when nothing was selected. The TUI persists a single target; if the user picked several, we
+  // bookkeep the first selected one (the same target whose outputs we poll below).
+  const activeTarget = useMemo(
+    () => selectedTargets?.[0] ?? context?.awsTargets[0],
+    [selectedTargets, context?.awsTargets]
+  );
+
   const [preDeployDiffStep, setPreDeployDiffStep] = useState<Step>({
     label: 'Computing diff changes...',
     status: 'pending',
@@ -267,7 +280,8 @@ export function useDeployFlow(options: DeployFlowOptions = {}): DeployFlowState 
       switchableIoHost?.setVerbose(true);
 
       try {
-        await cdkToolkitWrapper.diff();
+        // Scope the diff to the picker selection so it mirrors what will deploy (issue #1267).
+        await cdkToolkitWrapper.diff({ stacks: deployStacks });
       } catch {
         setDiffSummaries([{ stackName: 'Error', sections: [], hasSecurityChanges: false, totalChanges: 0 }]);
       } finally {
@@ -279,7 +293,7 @@ export function useDeployFlow(options: DeployFlowOptions = {}): DeployFlowState 
     };
 
     void run();
-  }, [cdkToolkitWrapper, diffSummaries.length, switchableIoHost, logger]);
+  }, [cdkToolkitWrapper, diffSummaries.length, switchableIoHost, logger, deployStacks]);
 
   /**
    * Persist deployed state after successful deployment.
@@ -287,8 +301,13 @@ export function useDeployFlow(options: DeployFlowOptions = {}): DeployFlowState 
    */
   const persistDeployedState = useCallback(async () => {
     const ctx = context;
-    const currentStackName = stackNames[0];
-    const target = ctx?.awsTargets[0];
+    const target = activeTarget;
+    // Persist against the deployed target's stack, not stackNames[0]. For a multi-target project
+    // where the user picked a non-first target, stackNames[0] is a sibling stack that was never
+    // deployed — polling it would fail and we'd write deployed-state under the wrong target name.
+    // The plan path (no project name / no picker) still falls back to the lone synthesized stack.
+    const projectName = ctx?.projectSpec.name;
+    const currentStackName = projectName && target ? toStackName(projectName, target.name) : stackNames[0];
 
     if (!ctx || !currentStackName || !target) return;
 
@@ -700,7 +719,7 @@ export function useDeployFlow(options: DeployFlowOptions = {}): DeployFlowState 
     if (allStatuses.length > 0) {
       setTargetStatuses(allStatuses);
     }
-  }, [context, stackNames, logger, identityKmsKeyArn, allCredentials]);
+  }, [context, stackNames, activeTarget, logger, identityKmsKeyArn, allCredentials]);
 
   // Start deploy when preflight completes OR when shouldStartDeploy is set
   useEffect(() => {
@@ -744,7 +763,9 @@ export function useDeployFlow(options: DeployFlowOptions = {}): DeployFlowState 
         });
         switchableIoHost?.setVerbose(true);
         try {
-          await cdkToolkitWrapper.diff();
+          // Scope the pre-deploy diff to the same stacks the deploy will touch (issue #1267),
+          // so a single-target pick doesn't diff every configured target's stack.
+          await cdkToolkitWrapper.diff({ stacks: deployStacks });
         } catch {
           // Diff failure is non-fatal — deploy will proceed
         } finally {
@@ -828,15 +849,15 @@ export function useDeployFlow(options: DeployFlowOptions = {}): DeployFlowState 
           // After deploying the empty spec, destroy the stack entirely.
           // Harnesses are part of the CloudFormation stack, so stack destroy handles them.
           // Clean up imperative payment credential providers before stack teardown.
-          const targetName = context.awsTargets[0]?.name;
+          // Tear down the deployed target (the picker selection), not blindly awsTargets[0].
+          const targetName = activeTarget?.name;
           if (targetName) {
             try {
               const configIO = new ConfigIO();
               const deployedState = await configIO.readDeployedState();
               const existingPayments = deployedState?.targets?.[targetName]?.resources?.payments;
-              if (existingPayments && Object.keys(existingPayments).length > 0) {
-                const target = context.awsTargets[0]!;
-                await cleanupPaymentCredentialProviders({ region: target.region, payments: existingPayments });
+              if (existingPayments && Object.keys(existingPayments).length > 0 && activeTarget) {
+                await cleanupPaymentCredentialProviders({ region: activeTarget.region, payments: existingPayments });
               }
             } catch {
               // Best-effort: continue with teardown even if credential cleanup fails
@@ -866,9 +887,10 @@ export function useDeployFlow(options: DeployFlowOptions = {}): DeployFlowState 
           }
 
           // Post-deploy: Enable CloudWatch Transaction Search (non-blocking, silent)
+          // Wire it in the deployed target's account/region (the picker selection), not awsTargets[0].
           const agentNames = context?.projectSpec.runtimes?.map((a: { name: string }) => a.name) ?? [];
-          const targetRegion = context?.awsTargets[0]?.region;
-          const targetAccount = context?.awsTargets[0]?.account;
+          const targetRegion = activeTarget?.region;
+          const targetAccount = activeTarget?.account;
           const hasGateways = (context?.projectSpec.agentCoreGateways?.length ?? 0) > 0;
           const hasPythonAgent =
             context?.projectSpec.runtimes?.some(
@@ -960,6 +982,7 @@ export function useDeployFlow(options: DeployFlowOptions = {}): DeployFlowState 
     context?.isTeardownDeploy,
     context?.awsTargets,
     context?.projectSpec.runtimes,
+    activeTarget,
     diffMode,
     deployStacks,
   ]);
@@ -1007,7 +1030,8 @@ export function useDeployFlow(options: DeployFlowOptions = {}): DeployFlowState 
       switchableIoHost?.setVerbose(true);
 
       try {
-        await cdkToolkitWrapper.diff();
+        // Scope the standalone diff to the picker selection (issue #1267).
+        await cdkToolkitWrapper.diff({ stacks: deployStacks });
         logger.endStep('success');
         logger.finalize(true);
         setDiffStep(prev => ({ ...prev, status: 'success' }));
@@ -1045,6 +1069,7 @@ export function useDeployFlow(options: DeployFlowOptions = {}): DeployFlowState 
     skipPreflight,
     shouldStartDeploy,
     switchableIoHost,
+    deployStacks,
   ]);
 
   // Finalize logger and dispose toolkit when preflight fails


### PR DESCRIPTION
## Description

**#1267**

In the TUI deploy flow, when aws-targets.json has more than one target the multi-select picker lets the user choose a subset, but the choice is dropped: the deploy screen header lists every target (cosmetic), and far worse, the deploy itself runs against ALL synthesized stacks (all targets), not the selected one(s). A user who picks a single target silently deploys real infrastructure to every configured account/region. Only affects multi-target projects; single-target (the default) is correct.

## Fix

Thread the picker selection through preflight AND scope the deploy. (1) Display + context (what open PR #1302 does): add selectedTargets?: AwsDeploymentTarget[] to PreflightOptions/DeployFlowOptions; DeployScreen derives it from awsConfig.selectedTargetIndices over availableTargets and passes it down; useCdkPreflight filters preflightContext.awsTargets to the selected names after validateProject(). This fixes the header (DeployScreen.tsx:279) and makes awsTargets[0] reads (persist/teardown/transaction-search; checkBootstrapNeeded preflight.ts:307) reflect the user's choice. (2) ADDITIONALLY (NOT in PR #1302, and the load-bearing part): scope the actual deploy by passing a stacks selector into the TUI cdkToolkitWrapper.deploy() at useDeployFlow.ts:784, built from the selected target names mapped through toStackName(projectName, targetName) with StackSelectionStrategy.PATTERN_MUST_MATCH, e


## Related Issue

Closes #1267

## Documentation PR

N/A — bug fix; no devguide change required.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change? (full validation in PR comments after bug bash)

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots — N/A, no `src/assets/` changes

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
