### PR TITLE
feat(project): scaffold `agentcore project create` with --template flag

### DIFF
--- a/src/handlers/index.tsx
+++ b/src/handlers/index.tsx
@@ -2,6 +2,7 @@ import { Router } from "../router";
 import { createHarnessHandler } from "./harness/index.tsx";
 import { DebugKey, EndpointKey, JsonKey, RegionKey } from "./keys.tsx";
 import { createConfigHandler } from "./config/";
+import { createProjectHandler } from "./project/index.ts";
 import { renderTui } from "../tui";
 import { withRegion, withJsonRenderer, withLogging } from "../middleware";
 import type { AppIO, Core } from "./types.tsx";
@@ -33,6 +34,7 @@ export function createRootHandler(core: Core, config: RootHandlerConfig): Router
   // Install sub handlers
   root.handler(createHarnessHandler(core, io));
   root.handler(createConfigHandler(io));
+  root.handler(createProjectHandler());
 
   // Invoking with no subcommand launches the interactive TUI.
   root.default(renderTui(core, io));

--- a/src/handlers/project/create/index.ts
+++ b/src/handlers/project/create/index.ts
@@ -1,0 +1,20 @@
+import z from "zod";
+import { createHandler, flag } from "../../../router";
+
+export const PROJECT_TEMPLATES = ["placeholder"] as const;
+
+export const createCreateProjectHandler = () =>
+  createHandler({
+    name: "create",
+    description: "create a new AgentCore project",
+    flags: [
+      flag(
+        "template",
+        "project template to scaffold from",
+        z.enum(PROJECT_TEMPLATES).default("placeholder"),
+      ),
+    ],
+    handle: async () => {
+      throw new Error("`agentcore project create` is not implemented yet");
+    },
+  });

--- a/src/handlers/project/index.ts
+++ b/src/handlers/project/index.ts
@@ -1,0 +1,10 @@
+import { Router } from "../../router";
+import { createCreateProjectHandler } from "./create";
+
+export function createProjectHandler(): Router {
+  const project = new Router("project", "manage an AgentCore project");
+
+  project.handler(createCreateProjectHandler());
+
+  return project;
+}

--- a/src/handlers/project/project.test.ts
+++ b/src/handlers/project/project.test.ts
@@ -2,10 +2,6 @@ import { test, expect, describe } from "bun:test";
 import { createRootHandler } from "../index";
 import { createSilentLogger, TestCoreClient, testIO } from "../../testing";
 
-// End-to-end tests for the `project` command, driven through the real root
-// handler and top-level route(). A TestCoreClient stands in for Core (the
-// scaffold doesn't touch it, but createRootHandler requires one).
-
 async function run(args: string[]): Promise<void> {
   const io = testIO();
   const root = createRootHandler(new TestCoreClient(), {

--- a/src/handlers/project/project.test.ts
+++ b/src/handlers/project/project.test.ts
@@ -1,0 +1,30 @@
+import { test, expect, describe } from "bun:test";
+import { createRootHandler } from "../index";
+import { createSilentLogger, TestCoreClient, testIO } from "../../testing";
+
+// End-to-end tests for the `project` command, driven through the real root
+// handler and top-level route(). A TestCoreClient stands in for Core (the
+// scaffold doesn't touch it, but createRootHandler requires one).
+
+async function run(args: string[]): Promise<void> {
+  const io = testIO();
+  const root = createRootHandler(new TestCoreClient(), {
+    io: io.io,
+    logger: createSilentLogger(),
+  });
+  await root.route(["node", "agentcore", "project", ...args]);
+}
+
+describe("project create", () => {
+  test("throws because it is not implemented yet", async () => {
+    await expect(run(["create"])).rejects.toThrow(/not implemented/);
+  });
+
+  test("accepts a known --template value", async () => {
+    await expect(run(["create", "--template", "placeholder"])).rejects.toThrow(/not implemented/);
+  });
+
+  test("rejects an unknown --template value", async () => {
+    await expect(run(["create", "--template", "nonsense"])).rejects.toThrow();
+  });
+});

--- a/src/handlers/root.test.tsx
+++ b/src/handlers/root.test.tsx
@@ -9,6 +9,6 @@ describe("createRootHandler", () => {
       logger: createSilentLogger(),
     });
     expect(root.name()).toBe("agentcore");
-    expect(root.children().map((c) => c.name())).toEqual(["harness", "config"]);
+    expect(root.children().map((c) => c.name())).toEqual(["harness", "config", "project"]);
   });
 });


### PR DESCRIPTION
## What

First horizontal slice of the CLI project-commands re-org: introduces the `project` namespace with a stubbed `create` leaf.

## Why

Per the project-commands restructure, project (`create`, `add`, `deploy`, ...) move under `agentcore project`

## Scope 
- CLI scaffolding only. 

## Tests
- `create` throws not-implemented
- known `--template` value accepted (parses, then hits the stub)
- unknown `--template` value rejected by the enum