### PR TITLE
fix: reap orphaned dev-server child on process exit

### DIFF
--- a/src/cli/operations/dev/__tests__/dev-server.test.ts
+++ b/src/cli/operations/dev/__tests__/dev-server.test.ts
@@ -1,7 +1,7 @@
 import type { DevConfig } from '../config.js';
 import { DevServer, type DevServerCallbacks, type DevServerOptions, type SpawnConfig } from '../dev-server.js';
 import { EventEmitter } from 'events';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type MockInstance, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockSpawn = vi.fn();
 vi.mock('child_process', () => ({
@@ -56,6 +56,8 @@ describe('DevServer', () => {
   let options: DevServerOptions;
   let server: TestDevServer;
   let mockChild: ReturnType<typeof createMockChildProcess>;
+  let onceSpy: MockInstance;
+  let removeListenerSpy: MockInstance;
 
   beforeEach(() => {
     onLog = vi.fn<DevServerCallbacks['onLog']>();
@@ -65,11 +67,19 @@ describe('DevServer', () => {
     server = new TestDevServer(config, options);
     mockChild = createMockChildProcess();
     mockSpawn.mockReturnValue(mockChild);
+    onceSpy = vi.spyOn(process, 'once').mockReturnValue(process);
+    removeListenerSpy = vi.spyOn(process, 'removeListener').mockReturnValue(process);
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.clearAllMocks();
   });
+
+  function getRegisteredExitHandler(): (() => void) | undefined {
+    const call = onceSpy.mock.calls.find(([event]) => event === 'exit');
+    return call?.[1] as (() => void) | undefined;
+  }
 
   describe('start()', () => {
     it('calls spawn with correct cmd, args, cwd, env, and stdio when prepare succeeds', async () => {
@@ -170,6 +180,47 @@ describe('DevServer', () => {
       expect(mockChild.kill).toHaveBeenCalledWith('SIGTERM');
 
       vi.useRealTimers();
+    });
+  });
+
+  describe('exit cleanup', () => {
+    it('reaps the detached process group on process exit', async () => {
+      mockChild.pid = 4242;
+      const processKillSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+
+      await server.start();
+      const exitHandler = getRegisteredExitHandler();
+      expect(exitHandler).toBeDefined();
+
+      exitHandler!();
+      expect(processKillSpy).toHaveBeenCalledWith(-4242, 'SIGKILL');
+    });
+
+    it('does not register an exit reaper when the child has no pid', async () => {
+      await server.start();
+      expect(getRegisteredExitHandler()).toBeUndefined();
+    });
+
+    it('removes the exit reaper once the child exits on its own', async () => {
+      mockChild.pid = 4242;
+
+      await server.start();
+      const exitHandler = getRegisteredExitHandler();
+      mockChild.emit('exit', 0);
+
+      expect(removeListenerSpy).toHaveBeenCalledWith('exit', exitHandler);
+    });
+
+    it('swallows errors when the process group is already gone', async () => {
+      mockChild.pid = 4242;
+      vi.spyOn(process, 'kill').mockImplementation(() => {
+        throw new Error('kill ESRCH');
+      });
+
+      await server.start();
+      const exitHandler = getRegisteredExitHandler();
+
+      expect(() => exitHandler!()).not.toThrow();
     });
   });
 

--- a/src/cli/operations/dev/dev-server.ts
+++ b/src/cli/operations/dev/dev-server.ts
@@ -48,6 +48,7 @@ function isInternalFrame(line: string): boolean {
 
 export abstract class DevServer {
   protected child: ChildProcess | null = null;
+  private onProcessExit: (() => void) | null = null;
   private recentStderr: string[] = [];
   private inTraceback = false;
   private tracebackBuffer: string[] = [];
@@ -77,7 +78,36 @@ export abstract class DevServer {
     });
 
     this.attachHandlers();
+    this.registerExitCleanup();
     return this.child;
+  }
+
+  /**
+   * Reap the detached child's process group when this process exits.
+   *
+   * The dev command's SIGINT/SIGTERM handler (which calls kill()) is registered after the
+   * global handler in setupAltScreenCleanup, which runs first and calls process.exit(0) — so
+   * kill() never runs and the child (its own process group since it is spawned detached) is
+   * orphaned, holding the port. The 'exit' event always fires on process.exit(), so use it as
+   * a last-resort reaper. POSIX only: on Windows the child is not detached and dies with the parent.
+   */
+  private registerExitCleanup(): void {
+    const pid = this.child?.pid;
+    if (isWindows || !pid) return;
+    this.onProcessExit = () => {
+      try {
+        process.kill(-pid, 'SIGKILL');
+      } catch {
+        // Group already gone — nothing to reap.
+      }
+    };
+    process.once('exit', this.onProcessExit);
+  }
+
+  private clearExitCleanup(): void {
+    if (!this.onProcessExit) return;
+    process.removeListener('exit', this.onProcessExit);
+    this.onProcessExit = null;
   }
 
   /** Kill the dev server process tree. Sends SIGTERM to the process group, then SIGKILL after 2 seconds. */
@@ -203,6 +233,7 @@ export abstract class DevServer {
     });
 
     this.child?.on('exit', code => {
+      this.clearExitCleanup();
       if (code !== 0 && code !== null && this.recentStderr.length > 0) {
         for (const line of this.recentStderr) {
           onLog('error', line);


### PR DESCRIPTION
## Description

`agentcore dev` spawns the dev server **detached** (its own process group, added in #1438) and relies on the dev command's `SIGINT`/`SIGTERM` handler (`onShutdownSignal`, registered with `process.once`) to call `server.kill()` and tree-kill the group. But `setupAltScreenCleanup()` (`src/cli/cli.ts`, called first thing in `main()`) registers a **global** `process.on('SIGINT'/'SIGTERM')` handler that calls `process.exit(0)`. Node runs signal listeners in registration order, and this global handler is registered **before** the dev command's — so it fires first, `process.exit(0)` terminates the process, and `server.kill()` never runs. The detached child is then reparented to PID 1 and keeps holding the port.

This reproduces on **every** stop — both interactive `Ctrl+C` (SIGINT) and programmatic `kill $PID` (SIGTERM) — for both Python (uvicorn) and TypeScript/Node dev servers. #1438 correctly fixed the reparenting mechanics (`detached` spawn + process-group tree-kill in `kill()`), but the compensating handler it added is preempted by the pre-existing global `process.exit(0)`, so the orphan is back in 0.22.0 (and now also on `Ctrl+C`, since the detached child no longer receives the terminal's group SIGINT directly).

### Fix

Register a `process.on('exit')` reaper in `DevServer.start()` that sends `SIGKILL` to the detached child's process group. The `'exit'` event **always** fires on `process.exit()`, so the child is reaped no matter which path exits the process (the global cleanup handler, an uncaught exception in `index.ts`, or a normal exit). `kill()`'s graceful `SIGTERM`-then-`SIGKILL` path is unchanged and still runs when it is reached; this is a last-resort net for when it isn't. The listener is removed when the child exits on its own, to avoid a stale reaper firing at final process exit. POSIX-only, matching the POSIX-only `detached` spawn (on Windows the child is not detached and dies with the parent).

## Related Issue

Closes #1690

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

Added unit tests in `dev-server.test.ts` covering the reaper: it `SIGKILL`s the child's process group on exit, is skipped when there is no pid, is removed once the child exits on its own, and swallows `ESRCH` when the group is already gone.

Verified end-to-end on macOS with a TypeScript agent, before vs. after this change, mirroring the repro in #1690 / #1440:

```bash
agentcore dev --logs --port 9137 &
DEV_PID=$!
# wait for the port to bind, then:
kill $DEV_PID
sleep 4
lsof -ti :9137
# before this change: orphaned node still listening (reparented to PPID 1)
# after this change:  empty — port freed
```

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots (N/A — no asset changes)

> Note on the local runs: `typecheck`, `lint`, and the added `dev-server` unit tests all pass. The remaining `test:unit` / `test:integ` failures on my machine are environmental and outside the changed `dev-server` area: the unit failures are AWS SSO credential-resolution tests (`resolveSSOCredentials`, need live AWS credentials), and the integ failures are Python-project `create` tests that require the `uv` toolchain, which isn't installed in my sandbox (`'uv' is required for Python projects`). The repo's own `integ-tests/dev-server.test.ts` is `skipIf(!hasUv)` and skips cleanly here.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
