### PR TITLE
test(e2e): structured failure debugging that leads with the exact error

### DIFF
--- a/e2e-tests/e2e-helper.ts
+++ b/e2e-tests/e2e-helper.ts
@@ -7,6 +7,7 @@ import {
   spawnAndCollect,
 } from '../src/test-utils/index.js';
 import { deleteCredentialProvider } from './utils/credential-provider-cleanup.js';
+import { dumpFailureContext } from './utils/failure-context.js';
 import { getLogger } from './utils/logger.js';
 import { BedrockAgentCoreControlClient, GetAgentRuntimeCommand } from '@aws-sdk/client-bedrock-agentcore-control';
 import { execSync } from 'node:child_process';
@@ -153,8 +154,12 @@ export function createE2ESuite(cfg: E2EConfig) {
             const result = await runAgentCoreCLI(['deploy', '--yes', '--json'], projectPath);
 
             if (result.exitCode !== 0) {
-              console.log('Deploy stdout:', result.stdout);
-              console.log('Deploy stderr:', result.stderr);
+              await dumpFailureContext({
+                label: 'deploy',
+                result,
+                cwd: projectPath,
+                stackName: `AgentCore-${agentName}-default`,
+              });
             }
 
             expect(result.exitCode, `Deploy failed (stderr: ${result.stderr}, stdout: ${result.stdout})`).toBe(0);
@@ -183,8 +188,7 @@ export function createE2ESuite(cfg: E2EConfig) {
             );
 
             if (result.exitCode !== 0) {
-              console.log('Invoke stdout:', result.stdout);
-              console.log('Invoke stderr:', result.stderr);
+              await dumpFailureContext({ label: 'invoke', result, cwd: projectPath });
             }
 
             expect(result.exitCode, `Invoke failed: ${result.stderr}`).toBe(0);

--- a/e2e-tests/utils/failure-context.ts
+++ b/e2e-tests/utils/failure-context.ts
@@ -1,0 +1,123 @@
+import { type RunResult, spawnAndCollect } from '../../src/test-utils/index.js';
+
+/**
+ * Structured failure debugging for E2E tests (E2E infra doc §5). When a CLI
+ * step fails, on-call scrolls a wall of raw stdout/stderr. This surfaces the
+ * *exact* error first, plus the CLI's own classification when available, plus
+ * (best-effort) the CloudFormation events that explain a deploy failure.
+ */
+
+/** Parsed view of a failed `--json` CLI result. */
+export interface ParsedFailure {
+  /** The exact error message the CLI reported (the thing you actually want). */
+  error: string;
+  /** The CLI's own error class, e.g. "ThrottlingError" — present when the CLI
+   *  emits a typed BaseError via serializeResult(). */
+  errorName?: string;
+  /** The CLI's own source classification: user | client | service | unknown. */
+  errorSource?: string;
+}
+
+/**
+ * Extract the exact error from a failed CLI result. Prefers the structured
+ * `{ success: false, error, errorName?, errorSource? }` JSON the CLI prints with
+ * `--json`; falls back to raw stderr (then stdout) when the output isn't JSON.
+ * Pure — no network/fs — so it's unit-testable.
+ */
+export function parseFailure(result: Pick<RunResult, 'stdout' | 'stderr'>): ParsedFailure {
+  // The JSON envelope is usually the last non-empty stdout line.
+  const lines = result.stdout
+    .split('\n')
+    .map(l => l.trim())
+    .filter(Boolean);
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i]!;
+    if (!line.startsWith('{')) continue;
+    try {
+      const obj = JSON.parse(line) as Record<string, unknown>;
+      if (obj.success === false && typeof obj.error === 'string') {
+        return {
+          error: obj.error,
+          errorName: typeof obj.errorName === 'string' ? obj.errorName : undefined,
+          errorSource: typeof obj.errorSource === 'string' ? obj.errorSource : undefined,
+        };
+      }
+    } catch {
+      /* not JSON — keep scanning */
+    }
+  }
+  const fallback = result.stderr.trim() || result.stdout.trim() || '(no output)';
+  return { error: fallback };
+}
+
+export interface DumpFailureOptions {
+  /** Label for the failing step, e.g. "deploy" / "invoke". */
+  label: string;
+  result: RunResult;
+  cwd: string;
+  /** CloudFormation stack to pull failed events from (deploy failures). */
+  stackName?: string;
+  region?: string;
+  /** Sink for output; defaults to console.log. Injectable for tests. */
+  log?: (msg: string) => void;
+}
+
+/** Query CloudFormation for the events that explain a failed deploy. */
+async function fetchFailedStackEvents(stackName: string, region: string, cwd: string): Promise<string | undefined> {
+  const events = await spawnAndCollect(
+    'aws',
+    [
+      'cloudformation',
+      'describe-stack-events',
+      '--stack-name',
+      stackName,
+      '--query',
+      // Only events that carry a failure reason — filter out the noise.
+      "StackEvents[?contains(ResourceStatus, 'FAILED') || contains(ResourceStatus, 'ROLLBACK')].{Resource:LogicalResourceId,Status:ResourceStatus,Reason:ResourceStatusReason}",
+      '--output',
+      'json',
+      '--region',
+      region,
+    ],
+    cwd
+  );
+  if (events.exitCode === 0 && events.stdout.trim() && events.stdout.trim() !== '[]') {
+    return events.stdout;
+  }
+  return undefined;
+}
+
+/**
+ * Emit a single structured failure report instead of scattered console.logs.
+ * Leads with the exact error; adds the CLI's own errorName/errorSource when
+ * present. Best-effort context fetch — never throws (a debug helper must not
+ * mask the real assertion).
+ */
+export async function dumpFailureContext(opts: DumpFailureOptions): Promise<void> {
+  const log = opts.log ?? ((m: string) => console.log(m));
+  const region = opts.region ?? process.env.AWS_REGION ?? 'us-east-1';
+  const parsed = parseFailure(opts.result);
+
+  const lines: string[] = [];
+  lines.push(`\n──────── E2E failure: ${opts.label} (exit ${opts.result.exitCode}) ────────`);
+  // The exact error, first and prominent.
+  lines.push(`▸ error: ${parsed.error}`);
+  if (parsed.errorName) {
+    lines.push(`▸ type: ${parsed.errorName}${parsed.errorSource ? ` (source: ${parsed.errorSource})` : ''}`);
+  }
+  // Full raw output stays available below the summary for anything the parse missed.
+  lines.push(`▸ stdout:\n${opts.result.stdout}`);
+  lines.push(`▸ stderr:\n${opts.result.stderr}`);
+  log(lines.join('\n'));
+
+  // Deploy failures: pull the CloudFormation events the CLI output doesn't have.
+  try {
+    if (opts.stackName) {
+      const events = await fetchFailedStackEvents(opts.stackName, region, opts.cwd);
+      if (events) log(`▸ CloudFormation failed/rollback events for ${opts.label}:\n${events}`);
+    }
+  } catch {
+    // A debug helper must never mask the real test failure.
+    log(`▸ (failed to fetch CloudFormation events for ${opts.label})`);
+  }
+}

--- a/integ-tests/failure-context.test.ts
+++ b/integ-tests/failure-context.test.ts
@@ -1,0 +1,58 @@
+import { parseFailure } from '../e2e-tests/utils/failure-context.js';
+import { describe, expect, it } from 'vitest';
+
+// Unit tests for the E2E failure parser (E2E infra doc §5). Pure function over
+// CLI output — no AWS needed. Surfaces the EXACT error the CLI reported, plus
+// its own errorName/errorSource classification when present.
+const r = (stdout = '', stderr = '') => ({ stdout, stderr });
+
+describe('parseFailure', () => {
+  it('extracts the exact error from the --json envelope', () => {
+    const out = JSON.stringify({ success: false, error: 'Deploy failed: stack rolled back' });
+    expect(parseFailure(r(out))).toEqual({ error: 'Deploy failed: stack rolled back' });
+  });
+
+  it('surfaces errorName/errorSource when the CLI emits a typed error', () => {
+    const out = JSON.stringify({
+      success: false,
+      error: 'Rate exceeded',
+      errorName: 'ThrottlingError',
+      errorSource: 'service',
+    });
+    expect(parseFailure(r(out))).toEqual({
+      error: 'Rate exceeded',
+      errorName: 'ThrottlingError',
+      errorSource: 'service',
+    });
+  });
+
+  it('picks the JSON envelope even when preceded by log noise on stdout', () => {
+    const out = ['building...', 'deploying...', JSON.stringify({ success: false, error: 'boom' })].join('\n');
+    expect(parseFailure(r(out)).error).toBe('boom');
+  });
+
+  it('falls back to stderr when stdout is not JSON', () => {
+    expect(parseFailure(r('some non-json log', 'AccessDenied: not authorized')).error).toBe(
+      'AccessDenied: not authorized'
+    );
+  });
+
+  it('falls back to stdout when there is no stderr and no JSON', () => {
+    expect(parseFailure(r('raw failure text', '')).error).toBe('raw failure text');
+  });
+
+  it('returns a placeholder when there is no output at all', () => {
+    expect(parseFailure(r('', '')).error).toBe('(no output)');
+  });
+
+  it('ignores a success envelope and falls back', () => {
+    const out = JSON.stringify({ success: true, response: 'ok' });
+    expect(parseFailure(r(out, 'warning on stderr')).error).toBe('warning on stderr');
+  });
+
+  it('omits errorName/errorSource when the envelope lacks them', () => {
+    const parsed = parseFailure(r(JSON.stringify({ success: false, error: 'plain' })));
+    expect(parsed.errorName).toBeUndefined();
+    expect(parsed.errorSource).toBeUndefined();
+  });
+});

--- a/src/lib/result.test.ts
+++ b/src/lib/result.test.ts
@@ -1,3 +1,4 @@
+import { ThrottlingError } from './errors/types';
 import { serializeResult, unwrapResult } from './result';
 import type { Result } from './result';
 import { describe, expect, it } from 'vitest';
@@ -16,6 +17,28 @@ describe('serializeResult', () => {
   it('preserves extra fields on failure branch', () => {
     const result = { success: false as const, error: new Error('fail'), logPath: '/tmp/log' };
     expect(serializeResult(result)).toEqual({ success: false, error: 'fail', logPath: '/tmp/log' });
+  });
+
+  it('emits errorName and errorSource for typed BaseErrors', () => {
+    const result = { success: false as const, error: new ThrottlingError('slow down') };
+    expect(serializeResult(result)).toEqual({
+      success: false,
+      error: 'slow down',
+      errorName: 'ThrottlingError',
+      errorSource: 'service',
+    });
+  });
+
+  it('does NOT add errorName/errorSource for a plain Error (backward compatible)', () => {
+    const result = { success: false as const, error: new Error('plain') };
+    const serialized = serializeResult(result);
+    expect(serialized).not.toHaveProperty('errorName');
+    expect(serialized).not.toHaveProperty('errorSource');
+  });
+
+  it('respects a per-throw errorSource override', () => {
+    const result = { success: false as const, error: new ThrottlingError('x', { errorSource: 'user' }) };
+    expect(serializeResult(result)).toMatchObject({ errorName: 'ThrottlingError', errorSource: 'user' });
   });
 });
 

--- a/src/lib/result.ts
+++ b/src/lib/result.ts
@@ -1,3 +1,5 @@
+import { BaseError } from './errors/types.js';
+
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions -- discriminated union member; interface would allow declaration merging which breaks type narrowing
 type FailureResult<E extends Error> = { success: false; error: E };
 
@@ -22,13 +24,25 @@ export type Result<T extends Record<string, unknown> = {}, E extends Error = Err
  * Converts a Result object to a JSON-serializable form.
  * Error objects have non-enumerable properties, so JSON.stringify produces `{}`.
  * This replaces the `error` field with the error message string.
+ *
+ * When the error is one of our typed {@link BaseError}s, also emits `errorName`
+ * (the error class, e.g. "ThrottlingError") and `errorSource`
+ * ("user" | "client" | "service" | "unknown"). This lets programmatic consumers
+ * — e.g. E2E failure debugging — classify a failure from the CLI's own taxonomy
+ * instead of re-parsing the message string. Purely additive: the `error` message
+ * field is unchanged, so existing consumers keep working.
  */
 export function serializeResult<T extends Record<string, unknown>>(
   result: ({ success: true } & T) | ({ success: false; error: Error } & Record<string, unknown>)
 ): Record<string, unknown> {
   if (!result.success) {
     const { error, ...rest } = result;
-    return { ...rest, error: error.message };
+    const serialized: Record<string, unknown> = { ...rest, error: error.message };
+    if (error instanceof BaseError) {
+      serialized.errorName = error.name;
+      serialized.errorSource = error.errorSource;
+    }
+    return serialized;
   }
   return result;
 }


### PR DESCRIPTION
This PR makes imprvoments in the e2e test debugging. serializeResult() (the shared --json envelope builder) now also emits errorName + errorSource for typed BaseErrors. E2E failure-context.ts parses the exact error from the CLI's --json output (past log noise, falling back to stderr), surfaces the CLI's own error type/source, and best-effort pulls filtered CloudFormation FAILED/ROLLBACK events for deploys. Adopted in createE2ESuite deploy/invoke paths. 18 unit tests added