### PR TITLE
ci: run all workflows on CodeBuild-hosted runners

### DIFF
--- a/.github/workflows/agent-restricted.yml
+++ b/.github/workflows/agent-restricted.yml
@@ -53,7 +53,7 @@ permissions:
 
 jobs:
   agent:
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Check authorization
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -147,6 +147,32 @@ jobs:
           pattern: blob-20.x-*
           merge-multiple: true
           path: .vitest-reports/
+      - name: Normalize blob report paths
+        # Vitest blob reports store absolute test-file paths tied to the runner's
+        # working directory. On GitHub-hosted runners every job shares
+        # /home/runner/work/agentcore-cli/agentcore-cli, so the merge resolves fine.
+        # On CodeBuild-hosted runners each job gets a unique
+        # /codebuild/output/src<N>/... dir, so the merge job can't find the
+        # shard-recorded paths and vitest exits with "No test files found".
+        # Rewrite each shard's recorded repo root to this job's workspace before
+        # merging. The regex is anchored to the CodeBuild src<N> path so it can't
+        # touch test titles or other blob content; it is a no-op on GitHub runners.
+        run: |
+          node -e '
+            const fs = require("node:fs");
+            const dir = ".vitest-reports";
+            const cwd = process.cwd();
+            const re = /\/codebuild\/output\/src[0-9]+\/src\/actions-runner\/_work\/agentcore-cli\/agentcore-cli/g;
+            for (const f of fs.readdirSync(dir)) {
+              const p = `${dir}/${f}`;
+              const before = fs.readFileSync(p, "utf8");
+              const after = before.replace(re, () => cwd);
+              if (after !== before) {
+                fs.writeFileSync(p, after);
+                console.log(`normalized paths in ${f}`);
+              }
+            }
+          '
       - name: Merge reports
         run: npx vitest --mergeReports=.vitest-reports/ --project unit --coverage
       - name: Upload coverage artifact

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 15
 
     strategy:
@@ -63,7 +63,7 @@ jobs:
           path: '*.tgz'
 
   integ-test:
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 15
 
     strategy:
@@ -92,7 +92,7 @@ jobs:
         run: npx vitest run --project integ --shard=${{ matrix.shard }}
 
   unit-test:
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 15
 
     strategy:
@@ -131,7 +131,7 @@ jobs:
 
   merge-reports:
     needs: unit-test
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     if: always()
 
     steps:
@@ -157,7 +157,7 @@ jobs:
 
   coverage:
     needs: merge-reports
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     if: github.event_name == 'pull_request'
     permissions:
       contents: read

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   canary:
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     environment: e2e-testing
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/ci-failure-issue.yml
+++ b/.github/workflows/ci-failure-issue.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   create-issue:
     concurrency: ci-failure-issue-${{ github.event.workflow_run.name }}
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 5
     if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.head_branch == 'main' }}
     permissions:

--- a/.github/workflows/ci-failure-issue.yml
+++ b/.github/workflows/ci-failure-issue.yml
@@ -13,7 +13,13 @@ on:
 jobs:
   create-issue:
     concurrency: ci-failure-issue-${{ github.event.workflow_run.name }}
-    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
+    # Stays on a GitHub-hosted runner on purpose: this workflow is the alarm that
+    # opens an issue when main CI fails, so it must not depend on the CodeBuild
+    # runner it may need to report on. If CodeBuild is unhealthy (webhook drift,
+    # quota exhaustion, broken image), a CodeBuild-hosted alarm couldn't start
+    # either and the failure would be silently swallowed. It's GitHub-API-only
+    # (no AWS calls), so it gains nothing from running inside the AWS network.
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.head_branch == 'main' }}
     permissions:

--- a/.github/workflows/cleanup-pr-tarballs.yml
+++ b/.github/workflows/cleanup-pr-tarballs.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   cleanup:
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:
       - name: Generate GitHub App Token

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 15
     permissions:
       actions: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,10 +16,7 @@ concurrency:
 jobs:
   analyze:
     name: Analyze
-    # Stays on a GitHub-hosted runner: CodeQL's query evaluation OOMs on the
-    # CodeBuild general1.small runner (3 GB; CodeQL needs more). CodeQL does no
-    # AWS/service calls, so it has no WAF exposure and gains nothing from CodeBuild.
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 15
     permissions:
       actions: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,7 +16,10 @@ concurrency:
 jobs:
   analyze:
     name: Analyze
-    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
+    # Stays on a GitHub-hosted runner: CodeQL's query evaluation OOMs on the
+    # CodeBuild general1.small runner (3 GB; CodeQL needs more). CodeQL does no
+    # AWS/service calls, so it has no WAF exposure and gains nothing from CodeBuild.
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       actions: read

--- a/.github/workflows/e2e-tests-full.yml
+++ b/.github/workflows/e2e-tests-full.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   e2e:
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     environment: e2e-testing
     timeout-minutes: 60
     strategy:
@@ -111,7 +111,7 @@ jobs:
           CDP_WALLET_SECRET: ${{ env.E2E_CDP_WALLET_SECRET }}
         run: npx vitest run --project e2e --shard=${{ matrix.shard }}
   browser-tests:
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     environment: e2e-testing
     timeout-minutes: 30
     steps:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -40,7 +40,7 @@ permissions:
 
 jobs:
   authorize:
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request_target'
     outputs:
       is_authorized: ${{ steps.check.outputs.is_authorized }}

--- a/.github/workflows/github-slack-notifications.yml
+++ b/.github/workflows/github-slack-notifications.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   notify-issue-opened:
     if: github.event_name == 'issues'
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     permissions: {}
     steps:
       - name: Send issue details to Slack
@@ -67,7 +67,7 @@ jobs:
     if: >-
       github.event_name == 'issue_comment' && github.event.issue.pull_request != null && github.event.issue.state ==
       'closed' && github.event.comment.user.type != 'Bot'
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     permissions:
       pull-requests: write
       issues: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   setup:
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v7
       - name: Setup Node.js
@@ -33,7 +33,7 @@ jobs:
 
   format:
     needs: setup
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
@@ -47,7 +47,7 @@ jobs:
 
   lint:
     needs: setup
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
@@ -61,7 +61,7 @@ jobs:
 
   security:
     needs: setup
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
@@ -75,7 +75,7 @@ jobs:
 
   secrets:
     needs: setup
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
@@ -89,7 +89,7 @@ jobs:
 
   typecheck:
     needs: setup
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
@@ -103,7 +103,7 @@ jobs:
 
   schema-check:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'release') }}
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/pr-ai-review.yml
+++ b/.github/workflows/pr-ai-review.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   authorize:
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     # explicitly require the PR to be open to avoid old events triggering a review on closed PRs: https://github.com/aws/agentcore-cli/issues/1463
     if:
       github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request_target' &&
@@ -71,7 +71,7 @@ jobs:
   ai-review:
     needs: authorize
     if: needs.authorize.outputs.authorized == 'true' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Determine PR URL
         id: pr-url

--- a/.github/workflows/pr-security-review.yml
+++ b/.github/workflows/pr-security-review.yml
@@ -43,7 +43,7 @@ concurrency:
 
 jobs:
   authorize:
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     # On 'labeled' events, only proceed when the label is exactly 'safe-to-review'.
     # Other labels (e.g. size/m) are filtered out so we don't spawn API calls.
     if: |
@@ -91,7 +91,7 @@ jobs:
   review:
     needs: authorize
     if: needs.authorize.outputs.authorized == 'true'
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 30
     env:
       AWS_REGION: us-west-2

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   label-size:
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/pr-tarball.yml
+++ b/.github/workflows/pr-tarball.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   authorize:
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     outputs:
       is_authorized: ${{ steps.check.outputs.is_authorized }}
     steps:
@@ -30,7 +30,7 @@ jobs:
   pr-tarball:
     needs: authorize
     if: needs.authorize.outputs.is_authorized == 'true'
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   validate-pr-title:
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     permissions:
       pull-requests: read
     steps:

--- a/.github/workflows/prerelease-tarball.yml
+++ b/.github/workflows/prerelease-tarball.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   prerelease-tarball:
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: 15
     env:
       TARBALL_BASE: agentcore-cli-prerelease

--- a/.github/workflows/publish-api-docs.yml
+++ b/.github/workflows/publish-api-docs.yml
@@ -27,7 +27,7 @@ env:
 
 jobs:
   generate:
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/release-main-and-preview.yml
+++ b/.github/workflows/release-main-and-preview.yml
@@ -54,7 +54,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════
   prepare-release:
     name: Prepare Release
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     outputs:
       main_version: ${{ steps.bump-main.outputs.version || steps.current-main.outputs.version }}
       preview_version: ${{ steps.bump-preview.outputs.version }}
@@ -216,7 +216,7 @@ jobs:
   release-approval:
     name: Release Approval
     needs: [prepare-release]
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     environment:
       name: npm-publish-approval
     steps:
@@ -242,7 +242,7 @@ jobs:
     name: Verify PR Merged
     needs: [prepare-release, release-approval]
     if: ${{ !inputs.dry_run }}
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -284,7 +284,7 @@ jobs:
     name: Publish Main (@latest)
     needs: [prepare-release, verify-merge]
     if: inputs.release_target != 'preview-only'
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     environment:
       name: npm-publish
       url: https://www.npmjs.com/package/@aws/agentcore
@@ -341,7 +341,7 @@ jobs:
     name: Publish Preview (@preview)
     needs: [prepare-release, verify-merge]
     if: inputs.release_target != 'main-only'
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     environment:
       name: npm-publish
       url: https://www.npmjs.com/package/@aws/agentcore
@@ -412,7 +412,7 @@ jobs:
     name: Release Summary
     needs: [prepare-release, publish-main, publish-preview]
     if: always() && !cancelled()
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Summary
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ permissions:
 jobs:
   prepare-release:
     name: Prepare Release
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     outputs:
       version: ${{ steps.bump.outputs.version }}
       branch: ${{ steps.bump.outputs.branch }}
@@ -211,7 +211,7 @@ jobs:
   test-and-build:
     name: Test and Build
     needs: prepare-release
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:
       - uses: actions/checkout@v7
@@ -276,7 +276,7 @@ jobs:
   release-approval:
     name: Release Approval
     needs: test-and-build
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     environment:
       name: npm-publish-approval
 
@@ -298,7 +298,7 @@ jobs:
   publish-npm:
     name: Publish to npm
     needs: [prepare-release, release-approval]
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     environment:
       name: npm-publish
       url: https://www.npmjs.com/package/@aws/agentcore

--- a/.github/workflows/slack-open-prs-notification.yml
+++ b/.github/workflows/slack-open-prs-notification.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   notify-slack:
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Get open PRs
         id: open-prs

--- a/.github/workflows/strands-command.yml
+++ b/.github/workflows/strands-command.yml
@@ -31,7 +31,7 @@ permissions:
 jobs:
   strands-agent:
     if: startsWith(github.event.comment.body, '/strands') || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Check authorization
         uses: actions/github-script@v9


### PR DESCRIPTION
Moves every job off ubuntu-latest onto our CodeBuild-hosted runner (agentcore-e2e, CI account us-east-1). Fixes the 5-10min GitHub-hosted runner pickup we've been hitting in the aws/ org, plus WAF 403s on AWS-calling jobs. 

Runners are ephemeral/per-job, bounded by the 300 Linux/Small concurrency quota, so parallelism is preserved. 

Follow-up: migrate the webhook from my PAT to the managed GitHub App connection once org admin scopes the repo.

edit: based on harness comment, keeping ci failure one still based on GH ubuntu runner 