### PR TITLE
fix(add): print confirmation after non-interactive add agent (#671)

### DIFF
--- a/src/cli/primitives/AgentPrimitive.tsx
+++ b/src/cli/primitives/AgentPrimitive.tsx
@@ -71,6 +71,7 @@ import {
 } from '../telemetry/schemas/common-shapes.js';
 import { createRenderer } from '../templates';
 import { requireTTY } from '../tui/guards/tty';
+import type { AddFlowExitSummary } from '../tui/screens/add/AddFlow';
 import type { GenerateConfig, MemoryOption } from '../tui/screens/generate/types';
 import { BasePrimitive } from './BasePrimitive';
 import { CredentialPrimitive } from './CredentialPrimitive';
@@ -490,9 +491,18 @@ export class AgentPrimitive extends BasePrimitive<AddAgentOptions, RemovableReso
               React.createElement(AddFlow, {
                 isInteractive: false,
                 initialResource: 'agent',
-                onExit: () => {
+                onExit: (summary?: AddFlowExitSummary) => {
                   clear();
                   unmount();
+                  // The TUI success screen is torn down by clear(); print a plain-text
+                  // confirmation so the user is not left at an empty prompt (#671).
+                  if (summary) {
+                    console.log(`✓ Created agent: ${summary.agentName}`);
+                    if (summary.projectPath) {
+                      console.log(`Agent code: ${summary.projectPath}`);
+                    }
+                    console.log('Next: run `agentcore dev` to test locally, or `agentcore deploy` to deploy.');
+                  }
                   process.exit(0);
                 },
               })

--- a/src/cli/tui/screens/add/AddFlow.tsx
+++ b/src/cli/tui/screens/add/AddFlow.tsx
@@ -166,10 +166,20 @@ function AgentAddedSummary({
   );
 }
 
+/** Summary passed to onExit when a non-interactive add flow completes successfully,
+ *  so the caller can print a confirmation to the terminal after the TUI tears down. */
+export interface AddFlowExitSummary {
+  kind: 'create' | 'byo';
+  agentName: string;
+  projectName: string;
+  projectPath?: string;
+}
+
 interface AddFlowProps {
   /** Whether running in interactive TUI mode (from App.tsx) vs CLI mode */
   isInteractive: boolean;
-  onExit: () => void;
+  /** Called when the flow exits. In non-interactive mode, carries a summary on success. */
+  onExit: (summary?: AddFlowExitSummary) => void;
   /** Called when user selects dev from success screen to run agent locally */
   onDev?: () => void;
   /** Called when user selects deploy from success screen */
@@ -224,12 +234,17 @@ export function AddFlow(props: AddFlowProps) {
   const { agents, refresh: refreshAgents } = useAvailableAgents();
   const [flow, setFlow] = useState<FlowState>(() => getInitialFlowState(props.initialResource));
 
-  // In non-interactive mode, exit after success (but not while loading)
+  // In non-interactive mode, exit after success (but not while loading),
+  // passing a summary so the caller can print a confirmation once the TUI is torn down.
   useEffect(() => {
     if (!props.isInteractive) {
-      const successStates = ['agent-create-success', 'agent-byo-success'];
-      if (successStates.includes(flow.name) && !('loading' in flow && flow.loading)) {
-        props.onExit();
+      if ((flow.name === 'agent-create-success' || flow.name === 'agent-byo-success') && !flow.loading) {
+        props.onExit({
+          kind: flow.name === 'agent-byo-success' ? 'byo' : 'create',
+          agentName: flow.agentName,
+          projectName: flow.projectName,
+          projectPath: flow.name === 'agent-create-success' ? flow.projectPath : undefined,
+        });
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/cli/tui/screens/add/__tests__/AddFlow.test.tsx
+++ b/src/cli/tui/screens/add/__tests__/AddFlow.test.tsx
@@ -1,0 +1,96 @@
+import type { AddAgentConfig } from '../../agent/types';
+import { render } from 'ink-testing-library';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Hoisted mock implementations so the vi.mock factories (which are hoisted above
+// imports by vitest) can reference them.
+const mockAddAgent = vi.hoisted(() => vi.fn());
+const mockReset = vi.hoisted(() => vi.fn());
+const mockRefresh = vi.hoisted(() => vi.fn());
+
+// Replace AddAgentFlow with a stub that immediately signals completion, so we can
+// drive AddFlow into its success state without walking the whole agent wizard.
+vi.mock('../../agent/AddAgentFlow', async () => {
+  const React = (await import('react')).default;
+  return {
+    AddAgentFlow: ({ onComplete }: { onComplete: (config: AddAgentConfig) => void }) => {
+      React.useEffect(() => {
+        onComplete({ name: 'TestAgent' } as never);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+      }, []);
+      return null;
+    },
+  };
+});
+
+vi.mock('../../agent/useAddAgent', () => ({
+  useAddAgent: () => ({ addAgent: mockAddAgent, reset: mockReset }),
+}));
+
+vi.mock('../../../hooks/useCreateMcp', () => ({
+  useAvailableAgents: () => ({ agents: [], refresh: mockRefresh }),
+}));
+
+// The success screen pulls in a lot of presentational deps we don't need here;
+// stub it so the test stays focused on the onExit contract.
+vi.mock('../AddSuccessScreen', () => ({
+  AddSuccessScreen: () => null,
+}));
+
+const { AddFlow } = await import('../AddFlow');
+
+function delay(ms = 200) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+describe('AddFlow — non-interactive agent success (#671)', () => {
+  beforeEach(() => {
+    mockAddAgent.mockReset();
+    mockReset.mockReset();
+    mockRefresh.mockReset();
+    mockAddAgent.mockResolvedValue({
+      ok: true,
+      type: 'create',
+      agentName: 'TestAgent',
+      projectName: 'TestProj',
+      projectPath: '/tmp/TestProj/app/TestAgent',
+    });
+  });
+
+  it('passes an exit summary to onExit so the caller can print a confirmation', async () => {
+    const onExit = vi.fn();
+    render(<AddFlow isInteractive={false} initialResource="agent" onExit={onExit} />);
+
+    await delay();
+
+    expect(mockAddAgent, 'addAgent should be invoked once').toHaveBeenCalledTimes(1);
+    expect(onExit, 'onExit should fire after success').toHaveBeenCalledTimes(1);
+    expect(onExit.mock.calls[0]?.[0]).toEqual({
+      kind: 'create',
+      agentName: 'TestAgent',
+      projectName: 'TestProj',
+      projectPath: '/tmp/TestProj/app/TestAgent',
+    });
+  });
+
+  it('uses kind "byo" and omits projectPath for bring-your-own agents', async () => {
+    mockAddAgent.mockResolvedValue({
+      ok: true,
+      type: 'byo',
+      agentName: 'ByoAgent',
+      projectName: 'TestProj',
+    });
+    const onExit = vi.fn();
+    render(<AddFlow isInteractive={false} initialResource="agent" onExit={onExit} />);
+
+    await delay();
+
+    expect(onExit).toHaveBeenCalledTimes(1);
+    expect(onExit.mock.calls[0]?.[0]).toEqual({
+      kind: 'byo',
+      agentName: 'ByoAgent',
+      projectName: 'TestProj',
+      projectPath: undefined,
+    });
+  });
+});


### PR DESCRIPTION
## Description

In non-interactive mode (`agentcore add agent` without flags), `AddFlow`'s success `useEffect` fired `onExit()` immediately after reaching the success state. The `onExit` handler in `AgentPrimitive` calls `clear()` (which tears down the ink TUI) and then `process.exit(0)` — so the success screen was destroyed before the user ever saw it, leaving the terminal at an empty prompt with no confirmation, file path, or next steps.

This passes an exit summary (agent name, project path, kind) from `AddFlow` to the `onExit` callback, and has `AgentPrimitive` print a plain-text confirmation after the TUI tears down:

```
✓ Created agent: MyAgent
Agent code: /path/to/project/app/MyAgent
Next: run `agentcore dev` to test locally, or `agentcore deploy` to deploy.
```

Interactive mode is unaffected — `onExit` is still called with no argument.

## Related Issue

Closes #671

## Documentation PR

N/A

## Type of Change

- [x] Bug fix

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ` — added unit tests pass; integ not applicable (TUI interaction path)
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

Added `src/cli/tui/screens/add/__tests__/AddFlow.test.tsx` with two regression tests covering the `create` and `byo` success paths, asserting `onExit` receives the expected summary. Also manually verified the fix by running `agentcore add agent` end-to-end and confirming the confirmation text now appears (previously the terminal was left empty).

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.