### PR TITLE
fix(deploy): upgrade outdated CDK bootstrap stacks

### DIFF
--- a/src/cli/cloudformation/__tests__/bootstrap-extended.test.ts
+++ b/src/cli/cloudformation/__tests__/bootstrap-extended.test.ts
@@ -25,12 +25,18 @@ describe('checkBootstrapStatus', () => {
 
   it('returns isBootstrapped true for CREATE_COMPLETE', async () => {
     mockSend.mockResolvedValue({
-      Stacks: [{ StackStatus: 'CREATE_COMPLETE' }],
+      Stacks: [
+        {
+          StackStatus: 'CREATE_COMPLETE',
+          Outputs: [{ OutputKey: 'BootstrapVersion', OutputValue: '30' }],
+        },
+      ],
     });
 
     const result = await checkBootstrapStatus('us-east-1');
     expect(result.isBootstrapped).toBe(true);
     expect(result.stackStatus).toBe('CREATE_COMPLETE');
+    expect(result.bootstrapVersion).toBe(30);
   });
 
   it('returns isBootstrapped true for UPDATE_COMPLETE', async () => {
@@ -75,6 +81,22 @@ describe('checkBootstrapStatus', () => {
 
     const result = await checkBootstrapStatus('us-east-1');
     expect(result.isBootstrapped).toBe(false);
+  });
+
+  it('returns no bootstrap version when the output is invalid', async () => {
+    mockSend.mockResolvedValue({
+      Stacks: [
+        {
+          StackStatus: 'CREATE_COMPLETE',
+          Outputs: [{ OutputKey: 'BootstrapVersion', OutputValue: 'invalid' }],
+        },
+      ],
+    });
+
+    const result = await checkBootstrapStatus('us-east-1');
+
+    expect(result.isBootstrapped).toBe(true);
+    expect(result.bootstrapVersion).toBeUndefined();
   });
 
   it('returns isBootstrapped false when stack not found (ValidationError)', async () => {

--- a/src/cli/cloudformation/bootstrap.ts
+++ b/src/cli/cloudformation/bootstrap.ts
@@ -6,6 +6,7 @@ export const CDK_TOOLKIT_STACK_NAME = 'CDKToolkit';
 export interface BootstrapStatus {
   isBootstrapped: boolean;
   stackStatus?: string;
+  bootstrapVersion?: number;
 }
 
 /**
@@ -25,10 +26,14 @@ export async function checkBootstrapStatus(region: string): Promise<BootstrapSta
     const status = stack.StackStatus;
     const isUsable =
       status === 'CREATE_COMPLETE' || status === 'UPDATE_COMPLETE' || status === 'UPDATE_ROLLBACK_COMPLETE';
+    const versionOutput = stack.Outputs?.find(output => output.OutputKey === 'BootstrapVersion')?.OutputValue;
+    const bootstrapVersion = versionOutput ? Number.parseInt(versionOutput, 10) : undefined;
 
     return {
       isBootstrapped: isUsable,
       stackStatus: status,
+      bootstrapVersion:
+        bootstrapVersion !== undefined && !Number.isNaN(bootstrapVersion) ? bootstrapVersion : undefined,
     };
   } catch (err: unknown) {
     // Stack doesn't exist - not bootstrapped

--- a/src/cli/operations/deploy/__tests__/preflight-utils.test.ts
+++ b/src/cli/operations/deploy/__tests__/preflight-utils.test.ts
@@ -105,13 +105,33 @@ describe('checkBootstrapNeeded', () => {
   });
 
   it('returns not needed when already bootstrapped', async () => {
-    mockCheckBootstrapStatus.mockResolvedValue({ isBootstrapped: true });
+    mockCheckBootstrapStatus.mockResolvedValue({ isBootstrapped: true, bootstrapVersion: 30 });
     const target = { name: 'dev', region: 'us-east-1', account: '123456789012' } as any;
 
     const result = await checkBootstrapNeeded([target]);
 
     expect(result.needsBootstrap).toBe(false);
     expect(result.target).toBeNull();
+  });
+
+  it('returns needed when the bootstrap version is outdated', async () => {
+    mockCheckBootstrapStatus.mockResolvedValue({ isBootstrapped: true, bootstrapVersion: 18 });
+    const target = { name: 'dev', region: 'us-east-1', account: '123456789012' } as any;
+
+    const result = await checkBootstrapNeeded([target]);
+
+    expect(result.needsBootstrap).toBe(true);
+    expect(result.target).toBe(target);
+  });
+
+  it('returns needed when a legacy bootstrap stack has no version output', async () => {
+    mockCheckBootstrapStatus.mockResolvedValue({ isBootstrapped: true });
+    const target = { name: 'dev', region: 'us-east-1', account: '123456789012' } as any;
+
+    const result = await checkBootstrapNeeded([target]);
+
+    expect(result.needsBootstrap).toBe(true);
+    expect(result.target).toBe(target);
   });
 
   it('returns not needed when check throws', async () => {

--- a/src/cli/operations/deploy/preflight.ts
+++ b/src/cli/operations/deploy/preflight.ts
@@ -37,6 +37,8 @@ export interface BootstrapCheckResult {
   target: AwsDeploymentTarget | null;
 }
 
+export const MINIMUM_CDK_BOOTSTRAP_VERSION = 30;
+
 export interface StackStatusCheckResult {
   /** Whether all stacks are in a deployable state */
   canDeploy: boolean;
@@ -409,7 +411,7 @@ export async function checkBootstrapNeeded(awsTargets: AwsDeploymentTarget[]): P
 
   try {
     const bootstrapStatus = await checkBootstrapStatus(target.region);
-    if (!bootstrapStatus.isBootstrapped) {
+    if (!bootstrapStatus.isBootstrapped || (bootstrapStatus.bootstrapVersion ?? 0) < MINIMUM_CDK_BOOTSTRAP_VERSION) {
       return { needsBootstrap: true, target };
     }
   } catch {


### PR DESCRIPTION
## Summary
- read the standard `BootstrapVersion` output from the `CDKToolkit` stack
- treat bootstrap versions below 30, or legacy stacks without a version output, as requiring bootstrap
- reuse the existing confirmation and `--yes` auto-bootstrap flow to upgrade outdated stacks before deploy
- add regression coverage for version parsing and outdated-stack detection

Fixes #659

## Testing
- `npx vitest run --project unit src/cli/cloudformation src/cli/operations/deploy` (337 tests passed)
- `npm run typecheck`
- `npx eslint src/cli/cloudformation/bootstrap.ts src/cli/operations/deploy/preflight.ts src/cli/cloudformation/__tests__/bootstrap-extended.test.ts src/cli/operations/deploy/__tests__/preflight-utils.test.ts`
- `npx prettier --check src/cli/cloudformation/bootstrap.ts src/cli/operations/deploy/preflight.ts src/cli/cloudformation/__tests__/bootstrap-extended.test.ts src/cli/operations/deploy/__tests__/preflight-utils.test.ts`
- `npm run build`