### PR TITLE
feat: add description field to connector configuration entries

### DIFF
--- a/integ-tests/add-remove-web-search.test.ts
+++ b/integ-tests/add-remove-web-search.test.ts
@@ -9,6 +9,7 @@ const telemetry = createTelemetryHelper();
 
 interface ConfigurationEntry {
   name: string;
+  description?: string;
   parameterValues?: Record<string, unknown>;
   parameterOverrides?: { path: string; description?: string; visible?: boolean }[];
 }
@@ -84,6 +85,7 @@ describe('integration: add and remove web-search via --connector flag', () => {
     expect(target?.connectorId).toBe('web-search');
     expect(target?.configurations).toHaveLength(1);
     expect(target?.configurations?.[0]?.name).toBe('WebSearch');
+    expect(target?.configurations?.[0]?.description).toBe('');
     expect(target?.configurations?.[0]?.parameterValues).toEqual({});
     expect(target?.configurations?.[0]?.parameterOverrides).toEqual([]);
     telemetry.assertMetricEmitted({ command: 'add.gateway-target', exit_reason: 'success' });

--- a/src/cli/operations/connectors/translators.ts
+++ b/src/cli/operations/connectors/translators.ts
@@ -8,6 +8,7 @@
 
 export interface ConfigurationEntry {
   name: string;
+  description: string;
   parameterValues: Record<string, unknown>;
   parameterOverrides: ParameterOverride[];
 }
@@ -35,13 +36,15 @@ function translateWebSearch(input: WebSearchTranslatorInput): ConfigurationEntry
   if (input.excludeDomains && input.excludeDomains.length > 0) {
     parameterValues.domainFilter = { exclude: input.excludeDomains };
   }
-  return [{ name: 'WebSearch', parameterValues, parameterOverrides: [] }];
+  return [{ name: 'WebSearch', description: '', parameterValues, parameterOverrides: [] }];
 }
 
 function translateKnowledgeBases(input: KnowledgeBasesTranslatorInput): ConfigurationEntry[] {
   return [
     {
       name: 'AgenticRetrieveStream',
+      description:
+        'Streaming endpoint for agentic retrieval from knowledge bases. Performs multi-step retrieval with planning and returns results as a stream of events.',
       parameterValues: {
         retrievers: [{ configuration: { knowledgeBase: { knowledgeBaseId: input.knowledgeBaseId } } }],
         agenticRetrieveConfiguration: { foundationModelType: 'MANAGED', rerankingModelType: 'MANAGED' },
@@ -50,6 +53,7 @@ function translateKnowledgeBases(input: KnowledgeBasesTranslatorInput): Configur
     },
     {
       name: 'Retrieve',
+      description: 'Queries a knowledge base and retrieves information from it.',
       parameterValues: { knowledgeBaseId: input.knowledgeBaseId },
       parameterOverrides: [],
     },

--- a/src/schema/schemas/mcp.ts
+++ b/src/schema/schemas/mcp.ts
@@ -474,6 +474,7 @@ export const AgentCoreGatewayTargetSchema = z
       .array(
         z.object({
           name: z.string(),
+          description: z.string().optional(),
           parameterValues: z.record(z.string(), z.unknown()).optional(),
           parameterOverrides: z
             .array(


### PR DESCRIPTION
Adds a description field to each connector configuration entry written to agentcore.json. KB configurations are pre-populated with a default description; web-search defaults to an empty string. This makes the field visible to customers editing agentcore.json directly, so they can provide tool descriptions without needing to know the field exists.

* Updated ConfigurationEntry interface and zod schema to include description
* Pre-populated KB descriptions with default string
* Updated integ tests to match new structure

## Description

<!-- Provide a detailed description of the changes in this PR -->

## Related Issue

<!-- Every PR must be associated with an issue. Link it below using #issue-number format. -->

Closes #

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:unit` and `npm run test:integ`
- [ ] I ran `npm run typecheck`
- [ ] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
