### PR TITLE
fix: agentcore dev overrides otel env vars

### DIFF
--- a/src/cli/commands/dev/browser-mode.ts
+++ b/src/cli/commands/dev/browser-mode.ts
@@ -3,7 +3,7 @@ import type { AgentCoreProjectSpec } from '../../../schema';
 import { ANSI } from '../../constants';
 import { isDeploySkippable } from '../../operations/deploy/change-detection';
 import { getDevConfig, getDevSupportedAgents, loadDevEnv, loadProjectConfig } from '../../operations/dev';
-import { type OtelCollector, startOtelCollector } from '../../operations/dev/otel';
+import { type OtelCollector, hasExternalOtelEndpoint, startOtelCollector } from '../../operations/dev/otel';
 import {
   type AgentInfo,
   type ListMemoryRecordsHandler,
@@ -142,8 +142,15 @@ export async function launchBrowserDev(): Promise<void> {
   }
 
   const configRoot = findConfigRoot(workingDir);
-  const persistTracesDir = path.join(configRoot ?? workingDir, '.cli', 'traces');
-  const { collector, otelEnvVars } = await startOtelCollector(persistTracesDir);
+  let collector: OtelCollector | undefined;
+  let otelEnvVars: Record<string, string> = {};
+
+  if (!hasExternalOtelEndpoint()) {
+    const persistTracesDir = path.join(configRoot ?? workingDir, '.cli', 'traces');
+    const result = await startOtelCollector(persistTracesDir);
+    collector = result.collector;
+    otelEnvVars = result.otelEnvVars;
+  }
 
   await runBrowserMode({
     workingDir,

--- a/src/cli/commands/dev/command.tsx
+++ b/src/cli/commands/dev/command.tsx
@@ -28,7 +28,7 @@ import {
   loadProjectConfig,
   onShutdownSignal,
 } from '../../operations/dev';
-import { OtelCollector, startOtelCollector } from '../../operations/dev/otel';
+import { OtelCollector, hasExternalOtelEndpoint, startOtelCollector } from '../../operations/dev/otel';
 import { withCommandRunTelemetry } from '../../telemetry/cli-command-run.js';
 import { AgentProtocol, standardize } from '../../telemetry/schemas/common-shapes.js';
 import { LayoutProvider } from '../../tui/context';
@@ -358,7 +358,7 @@ export const registerDev = (program: Command) => {
             let otelEnvVars: Record<string, string> = {};
             let collector: OtelCollector | undefined;
 
-            if (opts.traces !== false) {
+            if (opts.traces !== false && !hasExternalOtelEndpoint()) {
               const persistTracesDir = path.join(configRoot ?? workingDir, '.cli', 'traces');
               const otelResult = await startOtelCollector(persistTracesDir);
               collector = otelResult.collector;

--- a/src/cli/operations/dev/__tests__/otel-collector.test.ts
+++ b/src/cli/operations/dev/__tests__/otel-collector.test.ts
@@ -1,0 +1,34 @@
+import { hasExternalOtelEndpoint } from '../otel';
+import { afterEach, describe, expect, it } from 'vitest';
+
+describe('hasExternalOtelEndpoint', () => {
+  const savedEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...savedEnv };
+  });
+
+  it('returns false when no OTEL endpoint env vars are set', () => {
+    delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+    delete process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
+    expect(hasExternalOtelEndpoint()).toBe(false);
+  });
+
+  it('returns true when OTEL_EXPORTER_OTLP_ENDPOINT is set', () => {
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = 'http://localhost:4318';
+    delete process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
+    expect(hasExternalOtelEndpoint()).toBe(true);
+  });
+
+  it('returns true when OTEL_EXPORTER_OTLP_TRACES_ENDPOINT is set', () => {
+    delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+    process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = 'http://localhost:4318/v1/traces';
+    expect(hasExternalOtelEndpoint()).toBe(true);
+  });
+
+  it('returns true when both are set', () => {
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = 'http://localhost:4318';
+    process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = 'http://localhost:4318/v1/traces';
+    expect(hasExternalOtelEndpoint()).toBe(true);
+  });
+});

--- a/src/cli/operations/dev/otel/collector.ts
+++ b/src/cli/operations/dev/otel/collector.ts
@@ -285,6 +285,11 @@ function readBodyAsBuffer(req: IncomingMessage): Promise<Buffer> {
   });
 }
 
+/** Returns true if the user has already configured an external OTLP endpoint. */
+export function hasExternalOtelEndpoint(): boolean {
+  return !!process.env.OTEL_EXPORTER_OTLP_ENDPOINT || !!process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
+}
+
 /**
  * Start an OTEL collector and return it along with the env vars agents need
  * to export traces to it.

--- a/src/cli/operations/dev/otel/index.ts
+++ b/src/cli/operations/dev/otel/index.ts
@@ -1,2 +1,2 @@
-export { OtelCollector, startOtelCollector } from './collector';
+export { OtelCollector, hasExternalOtelEndpoint, startOtelCollector } from './collector';
 export type { OtlpResourceSpan, OtlpResourceLog } from './types';


### PR DESCRIPTION
## Description

`agentcore dev` unconditionally starts a built-in OTLP collector and sets `OTEL_EXPORTER_OTLP_ENDPOINT` to point at it. This overwrites any pre-existing endpoint the user has configured (e.g., for forwarding traces to their own collector.

Previously the only workaround was `--no-traces`, which is confusing since the user *does* want tracing — just not our built-in collector.

**Fix:** Before starting the built-in collector, check if `OTEL_EXPORTER_OTLP_ENDPOINT` or `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` is already set in the environment. If either is present, skip starting our collector and don't inject our OTLP env vars — let the user's configuration pass through to the agent process.

## Related Issue

Closes #1009

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

**Manual test:**
```bash
# Collector starts normally (no env var set):
agentcore dev -l --skip-deploy
# → "OTEL collector listening on port ..."

# Collector skipped when endpoint is pre-configured:
OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:9999 agentcore dev -l --skip-deploy
# → No collector started, spans go to user's endpoint
```

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.