### PR TITLE
fix(ci): pass codecov token to unit test workflow. 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,5 @@ jobs:
       contents: read
     with:
       ref: ${{ github.event.pull_request.head.sha || github.sha }}
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -6,6 +6,9 @@ on:
       ref:
         required: true
         type: string
+    secrets:
+      CODECOV_TOKEN:
+        required: false
 
 jobs:
   test:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -39,6 +39,8 @@ jobs:
       - run: bun test --coverage --coverage-reporter=lcov
 
       - name: Upload to CodeCov
+        # only upload on linux to avoid duplicates.
+        if: runner.os == 'Linux'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Upload to CodeCov
         # only upload on linux to avoid duplicates.
-        if: runner.os == 'Linux'
+        if: always() && runner.os == 'Linux'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
### Problem 
https://github.com/aws/agentcore-cli/issues/1775

Summary is that codecov uploads are passing on PRs, but not on push to refactor branch due to missing token error. 
Root cause is that we aren't passing the token through the workflow call confirmed by fix testing below. 

### Solution 
- pass secret to unit test job so that it can upload. 
- also only upload a single report, since AFAICT codecov is discarding them for the same commit anyway. 

### Testing 
- pushed to this branch directly, overwrote the trigger to include `fix/codecov-secrets`, and observed successful codecov publish: https://github.com/aws/agentcore-cli/actions/runs/29606846554/job/87972031386. 
- I can also see both events showing up separately in codecov: https://app.codecov.io/github/aws/agentcore-cli/commits. 