### PR TITLE
ci: use GitHub-hosted runners for release workflow

### DIFF
--- a/.github/workflows/release-main-and-preview.yml
+++ b/.github/workflows/release-main-and-preview.yml
@@ -54,7 +54,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════
   prepare-release:
     name: Prepare Release
-    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-latest
     outputs:
       main_version: ${{ steps.bump-main.outputs.version || steps.current-main.outputs.version }}
       preview_version: ${{ steps.bump-preview.outputs.version }}
@@ -216,7 +216,7 @@ jobs:
   release-approval:
     name: Release Approval
     needs: [prepare-release]
-    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-latest
     environment:
       name: npm-publish-approval
     steps:
@@ -242,7 +242,7 @@ jobs:
     name: Verify PR Merged
     needs: [prepare-release, release-approval]
     if: ${{ !inputs.dry_run }}
-    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -284,7 +284,7 @@ jobs:
     name: Publish Main (@latest)
     needs: [prepare-release, verify-merge]
     if: inputs.release_target != 'preview-only'
-    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-latest
     environment:
       name: npm-publish
       url: https://www.npmjs.com/package/@aws/agentcore
@@ -341,7 +341,7 @@ jobs:
     name: Publish Preview (@preview)
     needs: [prepare-release, verify-merge]
     if: inputs.release_target != 'main-only'
-    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-latest
     environment:
       name: npm-publish
       url: https://www.npmjs.com/package/@aws/agentcore
@@ -412,7 +412,7 @@ jobs:
     name: Release Summary
     needs: [prepare-release, publish-main, publish-preview]
     if: always() && !cancelled()
-    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: ubuntu-latest
     steps:
       - name: Summary
         env:


### PR DESCRIPTION
## Why

npm publish `--provenance` requires an OIDC token issued by `github.com`. Self-hosted CodeBuild runners (`codebuild-agentcore-e2e-*`) don't issue that token, so provenance publishing fails.

## What

Switch all 6 jobs in `release-main-and-preview.yml` from the self-hosted CodeBuild runner to `ubuntu-latest`:

- `prepare-release`
- `release-approval`
- `verify-merge`
- `publish-main`
- `publish-preview`
- `summary`

No other changes.