### PR TITLE
fix: auto-trigger ingestion on connector config file content changes

### DIFF
--- a/src/cli/commands/deploy/actions.ts
+++ b/src/cli/commands/deploy/actions.ts
@@ -59,6 +59,7 @@ import { hydrateKnowledgeBaseDataSources } from '../../operations/knowledge-base
 import { toStackName } from '../import/import-utils';
 import type { DeployResult } from './types';
 import { StackSelectionStrategy } from '@aws-cdk/toolkit-lib';
+import { resolve } from 'node:path';
 
 export interface ValidatedDeployOptions {
   target: string;
@@ -906,6 +907,7 @@ export async function handleDeploy(options: ValidatedDeployOptions): Promise<Dep
         previousKnowledgeBases: existingState?.targets?.[target.name]?.resources?.knowledgeBases,
         targetName: target.name,
         deployedState,
+        projectRoot: resolve(configIO.getConfigRoot(), '..'),
         onProgress: msg => logger.log(msg),
       });
 

--- a/src/cli/operations/deploy/__tests__/post-deploy-knowledge-bases.test.ts
+++ b/src/cli/operations/deploy/__tests__/post-deploy-knowledge-bases.test.ts
@@ -1,5 +1,9 @@
 import * as ingest from '../../ingest';
 import { autoIngestKnowledgeBases, computeSourcesHash } from '../post-deploy-knowledge-bases';
+import { randomUUID } from 'node:crypto';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../../ingest');
@@ -40,6 +44,81 @@ describe('computeSourcesHash', () => {
     const kb1 = kbWithSources('a', ['s3://b/x/', 's3://b/y/']);
     const kb2 = kbWithSources('a', ['s3://b/y/', 's3://b/x/']);
     expect(computeSourcesHash(kb1)).not.toBe(computeSourcesHash(kb2));
+  });
+});
+
+describe('computeSourcesHash — connector config file content', () => {
+  let projectRoot: string;
+
+  beforeEach(() => {
+    projectRoot = join(tmpdir(), `agentcore-hash-test-${randomUUID()}`);
+    mkdirSync(join(projectRoot, 'app/myKb'), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  const kbWithConnector = (name: string, configFile: string) =>
+    ({
+      type: 'AgentCoreKnowledgeBase',
+      name,
+      dataSources: [{ type: 'CONFLUENCE', connectorConfigFile: configFile }],
+    }) as never;
+
+  it('hashes file content when projectRoot is provided', () => {
+    const configFile = 'app/myKb/confluence.json';
+    writeFileSync(join(projectRoot, configFile), JSON.stringify({ type: 'CONFLUENCE', hostUrl: 'https://a.com' }));
+    const kb = kbWithConnector('myKb', configFile);
+
+    const hash1 = computeSourcesHash(kb, projectRoot);
+
+    writeFileSync(join(projectRoot, configFile), JSON.stringify({ type: 'CONFLUENCE', hostUrl: 'https://b.com' }));
+    const hash2 = computeSourcesHash(kb, projectRoot);
+
+    expect(hash1).not.toBe(hash2);
+  });
+
+  it('produces same hash when file content is unchanged', () => {
+    const configFile = 'app/myKb/confluence.json';
+    writeFileSync(join(projectRoot, configFile), JSON.stringify({ type: 'CONFLUENCE', hostUrl: 'https://a.com' }));
+    const kb = kbWithConnector('myKb', configFile);
+
+    expect(computeSourcesHash(kb, projectRoot)).toBe(computeSourcesHash(kb, projectRoot));
+  });
+
+  it('normalizes JSON whitespace differences', () => {
+    const configFile = 'app/myKb/confluence.json';
+    const kb = kbWithConnector('myKb', configFile);
+
+    writeFileSync(join(projectRoot, configFile), '{"type":"CONFLUENCE","hostUrl":"https://a.com"}');
+    const hash1 = computeSourcesHash(kb, projectRoot);
+
+    writeFileSync(join(projectRoot, configFile), '{\n  "type": "CONFLUENCE",\n  "hostUrl": "https://a.com"\n}');
+    const hash2 = computeSourcesHash(kb, projectRoot);
+
+    expect(hash1).toBe(hash2);
+  });
+
+  it('falls back to path-based hash when file cannot be read', () => {
+    const configFile = 'app/myKb/missing.json';
+    const kb = kbWithConnector('myKb', configFile);
+
+    const hashWithRoot = computeSourcesHash(kb, projectRoot);
+    const hashWithoutRoot = computeSourcesHash(kb);
+
+    expect(hashWithRoot).toBe(hashWithoutRoot);
+  });
+
+  it('falls back to path-based hash when projectRoot is not provided', () => {
+    const configFile = 'app/myKb/confluence.json';
+    writeFileSync(join(projectRoot, configFile), JSON.stringify({ type: 'CONFLUENCE', hostUrl: 'https://a.com' }));
+    const kb = kbWithConnector('myKb', configFile);
+
+    const hashWithRoot = computeSourcesHash(kb, projectRoot);
+    const hashWithoutRoot = computeSourcesHash(kb);
+
+    expect(hashWithRoot).not.toBe(hashWithoutRoot);
   });
 });
 

--- a/src/cli/operations/deploy/post-deploy-knowledge-bases.ts
+++ b/src/cli/operations/deploy/post-deploy-knowledge-bases.ts
@@ -1,6 +1,8 @@
 import type { DeployedState, KnowledgeBase, KnowledgeBaseDeployedState } from '../../../schema';
 import { runKbIngestionByName } from '../ingest';
 import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 
 export interface AutoIngestKnowledgeBasesOptions {
   region: string;
@@ -13,6 +15,8 @@ export interface AutoIngestKnowledgeBasesOptions {
   targetName: string;
   /** Full deployed-state (passed through to runKbIngestionByName). */
   deployedState: DeployedState;
+  /** Project root directory for resolving connector config file paths. */
+  projectRoot?: string;
   /**
    * Optional progress callback. When the retry loop sleeps because Bedrock
    * is busy with a sibling job, this is called with a short status line so
@@ -42,14 +46,29 @@ export interface AutoIngestKnowledgeBasesResult {
 }
 
 /**
- * Compute the SHA-256 over the data-source URIs of a KB spec, joined with
- * newlines. The post-deploy hook compares this to the previously-stored
- * sourcesHash to decide whether to re-trigger ingestion.
+ * Compute a SHA-256 over each data source's identity + configuration content.
+ * For S3 data sources, the URI is the full configuration. For connector-file
+ * data sources, the file contents are hashed so that edits to the connector
+ * configuration (filters, host, credentials) trigger re-ingestion even when
+ * the file path stays the same. If the file cannot be read, falls back to
+ * hashing the path to avoid blocking the deploy.
  */
-export function computeSourcesHash(kb: KnowledgeBase): string {
-  return createHash('sha256')
-    .update(kb.dataSources.map(ds => (ds.type === 'S3' ? ds.uri : ds.connectorConfigFile)).join('\n'))
-    .digest('hex');
+export function computeSourcesHash(kb: KnowledgeBase, projectRoot?: string): string {
+  const parts = kb.dataSources.map(ds => {
+    if (ds.type === 'S3') return ds.uri;
+    if (projectRoot) {
+      try {
+        const abs = resolve(projectRoot, ds.connectorConfigFile);
+        const content = readFileSync(abs, 'utf-8');
+        const normalized = JSON.stringify(JSON.parse(content));
+        return `${ds.connectorConfigFile}:${normalized}`;
+      } catch {
+        return ds.connectorConfigFile;
+      }
+    }
+    return ds.connectorConfigFile;
+  });
+  return createHash('sha256').update(parts.join('\n')).digest('hex');
 }
 
 /**
@@ -89,7 +108,7 @@ export async function autoIngestKnowledgeBases(
       continue;
     }
 
-    const newHash = computeSourcesHash(kb);
+    const newHash = computeSourcesHash(kb, opts.projectRoot);
     const previousHash = opts.previousKnowledgeBases?.[kb.name]?.sourcesHash;
 
     if (previousHash && previousHash === newHash) {

--- a/src/cli/tui/screens/deploy/useDeployFlow.ts
+++ b/src/cli/tui/screens/deploy/useDeployFlow.ts
@@ -46,6 +46,7 @@ import {
 } from '../../components';
 import { type MissingCredential, type PreflightContext, useCdkPreflight } from '../../hooks';
 import { StackSelectionStrategy } from '@aws-cdk/toolkit-lib';
+import { resolve } from 'node:path';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 type DeployPhase =
@@ -555,6 +556,7 @@ export function useDeployFlow(options: DeployFlowOptions = {}): DeployFlowState 
           previousKnowledgeBases,
           targetName: target.name,
           deployedState,
+          projectRoot: resolve(configIO.getConfigRoot(), '..'),
           onProgress: msg => logger.log(msg),
         });
 


### PR DESCRIPTION
## Description

Previously, auto-ingestion only triggered when a data source was added/removed or its file path changed. If a user edited their `app/<kbName>/confluence.json` to change the Confluence space, filters, or host URL, the hash was unchanged (same path) and ingestion was skipped — leaving the KB serving stale content from the old configuration.

`computeSourcesHash` now hashes the content of connector config files instead of just the file path. This guarantees edits to filters, host URLs, credentials, or any other connector configuration will trigger re-ingestion on the next deploy even when the filename is unchanged.
 * falls back to path-based hashing if the file cannot be read, so deploy is never blocked.
 * Passes projectRoot through from both the CLI and TUI deploy flows.

## Related Issue

<!-- Every PR must be associated with an issue. Link it below using #issue-number format. -->

Closes #

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
