### PR TITLE
ci(e2e): cancel superseded in-progress E2E runs

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -13,7 +13,7 @@ on:
 
 concurrency:
   group: e2e-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 permissions:
   id-token: write # OIDC — lets GitHub assume an AWS IAM role via short-lived token (no stored keys)


### PR DESCRIPTION
Flips cancel-in-progress false->true on the existing e2e concurrency group so a new push to a PR cancels the prior in-progress run instead of running both. Frees the shared CI AWS account slot sooner and cuts
  wall-clock latency.