### PR TITLE
fix: update e2e gateway test with new type

### DIFF
--- a/e2e-tests/httpgateway-all-targets.test.ts
+++ b/e2e-tests/httpgateway-all-targets.test.ts
@@ -5,7 +5,7 @@
  * AND the HTTP-only target types — so one gateway carries all targets:
  *
  *   http-runtime, mcp-server, lambda-function-arn, api-gateway,
- *   open-api-schema, smithy-model, web-search, passthrough
+ *   open-api-schema, smithy-model, connector (web-search), passthrough
  *
  * Flow: create project → ensure external prereqs (Lambda, REST API via a boto3
  *       fixture) → add gateway + credential → add every target → deploy ONE
@@ -250,8 +250,8 @@ describe.sequential('e2e: HTTP gateway with all target types', () => {
     assertAddTarget(['--name', 'tSmithy', '--type', 'smithy-model', '--schema', 'smithy.json'], 'tSmithy')
   );
 
-  it.skipIf(!canRun)('adds a web-search target', () =>
-    assertAddTarget(['--name', 'tWebSearch', '--type', 'web-search'], 'tWebSearch')
+  it.skipIf(!canRun)('adds a web-search connector target', () =>
+    assertAddTarget(['--name', 'tWebSearch', '--type', 'connector', '--connector', 'web-search'], 'tWebSearch')
   );
 
   it.skipIf(!canRun)('adds a passthrough target (gated; gateway-iam-role auth)', () =>
@@ -287,7 +287,7 @@ describe.sequential('e2e: HTTP gateway with all target types', () => {
       const gw = config.agentCoreGateways.find(g => g.name === gatewayName);
       expect(gw, `gateway ${gatewayName} should be in config`).toBeDefined();
       const types = new Set(gw!.targets.map(t => t.targetType));
-      const expected = ['httpRuntime', 'mcpServer', 'openApiSchema', 'smithyModel', 'webSearch', 'passthrough'];
+      const expected = ['httpRuntime', 'mcpServer', 'openApiSchema', 'smithyModel', 'connector', 'passthrough'];
       // Only expected when the fixture could provision their external prereqs.
       if (prereqsData.lambdaArn) expected.push('lambdaFunctionArn');
       if (prereqsData.restApiId) expected.push('apiGateway');


### PR DESCRIPTION
## Description

Update stale main branch e2e test with web search --target to --connector change

## Related Issue

<!-- Every PR must be associated with an issue. Link it below using #issue-number format. -->

Closes #

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:unit` and `npm run test:integ`
- [ ] I ran `npm run typecheck`
- [ ] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
