### PR TITLE
chore: add e2e and integ tests for web-search connector

### DIFF
--- a/e2e-tests/web-search-lifecycle.test.ts
+++ b/e2e-tests/web-search-lifecycle.test.ts
@@ -1,0 +1,156 @@
+import { type RunResult, hasAwsCredentials, parseJsonOutput, prereqs } from '../src/test-utils/index.js';
+import { installCdkTarball, runAgentCoreCLI, teardownE2EProject, writeAwsTargets } from './e2e-helper.js';
+import { randomUUID } from 'node:crypto';
+import { mkdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const hasAws = hasAwsCredentials();
+const canRun = prereqs.npm && prereqs.git && prereqs.uv && hasAws;
+
+describe.sequential('e2e: web-search gateway target lifecycle', () => {
+  const suffix = Date.now().toString().slice(-8);
+  const agentName = `E2eWs${suffix}`;
+  const gatewayName = 'WsGw';
+  const targetName = 'ws1';
+  const toolName = `${targetName}___WebSearch`;
+
+  let testDir: string;
+  let projectPath: string;
+  let originalRegion: string | undefined;
+  let lifecycleFailed = false;
+
+  beforeAll(async () => {
+    if (!canRun) return;
+
+    originalRegion = process.env.AWS_REGION;
+    process.env.AWS_REGION = 'us-east-1';
+
+    testDir = join(tmpdir(), `agentcore-e2e-web-search-${randomUUID()}`);
+    await mkdir(testDir, { recursive: true });
+
+    const create = await runAgentCoreCLI(
+      ['create', '--name', agentName, '--no-agent', '--defaults', '--skip-git', '--skip-python-setup', '--json'],
+      testDir
+    );
+    expect(create.exitCode, `Create failed: ${create.stderr}`).toBe(0);
+    projectPath = (parseJsonOutput(create.stdout) as { projectPath: string }).projectPath;
+
+    await writeAwsTargets(projectPath);
+    installCdkTarball(projectPath);
+  }, 600_000);
+
+  afterAll(async () => {
+    if (projectPath && hasAws) {
+      await teardownE2EProject(projectPath, agentName, 'Bedrock');
+    }
+    if (testDir) await rm(testDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 1000 });
+    if (originalRegion === undefined) delete process.env.AWS_REGION;
+    else process.env.AWS_REGION = originalRegion;
+  }, 600_000);
+
+  const run = (args: string[]): Promise<RunResult> => runAgentCoreCLI(args, projectPath);
+
+  const step = (label: string, fn: () => Promise<void>, timeout: number) =>
+    it.skipIf(!canRun)(
+      label,
+      async () => {
+        if (lifecycleFailed) {
+          throw new Error('Skipped: a prior step in the lifecycle failed.');
+        }
+        try {
+          await fn();
+        } catch (err) {
+          lifecycleFailed = true;
+          throw err;
+        }
+      },
+      timeout
+    );
+
+  step(
+    'adds a gateway and a web-search connector target',
+    async () => {
+      const gw = await run(['add', 'gateway', '--name', gatewayName, '--protocol-type', 'MCP', '--json']);
+      expect(gw.exitCode, `Add gateway failed: ${gw.stderr}`).toBe(0);
+
+      const target = await run([
+        'add',
+        'gateway-target',
+        '--type',
+        'connector',
+        '--connector',
+        'web-search',
+        '--gateway',
+        gatewayName,
+        '--name',
+        targetName,
+        '--json',
+      ]);
+      expect(target.exitCode, `Add web-search failed: ${target.stdout}\n${target.stderr}`).toBe(0);
+    },
+    120_000
+  );
+
+  step(
+    'deploys the stack',
+    async () => {
+      const result = await run(['deploy', '--yes', '--json']);
+      expect(result.exitCode, `Deploy failed: ${result.stderr}`).toBe(0);
+    },
+    900_000
+  );
+
+  step(
+    'status shows the gateway as deployed',
+    async () => {
+      const result = await run(['status', '--json']);
+      expect(result.exitCode, `Status failed: ${result.stderr}`).toBe(0);
+
+      const json = parseJsonOutput(result.stdout) as {
+        success: boolean;
+        resources: { resourceType: string; name: string; deploymentState: string }[];
+      };
+      expect(json.success).toBe(true);
+
+      const gateway = json.resources.find(r => r.resourceType === 'gateway' && r.name === gatewayName);
+      expect(gateway, 'Gateway should appear in status').toBeDefined();
+      expect(gateway?.deploymentState).toBe('deployed');
+    },
+    120_000
+  );
+
+  step(
+    'call-tool returns search results',
+    async () => {
+      const result = await run([
+        'invoke',
+        'call-tool',
+        '--gateway',
+        gatewayName,
+        '--tool',
+        toolName,
+        '--input',
+        '{"query":"AWS Lambda pricing"}',
+        '--json',
+      ]);
+      expect(result.exitCode, `call-tool failed:\nstdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0);
+
+      const payload = parseJsonOutput(result.stdout) as { success: boolean; response?: string };
+      expect(payload.success, `call-tool result not successful. Raw stdout:\n${result.stdout}`).toBe(true);
+      expect(typeof payload.response, 'response should be a JSON envelope string').toBe('string');
+
+      const envelope = JSON.parse(payload.response!) as {
+        result?: { content?: { text?: string }[] };
+      };
+      const text = envelope.result?.content?.[0]?.text;
+      expect(text, `call-tool envelope missing result.content[0].text. Envelope:\n${payload.response}`).toBeTruthy();
+
+      const inner = JSON.parse(text!) as { results?: { url?: string }[] };
+      expect(Array.isArray(inner.results), 'Results array should be present').toBe(true);
+      expect(inner.results!.length, 'Results array should be non-empty').toBeGreaterThan(0);
+    },
+    180_000
+  );
+});

--- a/integ-tests/add-remove-web-search.test.ts
+++ b/integ-tests/add-remove-web-search.test.ts
@@ -1,0 +1,243 @@
+import { createTestProject, runCLI } from '../src/test-utils/index.js';
+import type { TestProject } from '../src/test-utils/index.js';
+import { createTelemetryHelper } from '../src/test-utils/telemetry-helper.js';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const telemetry = createTelemetryHelper();
+
+interface ConfigurationEntry {
+  name: string;
+  parameterValues?: Record<string, unknown>;
+  parameterOverrides?: { path: string; description?: string; visible?: boolean }[];
+}
+
+interface ConnectorTarget {
+  name: string;
+  targetType: string;
+  connectorId?: string;
+  configurations?: ConfigurationEntry[];
+}
+
+interface Gateway {
+  name: string;
+  targets?: ConnectorTarget[];
+}
+
+async function readProjectConfig(projectPath: string) {
+  return JSON.parse(await readFile(join(projectPath, 'agentcore/agentcore.json'), 'utf-8'));
+}
+
+async function findTarget(
+  projectPath: string,
+  gatewayName: string,
+  targetName: string
+): Promise<ConnectorTarget | undefined> {
+  const config = await readProjectConfig(projectPath);
+  const gateway = (config.agentCoreGateways as Gateway[]).find(g => g.name === gatewayName);
+  return gateway?.targets?.find(t => t.name === targetName);
+}
+
+describe('integration: add and remove web-search via --connector flag', () => {
+  let project: TestProject;
+  const gatewayName = 'WsGateway';
+
+  beforeAll(async () => {
+    project = await createTestProject({ noAgent: true });
+    const result = await runCLI(
+      ['add', 'gateway', '--name', gatewayName, '--protocol-type', 'MCP', '--json'],
+      project.projectPath
+    );
+    expect(result.exitCode).toBe(0);
+  });
+
+  afterAll(async () => {
+    await project.cleanup();
+    telemetry.destroy();
+  });
+
+  it('adds a web-search connector target with no excludeDomains', async () => {
+    const result = await runCLI(
+      [
+        'add',
+        'gateway-target',
+        '--type',
+        'connector',
+        '--connector',
+        'web-search',
+        '--gateway',
+        gatewayName,
+        '--name',
+        'ws-plain',
+        '--json',
+      ],
+      project.projectPath,
+      { env: telemetry.env }
+    );
+
+    expect(result.exitCode, `stdout: ${result.stdout}, stderr: ${result.stderr}`).toBe(0);
+
+    const target = await findTarget(project.projectPath, gatewayName, 'ws-plain');
+    expect(target).toBeTruthy();
+    expect(target?.targetType).toBe('connector');
+    expect(target?.connectorId).toBe('web-search');
+    expect(target?.configurations).toHaveLength(1);
+    expect(target?.configurations?.[0]?.name).toBe('WebSearch');
+    expect(target?.configurations?.[0]?.parameterValues).toEqual({});
+    expect(target?.configurations?.[0]?.parameterOverrides).toEqual([]);
+    telemetry.assertMetricEmitted({ command: 'add.gateway-target', exit_reason: 'success' });
+  });
+
+  it('adds a web-search connector target with --exclude-domains', async () => {
+    const result = await runCLI(
+      [
+        'add',
+        'gateway-target',
+        '--type',
+        'connector',
+        '--connector',
+        'web-search',
+        '--gateway',
+        gatewayName,
+        '--name',
+        'ws-filtered',
+        '--exclude-domains',
+        'foo.com,bar.net',
+        '--json',
+      ],
+      project.projectPath
+    );
+
+    expect(result.exitCode, `stdout: ${result.stdout}, stderr: ${result.stderr}`).toBe(0);
+
+    const target = await findTarget(project.projectPath, gatewayName, 'ws-filtered');
+    const pv = target!.configurations![0]!.parameterValues!;
+    expect((pv?.domainFilter as { exclude: string[] })?.exclude).toEqual(['foo.com', 'bar.net']);
+  });
+
+  it('trims whitespace in --exclude-domains values', async () => {
+    const result = await runCLI(
+      [
+        'add',
+        'gateway-target',
+        '--type',
+        'connector',
+        '--connector',
+        'web-search',
+        '--gateway',
+        gatewayName,
+        '--name',
+        'ws-trimmed',
+        '--exclude-domains',
+        'a.com, b.com,  c.com',
+        '--json',
+      ],
+      project.projectPath
+    );
+
+    expect(result.exitCode).toBe(0);
+    const target = await findTarget(project.projectPath, gatewayName, 'ws-trimmed');
+    const pv = target!.configurations![0]!.parameterValues!;
+    expect((pv?.domainFilter as { exclude: string[] })?.exclude).toEqual(['a.com', 'b.com', 'c.com']);
+  });
+
+  it('rejects repeated --exclude-domains', async () => {
+    const result = await runCLI(
+      [
+        'add',
+        'gateway-target',
+        '--type',
+        'connector',
+        '--connector',
+        'web-search',
+        '--gateway',
+        gatewayName,
+        '--name',
+        'ws-repeat',
+        '--exclude-domains',
+        'foo.com',
+        '--exclude-domains',
+        'bar.net',
+        '--json',
+      ],
+      project.projectPath
+    );
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout + result.stderr).toContain('--exclude-domains may only be specified once');
+    const target = await findTarget(project.projectPath, gatewayName, 'ws-repeat');
+    expect(target).toBeUndefined();
+  });
+
+  it('rejects --exclude-domains on non-web-search connector', async () => {
+    const result = await runCLI(
+      [
+        'add',
+        'gateway-target',
+        '--type',
+        'connector',
+        '--connector',
+        'bedrock-knowledge-bases',
+        '--gateway',
+        gatewayName,
+        '--name',
+        'x',
+        '--knowledge-base-id',
+        'ABCDEFGHIJ',
+        '--exclude-domains',
+        'foo.com',
+        '--json',
+      ],
+      project.projectPath
+    );
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout + result.stderr).toContain('--exclude-domains only applies to --connector web-search');
+  });
+
+  it('rejects --type web-search (old path removed)', async () => {
+    const result = await runCLI(
+      ['add', 'gateway-target', '--type', 'web-search', '--gateway', gatewayName, '--name', 'ws-old', '--json'],
+      project.projectPath
+    );
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout + result.stderr).toContain('Invalid type');
+  });
+
+  it('removes a web-search target via remove gateway-target', async () => {
+    const result = await runCLI(
+      ['remove', 'gateway-target', '--name', 'ws-plain', '--yes', '--json'],
+      project.projectPath,
+      { env: telemetry.env }
+    );
+
+    expect(result.exitCode).toBe(0);
+    const target = await findTarget(project.projectPath, gatewayName, 'ws-plain');
+    expect(target).toBeUndefined();
+    telemetry.assertMetricEmitted({ command: 'remove.gateway-target', exit_reason: 'success' });
+  });
+
+  it('rejects re-adding a target with the same name', async () => {
+    const result = await runCLI(
+      [
+        'add',
+        'gateway-target',
+        '--type',
+        'connector',
+        '--connector',
+        'web-search',
+        '--gateway',
+        gatewayName,
+        '--name',
+        'ws-filtered',
+        '--json',
+      ],
+      project.projectPath
+    );
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout + result.stderr).toContain('already exists');
+  });
+});


### PR DESCRIPTION
## Description

Add back integ and e2e test suite for web search, refactored to match latest connector devEx and config output schema.

## Related Issue

<!-- Every PR must be associated with an issue. Link it below using #issue-number format. -->

Closes #

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:unit` and `npm run test:integ`
- [ ] I ran `npm run typecheck`
- [ ] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
