### PR TITLE
ci(e2e): skip E2E tests on docs-only PRs

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -21,6 +21,13 @@ on:
       - 'package-lock.json'
       - 'npm-shrinkwrap.json'
       - 'vitest.config.*'
+      # Build inputs that produce the `agentcore` binary E2E installs globally:
+      # TS compiler config, the esbuild bundler config, and scripts/** (which
+      # includes bundle/copy-assets/generate-schema and the check-old-cli.mjs
+      # postinstall hook — a bug there breaks `npm install -g` in the E2E job).
+      - 'tsconfig*.json'
+      - 'esbuild.config.*'
+      - 'scripts/**'
       - '.github/workflows/e2e*'
 
 concurrency:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -10,6 +10,18 @@ on:
         default: 'main'
   pull_request_target:
     branches: [main, feat/**]
+    # Skip E2E on changes that can't affect agent behavior (e.g. docs-only PRs).
+    # Only run when CLI source, e2e/browser tests, packaging, or the e2e
+    # workflows themselves change.
+    paths:
+      - 'src/**'
+      - 'e2e-tests/**'
+      - 'browser-tests/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'npm-shrinkwrap.json'
+      - 'vitest.config.*'
+      - '.github/workflows/e2e*'
 
 concurrency:
   group: e2e-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
Adds a paths filter to pull_request_target so E2E only runs when CLI source, e2e/browser tests, packaging manifests, vitest config, or the e2e workflows change. Docs-only PRs no longer consume a CI AWS account slot
  or ~30 min runtime.