### PR TITLE
fix(ci): prevent script injection in GitHub Actions workflows

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -28,18 +28,21 @@ jobs:
     steps:
       - name: Check authorization
         id: check
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          AUTHORIZED_USERS: ${{ secrets.AUTHORIZED_USERS }}
+          GITHUB_ACTOR: ${{ github.actor }}
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             echo "✅ Manual workflow dispatch — authorized"
             echo "is_authorized=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          AUTHORIZED_USERS="${{ secrets.AUTHORIZED_USERS }}"
-          if [[ ",$AUTHORIZED_USERS," == *",${{ github.actor }},"* ]]; then
-            echo "✅ User ${{ github.actor }} is authorized"
+          if [[ ",$AUTHORIZED_USERS," == *",${GITHUB_ACTOR},"* ]]; then
+            echo "✅ User ${GITHUB_ACTOR} is authorized"
             echo "is_authorized=true" >> "$GITHUB_OUTPUT"
           else
-            echo "⏭️ User ${{ github.actor }} is not in AUTHORIZED_USERS — skipping E2E tests."
+            echo "⏭️ User ${GITHUB_ACTOR} is not in AUTHORIZED_USERS — skipping E2E tests."
             echo "ℹ️ External contributors: ask a maintainer to run the E2E tests manually via workflow_dispatch."
             echo "is_authorized=false" >> "$GITHUB_OUTPUT"
           fi
@@ -91,10 +94,11 @@ jobs:
       # Clone CDK repo for bundle script (requires App token for private repo access)
       - name: Clone CDK repo
         run: |
-          CDK_BRANCH="${{ inputs.cdk_branch || 'main' }}"
+          CDK_BRANCH="${INPUT_CDK_BRANCH:-main}"
           echo "Cloning CDK from branch: $CDK_BRANCH"
           git clone --depth 1 --branch "$CDK_BRANCH" "https://x-access-token:${CDK_REPO_TOKEN}@github.com/${CDK_REPO}.git" /tmp/cdk-repo
         env:
+          INPUT_CDK_BRANCH: ${{ inputs.cdk_branch }}
           CDK_REPO_TOKEN: ${{ steps.app-token.outputs.token }}
           CDK_REPO: ${{ secrets.CDK_REPO_NAME }}
 
@@ -113,8 +117,9 @@ jobs:
 
       - name: Detect changed e2e test files
         id: changed
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || 'HEAD~1' }}
         run: |
-          BASE_SHA=${{ github.event.pull_request.base.sha || 'HEAD~1' }}
           # If any helper file changed, run all e2e tests
           HELPERS_CHANGED=$(git diff --name-only "$BASE_SHA"..HEAD -- 'e2e-tests/*.ts' \
             | grep -v '\.test\.ts$' | head -1)
@@ -160,9 +165,11 @@ jobs:
           CDP_API_KEY_ID: ${{ env.E2E_CDP_API_KEY_ID }}
           CDP_API_KEY_SECRET: ${{ env.E2E_CDP_API_KEY_SECRET }}
           CDP_WALLET_SECRET: ${{ env.E2E_CDP_WALLET_SECRET }}
+          GA_EXTRA: ${{ steps.changed.outputs.ga_extra }}
+        # GA_EXTRA is a space-separated test-file list; left unquoted intentionally so it word-splits into vitest args.
         run:
-          npx vitest run --project e2e e2e-tests/strands-bedrock.test.ts e2e-tests/payment-strands-bedrock.test.ts ${{
-          steps.changed.outputs.ga_extra }}
+          npx vitest run --project e2e e2e-tests/strands-bedrock.test.ts e2e-tests/payment-strands-bedrock.test.ts
+          $GA_EXTRA
 
       - name: Run E2E tests (harness)
         env:
@@ -175,4 +182,6 @@ jobs:
           E2E_S3_ACCESS_POINT_ARN: ${{ env.E2E_S3_ACCESS_POINT_ARN }}
           E2E_FILESYSTEM_SUBNET_ID: ${{ env.E2E_FILESYSTEM_SUBNET_ID }}
           E2E_FILESYSTEM_SECURITY_GROUP_ID: ${{ env.E2E_FILESYSTEM_SECURITY_GROUP_ID }}
-        run: npx vitest run --project e2e e2e-tests/harness-bedrock.test.ts ${{ steps.changed.outputs.harness_extra }}
+          HARNESS_EXTRA: ${{ steps.changed.outputs.harness_extra }}
+        # HARNESS_EXTRA is a space-separated test-file list; left unquoted intentionally so it word-splits into vitest args.
+        run: npx vitest run --project e2e e2e-tests/harness-bedrock.test.ts $HARNESS_EXTRA

--- a/.github/workflows/pr-ai-review.yml
+++ b/.github/workflows/pr-ai-review.yml
@@ -75,25 +75,32 @@ jobs:
     steps:
       - name: Determine PR URL
         id: pr-url
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_PR_URL: ${{ inputs.pr_url }}
+          PR_HTML_URL: ${{ github.event.pull_request.html_url }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "url=${{ inputs.pr_url }}" >> "$GITHUB_OUTPUT"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "url=$INPUT_PR_URL" >> "$GITHUB_OUTPUT"
           else
-            echo "url=${{ github.event.pull_request.html_url }}" >> "$GITHUB_OUTPUT"
+            echo "url=$PR_HTML_URL" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Extract PR number
         id: pr-number
+        env:
+          PR_URL: ${{ steps.pr-url.outputs.url }}
         run: |
-          PR_URL="${{ steps.pr-url.outputs.url }}"
           PR_NUM="${PR_URL##*/}"
           echo "number=$PR_NUM" >> "$GITHUB_OUTPUT"
 
       - name: Add agentcore-harness-reviewing label
         uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ steps.pr-number.outputs.number }}
         with:
           script: |
-            const prNumber = parseInt('${{ steps.pr-number.outputs.number }}');
+            const prNumber = parseInt(process.env.PR_NUMBER);
             try {
               await github.rest.issues.getLabel({
                 owner: context.repo.owner,
@@ -147,9 +154,11 @@ jobs:
       - name: Remove agentcore-harness-reviewing label
         if: always()
         uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ steps.pr-number.outputs.number }}
         with:
           script: |
-            const prNumber = parseInt('${{ steps.pr-number.outputs.number }}');
+            const prNumber = parseInt(process.env.PR_NUMBER);
             try {
               await github.rest.issues.removeLabel({
                 owner: context.repo.owner,

--- a/.github/workflows/pr-tarball.yml
+++ b/.github/workflows/pr-tarball.yml
@@ -15,13 +15,15 @@ jobs:
     steps:
       - name: Check authorization
         id: check
+        env:
+          AUTHORIZED_USERS: ${{ secrets.AUTHORIZED_USERS }}
+          GITHUB_ACTOR: ${{ github.actor }}
         run: |
-          AUTHORIZED_USERS="${{ secrets.AUTHORIZED_USERS }}"
-          if [[ ",$AUTHORIZED_USERS," == *",${{ github.actor }},"* ]]; then
-            echo "✅ User ${{ github.actor }} is authorized"
+          if [[ ",$AUTHORIZED_USERS," == *",${GITHUB_ACTOR},"* ]]; then
+            echo "✅ User ${GITHUB_ACTOR} is authorized"
             echo "is_authorized=true" >> "$GITHUB_OUTPUT"
           else
-            echo "⏭️ User ${{ github.actor }} is not in AUTHORIZED_USERS — skipping."
+            echo "⏭️ User ${GITHUB_ACTOR} is not in AUTHORIZED_USERS — skipping."
             echo "is_authorized=false" >> "$GITHUB_OUTPUT"
           fi
 
@@ -62,6 +64,8 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           TARBALL_NAME: ${{ steps.tarball.outputs.name }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           TAG="pr-${PR_NUMBER}-tarball"
 
@@ -74,9 +78,9 @@ jobs:
             --title "PR #${PR_NUMBER} Tarball" \
             --notes "Auto-generated tarball for PR #${PR_NUMBER}." \
             --draft \
-            --target "${{ github.event.pull_request.head.sha }}"
+            --target "$HEAD_SHA"
 
-          DOWNLOAD_URL="https://github.com/${{ github.repository }}/releases/download/${TAG}/${TARBALL_NAME}"
+          DOWNLOAD_URL="https://github.com/${REPOSITORY}/releases/download/${TAG}/${TARBALL_NAME}"
           echo "url=$DOWNLOAD_URL" >> $GITHUB_OUTPUT
       - name: Comment on PR
         uses: marocchino/sticky-pull-request-comment@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,10 +39,10 @@ jobs:
     steps:
       - name: Determine release metadata
         id: release-meta
+        env:
+          BRANCH_NAME: ${{ github.ref_name }}
+          VERSION_BUMP: ${{ github.event.inputs.bump_type }}
         run: |
-          BRANCH_NAME="${{ github.ref_name }}"
-          VERSION_BUMP="${{ github.event.inputs.bump_type }}"
-
           if [[ "$BRANCH_NAME" == "main" ]]; then
             echo "dist_tag=latest" >> $GITHUB_OUTPUT
             echo "base_branch=main" >> $GITHUB_OUTPUT
@@ -314,8 +314,10 @@ jobs:
           fetch-depth: 0
 
       - name: Verify we have the merged code
+        env:
+          BASE_BRANCH: ${{ needs.prepare-release.outputs.base_branch }}
         run: |
-          echo "Branch: ${{ needs.prepare-release.outputs.base_branch }}"
+          echo "Branch: $BASE_BRANCH"
           echo "Current version in package.json:"
           cat package.json | grep '"version"'
           echo ""


### PR DESCRIPTION
## Description

Hardens our GitHub Actions workflows against **script injection** (the AppSec/ACAT "Script Injection in GitHub Actions workflows" finding class).

Several `run:` and `actions/github-script` steps interpolated GitHub context values directly into the script body via `${{ … }}`. Because the Actions runner performs that substitution *before* the shell/JS sees the line, any attacker-controlled event data lands as executable code. The most sensitive cases here run under `pull_request_target` (so they execute with repo secrets + a write token against untrusted PR content).

The fix follows GitHub's recommended pattern: bind each expression to an `env:` variable and reference the **shell/JS** variable instead. `env:` assignments are not an injection vector. No behavior changes.

### Files & what changed
- **pr-ai-review.yml** — `Determine PR URL` / `Extract PR number` steps now read `inputs.pr_url`, `github.event.pull_request.html_url`, `github.event_name` from `env:`; both `github-script` steps read the PR number via `process.env.PR_NUMBER`.
- **e2e-tests.yml** — authorization check (`github.actor`, `secrets.AUTHORIZED_USERS`), CDK clone branch (`inputs.cdk_branch`), changed-file detection (`github.event.pull_request.base.sha`), and both `vitest` runs (diff-derived `*_extra` test-file lists) now flow through `env:`. The `*_EXTRA` vars are intentionally left unquoted so they still word-split into vitest args.
- **pr-tarball.yml** — authorization check and the release step's `github.event.pull_request.head.sha` / `github.repository` now flow through `env:`.
- **release.yml** — `Determine release metadata` (`github.ref_name`, `github.event.inputs.bump_type`) and `Verify we have the merged code` (`needs.*.outputs.base_branch`) now flow through `env:`.

## Type of Change

- [x] Bug fix (security hardening)

## Testing

These are CI workflow files; changes are mechanical (context → `env:` var) and preserve existing behavior. Validated by:
- [x] YAML parses cleanly for all four workflows
- [x] Verified no `${{ }}` expressions remain inside any `run:`/`script:` body across the four files

## Checklist

- [x] My changes generate no new warnings
- [x] No source/asset changes (workflow-only), so no snapshot updates needed
