### PR TITLE
fix(ci): migrate runners to codebuild

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     permissions:
       contents: read
     steps:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -9,14 +9,22 @@ on:
 
 jobs:
   test:
-    name: Test (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+    name: Test (${{ matrix.name }})
+    runs-on: ${{ fromJSON(matrix.runner) }}
     permissions:
       contents: read
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - name: Linux
+            runner: '["codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}"]'
+          - name: Windows
+            runner: '["codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}", "image:windows-1.0"]'
+          # CodeBuild does not support macOS.
+          # https://docs.aws.amazon.com/codebuild/latest/userguide/action-runner-questions.html#action-runner-platform
+          - name: macOS
+            runner: '["macos-latest"]'
     steps:
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
### Problem
https://github.com/aws/agentcore-cli/issues/1772

The refactor branch workflows leverage GitHub-hosted `ubuntu-latest` runners. The main branch already runs everything on CodeBuild via #1715, so the refactor branch is inconsistent.

For motivations on why we use codebuild, see https://github.com/aws/agentcore-cli/issues/1494. 

### Solution
- Replace `ubuntu-latest` with the CodeBuild runner in `build.yml`. (https://docs.aws.amazon.com/codebuild/latest/userguide/action-runner-questions.html)
- macOS stays on a GH-hosted runner — [CodeBuild doesn't support
  it](https://docs.aws.amazon.com/codebuild/latest/userguide/action-runner-questions.html#action-runner-platform).
  
### Testing
See PR CI logs on the checkout stage, and notice the file paths mentioned include `codebuild`, indicating its running on a codebuild machine. The macOS test does not show this same path, since its running on GH runners. 

### Notes 
failures are unrelated, and fixed in https://github.com/aws/agentcore-cli/pull/1756, and https://github.com/aws/agentcore-cli/pull/1758