### PR TITLE
fix: agentcore dev overwrites otel exporter env var

### DIFF
--- a/src/cli/operations/dev/__tests__/otel-collector.test.ts
+++ b/src/cli/operations/dev/__tests__/otel-collector.test.ts
@@ -1,0 +1,32 @@
+import { startOtelCollector } from '../otel';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+describe('startOtelCollector', () => {
+  const savedEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...savedEnv };
+  });
+
+  it('uses built-in collector endpoint when no external endpoint is set', async () => {
+    delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+    const { collector, otelEnvVars } = await startOtelCollector(join(tmpdir(), 'otel-test'));
+    try {
+      expect(otelEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+    } finally {
+      collector.stop();
+    }
+  });
+
+  it('uses external endpoint when OTEL_EXPORTER_OTLP_ENDPOINT is set', async () => {
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = 'http://my-collector:4318';
+    const { collector, otelEnvVars } = await startOtelCollector(join(tmpdir(), 'otel-test'));
+    try {
+      expect(otelEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT).toBe('http://my-collector:4318');
+    } finally {
+      collector.stop();
+    }
+  });
+});

--- a/src/cli/operations/dev/otel/collector.ts
+++ b/src/cli/operations/dev/otel/collector.ts
@@ -298,11 +298,13 @@ export async function startOtelCollector(persistTracesDir: string): Promise<{
 
   const otelEnvVars: Record<string, string> = {
     OTEL_EXPORTER_OTLP_ENDPOINT: process.env.OTEL_EXPORTER_OTLP_ENDPOINT ?? `http://127.0.0.1:${collectorPort}`,
-    OTEL_EXPORTER_OTLP_PROTOCOL: 'http/protobuf',
-    OTEL_METRICS_EXPORTER: 'none',
-    AGENT_OBSERVABILITY_ENABLED: 'true',
-    OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT: 'true',
-    OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED: 'true',
+    OTEL_EXPORTER_OTLP_PROTOCOL: process.env.OTEL_EXPORTER_OTLP_PROTOCOL ?? 'http/protobuf',
+    OTEL_METRICS_EXPORTER: process.env.OTEL_METRICS_EXPORTER ?? 'none',
+    AGENT_OBSERVABILITY_ENABLED: process.env.AGENT_OBSERVABILITY_ENABLED ?? 'true',
+    OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT:
+      process.env.OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT ?? 'true',
+    OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED:
+      process.env.OTEL_PYTHON_LOGGING_AUTO_INSTRUMENTATION_ENABLED ?? 'true',
   };
 
   return { collector, otelEnvVars };

--- a/src/cli/operations/dev/otel/collector.ts
+++ b/src/cli/operations/dev/otel/collector.ts
@@ -297,7 +297,7 @@ export async function startOtelCollector(persistTracesDir: string): Promise<{
   const collectorPort = await collector.start();
 
   const otelEnvVars: Record<string, string> = {
-    OTEL_EXPORTER_OTLP_ENDPOINT: `http://127.0.0.1:${collectorPort}`,
+    OTEL_EXPORTER_OTLP_ENDPOINT: process.env.OTEL_EXPORTER_OTLP_ENDPOINT ?? `http://127.0.0.1:${collectorPort}`,
     OTEL_EXPORTER_OTLP_PROTOCOL: 'http/protobuf',
     OTEL_METRICS_EXPORTER: 'none',
     AGENT_OBSERVABILITY_ENABLED: 'true',


### PR DESCRIPTION
## Description

`agentcore dev` unconditionally overwrites OTel env vars (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL`, etc.) with its own values, ignoring any the user has already configured. This breaks workflows where users have their own collector or instrumentation setup.

Previously the only workaround was `--no-traces`, which is confusing since the user *does* want tracing — just not our defaults.

**Fix:** In `startOtelCollector`, respect any OTel env vars the user has already set in `process.env`. We provide sensible defaults only for vars that aren't already configured. User's env always wins.

## Related Issue

Closes #1009

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

**Manual test:**
```bash
# Start a dummy OTLP receiver:
python3 ~/Desktop/dummy-otel-collector.py  # listens on :9999

# Run agent with external endpoint:
OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:9999 \
OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
AGENT_OBSERVABILITY_ENABLED=true \
agentcore dev -l --skip-deploy

# Invoke agent → dummy server receives traces
```

**Unit test:** Added `otel-collector.test.ts` — verifies endpoint passthrough vs default behavior. Test fails without the fix, passes with it.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.