### PR TITLE
fix(policy): resolve HTTP gateways for policy generation and guardrails (#1658)

### DIFF
--- a/src/cli/primitives/PolicyEnginePrimitive.ts
+++ b/src/cli/primitives/PolicyEnginePrimitive.ts
@@ -9,6 +9,7 @@ import { AttachMode, standardize } from '../telemetry/schemas/common-shapes.js';
 import { requireTTY } from '../tui/guards/tty';
 import { BasePrimitive } from './BasePrimitive';
 import { SOURCE_CODE_NOTE } from './constants';
+import { mergeDeployedGateways } from './deployed-gateways';
 import type { AddResult, AddScreenComponent, RemovableResource } from './types';
 import type { Command } from '@commander-js/extra-typings';
 
@@ -196,12 +197,10 @@ export class PolicyEnginePrimitive extends BasePrimitive<AddPolicyEngineOptions,
       );
       const result: Record<string, string> = {};
       for (const target of Object.values(deployedState.targets)) {
-        const gateways = target.resources?.mcp?.gateways ?? target.resources?.gateways;
-        if (gateways) {
-          for (const [name, gw] of Object.entries(gateways)) {
-            if (gw?.gatewayArn && !mcpGatewayNames.has(name)) {
-              result[name] = gw.gatewayArn;
-            }
+        const gateways = mergeDeployedGateways(target);
+        for (const [name, gw] of Object.entries(gateways)) {
+          if (gw?.gatewayArn && !mcpGatewayNames.has(name)) {
+            result[name] = gw.gatewayArn;
           }
         }
       }

--- a/src/cli/primitives/PolicyPrimitive.ts
+++ b/src/cli/primitives/PolicyPrimitive.ts
@@ -19,6 +19,7 @@ import {
 } from '../tui/screens/policy/types';
 import { BasePrimitive } from './BasePrimitive';
 import { SOURCE_CODE_NOTE } from './constants';
+import { mergeDeployedGateways } from './deployed-gateways';
 import type { AddResult, AddScreenComponent, RemovableResource } from './types';
 import type { Command } from '@commander-js/extra-typings';
 import { existsSync, readFileSync } from 'fs';
@@ -83,18 +84,16 @@ export class PolicyPrimitive extends BasePrimitive<AddPolicyOptions, RemovablePo
 
         for (const target of Object.values(deployedState.targets)) {
           engineId ??= target.resources?.policyEngines?.[options.engine]?.policyEngineId;
-          const gateways = target.resources?.mcp?.gateways;
-          if (gateways) {
-            if (options.gateway) {
-              const gw = gateways[options.gateway];
-              if (gw?.gatewayArn) {
-                gatewayArn = gw.gatewayArn;
-              }
-            } else if (!gatewayArn) {
-              const firstGateway = Object.values(gateways)[0];
-              if (firstGateway?.gatewayArn) {
-                gatewayArn = firstGateway.gatewayArn;
-              }
+          const gateways = mergeDeployedGateways(target);
+          if (options.gateway) {
+            const gw = gateways[options.gateway];
+            if (gw?.gatewayArn) {
+              gatewayArn = gw.gatewayArn;
+            }
+          } else if (!gatewayArn) {
+            const firstGateway = Object.values(gateways)[0];
+            if (firstGateway?.gatewayArn) {
+              gatewayArn = firstGateway.gatewayArn;
             }
           }
         }
@@ -430,26 +429,24 @@ export class PolicyPrimitive extends BasePrimitive<AddPolicyOptions, RemovablePo
                   try {
                     const deployedState = await this.configIO.readDeployedState();
                     for (const target of Object.values(deployedState.targets)) {
-                      const gateways = target.resources?.mcp?.gateways ?? target.resources?.gateways;
-                      if (gateways) {
-                        const gw = gateways[cliOptions.gateway];
-                        if (gw?.gatewayArn) {
-                          resolvedGatewayArn = gw.gatewayArn;
-                          if (!resolvedTargetName) {
-                            const gwTargets = gw.targets;
-                            if (gwTargets) {
-                              const targetNames = Object.keys(gwTargets);
-                              if (targetNames.length === 1) {
-                                resolvedTargetName = targetNames[0];
-                              } else if (targetNames.length > 1) {
-                                throw new ValidationError(
-                                  `Multiple targets found on gateway "${cliOptions.gateway}": ${targetNames.join(', ')}. Use --target <name> to specify one.`
-                                );
-                              }
+                      const gateways = mergeDeployedGateways(target);
+                      const gw = gateways[cliOptions.gateway];
+                      if (gw?.gatewayArn) {
+                        resolvedGatewayArn = gw.gatewayArn;
+                        if (!resolvedTargetName) {
+                          const gwTargets = gw.targets;
+                          if (gwTargets) {
+                            const targetNames = Object.keys(gwTargets);
+                            if (targetNames.length === 1) {
+                              resolvedTargetName = targetNames[0];
+                            } else if (targetNames.length > 1) {
+                              throw new ValidationError(
+                                `Multiple targets found on gateway "${cliOptions.gateway}": ${targetNames.join(', ')}. Use --target <name> to specify one.`
+                              );
                             }
                           }
-                          break;
                         }
+                        break;
                       }
                     }
                   } catch (e) {

--- a/src/cli/primitives/PolicyPrimitive.ts
+++ b/src/cli/primitives/PolicyPrimitive.ts
@@ -19,7 +19,7 @@ import {
 } from '../tui/screens/policy/types';
 import { BasePrimitive } from './BasePrimitive';
 import { SOURCE_CODE_NOTE } from './constants';
-import { mergeDeployedGateways } from './deployed-gateways';
+import { findDeployedGateway, firstDeployedGateway } from './deployed-gateways';
 import type { AddResult, AddScreenComponent, RemovableResource } from './types';
 import type { Command } from '@commander-js/extra-typings';
 import { existsSync, readFileSync } from 'fs';
@@ -79,24 +79,16 @@ export class PolicyPrimitive extends BasePrimitive<AddPolicyOptions, RemovablePo
 
       if (options.generate && !statement) {
         const deployedState = await this.configIO.readDeployedState();
-        let engineId: string | undefined;
-        let gatewayArn: string | undefined;
 
+        let engineId: string | undefined;
         for (const target of Object.values(deployedState.targets)) {
           engineId ??= target.resources?.policyEngines?.[options.engine]?.policyEngineId;
-          const gateways = mergeDeployedGateways(target);
-          if (options.gateway) {
-            const gw = gateways[options.gateway];
-            if (gw?.gatewayArn) {
-              gatewayArn = gw.gatewayArn;
-            }
-          } else if (!gatewayArn) {
-            const firstGateway = Object.values(gateways)[0];
-            if (firstGateway?.gatewayArn) {
-              gatewayArn = firstGateway.gatewayArn;
-            }
-          }
         }
+
+        const gateway = options.gateway
+          ? findDeployedGateway(deployedState, options.gateway)
+          : firstDeployedGateway(deployedState);
+        const gatewayArn = gateway?.gatewayArn;
 
         if (!engineId) {
           return {
@@ -428,25 +420,17 @@ export class PolicyPrimitive extends BasePrimitive<AddPolicyOptions, RemovablePo
                 if (cliOptions.gateway) {
                   try {
                     const deployedState = await this.configIO.readDeployedState();
-                    for (const target of Object.values(deployedState.targets)) {
-                      const gateways = mergeDeployedGateways(target);
-                      const gw = gateways[cliOptions.gateway];
-                      if (gw?.gatewayArn) {
-                        resolvedGatewayArn = gw.gatewayArn;
-                        if (!resolvedTargetName) {
-                          const gwTargets = gw.targets;
-                          if (gwTargets) {
-                            const targetNames = Object.keys(gwTargets);
-                            if (targetNames.length === 1) {
-                              resolvedTargetName = targetNames[0];
-                            } else if (targetNames.length > 1) {
-                              throw new ValidationError(
-                                `Multiple targets found on gateway "${cliOptions.gateway}": ${targetNames.join(', ')}. Use --target <name> to specify one.`
-                              );
-                            }
-                          }
+                    const gateway = findDeployedGateway(deployedState, cliOptions.gateway);
+                    if (gateway?.gatewayArn) {
+                      resolvedGatewayArn = gateway.gatewayArn;
+                      if (!resolvedTargetName) {
+                        const targetNames = Object.keys(gateway.targets ?? {});
+                        if (targetNames.length > 1) {
+                          throw new ValidationError(
+                            `Multiple targets found on gateway "${cliOptions.gateway}": ${targetNames.join(', ')}. Use --target <name> to specify one.`
+                          );
                         }
-                        break;
+                        resolvedTargetName = targetNames[0];
                       }
                     }
                   } catch (e) {

--- a/src/cli/primitives/__tests__/PolicyPrimitive.test.ts
+++ b/src/cli/primitives/__tests__/PolicyPrimitive.test.ts
@@ -23,10 +23,27 @@ const defaultProject: AgentCoreProjectSpec = {
   payments: [],
 };
 
-const { mockConfigExists, mockReadProjectSpec, mockWriteProjectSpec } = vi.hoisted(() => ({
+const { mockConfigExists, mockReadProjectSpec, mockWriteProjectSpec, mockReadDeployedState } = vi.hoisted(() => ({
   mockConfigExists: vi.fn().mockReturnValue(true),
   mockReadProjectSpec: vi.fn(),
   mockWriteProjectSpec: vi.fn().mockResolvedValue(undefined),
+  mockReadDeployedState: vi.fn(),
+}));
+
+const { mockStartPolicyGeneration, mockGetPolicyGeneration } = vi.hoisted(() => ({
+  mockStartPolicyGeneration: vi.fn().mockResolvedValue({ generationId: 'gen-1' }),
+  mockGetPolicyGeneration: vi
+    .fn()
+    .mockResolvedValue({ status: 'COMPLETED', statement: 'permit(principal, action, resource);' }),
+}));
+
+vi.mock('../../aws/policy-generation', () => ({
+  startPolicyGeneration: mockStartPolicyGeneration,
+  getPolicyGeneration: mockGetPolicyGeneration,
+}));
+
+vi.mock('../../aws', () => ({
+  detectRegion: vi.fn().mockResolvedValue({ region: 'us-west-2' }),
 }));
 
 vi.mock('../../../lib', () => {
@@ -34,6 +51,7 @@ vi.mock('../../../lib', () => {
     this.configExists = mockConfigExists;
     this.readProjectSpec = mockReadProjectSpec;
     this.writeProjectSpec = mockWriteProjectSpec;
+    this.readDeployedState = mockReadDeployedState;
   });
   return {
     ConfigIO: MockConfigIO,
@@ -107,5 +125,91 @@ describe('PolicyPrimitive — enforcementMode', () => {
     });
     expect(result.success).toBe(true);
     expect(getWrittenPolicy().enforcementMode).toBe('ACTIVE');
+  });
+});
+
+describe('PolicyPrimitive — --generate gateway resolution', () => {
+  let primitive: PolicyPrimitive;
+
+  const deployedEngine = {
+    resources: { policyEngines: { eng: { policyEngineId: 'pe-1', policyEngineArn: 'arn:pe' } } },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStartPolicyGeneration.mockResolvedValue({ generationId: 'gen-1' });
+    mockGetPolicyGeneration.mockResolvedValue({
+      status: 'COMPLETED',
+      statement: 'permit(principal, action, resource);',
+    });
+    mockReadProjectSpec.mockImplementation(() =>
+      Promise.resolve({ ...defaultProject, policyEngines: [{ name: 'eng', policies: [] }] })
+    );
+    primitive = new PolicyPrimitive();
+  });
+
+  it('resolves an MCP gateway stored under resources.mcp.gateways', async () => {
+    mockReadDeployedState.mockResolvedValue({
+      targets: {
+        default: {
+          resources: {
+            ...deployedEngine.resources,
+            mcp: { gateways: { 'my-gw': { gatewayId: 'g', gatewayArn: 'arn:mcp-gw' } } },
+          },
+        },
+      },
+    });
+    const result = await primitive.add({ name: 'p', engine: 'eng', generate: 'Forbid X', gateway: 'my-gw' });
+    expect(result.success).toBe(true);
+    expect(mockStartPolicyGeneration).toHaveBeenCalledWith(expect.objectContaining({ resourceArn: 'arn:mcp-gw' }));
+  });
+
+  it('resolves an HTTP gateway stored under resources.gateways (the reported bug)', async () => {
+    mockReadDeployedState.mockResolvedValue({
+      targets: {
+        default: {
+          resources: {
+            ...deployedEngine.resources,
+            gateways: { 'my-gw': { gatewayId: 'g', gatewayArn: 'arn:http-gw' } },
+          },
+        },
+      },
+    });
+    const result = await primitive.add({ name: 'p', engine: 'eng', generate: 'Forbid X', gateway: 'my-gw' });
+    expect(result.success).toBe(true);
+    expect(mockStartPolicyGeneration).toHaveBeenCalledWith(expect.objectContaining({ resourceArn: 'arn:http-gw' }));
+  });
+
+  it('resolves an HTTP gateway even when an MCP gateway coexists', async () => {
+    mockReadDeployedState.mockResolvedValue({
+      targets: {
+        default: {
+          resources: {
+            ...deployedEngine.resources,
+            mcp: { gateways: { 'mcp-gw': { gatewayId: 'm', gatewayArn: 'arn:mcp-gw' } } },
+            gateways: { 'http-gw': { gatewayId: 'h', gatewayArn: 'arn:http-gw' } },
+          },
+        },
+      },
+    });
+    const result = await primitive.add({ name: 'p', engine: 'eng', generate: 'Forbid X', gateway: 'http-gw' });
+    expect(result.success).toBe(true);
+    expect(mockStartPolicyGeneration).toHaveBeenCalledWith(expect.objectContaining({ resourceArn: 'arn:http-gw' }));
+  });
+
+  it('errors when the named gateway is not deployed', async () => {
+    mockReadDeployedState.mockResolvedValue({
+      targets: {
+        default: {
+          resources: {
+            ...deployedEngine.resources,
+            mcp: { gateways: { other: { gatewayId: 'o', gatewayArn: 'arn:other' } } },
+          },
+        },
+      },
+    });
+    const result = await primitive.add({ name: 'p', engine: 'eng', generate: 'Forbid X', gateway: 'missing' });
+    expect(result.success).toBe(false);
+    expect(result.success ? '' : result.error.message).toContain('not found in deployed state');
   });
 });

--- a/src/cli/primitives/__tests__/deployed-gateways.test.ts
+++ b/src/cli/primitives/__tests__/deployed-gateways.test.ts
@@ -1,0 +1,30 @@
+import type { TargetDeployedState } from '../../../schema';
+import { mergeDeployedGateways } from '../deployed-gateways';
+import { describe, expect, it } from 'vitest';
+
+const mcpGw = { gatewayId: 'mcp-id', gatewayArn: 'arn:mcp' };
+const httpGw = { gatewayId: 'http-id', gatewayArn: 'arn:http' };
+
+describe('mergeDeployedGateways', () => {
+  it('returns MCP gateways stored under resources.mcp.gateways', () => {
+    const target: TargetDeployedState = { resources: { mcp: { gateways: { 'mcp-gw': mcpGw } } } };
+    expect(mergeDeployedGateways(target)).toEqual({ 'mcp-gw': mcpGw });
+  });
+
+  it('returns HTTP gateways stored under resources.gateways', () => {
+    const target: TargetDeployedState = { resources: { gateways: { 'http-gw': httpGw } } };
+    expect(mergeDeployedGateways(target)).toEqual({ 'http-gw': httpGw });
+  });
+
+  it('merges both locations when MCP and HTTP gateways coexist', () => {
+    const target: TargetDeployedState = {
+      resources: { mcp: { gateways: { 'mcp-gw': mcpGw } }, gateways: { 'http-gw': httpGw } },
+    };
+    expect(mergeDeployedGateways(target)).toEqual({ 'mcp-gw': mcpGw, 'http-gw': httpGw });
+  });
+
+  it('returns an empty record when no gateways are deployed', () => {
+    expect(mergeDeployedGateways({ resources: {} })).toEqual({});
+    expect(mergeDeployedGateways({})).toEqual({});
+  });
+});

--- a/src/cli/primitives/__tests__/deployed-gateways.test.ts
+++ b/src/cli/primitives/__tests__/deployed-gateways.test.ts
@@ -1,5 +1,5 @@
-import type { TargetDeployedState } from '../../../schema';
-import { mergeDeployedGateways } from '../deployed-gateways';
+import type { DeployedState, TargetDeployedState } from '../../../schema';
+import { findDeployedGateway, firstDeployedGateway, mergeDeployedGateways } from '../deployed-gateways';
 import { describe, expect, it } from 'vitest';
 
 const mcpGw = { gatewayId: 'mcp-id', gatewayArn: 'arn:mcp' };
@@ -26,5 +26,39 @@ describe('mergeDeployedGateways', () => {
   it('returns an empty record when no gateways are deployed', () => {
     expect(mergeDeployedGateways({ resources: {} })).toEqual({});
     expect(mergeDeployedGateways({})).toEqual({});
+  });
+});
+
+describe('findDeployedGateway', () => {
+  const state: DeployedState = {
+    targets: {
+      t1: { resources: { mcp: { gateways: { 'mcp-gw': mcpGw } } } },
+      t2: { resources: { gateways: { 'http-gw': httpGw } } },
+    },
+  };
+
+  it('finds a named MCP gateway across targets', () => {
+    expect(findDeployedGateway(state, 'mcp-gw')).toEqual(mcpGw);
+  });
+
+  it('finds a named HTTP gateway across targets', () => {
+    expect(findDeployedGateway(state, 'http-gw')).toEqual(httpGw);
+  });
+
+  it('returns undefined when the named gateway is absent', () => {
+    expect(findDeployedGateway(state, 'missing')).toBeUndefined();
+    expect(findDeployedGateway({ targets: {} }, 'anything')).toBeUndefined();
+  });
+});
+
+describe('firstDeployedGateway', () => {
+  it('returns the first gateway found across targets', () => {
+    const state: DeployedState = { targets: { t1: { resources: { gateways: { 'http-gw': httpGw } } } } };
+    expect(firstDeployedGateway(state)).toEqual(httpGw);
+  });
+
+  it('returns undefined when no gateways are deployed', () => {
+    expect(firstDeployedGateway({ targets: { t1: { resources: {} } } })).toBeUndefined();
+    expect(firstDeployedGateway({ targets: {} })).toBeUndefined();
   });
 });

--- a/src/cli/primitives/deployed-gateways.ts
+++ b/src/cli/primitives/deployed-gateways.ts
@@ -1,0 +1,15 @@
+import type { GatewayDeployedState, TargetDeployedState } from '../../schema';
+
+/**
+ * Resolve every deployed gateway on a target, regardless of where it was stored.
+ *
+ * Deployed state keeps gateways in two locations: MCP gateways under
+ * `resources.mcp.gateways` and HTTP gateways (`protocolType: "None"`) under
+ * `resources.gateways` (see `buildDeployedState` in cloudformation/outputs.ts).
+ * A `??` fallback is wrong here because a project can populate BOTH maps at once,
+ * in which case `??` returns only the MCP map and HTTP gateways disappear. Merging
+ * is the only correct resolution (mirrors status/action.ts).
+ */
+export function mergeDeployedGateways(target: TargetDeployedState): Record<string, GatewayDeployedState> {
+  return { ...(target.resources?.mcp?.gateways ?? {}), ...(target.resources?.gateways ?? {}) };
+}

--- a/src/cli/primitives/deployed-gateways.ts
+++ b/src/cli/primitives/deployed-gateways.ts
@@ -1,4 +1,4 @@
-import type { GatewayDeployedState, TargetDeployedState } from '../../schema';
+import type { DeployedState, GatewayDeployedState, TargetDeployedState } from '../../schema';
 
 /**
  * Resolve every deployed gateway on a target, regardless of where it was stored.
@@ -12,4 +12,22 @@ import type { GatewayDeployedState, TargetDeployedState } from '../../schema';
  */
 export function mergeDeployedGateways(target: TargetDeployedState): Record<string, GatewayDeployedState> {
   return { ...(target.resources?.mcp?.gateways ?? {}), ...(target.resources?.gateways ?? {}) };
+}
+
+/** Find a deployed gateway by name across all targets, searching both storage locations. */
+export function findDeployedGateway(state: DeployedState, name: string): GatewayDeployedState | undefined {
+  for (const target of Object.values(state.targets)) {
+    const gateway = mergeDeployedGateways(target)[name];
+    if (gateway) return gateway;
+  }
+  return undefined;
+}
+
+/** The first deployed gateway across all targets, searching both storage locations. */
+export function firstDeployedGateway(state: DeployedState): GatewayDeployedState | undefined {
+  for (const target of Object.values(state.targets)) {
+    const [gateway] = Object.values(mergeDeployedGateways(target));
+    if (gateway) return gateway;
+  }
+  return undefined;
 }


### PR DESCRIPTION
## Description

`agentcore add policy --generate --gateway <name>` fails with `Gateway "<name>" not found in deployed state` for any **HTTP gateway** (`protocolType: "None"`), even when `agentcore status` confirms the gateway is deployed. The only workaround is `--statement`, which bypasses AI policy generation entirely — defeating the purpose of the flag.

Root cause: deployed state stores gateways in two locations. `buildDeployedState` writes MCP gateways under `resources.mcp.gateways` and HTTP gateways under `resources.gateways` (`src/cli/cloudformation/outputs.ts`, split by `protocolType` in `src/cli/commands/deploy/actions.ts`). The `--generate` path read **only** `resources.mcp.gateways`, so HTTP gateways were invisible to it.

Two sibling sites shared the same root cause via a `??` fallback (`mcp?.gateways ?? gateways`), which is also wrong: when a project has **both** an MCP and an HTTP gateway, `??` resolves to the MCP map only and the HTTP gateway is silently dropped. This affected the policy **form** path and `PolicyEnginePrimitive.getDeployedGateways` (the guardrails HTTP-gateway resolver — where it bites hardest, since that resolver exists specifically to surface HTTP gateways).

## Fix

| Change | Location |
| --- | --- |
| New `mergeDeployedGateways()` helper — merges `resources.mcp.gateways` + `resources.gateways` (mirrors the existing pattern in `status/action.ts`). Plus `findDeployedGateway()` / `firstDeployedGateway()` to resolve by name / pick the first across all targets. | `src/cli/primitives/deployed-gateways.ts` |
| `--generate` path resolves gateways via the helpers (the reported bug) | `src/cli/primitives/PolicyPrimitive.ts` |
| Policy form path resolves gateways via the helpers (latent `??` flaw) | `src/cli/primitives/PolicyPrimitive.ts` |
| Guardrails resolver uses the merge helper (latent `??` flaw) | `src/cli/primitives/PolicyEnginePrimitive.ts` |

A merge (not `??`) is the only correct resolution because both maps can be populated simultaneously. The helpers centralize the logic so this class of bug can't reappear at a fourth call site, and collapse the previously duplicated/over-nested per-target search loops.

## Related Issue

Closes #1658

## Documentation PR

N/A — bug fix; no devguide change required.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [x] If I modified `src/assets/`, I ran `npm run test:update-snapshots` — N/A, no asset changes

**Unit coverage added:**
- `src/cli/primitives/__tests__/deployed-gateways.test.ts` — `mergeDeployedGateways` / `findDeployedGateway` / `firstDeployedGateway` across MCP-only, HTTP-only, both-present, and empty states.
- `src/cli/primitives/__tests__/PolicyPrimitive.test.ts` — `--generate` resolves an MCP gateway, an HTTP gateway (the reported bug), an HTTP gateway when an MCP gateway coexists (the `??`-trap regression), and still errors for a genuinely-missing gateway.

Full unit suite: **5577 passed**. Typecheck, lint, and `npm run build` all clean.

**Real-deploy validation (us-west-2):** deployed a project with both an HTTP gateway (lands under `deployed-state.resources.gateways`) and an MCP gateway (under `resources.mcp.gateways`) plus a policy engine, then exercised every policy-generation path against the live deployed state:

| Scenario | Result |
| --- | --- |
| `--generate --gateway <http-gw>` (the reported bug) | Resolves the HTTP gateway → reaches the live `StartPolicyGeneration` API. Pre-fix build errored `Gateway "<name>" not found in deployed state` here. |
| `--generate --gateway <mcp-gw>` | Resolves → live API (no regression) |
| `--generate` (no `--gateway`, auto-pick) | Resolves first gateway across both maps → live API |
| `--generate --gateway does-not-exist` | Correctly still errors `not found in deployed state` (not a blanket pass) |
| `--form-category contentFilter --gateway <http-gw>` | Writes a Cedar guardrail policy scoped to the **resolved HTTP gateway ARN** |

The form-path proof — the synthesized Cedar embeds the resolved HTTP gateway ARN:
```cedar
forbid (principal, action, resource == AgentCore::Gateway::"arn:…:gateway/…-acfixhttpgw-…")
when guardrails { BedrockGuardrails::ContentFilter(["HATE","VIOLENCE"], [context.input.prompt]).maxConfidenceScore().greaterThan(decimal("0.2")) };
```

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly — N/A, no user-facing doc change
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
