### PR TITLE
fix(test): address failing windows test by standardizing line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# normalize line endings across platforms: https://git-scm.com/docs/gitattributes#_end_of_line_conversion 
+* text=auto eol=lf


### PR DESCRIPTION
Built on https://github.com/aws/agentcore-cli/pull/1748

## Problem 
Windows tests are failing https://github.com/aws/agentcore-cli/issues/1751. 

### Root Cause
When the CI runner checks out the repo on windows, its changing the `\n` at the end of line to `\r\n` to be windows friendly (crlf). However, this causes the tests to fail when comparing results against golden files, which now include extra `\r` at the end of each line. 

## Solution
Normalize line endings on each commit, and on each checkout via `.gitattributes`. 

From docs here https://git-scm.com/docs/gitattributes#_end_of_line_conversion:

> If the eol attribute is unspecified for a file, its line endings in the working directory are determined by the core.autocrlf or core.eol configuration variable (see the definitions of those options in [git-config[1]](https://git-scm.com/docs/git-config)). If text is set but neither of those variables is, the default is eol=crlf on Windows and eol=lf on all other platforms.

We set `text=auto` to ensure windows developers cannot commit code with lines following crlf, and `eol=lf` to ensure that checkouts on windows leverage the `lf` format and don't attempt to reformat. 

## Testing 
I do not have a windows laptop readily available, but this tests are now passing in CI with the fix. 

