### PR TITLE
fix(tui): validate empty input in SecretInput before triggering cancel

### DIFF
--- a/src/cli/tui/components/SecretInput.tsx
+++ b/src/cli/tui/components/SecretInput.tsx
@@ -38,14 +38,14 @@ export interface SecretInputProps {
 }
 
 function validateValue(value: string, schema?: ZodString, customValidation?: CustomValidation): string | undefined {
-  if (!value) return undefined;
-
   if (customValidation) {
     const result = customValidation(value);
     if (result !== true) {
       return result;
     }
   }
+
+  if (!value) return undefined;
 
   if (schema) {
     const parseResult = schema.safeParse(value);
@@ -89,6 +89,11 @@ export function SecretInput({
     onSubmit: val => {
       const trimmed = val.trim();
       if (!trimmed) {
+        const validationError = validateValue(trimmed, schema, customValidation);
+        if (validationError) {
+          setShowError(true);
+          return;
+        }
         if (onSkip) {
           onSkip();
         } else {

--- a/src/cli/tui/components/__tests__/SecretInput.test.tsx
+++ b/src/cli/tui/components/__tests__/SecretInput.test.tsx
@@ -150,6 +150,23 @@ describe('SecretInput', () => {
     expect(onCancel).toHaveBeenCalledTimes(1);
   });
 
+  it('shows validation error instead of calling onCancel when customValidation rejects empty value', async () => {
+    const onCancel = vi.fn();
+    const onSubmit = vi.fn();
+    const customValidation = (val: string) => val.trim().length > 0 || 'API key is required';
+    const { lastFrame, stdin } = render(
+      <SecretInput prompt="API Key" customValidation={customValidation} onSubmit={onSubmit} onCancel={onCancel} />
+    );
+
+    await delay();
+    stdin.write(ENTER);
+    await delay();
+
+    expect(onCancel).not.toHaveBeenCalled();
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(lastFrame()).toContain('API key is required');
+  });
+
   it('shows skip hint when onSkip is provided', () => {
     const { lastFrame } = render(<SecretInput prompt="Key" onSubmit={vi.fn()} onCancel={vi.fn()} onSkip={vi.fn()} />);
 


### PR DESCRIPTION
This PR fixes the "add credential" TUI flow going back to the previous step when pressing Enter with no API key input

Fixes #1618