### PR TITLE
fix(e2e): reap stale OAuth2 credential providers alongside API key providers

### DIFF
--- a/e2e-tests/global-setup.ts
+++ b/e2e-tests/global-setup.ts
@@ -1,7 +1,4 @@
-import {
-  cleanupStaleCredentialProviders,
-  cleanupStaleOAuth2CredentialProviders,
-} from './utils/credential-provider-cleanup';
+import { cleanupStaleCredentialProviders } from './utils/credential-provider-cleanup';
 import { getLogger } from './utils/logger';
 import { cleanupStaleRecommendations } from './utils/recommendation-cleanup';
 import { cleanUpOldStacks } from './utils/stack-cleanup';
@@ -48,21 +45,6 @@ export default async function setup(_project: TestProject): Promise<() => void> 
   } catch (e) {
     logger.error(String(e));
     logger.warn(`failed to clean up all credential providers`);
-  }
-
-  // OAuth2 providers are a separate resource type with their own List/Delete APIs — they do
-  // NOT show up in ListApiKeyCredentialProviders, so the reaper above can't touch them. The
-  // CUSTOM_JWT harness test leaks `<name>-oauth` providers (created outside the CFN stack), so
-  // reap them here too or the account's 50-provider OAuth2 quota fills up and CUSTOM_JWT deploys fail.
-  logger.info(`cleaning up stale OAuth2 credential providers...`);
-  try {
-    await cleanupStaleOAuth2CredentialProviders(bedrockCPClient, logger.child('oauth2-credential-provider-cleanup'), {
-      minAgeMs: 30 * 60 * 1000,
-      prefix: 'E2e',
-    });
-  } catch (e) {
-    logger.error(String(e));
-    logger.warn(`failed to clean up all OAuth2 credential providers`);
   } finally {
     bedrockCPClient.destroy();
   }

--- a/e2e-tests/global-setup.ts
+++ b/e2e-tests/global-setup.ts
@@ -1,4 +1,7 @@
-import { cleanupStaleCredentialProviders } from './utils/credential-provider-cleanup';
+import {
+  cleanupStaleCredentialProviders,
+  cleanupStaleOAuth2CredentialProviders,
+} from './utils/credential-provider-cleanup';
 import { getLogger } from './utils/logger';
 import { cleanupStaleRecommendations } from './utils/recommendation-cleanup';
 import { cleanUpOldStacks } from './utils/stack-cleanup';
@@ -45,6 +48,21 @@ export default async function setup(_project: TestProject): Promise<() => void> 
   } catch (e) {
     logger.error(String(e));
     logger.warn(`failed to clean up all credential providers`);
+  }
+
+  // OAuth2 providers are a separate resource type with their own List/Delete APIs — they do
+  // NOT show up in ListApiKeyCredentialProviders, so the reaper above can't touch them. The
+  // CUSTOM_JWT harness test leaks `<name>-oauth` providers (created outside the CFN stack), so
+  // reap them here too or the account's 50-provider OAuth2 quota fills up and CUSTOM_JWT deploys fail.
+  logger.info(`cleaning up stale OAuth2 credential providers...`);
+  try {
+    await cleanupStaleOAuth2CredentialProviders(bedrockCPClient, logger.child('oauth2-credential-provider-cleanup'), {
+      minAgeMs: 30 * 60 * 1000,
+      prefix: 'E2e',
+    });
+  } catch (e) {
+    logger.error(String(e));
+    logger.warn(`failed to clean up all OAuth2 credential providers`);
   } finally {
     bedrockCPClient.destroy();
   }

--- a/e2e-tests/utils/credential-provider-cleanup.ts
+++ b/e2e-tests/utils/credential-provider-cleanup.ts
@@ -2,7 +2,9 @@ import type { Logger } from './logger';
 import {
   BedrockAgentCoreControlClient,
   DeleteApiKeyCredentialProviderCommand,
+  DeleteOauth2CredentialProviderCommand,
   ListApiKeyCredentialProvidersCommand,
+  ListOauth2CredentialProvidersCommand,
 } from '@aws-sdk/client-bedrock-agentcore-control';
 
 export async function deleteCredentialProvider(
@@ -16,6 +18,20 @@ export async function deleteCredentialProvider(
   } catch (error) {
     const err = error as Error;
     logger.warn(`Failed to delete credential provider ${name}: ${err.name}:${err.message}`);
+  }
+}
+
+export async function deleteOAuth2CredentialProvider(
+  client: BedrockAgentCoreControlClient,
+  logger: Logger,
+  name: string
+): Promise<void> {
+  try {
+    await client.send(new DeleteOauth2CredentialProviderCommand({ name }));
+    logger.info(`Deleted OAuth2 credential provider: ${name}`);
+  } catch (error) {
+    const err = error as Error;
+    logger.warn(`Failed to delete OAuth2 credential provider ${name}: ${err.name}:${err.message}`);
   }
 }
 
@@ -36,6 +52,39 @@ export async function cleanupStaleCredentialProviders(
     const stale = providers.filter(p => p.name?.startsWith(options.prefix) && p.createdTime && p.createdTime < cutoff);
 
     await Promise.all(stale.map(p => deleteCredentialProvider(client, logger, p.name!)));
+
+    nextToken = response.nextToken;
+  } while (nextToken);
+}
+
+/**
+ * Delete stale OAuth2 credential providers matching `prefix` and older than `minAgeMs`.
+ *
+ * OAuth2 providers are a distinct resource type from API key providers — they have their
+ * own List/Delete APIs and do NOT appear in ListApiKeyCredentialProviders. So
+ * `cleanupStaleCredentialProviders` (which lists only API key providers) can never reap
+ * them. The CUSTOM_JWT harness e2e test registers a managed OAuth2 provider (`<name>-oauth`)
+ * that is created outside the CloudFormation stack, so teardown leaves it behind. Without
+ * this reaper they accumulate against the account's 50-provider OAuth2 quota (L-431051DC)
+ * until every CUSTOM_JWT deploy fails with a limit-reached error.
+ */
+export async function cleanupStaleOAuth2CredentialProviders(
+  client: BedrockAgentCoreControlClient,
+  logger: Logger,
+  options: {
+    minAgeMs: number;
+    prefix: string;
+  }
+): Promise<void> {
+  const cutoff = new Date(Date.now() - options.minAgeMs);
+
+  let nextToken: string | undefined;
+  do {
+    const response = await client.send(new ListOauth2CredentialProvidersCommand({ nextToken }));
+    const providers = response.credentialProviders ?? [];
+    const stale = providers.filter(p => p.name?.startsWith(options.prefix) && p.createdTime && p.createdTime < cutoff);
+
+    await Promise.all(stale.map(p => deleteOAuth2CredentialProvider(client, logger, p.name!)));
 
     nextToken = response.nextToken;
   } while (nextToken);

--- a/e2e-tests/utils/credential-provider-cleanup.ts
+++ b/e2e-tests/utils/credential-provider-cleanup.ts
@@ -35,6 +35,17 @@ export async function deleteOAuth2CredentialProvider(
   }
 }
 
+/**
+ * Delete stale credential providers matching `prefix` and older than `minAgeMs`.
+ *
+ * Reaps BOTH provider types the e2e suite creates: API key providers and OAuth2 providers.
+ * These are distinct resource types with separate List/Delete APIs — an OAuth2 provider does
+ * NOT appear in ListApiKeyCredentialProviders — so both lists must be walked. The CUSTOM_JWT
+ * harness test registers a managed OAuth2 provider (`<name>-oauth`) created outside the
+ * CloudFormation stack, so teardown leaves it behind; without reaping it here, they accumulate
+ * against the account's 50-provider OAuth2 quota (L-431051DC) until every CUSTOM_JWT deploy
+ * fails with a limit-reached error.
+ */
 export async function cleanupStaleCredentialProviders(
   client: BedrockAgentCoreControlClient,
   logger: Logger,
@@ -44,48 +55,22 @@ export async function cleanupStaleCredentialProviders(
   }
 ): Promise<void> {
   const cutoff = new Date(Date.now() - options.minAgeMs);
+  const isStale = (p: { name?: string; createdTime?: Date }): boolean =>
+    !!p.name?.startsWith(options.prefix) && !!p.createdTime && p.createdTime < cutoff;
 
-  let nextToken: string | undefined;
+  let apiKeyNextToken: string | undefined;
   do {
-    const response = await client.send(new ListApiKeyCredentialProvidersCommand({ nextToken }));
-    const providers = response.credentialProviders ?? [];
-    const stale = providers.filter(p => p.name?.startsWith(options.prefix) && p.createdTime && p.createdTime < cutoff);
-
+    const response = await client.send(new ListApiKeyCredentialProvidersCommand({ nextToken: apiKeyNextToken }));
+    const stale = (response.credentialProviders ?? []).filter(isStale);
     await Promise.all(stale.map(p => deleteCredentialProvider(client, logger, p.name!)));
+    apiKeyNextToken = response.nextToken;
+  } while (apiKeyNextToken);
 
-    nextToken = response.nextToken;
-  } while (nextToken);
-}
-
-/**
- * Delete stale OAuth2 credential providers matching `prefix` and older than `minAgeMs`.
- *
- * OAuth2 providers are a distinct resource type from API key providers — they have their
- * own List/Delete APIs and do NOT appear in ListApiKeyCredentialProviders. So
- * `cleanupStaleCredentialProviders` (which lists only API key providers) can never reap
- * them. The CUSTOM_JWT harness e2e test registers a managed OAuth2 provider (`<name>-oauth`)
- * that is created outside the CloudFormation stack, so teardown leaves it behind. Without
- * this reaper they accumulate against the account's 50-provider OAuth2 quota (L-431051DC)
- * until every CUSTOM_JWT deploy fails with a limit-reached error.
- */
-export async function cleanupStaleOAuth2CredentialProviders(
-  client: BedrockAgentCoreControlClient,
-  logger: Logger,
-  options: {
-    minAgeMs: number;
-    prefix: string;
-  }
-): Promise<void> {
-  const cutoff = new Date(Date.now() - options.minAgeMs);
-
-  let nextToken: string | undefined;
+  let oauth2NextToken: string | undefined;
   do {
-    const response = await client.send(new ListOauth2CredentialProvidersCommand({ nextToken }));
-    const providers = response.credentialProviders ?? [];
-    const stale = providers.filter(p => p.name?.startsWith(options.prefix) && p.createdTime && p.createdTime < cutoff);
-
+    const response = await client.send(new ListOauth2CredentialProvidersCommand({ nextToken: oauth2NextToken }));
+    const stale = (response.credentialProviders ?? []).filter(isStale);
     await Promise.all(stale.map(p => deleteOAuth2CredentialProvider(client, logger, p.name!)));
-
-    nextToken = response.nextToken;
-  } while (nextToken);
+    oauth2NextToken = response.nextToken;
+  } while (oauth2NextToken);
 }


### PR DESCRIPTION
## Description

The E2E suite's `globalSetup` reaps stale credential providers before each run via `cleanupStaleCredentialProviders`, but it only walked the **API key** list. **OAuth2 credential providers are a separate resource type** with their own List/Delete APIs — they do **not** appear in `ListApiKeyCredentialProviders` — so they were never reaped.

The CUSTOM_JWT harness test (`harness-custom-jwt.test.ts`) registers a managed OAuth2 provider named `<harness>-oauth`, created imperatively outside the CloudFormation stack. Stack teardown doesn't remove it and nothing else reaped it, so every run leaked one `E2eHrnsJwt<ts>-oauth` provider. These accumulate against the account's **50-provider** OAuth2 quota (`L-431051DC`). Once full, every CUSTOM_JWT deploy fails with:

```
The number of agent identity Oauth2 credential providers in this account has reached its limit
```

which fails the `E2E Tests (Full Suite)` CUSTOM_JWT shard (the account was at exactly 50/50, all `E2eHrnsJwt*-oauth`).

This is a **test-infra** fix. (The underlying CLI-side leak — the CLI orphaning providers it creates on teardown, which affects real users too — is addressed separately in #1675.)

### Changes

Single-file change in `e2e-tests/utils/credential-provider-cleanup.ts`:

- `cleanupStaleCredentialProviders` now reaps **both** provider types in one call — it walks the API key list *and* the OAuth2 list (`ListOauth2CredentialProvidersCommand` / `DeleteOauth2CredentialProviderCommand`). Splitting cleanup by resource type is exactly what let OAuth2 providers go unreaped; from the caller's view "reap stale credential providers" is one job, so it's one function.
- Adds a `deleteOAuth2CredentialProvider` helper (mirrors the existing `deleteCredentialProvider`).

`globalSetup` is unchanged — it already calls `cleanupStaleCredentialProviders`, which now covers OAuth2 too.

## Related Issue

Closes #1674

## Documentation PR

N/A — internal E2E test infrastructure only.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

Additional verification (live, against the E2E account):
- Confirmed OAuth2 providers do **not** appear in `ListApiKeyCredentialProviders` (only in `ListOauth2CredentialProviders`), proving the old single-list cleanup could never reap them.
- Seeded one `E2e`-prefixed API key provider and one OAuth2 provider, ran the unified `cleanupStaleCredentialProviders`, and confirmed it deleted **both** (`Deleted credential provider: ...` + `Deleted OAuth2 credential provider: ...`), leaving none behind.
- Manually reaped the 5 leaked `E2eHrnsJwt*-oauth` providers to unblock the suite immediately.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
