### PR TITLE
fix(dev): apply model config for all providers in dev, not just Bedrock

### DIFF
--- a/src/cli/operations/dev/web-ui/__tests__/harness-utils.test.ts
+++ b/src/cli/operations/dev/web-ui/__tests__/harness-utils.test.ts
@@ -33,14 +33,60 @@ describe('buildInvokeOptions — model resolution', () => {
     expect(opts.skills).toEqual([{ path: './skills' }]);
   });
 
-  it('sends no default override for non-bedrock providers', () => {
+  it('defaults an OpenAI model with maxTokens + apiKeyArn (dropping converse_stream apiFormat)', () => {
+    const openAiModel: HarnessModel = {
+      provider: 'open_ai',
+      modelId: 'gpt-4.1',
+      apiKeyArn: 'arn:aws:secretsmanager:us-east-1:123:secret/openai',
+      maxTokens: 2048,
+      temperature: 0.5,
+    };
+    const opts = buildInvokeOptions(ARN, 'us-west-2', 's-1', [], undefined, openAiModel);
+    expect(opts.model).toEqual({
+      openAiModelConfig: {
+        modelId: 'gpt-4.1',
+        temperature: 0.5,
+        maxTokens: 2048,
+        apiKeyArn: 'arn:aws:secretsmanager:us-east-1:123:secret/openai',
+      },
+    });
+  });
+
+  it('defaults a Gemini model with maxTokens + topK', () => {
     const geminiModel: HarnessModel = {
       provider: 'gemini',
       modelId: 'gemini-2.5-flash',
       apiKeyArn: 'arn:aws:secretsmanager:us-east-1:123:secret/gemini',
       maxTokens: 512,
+      topK: 40,
     };
     const opts = buildInvokeOptions(ARN, 'us-west-2', 's-1', [], undefined, geminiModel);
-    expect(opts.model).toBeUndefined();
+    expect(opts.model).toEqual({
+      geminiModelConfig: {
+        modelId: 'gemini-2.5-flash',
+        maxTokens: 512,
+        apiKeyArn: 'arn:aws:secretsmanager:us-east-1:123:secret/gemini',
+        topK: 40,
+      },
+    });
+  });
+
+  it('defaults a LiteLLM model with maxTokens + apiBase + additionalParams', () => {
+    const liteLlmModel: HarnessModel = {
+      provider: 'lite_llm',
+      modelId: 'bedrock/us.anthropic.claude-sonnet-4-5',
+      maxTokens: 8192,
+      apiBase: 'https://proxy.example.com',
+      additionalParams: { foo: 'bar' },
+    };
+    const opts = buildInvokeOptions(ARN, 'us-west-2', 's-1', [], undefined, liteLlmModel);
+    expect(opts.model).toEqual({
+      liteLlmModelConfig: {
+        modelId: 'bedrock/us.anthropic.claude-sonnet-4-5',
+        maxTokens: 8192,
+        apiBase: 'https://proxy.example.com',
+        additionalParams: { foo: 'bar' },
+      },
+    });
   });
 });

--- a/src/cli/operations/dev/web-ui/handlers/harness-utils.ts
+++ b/src/cli/operations/dev/web-ui/handlers/harness-utils.ts
@@ -1,9 +1,64 @@
 import { ConfigIO } from '../../../../../lib';
 import type { HarnessModel } from '../../../../../schema';
-import type { HarnessSystemPrompt, InvokeHarnessOptions } from '../../../../aws/agentcore-harness';
+import type {
+  HarnessModelConfiguration,
+  HarnessSystemPrompt,
+  InvokeHarnessOptions,
+} from '../../../../aws/agentcore-harness';
 import type { HarnessInvocationOverrides } from '../api-types';
 
 const DEFAULT_MAX_ITERATIONS = 75;
+
+/**
+ * Map the local harness spec's model onto the invoke API's model-configuration shape, so dev
+ * invocations honor agentcore.json model settings (notably maxTokens) without a redeploy. The web
+ * UI only sends a model override when the user edits the model panel — without this default the
+ * deployed model config silently wins. Each provider gets its own config key with only the fields
+ * that provider's config accepts (see BedrockModelConfig / OpenAiModelConfig / GeminiModelConfig /
+ * LiteLlmModelConfig). Returns undefined for an unknown provider.
+ */
+function buildModelOverride(specModel: HarnessModel): HarnessModelConfiguration | undefined {
+  // Fields common to every provider config.
+  const common = {
+    modelId: specModel.modelId,
+    ...(specModel.temperature !== undefined && { temperature: specModel.temperature }),
+    ...(specModel.topP !== undefined && { topP: specModel.topP }),
+    ...(specModel.maxTokens !== undefined && { maxTokens: specModel.maxTokens }),
+  };
+
+  switch (specModel.provider) {
+    case 'bedrock':
+      return { bedrockModelConfig: { ...common, ...(specModel.apiFormat && { apiFormat: specModel.apiFormat }) } };
+    case 'open_ai':
+      return {
+        openAiModelConfig: {
+          ...common,
+          ...(specModel.apiKeyArn && { apiKeyArn: specModel.apiKeyArn }),
+          // OpenAI accepts only 'responses' | 'chat_completions'; the schema rejects converse_stream here.
+          ...(specModel.apiFormat && specModel.apiFormat !== 'converse_stream' && { apiFormat: specModel.apiFormat }),
+        },
+      };
+    case 'gemini':
+      return {
+        geminiModelConfig: {
+          ...common,
+          ...(specModel.apiKeyArn && { apiKeyArn: specModel.apiKeyArn }),
+          ...(specModel.topK !== undefined && { topK: specModel.topK }),
+        },
+      };
+    case 'lite_llm':
+      return {
+        liteLlmModelConfig: {
+          ...common,
+          ...(specModel.apiKeyArn && { apiKeyArn: specModel.apiKeyArn }),
+          ...(specModel.apiBase && { apiBase: specModel.apiBase }),
+          ...(specModel.additionalParams && { additionalParams: specModel.additionalParams }),
+        },
+      };
+    default:
+      return undefined;
+  }
+}
 
 /**
  * Read the model config from the local harness spec, best-effort. Returns undefined when there is
@@ -40,19 +95,10 @@ export function buildInvokeOptions(
 
   if (overrides?.model) {
     opts.model = overrides.model;
-  } else if (specModel?.provider === 'bedrock') {
-    // The web UI only sends a model override when the user edits the model panel, so without this
-    // default the deployed model config silently wins during dev. Send the local spec's Bedrock
-    // model config so agentcore.json settings (notably maxTokens) apply without a redeploy.
-    opts.model = {
-      bedrockModelConfig: {
-        modelId: specModel.modelId,
-        ...(specModel.apiFormat && { apiFormat: specModel.apiFormat }),
-        ...(specModel.temperature !== undefined && { temperature: specModel.temperature }),
-        ...(specModel.topP !== undefined && { topP: specModel.topP }),
-        ...(specModel.maxTokens !== undefined && { maxTokens: specModel.maxTokens }),
-      },
-    };
+  } else if (specModel) {
+    // Default the model from the local spec so agentcore.json settings (notably maxTokens) apply in
+    // dev without a redeploy. See buildModelOverride for the per-provider mapping.
+    opts.model = buildModelOverride(specModel);
   }
   if (overrides?.systemPrompt) opts.systemPrompt = [{ text: overrides.systemPrompt }] as HarnessSystemPrompt;
   if (overrides?.skills) opts.skills = overrides.skills;

--- a/src/cli/operations/dev/web-ui/handlers/harness-utils.ts
+++ b/src/cli/operations/dev/web-ui/handlers/harness-utils.ts
@@ -13,9 +13,7 @@ const DEFAULT_MAX_ITERATIONS = 75;
  * Map the local harness spec's model onto the invoke API's model-configuration shape, so dev
  * invocations honor agentcore.json model settings (notably maxTokens) without a redeploy. The web
  * UI only sends a model override when the user edits the model panel — without this default the
- * deployed model config silently wins. Each provider gets its own config key with only the fields
- * that provider's config accepts (see BedrockModelConfig / OpenAiModelConfig / GeminiModelConfig /
- * LiteLlmModelConfig). Returns undefined for an unknown provider.
+ * deployed model config silently wins. Returns undefined for an unknown provider.
  */
 function buildModelOverride(specModel: HarnessModel): HarnessModelConfiguration | undefined {
   // Fields common to every provider config.


### PR DESCRIPTION
## Description

Follow-up to #1719. That PR made `agentcore dev` default the harness invoke model from the local spec, so `agentcore.json` model settings (notably `maxTokens`) apply in dev without a redeploy — but the default only fired for `provider === 'bedrock'`. OpenAI / Gemini / LiteLLM harnesses still silently fell back to the **deployed** model config, so a local `maxTokens` edit did nothing for them until the next `agentcore deploy`.

This extends the same fix to all four providers.

## Changes

- Extract `buildModelOverride()` in `harness-utils.ts`, replacing the inline Bedrock-only branch. It maps each provider to its own invoke-API config key — `bedrockModelConfig` / `openAiModelConfig` / `geminiModelConfig` / `liteLlmModelConfig` — carrying only the fields that config accepts:
  - common: `modelId`, `temperature`, `topP`, `maxTokens`
  - Bedrock: `+ apiFormat`
  - OpenAI: `+ apiKeyArn`, `+ apiFormat` (drops `converse_stream`, which the OpenAI config rejects)
  - Gemini: `+ apiKeyArn`, `+ topK`
  - LiteLLM: `+ apiKeyArn`, `+ apiBase`, `+ additionalParams`
- `buildInvokeOptions` now defaults from the spec for any provider (was `else if (specModel?.provider === 'bedrock')`).
- Tests: replace the old "sends no override for non-bedrock providers" case (which asserted the bug) with mapping coverage for OpenAI, Gemini, and LiteLLM.

## Type of Change

- [x] Bug fix

## Testing

- [x] `npm run typecheck`
- [x] `npm run lint` (eslint + prettier clean on changed files)
- [x] `npx vitest run src/cli/operations/dev/web-ui/__tests__/harness-utils.test.ts` → 7/7 pass

> Note: verified the invoke API's config shapes accept `maxTokens` for all four providers. Runtime honoring for OpenAI/Gemini/LiteLLM is server-side and not verified end-to-end here — this wires the config through consistently, matching the Bedrock path.