### PR TITLE
fix(deploy): fail fast on AWS account mismatch

### DIFF
--- a/src/cli/aws/__tests__/account-extended.test.ts
+++ b/src/cli/aws/__tests__/account-extended.test.ts
@@ -1,4 +1,4 @@
-import { AwsCredentialsError } from '../../../lib/errors/types.js';
+import { AwsCredentialsError, ValidationError } from '../../../lib/errors/types.js';
 import { detectAccount, getCredentialProvider, validateAwsCredentials } from '../account.js';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -114,6 +114,22 @@ describe('validateAwsCredentials', () => {
     mockSend.mockResolvedValue({ Account: '123456789012' });
 
     await expect(validateAwsCredentials()).resolves.toBeUndefined();
+  });
+
+  it('does not throw when credentials match the deployment target', async () => {
+    mockSend.mockResolvedValue({ Account: '123456789012' });
+
+    await expect(validateAwsCredentials({ name: 'prod', account: '123456789012' })).resolves.toBeUndefined();
+  });
+
+  it('throws a clear error when credentials do not match the deployment target', async () => {
+    mockSend.mockResolvedValue({ Account: '111111111111' });
+
+    const validation = validateAwsCredentials({ name: 'prod', account: '222222222222' });
+    await expect(validation).rejects.toBeInstanceOf(ValidationError);
+    await expect(validation).rejects.toThrow(
+      'Your AWS credentials are for account 111111111111, but the target "prod" is configured for account 222222222222.'
+    );
   });
 
   it('throws AwsCredentialsError when detectAccount returns null', async () => {

--- a/src/cli/aws/account.ts
+++ b/src/cli/aws/account.ts
@@ -1,4 +1,5 @@
-import { AwsCredentialsError } from '../../lib/errors/types.js';
+import { AwsCredentialsError, ValidationError } from '../../lib/errors/types.js';
+import type { AwsDeploymentTarget } from '../../schema';
 import { getAwsLoginGuidance } from '../external-requirements/checks';
 import { GetCallerIdentityCommand, STSClient } from '@aws-sdk/client-sts';
 import { fromEnv, fromNodeProviderChain } from '@aws-sdk/credential-providers';
@@ -61,9 +62,10 @@ export async function detectAccount(): Promise<string | null> {
 
 /**
  * Validate that AWS credentials are configured and working.
+ * When a target is provided, also verify that the credentials belong to its account.
  * Throws AwsCredentialsError with a helpful message if not.
  */
-export async function validateAwsCredentials(): Promise<void> {
+export async function validateAwsCredentials(target?: Pick<AwsDeploymentTarget, 'name' | 'account'>): Promise<void> {
   const account = await detectAccount();
   if (!account) {
     const guidance = await getAwsLoginGuidance();
@@ -73,6 +75,12 @@ export async function validateAwsCredentials(): Promise<void> {
         'To fix this:\n' +
         `  1. ${guidance}\n` +
         '  2. Or set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables'
+    );
+  }
+
+  if (target?.account && account !== target.account) {
+    throw new ValidationError(
+      `Your AWS credentials are for account ${account}, but the target "${target.name}" is configured for account ${target.account}.\nEnsure your credentials match the deployment target.`
     );
   }
 }

--- a/src/cli/commands/deploy/actions.ts
+++ b/src/cli/commands/deploy/actions.ts
@@ -218,7 +218,7 @@ export async function handleDeploy(options: ValidatedDeployOptions): Promise<Dep
 
     // Preflight: validate project
     startStep('Validate project');
-    const context = await validateProject();
+    const context = await validateProject(target);
     endStep('success');
 
     // Warn about imperative-build orphan harnesses (preview→GA transition). These aren't
@@ -257,7 +257,7 @@ export async function handleDeploy(options: ValidatedDeployOptions): Promise<Dep
     // Validate AWS credentials (deferred for teardown deploys until after confirmation)
     if (context.isTeardownDeploy) {
       startStep('Validate AWS credentials');
-      await validateAwsCredentials();
+      await validateAwsCredentials(target);
       endStep('success');
     }
 

--- a/src/cli/operations/deploy/__tests__/preflight.test.ts
+++ b/src/cli/operations/deploy/__tests__/preflight.test.ts
@@ -179,6 +179,43 @@ describe('validateProject', () => {
     expect(result.isTeardownDeploy).toBe(false);
   });
 
+  it('validates credentials against the selected deployment target', async () => {
+    const selectedTarget = { name: 'prod', account: '222222222222', region: 'us-east-1' } as const;
+    mockRequireConfigRoot.mockReturnValue('/project/agentcore');
+    mockValidate.mockReturnValue(undefined);
+    mockReadProjectSpec.mockResolvedValue({
+      name: 'test-project',
+      runtimes: [{ name: 'test-agent' }],
+      agentCoreGateways: [],
+    });
+    mockReadAWSDeploymentTargets.mockResolvedValue([
+      { name: 'default', account: '111111111111', region: 'us-west-2' },
+      selectedTarget,
+    ]);
+    mockValidateAwsCredentials.mockResolvedValue(undefined);
+
+    await validateProject(selectedTarget);
+
+    expect(mockValidateAwsCredentials).toHaveBeenCalledWith(selectedTarget);
+  });
+
+  it('validates credentials against the first target when none is selected', async () => {
+    const firstTarget = { name: 'default', account: '111111111111', region: 'us-west-2' } as const;
+    mockRequireConfigRoot.mockReturnValue('/project/agentcore');
+    mockValidate.mockReturnValue(undefined);
+    mockReadProjectSpec.mockResolvedValue({
+      name: 'test-project',
+      runtimes: [{ name: 'test-agent' }],
+      agentCoreGateways: [],
+    });
+    mockReadAWSDeploymentTargets.mockResolvedValue([firstTarget]);
+    mockValidateAwsCredentials.mockResolvedValue(undefined);
+
+    await validateProject();
+
+    expect(mockValidateAwsCredentials).toHaveBeenCalledWith(firstTarget);
+  });
+
   it('accepts gateway target name within 48 chars when prefixed with project name', async () => {
     mockRequireConfigRoot.mockReturnValue('/project/agentcore');
     mockValidate.mockReturnValue(undefined);

--- a/src/cli/operations/deploy/preflight.ts
+++ b/src/cli/operations/deploy/preflight.ts
@@ -72,7 +72,7 @@ export function formatError(err: unknown): string {
  * Also validates AWS credentials are configured before proceeding.
  * Returns the project context needed for subsequent steps.
  */
-export async function validateProject(): Promise<PreflightContext> {
+export async function validateProject(selectedTarget?: AwsDeploymentTarget): Promise<PreflightContext> {
   // Find the agentcore config directory, walking up from cwd if needed
   const configRoot = requireConfigRoot();
   // Project root is the parent of the agentcore directory
@@ -152,7 +152,7 @@ export async function validateProject(): Promise<PreflightContext> {
   // Validate AWS credentials before proceeding with build/synth.
   // Skip for teardown deploys — callers validate after teardown confirmation.
   if (!isTeardownDeploy) {
-    await validateAwsCredentials();
+    await validateAwsCredentials(selectedTarget ?? awsTargets[0]);
   }
 
   return { projectSpec, awsTargets, cdkProject, isTeardownDeploy, isFirstDeploy: !hasExistingStack };

--- a/src/cli/tui/hooks/useCdkPreflight.ts
+++ b/src/cli/tui/hooks/useCdkPreflight.ts
@@ -441,7 +441,7 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
         // Validate AWS credentials (deferred for teardown deploys until after confirmation)
         if (preflightContext.isTeardownDeploy) {
           try {
-            await validateAwsCredentials();
+            await validateAwsCredentials(preflightContext.awsTargets[0]);
           } catch (err) {
             const errorMsg = formatError(err);
             logger.endStep('error', errorMsg);

--- a/src/cli/tui/hooks/useCdkPreflight.ts
+++ b/src/cli/tui/hooks/useCdkPreflight.ts
@@ -1,6 +1,6 @@
 import { ConfigIO, SecureCredentials, toError } from '../../../lib';
 import { AwsCredentialsError, UserCancellationError } from '../../../lib/errors/types';
-import type { DeployedState } from '../../../schema';
+import type { AwsDeploymentTarget, DeployedState } from '../../../schema';
 import { applyTargetRegionToEnv } from '../../aws';
 import { validateAwsCredentials } from '../../aws/account';
 import { type CdkToolkitWrapper, type SwitchableIoHost, createSwitchableIoHost } from '../../cdk/toolkit-lib';
@@ -35,7 +35,7 @@ const LABEL_PAYMENTS = 'Creating payment infrastructure';
 
 interface RunPaymentSetupOptions {
   projectSpec: PreflightContext['projectSpec'];
-  awsTargets: PreflightContext['awsTargets'];
+  target: NonNullable<PreflightContext['awsTargets'][0]>;
   runtimeCredentials?: SecureCredentials;
   logger: ExecLogger;
   setSteps: React.Dispatch<React.SetStateAction<Step[]>>;
@@ -52,7 +52,7 @@ interface RunPaymentSetupOptions {
 async function runPaymentPreDeploy(opts: RunPaymentSetupOptions): Promise<boolean> {
   const {
     projectSpec,
-    awsTargets,
+    target,
     runtimeCredentials,
     logger,
     setSteps,
@@ -70,7 +70,6 @@ async function runPaymentPreDeploy(opts: RunPaymentSetupOptions): Promise<boolea
   });
   logger.startStep('Setting up payment credentials...');
 
-  const target = awsTargets[0]!;
   const paymentConfigIO = new ConfigIO();
 
   const paymentResult = await setupPaymentCredentialProviders({
@@ -142,6 +141,8 @@ export interface PreflightOptions {
   isInteractive?: boolean;
   /** Skip identity provider check (for plan command which only synthesizes) */
   skipIdentityCheck?: boolean;
+  /** Target selected by the TUI. Falls back to the first configured target when omitted. */
+  selectedTarget?: AwsDeploymentTarget;
 }
 
 export interface PreflightResult {
@@ -205,7 +206,7 @@ const IDENTITY_STEP: Step = { label: LABEL_API_KEY, status: 'pending' };
 const BOOTSTRAP_STEP: Step = { label: 'Bootstrap AWS environment', status: 'pending' };
 
 export function useCdkPreflight(options: PreflightOptions): PreflightResult {
-  const { logger, isInteractive = false, skipIdentityCheck = false } = options;
+  const { logger, isInteractive = false, skipIdentityCheck = false, selectedTarget } = options;
 
   // Create switchable ioHost - starts silent, can be flipped to verbose for deploy
   const switchableIoHost = useMemo(() => createSwitchableIoHost(), []);
@@ -397,17 +398,18 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
         updateStep(STEP_VALIDATE, { status: 'running' });
         logger.startStep('Validate project');
         let preflightContext: PreflightContext;
+        let target: AwsDeploymentTarget | undefined;
         try {
-          preflightContext = await validateProject();
+          preflightContext = await validateProject(selectedTarget);
+          target = selectedTarget ?? preflightContext.awsTargets[0];
           setContext(preflightContext);
           // Make aws-targets.json region authoritative for downstream SDK / CDK
           // toolkit-lib clients that bypass explicit region options. Restored on
           // unmount, teardown rejection, or subsequent preflight start.
           // See https://github.com/aws/agentcore-cli/issues/924.
-          const firstTarget = preflightContext.awsTargets[0];
-          if (firstTarget) {
+          if (target) {
             restoreRegionEnv();
-            restoreRegionEnvRef.current = applyTargetRegionToEnv(firstTarget.region);
+            restoreRegionEnvRef.current = applyTargetRegionToEnv(target.region);
           }
           logger.endStep('success');
           updateStep(STEP_VALIDATE, { status: 'success' });
@@ -441,7 +443,7 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
         // Validate AWS credentials (deferred for teardown deploys until after confirmation)
         if (preflightContext.isTeardownDeploy) {
           try {
-            await validateAwsCredentials(preflightContext.awsTargets[0]);
+            await validateAwsCredentials(target);
           } catch (err) {
             const errorMsg = formatError(err);
             logger.endStep('error', errorMsg);
@@ -520,7 +522,7 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
         // Set up payment resources (no-identity-providers path)
         const paymentOk = await runPaymentPreDeploy({
           projectSpec: preflightContext.projectSpec,
-          awsTargets: preflightContext.awsTargets,
+          target: target!,
           logger,
           setSteps,
           updateStepByLabel,
@@ -561,7 +563,6 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
         }
 
         // Step: Check stack status (ensure stacks are not in UPDATE_IN_PROGRESS etc.)
-        const target = preflightContext.awsTargets[0];
         if (target && synthStackNames.length > 0) {
           updateStepByLabel(LABEL_STACK_STATUS, { status: 'running' });
           logger.startStep('Check stack status');
@@ -632,7 +633,16 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
     return () => {
       process.off('unhandledRejection', handleUnhandledRejection);
     };
-  }, [phase, logger, switchableIoHost, isInteractive, skipIdentityCheck, teardownConfirmed, restoreRegionEnv]);
+  }, [
+    phase,
+    logger,
+    switchableIoHost,
+    isInteractive,
+    skipIdentityCheck,
+    teardownConfirmed,
+    restoreRegionEnv,
+    selectedTarget,
+  ]);
 
   // Handle identity-setup phase (after user provides credentials)
   useEffect(() => {
@@ -649,7 +659,7 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
         // Set up payment resources even when identity is skipped
         const paymentOkSkip = await runPaymentPreDeploy({
           projectSpec: context.projectSpec,
-          awsTargets: context.awsTargets,
+          target: (selectedTarget ?? context.awsTargets[0])!,
           runtimeCredentials: runtimeCredentials ?? undefined,
           logger,
           setSteps,
@@ -687,7 +697,7 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
         }
 
         // Check stack status
-        const target = context.awsTargets[0];
+        const target = selectedTarget ?? context.awsTargets[0];
         if (target && synthStackNames.length > 0) {
           updateStepByLabel(LABEL_STACK_STATUS, { status: 'running' });
           logger.startStep('Check stack status');
@@ -751,7 +761,7 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
         logger.startStep('Set up API key providers');
       }
 
-      const target = context.awsTargets[0];
+      const target = selectedTarget ?? context.awsTargets[0];
       if (!target) {
         const errorMsg = 'No AWS target configured';
         if (hasApiKeys) {
@@ -880,7 +890,7 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
         if (Object.keys(deployedCredentials).length > 0) {
           setAllCredentials(deployedCredentials);
           const configIO = new ConfigIO();
-          const target = context.awsTargets[0];
+          const target = selectedTarget ?? context.awsTargets[0];
           const existingState = await configIO.readDeployedState().catch(() => ({ targets: {} }) as DeployedState);
           const targetState = existingState.targets?.[target!.name] ?? { resources: {} };
           targetState.resources ??= {};
@@ -895,7 +905,7 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
         // Set up payment resources (before CDK synth so ARNs are in deployed state)
         const paymentOkIdentity = await runPaymentPreDeploy({
           projectSpec: context.projectSpec,
-          awsTargets: context.awsTargets,
+          target: (selectedTarget ?? context.awsTargets[0])!,
           runtimeCredentials: runtimeCredentials ?? undefined,
           logger,
           setSteps,
@@ -998,7 +1008,7 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
     };
 
     void runIdentitySetup();
-  }, [phase, context, skipIdentitySetup, runtimeCredentials, logger, switchableIoHost.ioHost]);
+  }, [phase, context, skipIdentitySetup, runtimeCredentials, logger, switchableIoHost.ioHost, selectedTarget]);
 
   // Handle bootstrapping phase
   useEffect(() => {

--- a/src/cli/tui/screens/deploy/__tests__/useDeployFlow.targets.test.tsx
+++ b/src/cli/tui/screens/deploy/__tests__/useDeployFlow.targets.test.tsx
@@ -37,8 +37,9 @@ const fakeIoHost = {
 
 // Hoisted so the vi.mock factory below (hoisted above module init) can reference it, while the
 // test bodies keep a handle to assert the persist path polls the SELECTED target's stack/region.
-const { getStackOutputsSpy } = vi.hoisted(() => ({
+const { getStackOutputsSpy, useCdkPreflightSpy } = vi.hoisted(() => ({
   getStackOutputsSpy: vi.fn().mockRejectedValue(new Error('test: skip persist')),
+  useCdkPreflightSpy: vi.fn(),
 }));
 
 // preflightState is mutated per-test before render so the same mock can vary phase/context.
@@ -48,7 +49,10 @@ vi.mock('../../../hooks', async () => {
   const actual = await vi.importActual<any>('../../../hooks');
   return {
     ...actual,
-    useCdkPreflight: () => preflightState,
+    useCdkPreflight: (options: unknown) => {
+      useCdkPreflightSpy(options);
+      return preflightState;
+    },
   };
 });
 
@@ -144,6 +148,7 @@ describe('useDeployFlow target scoping (issue #1267)', () => {
     fakeIoHost.setVerbose.mockClear();
     getStackOutputsSpy.mockClear();
     getStackOutputsSpy.mockRejectedValue(new Error('test: skip persist'));
+    useCdkPreflightSpy.mockClear();
   });
   afterEach(() => {
     vi.clearAllTimers();
@@ -167,6 +172,20 @@ describe('useDeployFlow target scoping (issue #1267)', () => {
 
     // Regression: selecting B must never produce a pattern for A.
     expect(arg.stacks.patterns).not.toContain(toStackName(PROJECT_NAME, TARGET_A.name));
+  });
+
+  it('passes the first selected target to preflight validation', async () => {
+    preflightState = makePreflight({ awsTargets: [TARGET_A, TARGET_B] });
+
+    const { unmount } = render(<Harness selectedTargets={[TARGET_B]} />);
+    await flush();
+    unmount();
+
+    expect(useCdkPreflightSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selectedTarget: TARGET_B,
+      })
+    );
   });
 
   it('selecting target A produces only A’s stack (no cross-leak to B)', async () => {

--- a/src/cli/tui/screens/deploy/useDeployFlow.ts
+++ b/src/cli/tui/screens/deploy/useDeployFlow.ts
@@ -148,7 +148,7 @@ export function useDeployFlow(options: DeployFlowOptions = {}): DeployFlowState 
   const [logger] = useState(() => new ExecLogger({ command: 'deploy' }));
 
   // Always call the hook (React rules), but we won't use it when preSynthesized is provided
-  const preflight = useCdkPreflight({ logger, isInteractive });
+  const preflight = useCdkPreflight({ logger, isInteractive, selectedTarget: selectedTargets?.[0] });
 
   // Use pre-synthesized values when provided, otherwise use preflight values
   const cdkToolkitWrapper = preSynthesized?.cdkToolkitWrapper ?? preflight.cdkToolkitWrapper;


### PR DESCRIPTION
## Summary

- validate that active AWS credentials belong to the selected deployment target account
- run the check during preflight, before CDK build, synth, and asset publishing
- apply the same validation to CLI and TUI teardown deploys after confirmation
- preserve existing credential validation behavior for callers without a deployment target

The account comparison is integrated into `validateAwsCredentials`, so credential validity and target ownership are checked with one STS `GetCallerIdentity` request. Mismatches now name both account IDs and the selected target instead of surfacing later as a generic CDK asset publishing error.

## Testing

- `npx vitest run --project unit src/cli/aws/__tests__/account-extended.test.ts src/cli/operations/deploy/__tests__/preflight.test.ts src/cli/commands/deploy/__tests__/deploy-teardown.test.ts`
- `npm run typecheck`
- focused ESLint and Prettier checks
- `npm run build`

Fixes #761