### PR TITLE
fix(templates): enable Google ADK observability

### DIFF
--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -2518,8 +2518,7 @@ dependencies = [
     "fastapi >= 0.115.12",
     "google-adk >= 1.16.0, < 2.0.0",
     "google-genai >= 1.0.0, < 2.0.0",
-    "opentelemetry-distro",
-    "opentelemetry-exporter-otlp",
+    "aws-opentelemetry-distro >= 0.17.0",
     "uvicorn >= 0.34.3",
 ]
 
@@ -4196,8 +4195,7 @@ description = "AgentCore Runtime Application using Google ADK"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "opentelemetry-distro",
-    "opentelemetry-exporter-otlp",
+    "aws-opentelemetry-distro >= 0.17.0",
     "google-adk >= 1.35.0, < 2.0.0",
     "google-genai >= 1.0.0, < 2.0.0",
     "bedrock-agentcore >= 1.0.3",

--- a/src/assets/__tests__/googleadk-observability.test.ts
+++ b/src/assets/__tests__/googleadk-observability.test.ts
@@ -1,0 +1,23 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { describe, expect, it } from 'vitest';
+
+const ASSETS_DIR = path.resolve(__dirname, '..', 'python');
+const EXPECTED_DEPENDENCIES = [
+  ['http', '"aws-opentelemetry-distro >= 0.17.0"'],
+  ['agui', '"aws-opentelemetry-distro >= 0.17.0"'],
+  ['a2a', '"aws-opentelemetry-distro"'],
+] as const;
+
+describe('Google ADK observability dependencies', () => {
+  it.each(EXPECTED_DEPENDENCIES)('%s uses the AWS OpenTelemetry distro', (protocol, expectedDependency) => {
+    const pyproject = fs.readFileSync(
+      path.join(ASSETS_DIR, protocol, 'googleadk', 'base', 'pyproject.toml'),
+      'utf-8'
+    );
+
+    expect(pyproject).toContain(expectedDependency);
+    expect(pyproject).not.toMatch(/^\s*"opentelemetry-distro",?$/m);
+    expect(pyproject).not.toMatch(/^\s*"opentelemetry-exporter-otlp",?$/m);
+  });
+});

--- a/src/assets/python/agui/googleadk/base/pyproject.toml
+++ b/src/assets/python/agui/googleadk/base/pyproject.toml
@@ -15,8 +15,7 @@ dependencies = [
     "fastapi >= 0.115.12",
     "google-adk >= 1.16.0, < 2.0.0",
     "google-genai >= 1.0.0, < 2.0.0",
-    "opentelemetry-distro",
-    "opentelemetry-exporter-otlp",
+    "aws-opentelemetry-distro >= 0.17.0",
     "uvicorn >= 0.34.3",
 ]
 

--- a/src/assets/python/http/googleadk/base/pyproject.toml
+++ b/src/assets/python/http/googleadk/base/pyproject.toml
@@ -9,8 +9,7 @@ description = "AgentCore Runtime Application using Google ADK"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "opentelemetry-distro",
-    "opentelemetry-exporter-otlp",
+    "aws-opentelemetry-distro >= 0.17.0",
     "google-adk >= 1.35.0, < 2.0.0",
     "google-genai >= 1.0.0, < 2.0.0",
     "bedrock-agentcore >= 1.0.3",


### PR DESCRIPTION
## Description

Google ADK HTTP and AG-UI projects currently install the generic OpenTelemetry distro and exporter. Although their container entrypoint runs through `opentelemetry-instrument`, live AgentCore verification produced no spans.

This change:

- replaces the generic OpenTelemetry dependencies with `aws-opentelemetry-distro >= 0.17.0`
- keeps the dependency open-ended so the resolver can select the newest version compatible with Google ADK
- adds regression coverage across HTTP, AG-UI, and A2A Google ADK templates
- updates the affected asset snapshots

AWS distro 0.18.x currently requires OpenTelemetry 1.42.x while current Google ADK releases cap OpenTelemetry at 1.41.1. Fresh resolution therefore selects AWS distro 0.17.1 and OpenTelemetry 1.40.0 without requiring a stale upper pin.

## Framework Scope

LangChain is already working and is not changed by this PR. Its template includes the AWS OpenTelemetry distro and explicit LangChain instrumentation from #552, #835, and #836. A live deployed LangChain invocation completed a tool call and emitted 22 spans, including `invoke_agent`, `chat`, `execute_task`, and `execute_tool` operations.

The remaining issue is specific to the Google ADK HTTP and AG-UI dependency templates.

## Verification

Live runtime verification used a generated Google ADK HTTP project:

- Before the change: the invocation reached Google ADK but emitted zero spans to `aws/spans`.
- After replacing only the two generic OpenTelemetry dependencies with AWS distro 0.17.0: the same invocation emitted 18 spans.
- The emitted spans included Google ADK `invoke_agent` and `generate_content` operations, plus correlated request/error telemetry; `traces get` returned 15 correlated runtime records.
- The available Gemini key was invalid, so the model request ended with an authentication error. This still verified telemetry initialization and export on the ADK execution path; a successful model/tool invocation remains an additional end-to-end check.

Dependency and repository verification:

- fresh `uv pip compile` resolution for both changed templates selected `aws-opentelemetry-distro==0.17.1`, `google-adk==1.35.2`, and OpenTelemetry API/SDK 1.40.0
- 131 focused asset, snapshot, and regression tests passed
- `npm run build` passed
- the full unit run passed 5,911 tests; six unrelated failures caused by starting tests before the concurrent build produced `dist/cli/index.mjs`, plus one TUI timing failure, all passed when the two failed files were rerun after the build
- pre-commit typecheck, lint, formatting, and secret checks passed

## Related Issue

Addresses #140

## Documentation PR

Not applicable; this corrects generated runtime dependencies without changing the user-facing configuration.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added tests that prove the fix is effective
- [x] No documentation change is required
- [x] My changes generate no new warnings
- [x] No dependent changes are required

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
