### PR TITLE
ci: pin browser-tests to ubuntu-latest (fix Playwright deps on CodeBuild)

### DIFF
--- a/.github/workflows/e2e-tests-full.yml
+++ b/.github/workflows/e2e-tests-full.yml
@@ -111,7 +111,13 @@ jobs:
           CDP_WALLET_SECRET: ${{ env.E2E_CDP_WALLET_SECRET }}
         run: npx vitest run --project e2e --shard=${{ matrix.shard }}
   browser-tests:
-    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
+    # Pinned to GitHub-hosted ubuntu-latest, unlike the other jobs (#1715 moved
+    # everything to CodeBuild). Playwright's `install --with-deps` shells out to
+    # apt-get to install Chromium's OS libraries; the CodeBuild runner image has
+    # no apt-get and Playwright doesn't recognize the distro, so the step exits
+    # 127 ("apt-get: command not found"). ubuntu-latest is a Playwright-supported
+    # OS where --with-deps works. See #1715.
+    runs-on: ubuntu-latest
     environment: e2e-testing
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
## Problem

Browser tests have been failing on `main` since #1715 (\`ci: run all workflows on CodeBuild-hosted runners\`).

The **e2e matrix passes**; only **browser-tests** fails, at the **Install Playwright browsers** step:

\`\`\`
$ npx playwright install chromium --with-deps
BEWARE: your OS is not officially supported by Playwright; installing dependencies for ubuntu24.04-x64 as a fallback.
Installing dependencies...
sh: line 1: apt-get: command not found
Failed to install browsers
Error: Installation process exited with code: 127
\`\`\`

([failing run](https://github.com/aws/agentcore-cli/actions/runs/29102392179/job/86394289246))

## Root cause

`--with-deps` shells out to the system package manager to install Chromium's OS-level shared libraries. On the GitHub-hosted `ubuntu-latest` runner that worked (apt-get present, recognized distro). #1715 moved this job onto the CodeBuild-hosted runner, whose image has no `apt-get` and isn't a Playwright-recognized distro — so the step exits 127 deterministically. e2e jobs are unaffected because they never touch Playwright.

## Fix

Pin **only** `browser-tests` back to `ubuntu-latest` — a Playwright-supported OS where `--with-deps` works. This mirrors the pattern #1715 already uses for `codeql` and `ci-failure-issue`. All other jobs stay on CodeBuild.

## Tradeoff / follow-up

browser-tests makes real AWS calls (\`sts get-caller-identity\` + \`agentcore dev\`). If ubuntu-latest shared IPs reintroduce the service WAF 403s that #1715 was avoiding, the better fix is a custom Playwright-capable CodeBuild image (deps baked in, drop \`--with-deps\`) rather than reverting this pin. Not reproduced under current traffic.