### PR TITLE
feat(traces): add JSON output

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -925,6 +925,7 @@ View and download agent traces.
 agentcore traces list
 agentcore traces list --runtime MyAgent --limit 50
 agentcore traces list --since 1h --until now
+agentcore traces list --runtime MyAgent --json
 ```
 
 | Flag               | Description                                                                 |
@@ -933,12 +934,14 @@ agentcore traces list --since 1h --until now
 | `--limit <n>`      | Maximum number of traces to display (default: 20)                           |
 | `--since <time>`   | Start time (defaults to 12h ago; e.g. `5m`, `1h`, `2d`, ISO 8601, epoch ms) |
 | `--until <time>`   | End time (defaults to now; e.g. `now`, `1h`, ISO 8601, epoch ms)            |
+| `--json`           | Output as JSON                                                              |
 
 #### traces get
 
 ```bash
 agentcore traces get <traceId>
 agentcore traces get abc123 --runtime MyAgent --output ./trace.json
+agentcore traces get abc123 --runtime MyAgent --json
 ```
 
 | Flag               | Description                      |
@@ -948,6 +951,7 @@ agentcore traces get abc123 --runtime MyAgent --output ./trace.json
 | `--output <path>`  | Output file path                 |
 | `--since <time>`   | Start time (defaults to 12h ago) |
 | `--until <time>`   | End time (defaults to now)       |
+| `--json`           | Output as JSON                   |
 
 ---
 

--- a/src/cli/commands/traces/__tests__/command.test.ts
+++ b/src/cli/commands/traces/__tests__/command.test.ts
@@ -1,0 +1,170 @@
+import { registerTraces } from '../command.js';
+import { Command } from '@commander-js/extra-typings';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockGetProjectRootMismatch,
+  mockHandleTracesGet,
+  mockHandleTracesList,
+  mockLoadConfig,
+  mockProjectExists,
+  mockRender,
+  mockRequireProject,
+} = vi.hoisted(() => ({
+  mockGetProjectRootMismatch: vi.fn(),
+  mockHandleTracesGet: vi.fn(),
+  mockHandleTracesList: vi.fn(),
+  mockLoadConfig: vi.fn(),
+  mockProjectExists: vi.fn(),
+  mockRender: vi.fn(),
+  mockRequireProject: vi.fn(),
+}));
+
+vi.mock('../action', () => ({
+  handleTracesGet: (...args: unknown[]) => mockHandleTracesGet(...args),
+  handleTracesList: (...args: unknown[]) => mockHandleTracesList(...args),
+}));
+
+vi.mock('../../../operations/resolve-agent', () => ({
+  loadDeployedProjectConfig: () => mockLoadConfig(),
+}));
+
+vi.mock('../../../tui/guards', () => ({
+  getProjectRootMismatch: () => mockGetProjectRootMismatch(),
+  projectExists: () => mockProjectExists(),
+  requireProject: () => mockRequireProject(),
+}));
+
+vi.mock('ink', () => ({
+  Box: 'Box',
+  Text: 'Text',
+  render: (...args: unknown[]) => mockRender(...args),
+}));
+
+describe('traces JSON output', () => {
+  let program: Command;
+  let mockExit: ReturnType<typeof vi.spyOn>;
+  let mockLog: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    program = new Command();
+    program.exitOverride();
+    registerTraces(program);
+
+    mockLoadConfig.mockResolvedValue({ project: {}, deployment: {} });
+    mockProjectExists.mockReturnValue(true);
+    mockGetProjectRootMismatch.mockReturnValue(null);
+    mockExit = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+    mockLog = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it('emits trace list results as JSON', async () => {
+    mockHandleTracesList.mockResolvedValue({
+      success: true,
+      agentName: 'runtime-one',
+      targetName: 'default',
+      traces: [{ traceId: 'trace-1', timestamp: '1700000000000', sessionId: 'session-1' }],
+    });
+
+    await program.parseAsync(['traces', 'list', '--runtime', 'runtime-one', '--json'], { from: 'user' });
+
+    expect(JSON.parse(mockLog.mock.calls[0]![0])).toEqual({
+      success: true,
+      agentName: 'runtime-one',
+      targetName: 'default',
+      traces: [{ traceId: 'trace-1', timestamp: '1700000000000', sessionId: 'session-1' }],
+    });
+    expect(mockHandleTracesList).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ runtime: 'runtime-one', json: true })
+    );
+    expect(mockRender).not.toHaveBeenCalled();
+  });
+
+  it('emits trace get results as JSON', async () => {
+    mockHandleTracesGet.mockResolvedValue({
+      success: true,
+      agentName: 'runtime-one',
+      targetName: 'default',
+      filePath: '/tmp/trace-1.json',
+    });
+
+    await program.parseAsync(['traces', 'get', 'trace-1', '--runtime', 'runtime-one', '--json'], { from: 'user' });
+
+    expect(JSON.parse(mockLog.mock.calls[0]![0])).toEqual({
+      success: true,
+      agentName: 'runtime-one',
+      targetName: 'default',
+      filePath: '/tmp/trace-1.json',
+    });
+    expect(mockHandleTracesGet).toHaveBeenCalledWith(
+      expect.anything(),
+      'trace-1',
+      expect.objectContaining({ runtime: 'runtime-one', json: true })
+    );
+    expect(mockRender).not.toHaveBeenCalled();
+  });
+
+  it('emits typed failures as JSON and exits 1', async () => {
+    mockHandleTracesList.mockResolvedValue({
+      success: false,
+      error: new Error('Runtime not found'),
+      consoleUrl: 'https://console.aws.amazon.com/example',
+    });
+
+    await program.parseAsync(['traces', 'list', '--json'], { from: 'user' });
+
+    expect(JSON.parse(mockLog.mock.calls[0]![0])).toEqual({
+      success: false,
+      error: 'Runtime not found',
+      consoleUrl: 'https://console.aws.amazon.com/example',
+    });
+    expect(mockExit).toHaveBeenCalledWith(1);
+    expect(mockRender).not.toHaveBeenCalled();
+  });
+
+  it('emits thrown errors as JSON and exits 1', async () => {
+    mockLoadConfig.mockRejectedValue(new Error('Invalid project configuration'));
+
+    await program.parseAsync(['traces', 'get', 'trace-1', '--json'], { from: 'user' });
+
+    expect(JSON.parse(mockLog.mock.calls[0]![0])).toEqual({
+      success: false,
+      error: 'Invalid project configuration',
+    });
+    expect(mockExit).toHaveBeenCalledWith(1);
+    expect(mockRender).not.toHaveBeenCalled();
+  });
+
+  it('emits a JSON error when run outside a project', async () => {
+    mockProjectExists.mockReturnValue(false);
+
+    await program.parseAsync(['traces', 'list', '--json'], { from: 'user' });
+
+    expect(JSON.parse(mockLog.mock.calls[0]![0])).toEqual({
+      success: false,
+      error: 'No agentcore project found. Run agentcore create first.',
+    });
+    expect(mockExit).toHaveBeenCalledWith(1);
+    expect(mockLoadConfig).not.toHaveBeenCalled();
+    expect(mockRender).not.toHaveBeenCalled();
+  });
+
+  it('keeps Ink rendering for non-JSON output', async () => {
+    mockHandleTracesGet.mockResolvedValue({
+      success: true,
+      filePath: '/tmp/trace-1.json',
+    });
+
+    await program.parseAsync(['traces', 'get', 'trace-1'], { from: 'user' });
+
+    expect(mockRender).toHaveBeenCalledOnce();
+    expect(mockLog).not.toHaveBeenCalled();
+    expect(mockExit).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/commands/traces/command.tsx
+++ b/src/cli/commands/traces/command.tsx
@@ -1,7 +1,8 @@
+import { serializeResult } from '../../../lib';
 import { COMMAND_DESCRIPTIONS } from '../../constants';
 import { getErrorMessage } from '../../errors';
 import { loadDeployedProjectConfig } from '../../operations/resolve-agent';
-import { requireProject } from '../../tui/guards';
+import { getProjectRootMismatch, projectExists, requireProject } from '../../tui/guards';
 import { handleTracesGet, handleTracesList } from './action';
 import type { TracesGetOptions, TracesListOptions } from './types';
 import type { Command } from '@commander-js/extra-typings';
@@ -17,6 +18,33 @@ function formatTimestamp(ts: string): string {
     .replace(/\.\d+Z$/, 'Z');
 }
 
+function requireTracesProject(json?: boolean): boolean {
+  if (!json) {
+    requireProject();
+    return true;
+  }
+
+  if (!projectExists()) {
+    console.log(JSON.stringify({ success: false, error: 'No agentcore project found. Run agentcore create first.' }));
+    process.exit(1);
+    return false;
+  }
+
+  const projectRoot = getProjectRootMismatch();
+  if (projectRoot) {
+    console.log(
+      JSON.stringify({
+        success: false,
+        error: `Please run this command from your project root directory: ${projectRoot}`,
+      })
+    );
+    process.exit(1);
+    return false;
+  }
+
+  return true;
+}
+
 export const registerTraces = (program: Command) => {
   const traces = program.command('traces').alias('t').description(COMMAND_DESCRIPTIONS.traces);
 
@@ -27,21 +55,30 @@ export const registerTraces = (program: Command) => {
     .option('--limit <n>', 'Maximum number of traces to display', '20')
     .option('--since <time>', 'Start time — defaults to 12h ago (e.g. 5m, 1h, 2d, ISO 8601, epoch ms)')
     .option('--until <time>', 'End time — defaults to now (e.g. now, 1h, ISO 8601, epoch ms)')
+    .option('--json', 'Output as JSON')
     .action(async (cliOptions: TracesListOptions) => {
-      requireProject();
-
       try {
+        if (!requireTracesProject(cliOptions.json)) return;
         const context = await loadDeployedProjectConfig();
         const result = await handleTracesList(context, cliOptions);
 
         if (!result.success) {
-          render(
-            <Box flexDirection="column">
-              <Text color="red">Error: {result.error.message}</Text>
-              {result.consoleUrl && <Text color="gray">Console: {result.consoleUrl}</Text>}
-            </Box>
-          );
+          if (cliOptions.json) {
+            console.log(JSON.stringify(serializeResult(result)));
+          } else {
+            render(
+              <Box flexDirection="column">
+                <Text color="red">Error: {result.error.message}</Text>
+                {result.consoleUrl && <Text color="gray">Console: {result.consoleUrl}</Text>}
+              </Box>
+            );
+          }
           process.exit(1);
+          return;
+        }
+
+        if (cliOptions.json) {
+          console.log(JSON.stringify(serializeResult(result)));
           return;
         }
 
@@ -87,7 +124,11 @@ export const registerTraces = (program: Command) => {
           </Box>
         );
       } catch (error) {
-        render(<Text color="red">Error: {getErrorMessage(error)}</Text>);
+        if (cliOptions.json) {
+          console.log(JSON.stringify({ success: false, error: getErrorMessage(error) }));
+        } else {
+          render(<Text color="red">Error: {getErrorMessage(error)}</Text>);
+        }
         process.exit(1);
       }
     });
@@ -99,21 +140,30 @@ export const registerTraces = (program: Command) => {
     .option('--output <path>', 'Output file path')
     .option('--since <time>', 'Start time — defaults to 12h ago (e.g. 5m, 1h, 2d, ISO 8601, epoch ms)')
     .option('--until <time>', 'End time — defaults to now (e.g. now, 1h, ISO 8601, epoch ms)')
+    .option('--json', 'Output as JSON')
     .action(async (traceId: string, cliOptions: TracesGetOptions) => {
-      requireProject();
-
       try {
+        if (!requireTracesProject(cliOptions.json)) return;
         const context = await loadDeployedProjectConfig();
         const result = await handleTracesGet(context, traceId, cliOptions);
 
         if (!result.success) {
-          render(
-            <Box flexDirection="column">
-              <Text color="red">Error: {result.error.message}</Text>
-              {result.consoleUrl && <Text color="gray">Console: {result.consoleUrl}</Text>}
-            </Box>
-          );
+          if (cliOptions.json) {
+            console.log(JSON.stringify(serializeResult(result)));
+          } else {
+            render(
+              <Box flexDirection="column">
+                <Text color="red">Error: {result.error.message}</Text>
+                {result.consoleUrl && <Text color="gray">Console: {result.consoleUrl}</Text>}
+              </Box>
+            );
+          }
           process.exit(1);
+          return;
+        }
+
+        if (cliOptions.json) {
+          console.log(JSON.stringify(serializeResult(result)));
           return;
         }
 
@@ -124,7 +174,11 @@ export const registerTraces = (program: Command) => {
           </Box>
         );
       } catch (error) {
-        render(<Text color="red">Error: {getErrorMessage(error)}</Text>);
+        if (cliOptions.json) {
+          console.log(JSON.stringify({ success: false, error: getErrorMessage(error) }));
+        } else {
+          render(<Text color="red">Error: {getErrorMessage(error)}</Text>);
+        }
         process.exit(1);
       }
     });

--- a/src/cli/commands/traces/types.ts
+++ b/src/cli/commands/traces/types.ts
@@ -3,6 +3,7 @@ export interface TracesListOptions {
   limit?: string;
   since?: string;
   until?: string;
+  json?: boolean;
 }
 
 export interface TracesGetOptions {
@@ -10,4 +11,5 @@ export interface TracesGetOptions {
   output?: string;
   since?: string;
   until?: string;
+  json?: boolean;
 }


### PR DESCRIPTION
## Summary
- add `--json` to `traces list` and `traces get`
- serialize successful results and failures without Ink output in JSON mode
- preserve existing human-readable rendering when the flag is omitted
- document the new options and add command-level regression coverage

Fixes #624

## Testing
- `npx vitest run --project unit src/cli/commands/traces src/cli/operations/traces` (24 tests passed)
- `npm run typecheck`
- `npx eslint src/cli/commands/traces/command.tsx src/cli/commands/traces/types.ts src/cli/commands/traces/__tests__/command.test.ts`
- `npx prettier --check docs/commands.md src/cli/commands/traces/command.tsx src/cli/commands/traces/types.ts src/cli/commands/traces/__tests__/command.test.ts`
- `npm run build`
- packaged CLI smoke tests: `traces list --json` and `traces get trace-1 --json` emit one JSON error object and exit 1 outside a project