### PR TITLE
ci(e2e): run E2E job on CodeBuild-hosted runner (POC)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -50,7 +50,13 @@ jobs:
   e2e:
     needs: authorize
     if: needs.authorize.outputs.is_authorized == 'true'
-    runs-on: ubuntu-latest
+    # Run on our AWS CodeBuild-hosted runner instead of a GitHub-hosted runner.
+    # GitHub-hosted runner IPs rotate through shared pools whose reputation trips
+    # the service WAF (403s before the request reaches service code); dedicated
+    # CodeBuild compute inside AWS avoids that and cuts runner-pickup latency.
+    # Label format: codebuild-<project>-${{ github.run_id }}-${{ github.run_attempt }}
+    # backed by the `agentcore-e2e` project in the CI account (us-east-1).
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     environment: e2e-testing
     timeout-minutes: 30
     env:


### PR DESCRIPTION
Moves the e2e job off ubuntu-latest onto our AWS CodeBuild-hosted runner (project `agentcore-e2e`, CI account, us-east-1) to fix WAF 403s from GitHub-hosted runner IPs and cut runner-pickup latency (E2E infra doc, Section 1).

authorize job stays on ubuntu-latest. No E2E IAM changes — configure-aws-credentials still uses GitHub OIDC, which works from CodeBuild. POC scope: this workflow only; roll out to e2e-tests-full.yml + canary.yml after a bake.
