### PR TITLE
test(e2e): wait before archiving batch evaluation

### DIFF
--- a/e2e-tests/archive-lifecycle.test.ts
+++ b/e2e-tests/archive-lifecycle.test.ts
@@ -129,6 +129,7 @@ describe.sequential('e2e: archive command lifecycle', () => {
             'Builtin.Faithfulness',
             '--lookback-days',
             '1',
+            '--wait',
             '--json',
           ]);
           expect(result.exitCode, `batch-evaluation failed (stdout: ${result.stdout}, stderr: ${result.stderr})`).toBe(


### PR DESCRIPTION
## Description

Fix the archive lifecycle E2E race exposed by [full-suite run 29547583927](https://github.com/aws/agentcore-cli/actions/runs/29547583927/job/87783119598).

`agentcore run batch-evaluation` returns while the job is still `PENDING` unless `--wait` is provided. The test immediately attempted to archive that job, which intermittently failed with a service 409. Pass `--wait` so the evaluation reaches a terminal, archivable status first.

The other two failures in that run were cascading assertions after the initial archive failed.

## Related Issue

No issue; fixes a post-merge E2E failure.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other: E2E test stabilization

## Testing

- [x] `npx tsc --noEmit --incremental`
- [x] `npx prettier --check e2e-tests/archive-lifecycle.test.ts`
- [x] Pre-commit ESLint, Prettier, secretlint, and typecheck hooks
- [ ] Live AWS E2E (left to CI to avoid duplicating resource mutations)