### PR TITLE
ci(e2e): emit JUnit reports and upload as CI artifact

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -167,9 +167,12 @@ jobs:
           CDP_WALLET_SECRET: ${{ env.E2E_CDP_WALLET_SECRET }}
           GA_EXTRA: ${{ steps.changed.outputs.ga_extra }}
         # GA_EXTRA is a space-separated test-file list; left unquoted intentionally so it word-splits into vitest args.
+        # --reporter=verbose keeps the console log; --reporter=junit adds a machine-readable
+        # report surfaced in the GH Actions test-summary tab and uploaded as an artifact below.
         run:
-          npx vitest run --project e2e e2e-tests/strands-bedrock.test.ts e2e-tests/payment-strands-bedrock.test.ts
-          $GA_EXTRA
+          npx vitest run --project e2e --reporter=verbose --reporter=junit
+          --outputFile.junit=test-results/e2e-ga.junit.xml e2e-tests/strands-bedrock.test.ts
+          e2e-tests/payment-strands-bedrock.test.ts $GA_EXTRA
 
       - name: Run E2E tests (harness)
         env:
@@ -184,4 +187,16 @@ jobs:
           E2E_FILESYSTEM_SECURITY_GROUP_ID: ${{ env.E2E_FILESYSTEM_SECURITY_GROUP_ID }}
           HARNESS_EXTRA: ${{ steps.changed.outputs.harness_extra }}
         # HARNESS_EXTRA is a space-separated test-file list; left unquoted intentionally so it word-splits into vitest args.
-        run: npx vitest run --project e2e e2e-tests/harness-bedrock.test.ts $HARNESS_EXTRA
+        # Separate --outputFile from the GA step so the two vitest runs don't clobber each other's report.
+        run:
+          npx vitest run --project e2e --reporter=verbose --reporter=junit
+          --outputFile.junit=test-results/e2e-harness.junit.xml e2e-tests/harness-bedrock.test.ts $HARNESS_EXTRA
+
+      - name: Upload E2E test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-test-report
+          path: test-results/
+          if-no-files-found: warn
+          retention-days: 14


### PR DESCRIPTION
Adds --reporter=junit to both e2e vitest runs (GA + harness) with separate output files, kept alongside --reporter=verbose. An always()-guarded upload-artifact step publishes test-results/ (14-day retention),
  surfacing per-test pass/fail + durations in the Actions summary instead of raw log scrolling. Verified the junit reporter writes the file locally on vitest 4.1.8.