### PR TITLE
fix(templates): retrieve SUMMARIZATION summaries with an actor-scoped namespace (#665)

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -92,7 +92,7 @@ If you created an Strands agent without memory and want to integrate it with you
 
        retrieval_config = {
            f"/users/{actor_id}/facts": RetrievalConfig(top_k=3, relevance_score=0.5),
-           f"/summaries/{actor_id}/{session_id}": RetrievalConfig(top_k=3, relevance_score=0.5)
+           f"/summaries/{actor_id}": RetrievalConfig(top_k=3, relevance_score=0.5)
        }
 
        return AgentCoreMemorySessionManager(
@@ -157,7 +157,7 @@ specific memory configuration:
 | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `none`             | No memory resource created                                                                                                                                                                                                                                      |
 | `shortTerm`        | Memory with no strategies (session context via event expiry only, default 30 days)                                                                                                                                                                              |
-| `longAndShortTerm` | Memory with four strategies: `SEMANTIC` (`/users/{actorId}/facts`), `USER_PREFERENCE` (`/users/{actorId}/preferences`), `SUMMARIZATION` (`/summaries/{actorId}/{sessionId}`), `EPISODIC` (`/episodes/{actorId}/{sessionId}`, reflection: `/episodes/{actorId}`) |
+| `longAndShortTerm` | Memory with four strategies: `SEMANTIC` (`/users/{actorId}/facts`), `USER_PREFERENCE` (`/users/{actorId}/preferences`), `SUMMARIZATION` (`/summaries/{actorId}`), `EPISODIC` (`/episodes/{actorId}/{sessionId}`, reflection: `/episodes/{actorId}`) |
 
 **Short-term memory** provides basic conversation context within a session — events are stored and expire after the
 configured duration, but no long-term extraction or search is performed.

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -153,10 +153,10 @@ async def invoke(payload, context):
 The `create` and `add agent` commands accept a `--memory` flag with one of three shorthand values. Each maps to a
 specific memory configuration:
 
-| Shorthand          | Strategies Created                                                                                                                                                                                                                                              |
-| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `none`             | No memory resource created                                                                                                                                                                                                                                      |
-| `shortTerm`        | Memory with no strategies (session context via event expiry only, default 30 days)                                                                                                                                                                              |
+| Shorthand          | Strategies Created                                                                                                                                                                                                                                  |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `none`             | No memory resource created                                                                                                                                                                                                                          |
+| `shortTerm`        | Memory with no strategies (session context via event expiry only, default 30 days)                                                                                                                                                                  |
 | `longAndShortTerm` | Memory with four strategies: `SEMANTIC` (`/users/{actorId}/facts`), `USER_PREFERENCE` (`/users/{actorId}/preferences`), `SUMMARIZATION` (`/summaries/{actorId}`), `EPISODIC` (`/episodes/{actorId}/{sessionId}`, reflection: `/episodes/{actorId}`) |
 
 **Short-term memory** provides basic conversation context within a session — events are stored and expire after the

--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -2255,7 +2255,7 @@ def get_memory_session_manager(session_id: Optional[str], actor_id: str) -> Opti
         f"/episodes/{actor_id}/{session_id}": RetrievalConfig(top_k=5, relevance_score=0.5),
 {{/if}}
 {{#if (includes memoryProviders.[0].strategies "SUMMARIZATION")}}
-        f"/summaries/{actor_id}/{session_id}": RetrievalConfig(top_k=3, relevance_score=0.5),
+        f"/summaries/{actor_id}": RetrievalConfig(top_k=3, relevance_score=0.5),
 {{/if}}
     }
 {{/if}}
@@ -3277,7 +3277,7 @@ def get_memory_session_manager(session_id: Optional[str], actor_id: str) -> Opti
         f"/episodes/{actor_id}/{session_id}": RetrievalConfig(top_k=5, relevance_score=0.5),
 {{/if}}
 {{#if (includes memoryProviders.[0].strategies "SUMMARIZATION")}}
-        f"/summaries/{actor_id}/{session_id}": RetrievalConfig(top_k=3, relevance_score=0.5),
+        f"/summaries/{actor_id}": RetrievalConfig(top_k=3, relevance_score=0.5),
 {{/if}}
     }
 {{/if}}
@@ -6545,7 +6545,7 @@ def get_memory_session_manager(session_id: Optional[str], actor_id: str) -> Opti
         f"/episodes/{actor_id}/{session_id}": RetrievalConfig(top_k=5, relevance_score=0.5),
 {{/if}}
 {{#if (includes memoryProviders.[0].strategies "SUMMARIZATION")}}
-        f"/summaries/{actor_id}/{session_id}": RetrievalConfig(top_k=3, relevance_score=0.5),
+        f"/summaries/{actor_id}": RetrievalConfig(top_k=3, relevance_score=0.5),
 {{/if}}
     }
 {{/if}}

--- a/src/assets/__tests__/summarization-namespace.test.ts
+++ b/src/assets/__tests__/summarization-namespace.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Regression test for cross-session SUMMARIZATION recall (issue #665).
+ *
+ * The SUMMARIZATION retrieval namespace must be actor-scoped (`/summaries/{actor_id}`),
+ * not session-scoped. The SDK's namespace_path is a hierarchical prefix match, so a
+ * per-session prefix (`/summaries/{actor_id}/{session_id}`) only ever matches the current
+ * session's own summaries and never surfaces summaries written by prior sessions —
+ * silently breaking cross-session recall. This guards against another silent revert
+ * (see PR #1299, reverted by squash release #1547).
+ */
+import Handlebars from 'handlebars';
+import * as fs from 'fs';
+import * as path from 'path';
+import { describe, expect, it } from 'vitest';
+// Importing render registers the `includes` Handlebars helper used by the template.
+import '../../cli/templates/render.js';
+
+const FLAVORS = ['http', 'agui', 'a2a'] as const;
+
+function renderSessionTemplate(flavor: string): string {
+  const templatePath = path.resolve(
+    __dirname,
+    '..',
+    'python',
+    flavor,
+    'strands',
+    'capabilities',
+    'memory',
+    'session.py'
+  );
+  const content = fs.readFileSync(templatePath, 'utf-8');
+  return Handlebars.compile(content)({
+    memoryProviders: [{ envVarName: 'MEMORY_TEST_ID', strategies: ['SUMMARIZATION'] }],
+  });
+}
+
+describe('SUMMARIZATION retrieval namespace', () => {
+  it.each(FLAVORS)('%s session.py uses an actor-scoped summary namespace', flavor => {
+    const rendered = renderSessionTemplate(flavor);
+    expect(rendered).toContain('f"/summaries/{actor_id}": RetrievalConfig');
+    expect(rendered).not.toContain('/summaries/{actor_id}/{session_id}');
+  });
+});

--- a/src/assets/python/a2a/strands/capabilities/memory/session.py
+++ b/src/assets/python/a2a/strands/capabilities/memory/session.py
@@ -28,7 +28,7 @@ def get_memory_session_manager(session_id: Optional[str], actor_id: str) -> Opti
         f"/episodes/{actor_id}/{session_id}": RetrievalConfig(top_k=5, relevance_score=0.5),
 {{/if}}
 {{#if (includes memoryProviders.[0].strategies "SUMMARIZATION")}}
-        f"/summaries/{actor_id}/{session_id}": RetrievalConfig(top_k=3, relevance_score=0.5),
+        f"/summaries/{actor_id}": RetrievalConfig(top_k=3, relevance_score=0.5),
 {{/if}}
     }
 {{/if}}

--- a/src/assets/python/agui/strands/capabilities/memory/session.py
+++ b/src/assets/python/agui/strands/capabilities/memory/session.py
@@ -28,7 +28,7 @@ def get_memory_session_manager(session_id: Optional[str], actor_id: str) -> Opti
         f"/episodes/{actor_id}/{session_id}": RetrievalConfig(top_k=5, relevance_score=0.5),
 {{/if}}
 {{#if (includes memoryProviders.[0].strategies "SUMMARIZATION")}}
-        f"/summaries/{actor_id}/{session_id}": RetrievalConfig(top_k=3, relevance_score=0.5),
+        f"/summaries/{actor_id}": RetrievalConfig(top_k=3, relevance_score=0.5),
 {{/if}}
     }
 {{/if}}

--- a/src/assets/python/http/strands/capabilities/memory/session.py
+++ b/src/assets/python/http/strands/capabilities/memory/session.py
@@ -28,7 +28,7 @@ def get_memory_session_manager(session_id: Optional[str], actor_id: str) -> Opti
         f"/episodes/{actor_id}/{session_id}": RetrievalConfig(top_k=5, relevance_score=0.5),
 {{/if}}
 {{#if (includes memoryProviders.[0].strategies "SUMMARIZATION")}}
-        f"/summaries/{actor_id}/{session_id}": RetrievalConfig(top_k=3, relevance_score=0.5),
+        f"/summaries/{actor_id}": RetrievalConfig(top_k=3, relevance_score=0.5),
 {{/if}}
     }
 {{/if}}


### PR DESCRIPTION
## Description

**#665**

Agents created/extended with `--strategies SUMMARIZATION` write per-session conversation summaries correctly, but the generated session.py retrieves them with a per-session namespace, so a new session never sees prior sessions' summaries. Cross-session summary recall silently does nothing; the feature appears write-only to users.

## Fix

Re-apply PR #1299's one-line change in all three Strands session.py templates: change the SUMMARIZATION retrieval line at line 31 from f"/summaries/{actor_id}/{session_id}" to f"/summaries/{actor_id}". Run `npm run test:update-snapshots` to refresh the 3 affected entries in assets.snapshot.test.ts.snap (lines 2264, 3286, 6554). Update docs/memory.md:95 (manual-wiring snippet) and the strategy table at docs/memory.md:160 to /summaries/{actorId} for SUMMARIZATION. Leave the write-side namespaceTemplate (memory.ts:26) and EPISODIC ({session_id} kept intentionally; the issue is scoped to SUMMARIZATION) unchanged. Add a regression test asserting the generated SUMMARIZATION retrieval namespace contains no {session_id}, so a future squash-merge cannot silently revert it again. No SDK or CDK change needed (SDK prefix-retrieval is correct; CDK owns nothing in this path).


## Related Issue

Closes #665

## Documentation PR

N/A — bug fix; no devguide change required.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change? (full validation in PR comments after bug bash)

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [x] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
