### PR TITLE
feat(run): add --kms-key flag to run insights for KMS parity

### DIFF
--- a/src/cli/commands/run/command.tsx
+++ b/src/cli/commands/run/command.tsx
@@ -376,6 +376,7 @@ export const registerRun = (program: Command) => {
     .option('--wait', 'Block until the job reaches a terminal state')
     .option('--region <region>', 'AWS region (auto-detected if omitted)')
     .option('--endpoint <name>', 'Runtime endpoint name (e.g. PROMPT_V1)')
+    .option('--kms-key <arn>', 'KMS key ARN for encrypting insights job results')
     .option('--json', 'Output as JSON')
     .action(
       async (cliOptions: {
@@ -391,6 +392,7 @@ export const registerRun = (program: Command) => {
         wait?: boolean;
         region?: string;
         endpoint?: string;
+        kmsKey?: string;
         json?: boolean;
       }) => {
         requireProject();
@@ -424,6 +426,7 @@ export const registerRun = (program: Command) => {
             name: cliOptions.name,
             region: cliOptions.region,
             endpoint: cliOptions.endpoint,
+            kmsKeyArn: cliOptions.kmsKey,
             onProgress: cliOptions.json ? undefined : (_status, message) => console.log(message),
           });
           if (!startResult.success) {

--- a/src/cli/operations/jobs/insights/handler.ts
+++ b/src/cli/operations/jobs/insights/handler.ts
@@ -142,6 +142,7 @@ export const insightsHandler: InsightsHandler = {
           : {}),
         dataSourceConfig,
         clientToken: generateClientToken(),
+        ...(opts.kmsKeyArn ? { kmsKeyArn: opts.kmsKeyArn } : {}),
       });
       logger?.log(`Response: ${JSON.stringify(startResult, null, 2)}`);
       logger?.endStep('success');

--- a/src/cli/operations/jobs/shared/types.ts
+++ b/src/cli/operations/jobs/shared/types.ts
@@ -288,6 +288,8 @@ export interface StartInsightsJobOptions {
   name?: string;
   region?: string;
   endpoint?: string;
+  /** KMS key ARN for encrypting insights job results. */
+  kmsKeyArn?: string;
   onProgress?: (status: string, message: string) => void;
 }
 


### PR DESCRIPTION
## Summary

`run insights` uses the batch-evaluation API, which accepts a `kmsKeyArn` for encrypting results at rest, but the command exposed no `--kms-key` flag — while `run batch-evaluation` and `run recommendation` already support it. This adds the flag to close the parity gap.

Closes #1655.

## Changes

- **`src/cli/commands/run/command.tsx`** — add `--kms-key <arn>` to `run insights`, thread it through as `kmsKeyArn` to `engine.start('insights', ...)`.
- **`src/cli/operations/jobs/shared/types.ts`** — add `kmsKeyArn?` to `StartInsightsJobOptions` (mirrors the existing field on `StartBatchEvaluationJobOptions`).
- **`src/cli/operations/jobs/insights/handler.ts`** — pass `kmsKeyArn` through to `startBatchEvaluation`, matching the pattern already used by the batch-evaluation handler.

## Design note: flag name

The issue suggests `--kms-key-arn`, but the two existing sibling commands (`run batch-evaluation`, `run recommendation`) both use `--kms-key`. I used `--kms-key` for consistency with the siblings — the goal of this change is parity, so matching the established flag name is the right call. The CLI flag maps to the API's `kmsKeyArn` either way.

## Verification

- `tsc --noEmit` clean.
- `vitest --project unit` for the touched areas (`src/cli/operations/jobs/insights`, `src/cli/aws/__tests__/agentcore-batch-evaluation.test.ts`) — 17/17 pass. The existing API-layer tests already cover that `startBatchEvaluation` sends `kmsKeyArn` in the request body (`includes kmsKeyArn when provided` / `omits kmsKeyArn when not provided`), and the handler/command passthrough mirrors the batch-evaluation handler's pattern verbatim.