### PR TITLE
fix(tui): return to project name from create picker

### DIFF
--- a/src/cli/tui/screens/create/CreateScreen.tsx
+++ b/src/cli/tui/screens/create/CreateScreen.tsx
@@ -287,7 +287,7 @@ export function CreateScreen({ cwd, isInteractive, onExit, onNavigate }: CreateS
     onSelect: item => {
       flow.handleCreateTypeSelection(item.id as 'harness' | 'agent' | 'skip');
     },
-    onExit: handleExit,
+    onExit: flow.goBackToProjectName,
     isActive: flow.phase === 'create-type-prompt',
   });
 
@@ -342,7 +342,13 @@ export function CreateScreen({ cwd, isInteractive, onExit, onNavigate }: CreateS
             : undefined;
 
   return (
-    <Screen title="AgentCore Create" onExit={handleExit} headerContent={headerContent} helpText={helpText}>
+    <Screen
+      title="AgentCore Create"
+      onExit={handleExit}
+      headerContent={headerContent}
+      helpText={helpText}
+      exitEnabled={phase !== 'create-type-prompt'}
+    >
       {phase === 'existing-project-error' && (
         <Box marginBottom={1} flexDirection="column">
           <Text color="red">A project already exists at this location.</Text>

--- a/src/cli/tui/screens/create/__tests__/CreateScreen.test.tsx
+++ b/src/cli/tui/screens/create/__tests__/CreateScreen.test.tsx
@@ -1,0 +1,43 @@
+import { CreateScreen } from '../CreateScreen';
+import { mkdtempSync, rmSync } from 'fs';
+import { render } from 'ink-testing-library';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const ENTER = '\r';
+const ESCAPE = '\x1B';
+const delay = (ms = 50) => new Promise(resolve => setTimeout(resolve, ms));
+
+let testDir: string | undefined;
+
+afterEach(() => {
+  if (testDir) {
+    rmSync(testDir, { recursive: true, force: true });
+    testDir = undefined;
+  }
+});
+
+describe('CreateScreen navigation', () => {
+  it('returns to project name input when Escape is pressed on the create type prompt', async () => {
+    testDir = mkdtempSync(join(tmpdir(), 'agentcore-create-screen-'));
+    const onExit = vi.fn();
+    const { lastFrame, stdin } = render(<CreateScreen cwd={testDir} isInteractive={false} onExit={onExit} />);
+
+    await delay();
+    stdin.write('TestProject');
+    await delay();
+    stdin.write(ENTER);
+    await delay();
+
+    expect(lastFrame()).toContain('What would you like to build?');
+    expect(lastFrame()).toContain('Esc back');
+
+    stdin.write(ESCAPE);
+    await delay();
+
+    expect(lastFrame()).toContain('Create a new AgentCore project');
+    expect(lastFrame()).toContain('Project name');
+    expect(onExit).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/tui/screens/create/useCreateFlow.ts
+++ b/src/cli/tui/screens/create/useCreateFlow.ts
@@ -75,6 +75,7 @@ interface CreateFlowState {
   confirmProjectName: () => void;
   // Create type selection
   handleCreateTypeSelection: (choice: 'harness' | 'agent' | 'skip') => void;
+  goBackToProjectName: () => void;
   // Add agent config (set when AddAgentScreen completes)
   addAgentConfig: AddAgentConfig | null;
   handleAddAgentComplete: (config: AddAgentConfig) => void;
@@ -178,6 +179,10 @@ export function useCreateFlow(cwd: string): CreateFlowState {
 
   const confirmProjectName = useCallback(() => {
     setPhase('create-type-prompt');
+  }, []);
+
+  const goBackToProjectName = useCallback(() => {
+    setPhase('input');
   }, []);
 
   const updateStep = (index: number, update: Partial<Step>) => {
@@ -741,6 +746,7 @@ export function useCreateFlow(cwd: string): CreateFlowState {
     confirmProjectName,
     // Create type selection
     handleCreateTypeSelection,
+    goBackToProjectName,
     // Add agent
     addAgentConfig,
     handleAddAgentComplete,


### PR DESCRIPTION
## Summary
- route Escape from the create resource-type picker back to project-name input
- prevent the outer screen exit handler from also handling that Escape
- add regression coverage for the full keyboard flow

Fixes #602

## Testing
- `npx vitest run --project unit src/cli/tui/screens/create/__tests__/CreateScreen.test.tsx`
- `npm run typecheck`
- `npx eslint src/cli/tui/screens/create/CreateScreen.tsx src/cli/tui/screens/create/useCreateFlow.ts src/cli/tui/screens/create/__tests__/CreateScreen.test.tsx`
- `npx prettier --check src/cli/tui/screens/create/CreateScreen.tsx src/cli/tui/screens/create/useCreateFlow.ts src/cli/tui/screens/create/__tests__/CreateScreen.test.tsx`
- `npm run build`