### PR TITLE
Revert "feat(run): add --kms-key flag to run insights for KMS parity (#1688)"

### DIFF
--- a/src/cli/commands/run/command.tsx
+++ b/src/cli/commands/run/command.tsx
@@ -376,7 +376,6 @@ export const registerRun = (program: Command) => {
     .option('--wait', 'Block until the job reaches a terminal state')
     .option('--region <region>', 'AWS region (auto-detected if omitted)')
     .option('--endpoint <name>', 'Runtime endpoint name (e.g. PROMPT_V1)')
-    .option('--kms-key <arn>', 'KMS key ARN for encrypting insights job results')
     .option('--json', 'Output as JSON')
     .action(
       async (cliOptions: {
@@ -392,7 +391,6 @@ export const registerRun = (program: Command) => {
         wait?: boolean;
         region?: string;
         endpoint?: string;
-        kmsKey?: string;
         json?: boolean;
       }) => {
         requireProject();
@@ -426,7 +424,6 @@ export const registerRun = (program: Command) => {
             name: cliOptions.name,
             region: cliOptions.region,
             endpoint: cliOptions.endpoint,
-            kmsKeyArn: cliOptions.kmsKey,
             onProgress: cliOptions.json ? undefined : (_status, message) => console.log(message),
           });
           if (!startResult.success) {

--- a/src/cli/operations/jobs/insights/handler.ts
+++ b/src/cli/operations/jobs/insights/handler.ts
@@ -142,7 +142,6 @@ export const insightsHandler: InsightsHandler = {
           : {}),
         dataSourceConfig,
         clientToken: generateClientToken(),
-        ...(opts.kmsKeyArn ? { kmsKeyArn: opts.kmsKeyArn } : {}),
       });
       logger?.log(`Response: ${JSON.stringify(startResult, null, 2)}`);
       logger?.endStep('success');

--- a/src/cli/operations/jobs/shared/types.ts
+++ b/src/cli/operations/jobs/shared/types.ts
@@ -288,8 +288,6 @@ export interface StartInsightsJobOptions {
   name?: string;
   region?: string;
   endpoint?: string;
-  /** KMS key ARN for encrypting insights job results. */
-  kmsKeyArn?: string;
   onProgress?: (status: string, message: string) => void;
 }
 


### PR DESCRIPTION
## Summary

Reverts #1688, which added a `--kms-key` flag to `run insights` for KMS parity with `run batch-evaluation` and `run recommendation`.

This reverts merge commit e61338c38d3f96462f0ccc8e46ae47c5a2a6c9f8.

## Reverted changes

- `src/cli/commands/run/command.tsx` — removes `--kms-key <arn>` from `run insights`.
- `src/cli/operations/jobs/shared/types.ts` — removes `kmsKeyArn?` from `StartInsightsJobOptions`.
- `src/cli/operations/jobs/insights/handler.ts` — stops threading `kmsKeyArn` through to `startBatchEvaluation`.

Re-opens #1655.
