### PR TITLE
fix(templates): give TypeScript templates per-session in-process short-term memory

### DIFF
--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -8121,14 +8121,14 @@ const app = new BedrockAgentCoreApp({
   invocationHandler: {
     async *process(payload: any, context: any) {
       const sessionId = context?.sessionId ?? 'default-session';
-      const messages = getHistory(sessionId);
-      messages.push({ role: 'user', content: payload.prompt ?? '' });
+      const history = getHistory(sessionId);
+      const userMessage: ModelMessage = { role: 'user', content: payload.prompt ?? '' };
 
       const model = await loadModel();
       const result = streamText({
         model,
         system: SYSTEM_PROMPT,
-        messages,
+        messages: [...history, userMessage],
       });
 
       let assistant = '';
@@ -8136,7 +8136,14 @@ const app = new BedrockAgentCoreApp({
         assistant += chunk;
         yield { data: chunk };
       }
-      messages.push({ role: 'assistant', content: assistant });
+
+      // Commit the exchange to history only after a non-empty reply. On a failed
+      // or empty stream the turn is dropped instead of leaving a dangling user
+      // (or empty assistant) message — consecutive same-role or empty-content
+      // messages would otherwise be rejected on the next turn for this session.
+      if (assistant.length > 0) {
+        history.push(userMessage, { role: 'assistant', content: assistant });
+      }
     },
   },
 });

--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -7757,14 +7757,26 @@ const app = new BedrockAgentCoreApp({
         await agent.memoryManager?.flush();
       }
       {{else}}
-      for await (const event of agent.stream(payload.prompt ?? '')) {
-        if (
-          event.type === 'modelStreamUpdateEvent' &&
-          event.event?.type === 'modelContentBlockDeltaEvent' &&
-          event.event.delta?.type === 'textDelta'
-        ) {
-          yield { data: event.event.delta.text };
+      // Snapshot history before streaming so a failed turn can be rolled back.
+      // Agent.stream() appends the user message before invoking the model; on a
+      // mid-stream error that user turn would otherwise linger in the cached
+      // agent, and the next turn for this session would send consecutive user
+      // messages (rejected by providers that require strict role alternation,
+      // e.g. Anthropic). Restoring on error keeps the session reusable.
+      const snapshot = agent.takeSnapshot({ include: ['messages'] });
+      try {
+        for await (const event of agent.stream(payload.prompt ?? '')) {
+          if (
+            event.type === 'modelStreamUpdateEvent' &&
+            event.event?.type === 'modelContentBlockDeltaEvent' &&
+            event.event.delta?.type === 'textDelta'
+          ) {
+            yield { data: event.event.delta.text };
+          }
         }
+      } catch (error) {
+        agent.loadSnapshot(snapshot);
+        throw error;
       }
       {{/if}}
     },

--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -7695,18 +7695,35 @@ async function getOrCreateAgent(sessionId: string, actorId: string): Promise<Age
   return agent;
 }
 {{else}}
-let cachedAgent: Agent | null = null;
+const AGENT_CACHE_LIMIT = 128;
 
-async function getOrCreateAgent(): Promise<Agent> {
-  if (!cachedAgent) {
-    const model = await loadModel();
-    cachedAgent = new Agent({
-      model,
-      systemPrompt: SYSTEM_PROMPT,
-      tools,
-    });
+// Reuses one Agent per sessionId so each session keeps its own in-process
+// conversation history (best-effort; resets on cold start). A Map preserves
+// insertion order, so it doubles as an LRU bounded to 128 sessions — a local
+// dev process serving many sessions cannot leak history between them or grow
+// without bound. On AgentCore Runtime each microVM serves a single session, so
+// this holds one entry. For durable history, attach memory.
+const agentCache = new Map<string, Agent>();
+
+async function getOrCreateAgent(sessionId: string): Promise<Agent> {
+  const existing = agentCache.get(sessionId);
+  if (existing) {
+    agentCache.delete(sessionId);
+    agentCache.set(sessionId, existing);
+    return existing;
   }
-  return cachedAgent;
+  if (agentCache.size >= AGENT_CACHE_LIMIT) {
+    const oldest = agentCache.keys().next().value;
+    if (oldest !== undefined) agentCache.delete(oldest);
+  }
+  const model = await loadModel();
+  const agent = new Agent({
+    model,
+    systemPrompt: SYSTEM_PROMPT,
+    tools,
+  });
+  agentCache.set(sessionId, agent);
+  return agent;
 }
 {{/if}}
 
@@ -7718,7 +7735,8 @@ const app = new BedrockAgentCoreApp({
       const actorId = getActorId(payload, context);
       const agent = await getOrCreateAgent(sessionId, actorId);
       {{else}}
-      const agent = await getOrCreateAgent();
+      const sessionId = context?.sessionId ?? 'default-session';
+      const agent = await getOrCreateAgent(sessionId);
       {{/if}}
 
       {{#if hasMemory}}
@@ -8068,24 +8086,57 @@ Thumbs.db
 
 exports[`Assets Directory Snapshots > TypeScript assets > typescript/typescript/http/vercelai/base/main.ts should match snapshot 1`] = `
 "import { BedrockAgentCoreApp } from 'bedrock-agentcore/runtime';
-import { streamText } from 'ai';
+import { streamText, type ModelMessage } from 'ai';
 import { loadModel } from './model/load.js';
 
 const SYSTEM_PROMPT = \`You are a helpful assistant.\`;
 
+const HISTORY_LIMIT = 128;
+
+// Keeps one message history per sessionId so each session remembers its own
+// turns (best-effort; resets on cold start). A Map preserves insertion order,
+// so it doubles as an LRU bounded to 128 sessions — a local dev process serving
+// many sessions cannot leak history between them or grow without bound. On
+// AgentCore Runtime each microVM serves a single session, so this holds one
+// entry. For durable history, persist messages to an external store.
+const histories = new Map<string, ModelMessage[]>();
+
+function getHistory(sessionId: string): ModelMessage[] {
+  const existing = histories.get(sessionId);
+  if (existing) {
+    histories.delete(sessionId);
+    histories.set(sessionId, existing);
+    return existing;
+  }
+  if (histories.size >= HISTORY_LIMIT) {
+    const oldest = histories.keys().next().value;
+    if (oldest !== undefined) histories.delete(oldest);
+  }
+  const fresh: ModelMessage[] = [];
+  histories.set(sessionId, fresh);
+  return fresh;
+}
+
 const app = new BedrockAgentCoreApp({
   invocationHandler: {
     async *process(payload: any, context: any) {
+      const sessionId = context?.sessionId ?? 'default-session';
+      const messages = getHistory(sessionId);
+      messages.push({ role: 'user', content: payload.prompt ?? '' });
+
       const model = await loadModel();
       const result = streamText({
         model,
         system: SYSTEM_PROMPT,
-        prompt: payload.prompt ?? '',
+        messages,
       });
 
+      let assistant = '';
       for await (const chunk of result.textStream) {
+        assistant += chunk;
         yield { data: chunk };
       }
+      messages.push({ role: 'assistant', content: assistant });
     },
   },
 });

--- a/src/assets/typescript/http/strands/base/main.ts
+++ b/src/assets/typescript/http/strands/base/main.ts
@@ -115,14 +115,26 @@ const app = new BedrockAgentCoreApp({
         await agent.memoryManager?.flush();
       }
       {{else}}
-      for await (const event of agent.stream(payload.prompt ?? '')) {
-        if (
-          event.type === 'modelStreamUpdateEvent' &&
-          event.event?.type === 'modelContentBlockDeltaEvent' &&
-          event.event.delta?.type === 'textDelta'
-        ) {
-          yield { data: event.event.delta.text };
+      // Snapshot history before streaming so a failed turn can be rolled back.
+      // Agent.stream() appends the user message before invoking the model; on a
+      // mid-stream error that user turn would otherwise linger in the cached
+      // agent, and the next turn for this session would send consecutive user
+      // messages (rejected by providers that require strict role alternation,
+      // e.g. Anthropic). Restoring on error keeps the session reusable.
+      const snapshot = agent.takeSnapshot({ include: ['messages'] });
+      try {
+        for await (const event of agent.stream(payload.prompt ?? '')) {
+          if (
+            event.type === 'modelStreamUpdateEvent' &&
+            event.event?.type === 'modelContentBlockDeltaEvent' &&
+            event.event.delta?.type === 'textDelta'
+          ) {
+            yield { data: event.event.delta.text };
+          }
         }
+      } catch (error) {
+        agent.loadSnapshot(snapshot);
+        throw error;
       }
       {{/if}}
     },

--- a/src/assets/typescript/http/strands/base/main.ts
+++ b/src/assets/typescript/http/strands/base/main.ts
@@ -53,18 +53,35 @@ async function getOrCreateAgent(sessionId: string, actorId: string): Promise<Age
   return agent;
 }
 {{else}}
-let cachedAgent: Agent | null = null;
+const AGENT_CACHE_LIMIT = 128;
 
-async function getOrCreateAgent(): Promise<Agent> {
-  if (!cachedAgent) {
-    const model = await loadModel();
-    cachedAgent = new Agent({
-      model,
-      systemPrompt: SYSTEM_PROMPT,
-      tools,
-    });
+// Reuses one Agent per sessionId so each session keeps its own in-process
+// conversation history (best-effort; resets on cold start). A Map preserves
+// insertion order, so it doubles as an LRU bounded to 128 sessions — a local
+// dev process serving many sessions cannot leak history between them or grow
+// without bound. On AgentCore Runtime each microVM serves a single session, so
+// this holds one entry. For durable history, attach memory.
+const agentCache = new Map<string, Agent>();
+
+async function getOrCreateAgent(sessionId: string): Promise<Agent> {
+  const existing = agentCache.get(sessionId);
+  if (existing) {
+    agentCache.delete(sessionId);
+    agentCache.set(sessionId, existing);
+    return existing;
   }
-  return cachedAgent;
+  if (agentCache.size >= AGENT_CACHE_LIMIT) {
+    const oldest = agentCache.keys().next().value;
+    if (oldest !== undefined) agentCache.delete(oldest);
+  }
+  const model = await loadModel();
+  const agent = new Agent({
+    model,
+    systemPrompt: SYSTEM_PROMPT,
+    tools,
+  });
+  agentCache.set(sessionId, agent);
+  return agent;
 }
 {{/if}}
 
@@ -76,7 +93,8 @@ const app = new BedrockAgentCoreApp({
       const actorId = getActorId(payload, context);
       const agent = await getOrCreateAgent(sessionId, actorId);
       {{else}}
-      const agent = await getOrCreateAgent();
+      const sessionId = context?.sessionId ?? 'default-session';
+      const agent = await getOrCreateAgent(sessionId);
       {{/if}}
 
       {{#if hasMemory}}

--- a/src/assets/typescript/http/vercelai/base/main.ts
+++ b/src/assets/typescript/http/vercelai/base/main.ts
@@ -1,22 +1,55 @@
 import { BedrockAgentCoreApp } from 'bedrock-agentcore/runtime';
-import { streamText } from 'ai';
+import { streamText, type ModelMessage } from 'ai';
 import { loadModel } from './model/load.js';
 
 const SYSTEM_PROMPT = `You are a helpful assistant.`;
 
+const HISTORY_LIMIT = 128;
+
+// Keeps one message history per sessionId so each session remembers its own
+// turns (best-effort; resets on cold start). A Map preserves insertion order,
+// so it doubles as an LRU bounded to 128 sessions — a local dev process serving
+// many sessions cannot leak history between them or grow without bound. On
+// AgentCore Runtime each microVM serves a single session, so this holds one
+// entry. For durable history, persist messages to an external store.
+const histories = new Map<string, ModelMessage[]>();
+
+function getHistory(sessionId: string): ModelMessage[] {
+  const existing = histories.get(sessionId);
+  if (existing) {
+    histories.delete(sessionId);
+    histories.set(sessionId, existing);
+    return existing;
+  }
+  if (histories.size >= HISTORY_LIMIT) {
+    const oldest = histories.keys().next().value;
+    if (oldest !== undefined) histories.delete(oldest);
+  }
+  const fresh: ModelMessage[] = [];
+  histories.set(sessionId, fresh);
+  return fresh;
+}
+
 const app = new BedrockAgentCoreApp({
   invocationHandler: {
     async *process(payload: any, context: any) {
+      const sessionId = context?.sessionId ?? 'default-session';
+      const messages = getHistory(sessionId);
+      messages.push({ role: 'user', content: payload.prompt ?? '' });
+
       const model = await loadModel();
       const result = streamText({
         model,
         system: SYSTEM_PROMPT,
-        prompt: payload.prompt ?? '',
+        messages,
       });
 
+      let assistant = '';
       for await (const chunk of result.textStream) {
+        assistant += chunk;
         yield { data: chunk };
       }
+      messages.push({ role: 'assistant', content: assistant });
     },
   },
 });

--- a/src/assets/typescript/http/vercelai/base/main.ts
+++ b/src/assets/typescript/http/vercelai/base/main.ts
@@ -34,14 +34,14 @@ const app = new BedrockAgentCoreApp({
   invocationHandler: {
     async *process(payload: any, context: any) {
       const sessionId = context?.sessionId ?? 'default-session';
-      const messages = getHistory(sessionId);
-      messages.push({ role: 'user', content: payload.prompt ?? '' });
+      const history = getHistory(sessionId);
+      const userMessage: ModelMessage = { role: 'user', content: payload.prompt ?? '' };
 
       const model = await loadModel();
       const result = streamText({
         model,
         system: SYSTEM_PROMPT,
-        messages,
+        messages: [...history, userMessage],
       });
 
       let assistant = '';
@@ -49,7 +49,14 @@ const app = new BedrockAgentCoreApp({
         assistant += chunk;
         yield { data: chunk };
       }
-      messages.push({ role: 'assistant', content: assistant });
+
+      // Commit the exchange to history only after a non-empty reply. On a failed
+      // or empty stream the turn is dropped instead of leaving a dangling user
+      // (or empty assistant) message — consecutive same-role or empty-content
+      // messages would otherwise be rejected on the next turn for this session.
+      if (assistant.length > 0) {
+        history.push(userMessage, { role: 'assistant', content: assistant });
+      }
     },
   },
 });


### PR DESCRIPTION
## Description

The TypeScript agent templates did not provide correct per-session **short-term memory** — in-process, turn-to-turn conversation recall, which is distinct from the AgentCore Memory *service*.

**Strands (`memory: none`)** cached a single global `Agent`, so a process serving more than one session shared one conversation history across all of them. On AgentCore Runtime the 1:1 session→microVM model masks this, but in `agentcore dev` (one Node process, many sessions) it caused cross-session history bleed and unbounded growth. Reproduced: session A sets "favorite color is teal"; a different session B then asks and is told "teal".

**VercelAI** called `streamText({ prompt })` with no history, so it could not recall earlier turns even within a single session.

This change keys each template's in-process history by `sessionId`, bounded by an insertion-ordered `Map` acting as an LRU(128) — mirroring the Python templates. On AgentCore Runtime each microVM serves a single session, so this holds one entry; the bound only matters for many-session processes such as local dev. No AWS service is provisioned: this is free, best-effort short-term memory that resets on cold start. The `longAndShortTerm` (memory-service) Strands branch is unchanged.

A prior change had disabled TypeScript memory because the Strands TS SDK lacked the AgentCore Memory *session manager*; that correctly removed the durable service integration but also removed the free in-process continuity, which never needed the session manager. This restores it.

## Related Issue

Closes #1665

## Documentation PR

N/A — templates are self-documenting via inline comments; no user-facing docs change.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [x] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

Additionally, both templates were rendered, type-checked (`tsc --noEmit`), and exercised end-to-end against deployed AgentCore Runtime and a local server (account-isolated test account):

- Same `sessionId` across two turns → second turn recalls the first (Strands and VercelAI).
- Two distinct `sessionId`s in one process → histories stay isolated (the bleed is gone).
- Deployed Strands runtime regression → same-`--session-id` recall still works.

> Note on `test:integ`: the unit suite (5454 tests) and the asset snapshot suite pass. Integration tests that require provisioned AWS infra were not run locally; the behavioral change was instead validated by the real-deploy exercises above.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
