### PR TITLE
docs(templates): document Windows venv activation

### DIFF
--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -3324,7 +3324,8 @@ file defines a Starlette ASGI app with the AutoGen framework running within.
 
 If installation was successful, a virtual environment is already created with dependencies installed.
 
-Run \`source .venv/bin/activate\` before developing.
+Activate the environment with \`source .venv/bin/activate\` on macOS/Linux, \`.venv\\Scripts\\activate.bat\` in Windows
+Command Prompt, or \`.\\.venv\\Scripts\\activate.ps1\` in Windows PowerShell.
 
 \`agentcore dev\` will start a local server on 0.0.0.0:8080.
 
@@ -3779,7 +3780,8 @@ file defines a Starlette ASGI app with the Google ADK framework running within.
 
 If installation was successful, a virtual environment is already created with dependencies installed.
 
-Run \`source .venv/bin/activate\` before developing.
+Activate the environment with \`source .venv/bin/activate\` on macOS/Linux, \`.venv\\Scripts\\activate.bat\` in Windows
+Command Prompt, or \`.\\.venv\\Scripts\\activate.ps1\` in Windows PowerShell.
 
 \`agentcore dev\` will start a local server on 0.0.0.0:8080.
 
@@ -4236,7 +4238,8 @@ file defines a Starlette ASGI app with the LangChain/LangGraph framework running
 
 If installation was successful, a virtual environment is already created with dependencies installed.
 
-Run \`source .venv/bin/activate\` before developing.
+Activate the environment with \`source .venv/bin/activate\` on macOS/Linux, \`.venv\\Scripts\\activate.bat\` in Windows
+Command Prompt, or \`.\\.venv\\Scripts\\activate.ps1\` in Windows PowerShell.
 
 \`agentcore dev\` will start a local server on 0.0.0.0:8080.
 
@@ -4813,7 +4816,8 @@ file defines a Starlette ASGI app with the OpenAI Agents SDK framework running w
 
 If installation was successful, a virtual environment is already created with dependencies installed.
 
-Run \`source .venv/bin/activate\` before developing.
+Activate the environment with \`source .venv/bin/activate\` on macOS/Linux, \`.venv\\Scripts\\activate.bat\` in Windows
+Command Prompt, or \`.\\.venv\\Scripts\\activate.ps1\` in Windows PowerShell.
 
 \`agentcore dev\` will start a local server on 0.0.0.0:8080.
 
@@ -5257,7 +5261,8 @@ file defines a Starlette ASGI app with the chosen Agent framework SDK running wi
 
 If installation was successful, a virtual environment is already created with dependencies installed.
 
-Run \`source .venv/bin/activate\` before developing.
+Activate the environment with \`source .venv/bin/activate\` on macOS/Linux, \`.venv\\Scripts\\activate.bat\` in Windows
+Command Prompt, or \`.\\.venv\\Scripts\\activate.ps1\` in Windows PowerShell.
 
 \`agentcore dev\` will start a local server on 0.0.0.0:8080.
 

--- a/src/assets/python/http/autogen/base/README.md
+++ b/src/assets/python/http/autogen/base/README.md
@@ -24,7 +24,8 @@ file defines a Starlette ASGI app with the AutoGen framework running within.
 
 If installation was successful, a virtual environment is already created with dependencies installed.
 
-Run `source .venv/bin/activate` before developing.
+Activate the environment with `source .venv/bin/activate` on macOS/Linux, `.venv\Scripts\activate.bat` in Windows
+Command Prompt, or `.\.venv\Scripts\activate.ps1` in Windows PowerShell.
 
 `agentcore dev` will start a local server on 0.0.0.0:8080.
 

--- a/src/assets/python/http/googleadk/base/README.md
+++ b/src/assets/python/http/googleadk/base/README.md
@@ -24,7 +24,8 @@ file defines a Starlette ASGI app with the Google ADK framework running within.
 
 If installation was successful, a virtual environment is already created with dependencies installed.
 
-Run `source .venv/bin/activate` before developing.
+Activate the environment with `source .venv/bin/activate` on macOS/Linux, `.venv\Scripts\activate.bat` in Windows
+Command Prompt, or `.\.venv\Scripts\activate.ps1` in Windows PowerShell.
 
 `agentcore dev` will start a local server on 0.0.0.0:8080.
 

--- a/src/assets/python/http/langchain_langgraph/base/README.md
+++ b/src/assets/python/http/langchain_langgraph/base/README.md
@@ -24,7 +24,8 @@ file defines a Starlette ASGI app with the LangChain/LangGraph framework running
 
 If installation was successful, a virtual environment is already created with dependencies installed.
 
-Run `source .venv/bin/activate` before developing.
+Activate the environment with `source .venv/bin/activate` on macOS/Linux, `.venv\Scripts\activate.bat` in Windows
+Command Prompt, or `.\.venv\Scripts\activate.ps1` in Windows PowerShell.
 
 `agentcore dev` will start a local server on 0.0.0.0:8080.
 

--- a/src/assets/python/http/openaiagents/base/README.md
+++ b/src/assets/python/http/openaiagents/base/README.md
@@ -24,7 +24,8 @@ file defines a Starlette ASGI app with the OpenAI Agents SDK framework running w
 
 If installation was successful, a virtual environment is already created with dependencies installed.
 
-Run `source .venv/bin/activate` before developing.
+Activate the environment with `source .venv/bin/activate` on macOS/Linux, `.venv\Scripts\activate.bat` in Windows
+Command Prompt, or `.\.venv\Scripts\activate.ps1` in Windows PowerShell.
 
 `agentcore dev` will start a local server on 0.0.0.0:8080.
 

--- a/src/assets/python/http/strands/base/README.md
+++ b/src/assets/python/http/strands/base/README.md
@@ -24,7 +24,8 @@ file defines a Starlette ASGI app with the chosen Agent framework SDK running wi
 
 If installation was successful, a virtual environment is already created with dependencies installed.
 
-Run `source .venv/bin/activate` before developing.
+Activate the environment with `source .venv/bin/activate` on macOS/Linux, `.venv\Scripts\activate.bat` in Windows
+Command Prompt, or `.\.venv\Scripts\activate.ps1` in Windows PowerShell.
 
 `agentcore dev` will start a local server on 0.0.0.0:8080.
 


### PR DESCRIPTION
## Summary

- document the existing virtual environment activation command for Windows Command Prompt
- document the distinct activation command required by Windows PowerShell
- update snapshots for all generated Python HTTP agent READMEs

`uv venv` already creates the platform-specific activation scripts under `.venv\Scripts`, so the missing piece is documenting how Windows users invoke them rather than generating a redundant `source.bat` wrapper.

## Testing

- `npx vitest run --project unit src/assets/__tests__/assets.snapshot.test.ts`
- `npm run typecheck`
- `npx prettier --check` on the five modified README templates
- full unit suite during snapshot update: 410 files, 5,926 tests passed

Fixes #674