### PR TITLE
ci: gate fork-PR E2E/tarball on PR author (fix pwn-request + checkout@v7 fork block)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -85,6 +85,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          # This job runs only after the `authorize` gate confirms the actor is in AUTHORIZED_USERS,
+          # so checking out the PR head (incl. fork PRs) is intentional. checkout@v7 blocks fork
+          # checkout in pull_request_target by default; the authorize gate is our pwn-request guard.
+          allow-unsafe-pr-checkout: true
       - uses: actions/setup-node@v6
         with:
           node-version: '20.x'

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -88,6 +88,11 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          # Safe because the `authorize` job above gates on the PR AUTHOR being in AUTHORIZED_USERS:
+          # external authors skip at the gate, so only trusted authors' code is ever checked out here.
+          # Needed because authorized maintainers routinely open PRs from their own forks, and
+          # checkout@v7 otherwise refuses fork-PR checkout in pull_request_target.
+          allow-unsafe-pr-checkout: true
       - uses: actions/setup-node@v6
         with:
           node-version: '20.x'

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -50,19 +50,22 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           AUTHORIZED_USERS: ${{ secrets.AUTHORIZED_USERS }}
-          GITHUB_ACTOR: ${{ github.actor }}
+          # Gate on the PR AUTHOR (whose code this is), NOT github.actor (who triggered the run).
+          # On pull_request_target a trusted actor (e.g. a maintainer pushing to a fork PR) triggering
+          # a run must NOT cause an untrusted author's fork code to execute with our AWS role/secrets.
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             echo "✅ Manual workflow dispatch — authorized"
             echo "is_authorized=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if [[ ",$AUTHORIZED_USERS," == *",${GITHUB_ACTOR},"* ]]; then
-            echo "✅ User ${GITHUB_ACTOR} is authorized"
+          if [[ ",$AUTHORIZED_USERS," == *",${PR_AUTHOR},"* ]]; then
+            echo "✅ PR author ${PR_AUTHOR} is authorized"
             echo "is_authorized=true" >> "$GITHUB_OUTPUT"
           else
-            echo "⏭️ User ${GITHUB_ACTOR} is not in AUTHORIZED_USERS — skipping E2E tests."
-            echo "ℹ️ External contributors: ask a maintainer to run the E2E tests manually via workflow_dispatch."
+            echo "⏭️ PR author ${PR_AUTHOR} is not in AUTHORIZED_USERS — skipping E2E tests."
+            echo "ℹ️ External contributors: a maintainer can run the E2E tests via workflow_dispatch after reviewing the code."
             echo "is_authorized=false" >> "$GITHUB_OUTPUT"
           fi
 
@@ -85,10 +88,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
-          # This job runs only after the `authorize` gate confirms the actor is in AUTHORIZED_USERS,
-          # so checking out the PR head (incl. fork PRs) is intentional. checkout@v7 blocks fork
-          # checkout in pull_request_target by default; the authorize gate is our pwn-request guard.
-          allow-unsafe-pr-checkout: true
       - uses: actions/setup-node@v6
         with:
           node-version: '20.x'

--- a/.github/workflows/pr-security-review.yml
+++ b/.github/workflows/pr-security-review.yml
@@ -160,6 +160,12 @@ jobs:
         with:
           ref: ${{ steps.pr.outputs.head_sha }}
           fetch-depth: 0
+          # Safe to opt in here: the `authorize` job already gates on the PR AUTHOR having write/admin
+          # (getCollaboratorPermissionLevel), and this job only READS the code (compute diff, build
+          # prompt, run the review) — it never executes fork code (no npm ci / npm scripts). checkout@v7
+          # otherwise refuses fork-PR checkout in pull_request_target, which would break the review on
+          # an authorized author's fork PR. Reviewing the PR head is the whole point of this job.
+          allow-unsafe-pr-checkout: true
 
       - name: Compute diff
         id: diff

--- a/.github/workflows/pr-tarball.yml
+++ b/.github/workflows/pr-tarball.yml
@@ -38,6 +38,11 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          # Safe because the `authorize` job above gates on the PR AUTHOR being in AUTHORIZED_USERS:
+          # external authors skip at the gate, so only trusted authors' code is ever checked out here.
+          # Needed because authorized maintainers routinely open PRs from their own forks, and
+          # checkout@v7 otherwise refuses fork-PR checkout in pull_request_target.
+          allow-unsafe-pr-checkout: true
       - uses: actions/setup-node@v6
         with:
           node-version: '20.x'

--- a/.github/workflows/pr-tarball.yml
+++ b/.github/workflows/pr-tarball.yml
@@ -17,13 +17,16 @@ jobs:
         id: check
         env:
           AUTHORIZED_USERS: ${{ secrets.AUTHORIZED_USERS }}
-          GITHUB_ACTOR: ${{ github.actor }}
+          # Gate on the PR AUTHOR (whose code this npm build runs), NOT github.actor (who triggered the
+          # run). Otherwise a trusted actor pushing to a fork PR would run untrusted fork npm scripts
+          # with the contents:write GITHUB_TOKEN + App token in this job.
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
-          if [[ ",$AUTHORIZED_USERS," == *",${GITHUB_ACTOR},"* ]]; then
-            echo "✅ User ${GITHUB_ACTOR} is authorized"
+          if [[ ",$AUTHORIZED_USERS," == *",${PR_AUTHOR},"* ]]; then
+            echo "✅ PR author ${PR_AUTHOR} is authorized"
             echo "is_authorized=true" >> "$GITHUB_OUTPUT"
           else
-            echo "⏭️ User ${GITHUB_ACTOR} is not in AUTHORIZED_USERS — skipping."
+            echo "⏭️ PR author ${PR_AUTHOR} is not in AUTHORIZED_USERS — skipping."
             echo "is_authorized=false" >> "$GITHUB_OUTPUT"
           fi
 
@@ -35,10 +38,6 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          # This job runs only after the `authorize` gate confirms the actor is in AUTHORIZED_USERS,
-          # so checking out the PR head (incl. fork PRs) is intentional. checkout@v7 blocks fork
-          # checkout in pull_request_target by default; the authorize gate is our pwn-request guard.
-          allow-unsafe-pr-checkout: true
       - uses: actions/setup-node@v6
         with:
           node-version: '20.x'

--- a/.github/workflows/pr-tarball.yml
+++ b/.github/workflows/pr-tarball.yml
@@ -35,6 +35,10 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          # This job runs only after the `authorize` gate confirms the actor is in AUTHORIZED_USERS,
+          # so checking out the PR head (incl. fork PRs) is intentional. checkout@v7 blocks fork
+          # checkout in pull_request_target by default; the authorize gate is our pwn-request guard.
+          allow-unsafe-pr-checkout: true
       - uses: actions/setup-node@v6
         with:
           node-version: '20.x'


### PR DESCRIPTION
## Description

`e2e`, `pr-tarball`, and `pr-security-review` fail at checkout for **fork PRs**. Root cause: #1710 bumped `actions/checkout` v6→v7, and v7 refuses to check out fork-PR code in a `pull_request_target` workflow by default (the "pwn request" protection). Since PRs here (including from authorized maintainers) are routinely opened from forks, this hard-fails those jobs at checkout.

Fixing it also surfaced a pre-existing flaw in `e2e`/`pr-tarball`: their `authorize` gate keyed on **`github.actor`** (who *triggered* the run), not the PR **author** (whose *code* runs). On `pull_request_target`, a trusted actor pushing to a fork PR would pass the gate and run untrusted fork code with the AWS role / write token — a real pwn-request.

## Fix

All three `pull_request_target` workflows now use the same, safe combination — **gate on the PR author, then opt into the fork checkout**:

1. **Gate on `github.event.pull_request.user.login`** (the PR author):
   - `e2e` / `pr-tarball`: author must be in `AUTHORIZED_USERS` (curated list — appropriate since these deploy real AWS resources / publish releases). *(This replaces the previous `github.actor` gate — the actual pwn-request fix.)*
   - `pr-security-review`: already gated on author write/admin via `getCollaboratorPermissionLevel` (unchanged).
2. **`allow-unsafe-pr-checkout: true`** on the checkout step. This is safe *because* of (1): external/untrusted authors skip at the gate, so only trusted authors' code is ever checked out — and their fork PRs (the normal path here) run again instead of hard-failing.

The key correctness point: `allow-unsafe-pr-checkout` is only dangerous with an **actor**-based gate (trusted actor + untrusted author's code). With an **author**-based gate it's safe, since the code's author is the thing being trusted.

Other `pull_request_target` workflows were checked and are fine (`codeql.yml`, `pr-ai-review.yml` use the default merge-ref, not fork head; `pr-size.yml`/`pr-title.yml` have no checkout).

## Type of Change

- [x] Bug fix (CI) — also closes a pre-existing pull_request_target pwn-request in e2e/pr-tarball

## Related

Regression surfaced by #1710 (checkout v7 bump).

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] My changes generate no new warnings
