### PR TITLE
fix(deploy): select the auto-detected target so a fresh project's first deploy isn't scoped to zero stacks

### DIFF
--- a/src/cli/tui/hooks/__tests__/useAwsTargetConfig.test.tsx
+++ b/src/cli/tui/hooks/__tests__/useAwsTargetConfig.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * Regression test for the fresh-project first-deploy failure.
+ *
+ * A freshly-created project has an empty aws-targets.json. The deploy TUI auto-detects the AWS
+ * context and saves a default target, but the hook left `selectedTargetIndices` empty. The deploy
+ * flow scopes its stack selector to the selected targets (issue #1267), so an empty selection
+ * produced a PATTERN_MUST_MATCH selector with zero patterns and the first deploy failed with
+ * "Stack selection is ambiguous, please choose a specific stack for import".
+ *
+ * These tests assert every path that ends in `phase === 'configured'` also selects the target(s)
+ * the deploy should be scoped to.
+ */
+import { useAwsTargetConfig } from '../useAwsTargetConfig';
+import { render } from 'ink-testing-library';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockFindConfigRoot, mockResolveTargets, mockWriteTargets, mockDetectAwsContext } = vi.hoisted(() => ({
+  mockFindConfigRoot: vi.fn(),
+  mockResolveTargets: vi.fn(),
+  mockWriteTargets: vi.fn(),
+  mockDetectAwsContext: vi.fn(),
+}));
+
+vi.mock('../../../../lib', async () => {
+  const actual = await vi.importActual<any>('../../../../lib');
+  return {
+    ...actual,
+    findConfigRoot: mockFindConfigRoot,
+    ConfigIO: class {
+      resolveAWSDeploymentTargets = mockResolveTargets;
+      writeAWSDeploymentTargets = mockWriteTargets;
+    },
+  };
+});
+
+vi.mock('../../../aws', async () => {
+  const actual = await vi.importActual<any>('../../../aws');
+  return {
+    ...actual,
+    detectAwsContext: mockDetectAwsContext,
+  };
+});
+
+function Harness({ onState }: { onState: (state: ReturnType<typeof useAwsTargetConfig>) => void }) {
+  const state = useAwsTargetConfig();
+  onState(state);
+  return null as unknown as React.ReactElement;
+}
+
+async function flush() {
+  for (let i = 0; i < 10; i += 1) {
+    await new Promise(resolve => setTimeout(resolve, 5));
+  }
+}
+
+describe('useAwsTargetConfig target selection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindConfigRoot.mockReturnValue('/proj/agentcore');
+    mockWriteTargets.mockResolvedValue(undefined);
+  });
+
+  it('selects the auto-detected target on a fresh project (empty aws-targets.json)', async () => {
+    mockResolveTargets.mockResolvedValue([]);
+    mockDetectAwsContext.mockResolvedValue({ accountId: '111111111111', region: 'us-west-2' });
+
+    let latest: any;
+    const { unmount } = render(<Harness onState={s => (latest = s)} />);
+    await flush();
+    unmount();
+
+    expect(latest.phase).toBe('configured');
+    expect(mockWriteTargets).toHaveBeenCalledTimes(1);
+    // The just-saved default target must be available AND selected — deploy scopes its
+    // stack patterns to the selection, so an empty selection deploys nothing and errors.
+    expect(latest.availableTargets).toHaveLength(1);
+    expect(latest.availableTargets[0].name).toBe('default');
+    expect(latest.selectedTargetIndices).toEqual([0]);
+  });
+
+  it('selects the lone pre-configured target', async () => {
+    const target = { name: 'default', account: '111111111111', region: 'us-west-2' };
+    mockResolveTargets.mockResolvedValue([target]);
+
+    let latest: any;
+    const { unmount } = render(<Harness onState={s => (latest = s)} />);
+    await flush();
+    unmount();
+
+    expect(latest.phase).toBe('configured');
+    expect(latest.selectedTargetIndices).toEqual([0]);
+  });
+
+  it('multi-target projects go to select-target with no implicit selection', async () => {
+    mockResolveTargets.mockResolvedValue([
+      { name: 'a', account: '111111111111', region: 'us-east-1' },
+      { name: 'b', account: '222222222222', region: 'us-west-2' },
+    ]);
+
+    let latest: any;
+    const { unmount } = render(<Harness onState={s => (latest = s)} />);
+    await flush();
+    unmount();
+
+    expect(latest.phase).toBe('select-target');
+    expect(latest.selectedTargetIndices).toEqual([]);
+  });
+});

--- a/src/cli/tui/hooks/useAwsTargetConfig.ts
+++ b/src/cli/tui/hooks/useAwsTargetConfig.ts
@@ -94,6 +94,12 @@ export function useAwsTargetConfig(): AwsTargetConfigState {
       region: region,
     };
     await configIO.writeAWSDeploymentTargets([target]);
+    // Select the just-saved target, mirroring the single-existing-target path above.
+    // Deploy scopes its stack patterns to the selected targets, so leaving the
+    // selection empty here made a fresh project's first deploy build an empty
+    // PATTERN_MUST_MATCH pattern list and fail with "Stack selection is ambiguous".
+    setAvailableTargets([target]);
+    setSelectedTargetIndices([0]);
   }, []);
 
   // Check if targets already exist on mount


### PR DESCRIPTION
## Description

The very first interactive `agentcore deploy` on a freshly created project failed with:

```
Error: CDK deploy failed: Stack selection is ambiguous, please choose a specific stack for import [AgentCore-clitest-default]
```

**Root cause:** regression from the #1267 fix (#1659). The TUI deploy flow scopes its stack selector to the target picker's selection (`PATTERN_MUST_MATCH` over `selectedTargets`), and deliberately treats an empty selection as "deploy nothing" so the deploy-everything bug can't re-latent.

A fresh project has an empty `aws-targets.json`, so `useAwsTargetConfig` takes the auto-detect path: it detects the AWS account/region and saves a `default` target — but unlike the single-pre-configured-target and multi-target-picker paths, it never populated `selectedTargetIndices`. `DeployScreen` then passed `selectedTargets = []` into the deploy flow, producing a pattern selector with zero patterns, and toolkit-lib threw `NoStacksMatched`. Second deploys worked (the target file was populated by then), so every *first* deploy of a new project was broken.

**Fix:** `saveTarget()` now also registers and selects the just-saved target, mirroring the existing single-target path:

```ts
setAvailableTargets([target]);
setSelectedTargetIndices([0]);
```

## Related Issue

Closes #1752

## Documentation PR

N/A — bug fix, no doc changes needed.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

Additional verification:

- **Reproduced before the fix**: built the tarball with `npm run bundle`, installed it fresh, ran `agentcore create --name clitest` → `agentcore deploy` (interactive) — failed with the exact error above.
- **New regression test** `src/cli/tui/hooks/__tests__/useAwsTargetConfig.test.tsx` covering all three configuration paths (fresh-project auto-detect, lone pre-configured target, multi-target picker). The auto-detect case fails on the unfixed code and passes with the fix.
- **Verified after the fix end-to-end**: rebuilt the bundle, re-ran create → deploy against a real AWS account — deploy completed successfully (stack `CREATE_COMPLETE`, harness `READY`, deployed state persisted). Test stack cleaned up afterwards.
- All 806 TUI unit tests pass, including the 11 existing #1267 target-scoping regression tests.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings