### PR TITLE
ci(canary): run canary every 15 minutes instead of hourly

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,9 +1,10 @@
 name: Canary
 
 on:
-  # Run once an hour
+  # Run every 15 minutes to catch dependency/service breakages (e.g. CDK
+  # schema mismatches) quickly instead of up to an hour later.
   schedule:
-    - cron: '0 * * * *'
+    - cron: '*/15 * * * *'
   workflow_dispatch:
     inputs:
       aws_region:


### PR DESCRIPTION
Tightens canary cron from hourly to */15 so dependency/service breakages (e.g. the CDK schema mismatch) surface within ~15 min. Runs stay serialized via the existing 'canary' concurrency group; an overrun queues
  the next run rather than overlapping. Job timeout remains 30 min.