### PR TITLE
fix: fix infinite loop between source type and add another KB TUI screens

### DIFF
--- a/src/cli/tui/screens/knowledge-base/AddKnowledgeBaseScreen.tsx
+++ b/src/cli/tui/screens/knowledge-base/AddKnowledgeBaseScreen.tsx
@@ -212,10 +212,7 @@ export function AddKnowledgeBaseScreen({
       setPendingType(item.id as DataSourceTypeFlag);
       setStep('sources');
     },
-    // Esc from the type picker: if we already have at least one captured
-    // source, the only sensible return is the add-another decision (we can't
-    // un-capture earlier sources). Otherwise go back to description.
-    onExit: () => setStep(dataSources.length === 0 ? 'description' : 'add-another'),
+    onExit: () => setStep('description'),
   });
 
   // Surface the "Remove a captured source" option only when there's something
@@ -381,7 +378,7 @@ export function AddKnowledgeBaseScreen({
             prompt="Description (optional, press Enter to skip)"
             onSubmit={(value: string) => {
               setDescription(value);
-              setStep('data-source-type');
+              setStep(dataSources.length > 0 ? 'add-another' : 'data-source-type');
             }}
             onCancel={() => setStep('name')}
             allowEmpty
@@ -413,7 +410,7 @@ export function AddKnowledgeBaseScreen({
               setDataSources([...dataSources, { dataSourceType: pendingType, value }]);
               setStep('add-another');
             }}
-            onCancel={() => setStep(dataSources.length === 0 ? 'data-source-type' : 'add-another')}
+            onCancel={() => setStep('data-source-type')}
             schema={S3UriSchema}
           />
         )}
@@ -442,7 +439,7 @@ export function AddKnowledgeBaseScreen({
               ]);
               setStep('add-another');
             }}
-            onCancel={() => setStep(dataSources.length === 0 ? 'data-source-type' : 'add-another')}
+            onCancel={() => setStep('data-source-type')}
             schema={makeConnectorConfigSchema(pendingType)}
           />
         )}


### PR DESCRIPTION
## Description

Fix a bug which caused TUI screen to infinitely loop between "source type" and "add another?" when atleast one source was configured on a KB.

The previous cycle was caused by: 
  1. add-another Esc → data-source-type
  2. data-source-type  Esc (with existing sources) → add-another

The solution in this PR updates the logic in the following ways: 
* source-type always returns to description
* description advances conditionally to source-type or add-another, based on at least one data source already being configured
* sources always returns to data source type

New flow is as follows: 
  * First time through (no sources): description → data-source-type → sources → add-another
  * Esc from add-another → data-source-type (reconsider)
  * Esc from data-source-type → description 
  * Submit from description (with existing sources) → add-another (skip type picker, go straight to decide)

## Related Issue

<!-- Every PR must be associated with an issue. Link it below using #issue-number format. -->

Closes #

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Check all that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
