### PR TITLE
feat(templates): upgrade A2A agents to SDK v1

### DIFF
--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -1311,7 +1311,7 @@ from google.adk.agents import Agent
 from google.adk.a2a.executor.a2a_agent_executor import A2aAgentExecutor
 from google.adk.runners import Runner
 from google.adk.sessions import InMemorySessionService
-from a2a.types import AgentCapabilities, AgentCard, AgentSkill
+from a2a.types import AgentCapabilities, AgentCard, AgentInterface, AgentSkill
 from bedrock_agentcore.runtime import serve_a2a
 from model.load import load_model
 
@@ -1405,7 +1405,6 @@ runner = Runner(
 card = AgentCard(
     name=agent.name,
     description=agent.description,
-    url="http://localhost:9000/",
     version="0.1.0",
     capabilities=AgentCapabilities(streaming=True),
     skills=[
@@ -1418,6 +1417,13 @@ card = AgentCard(
     ],
     default_input_modes=["text"],
     default_output_modes=["text"],
+    supported_interfaces=[
+        AgentInterface(
+            protocol_binding="JSONRPC",
+            protocol_version="1.0",
+            url="http://localhost:9000/",
+        )
+    ],
 )
 
 if __name__ == "__main__":
@@ -1487,11 +1493,11 @@ description = "AgentCore A2A Agent using Google ADK"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "a2a-sdk >= 0.2.0, < 1.0.0",
+    "a2a-sdk[http-server] >= 1.0.1, < 2.0.0",
     "aws-opentelemetry-distro",
-    "bedrock-agentcore[a2a] >= 1.0.3",
-    "google-adk >= 1.0.0, < 2.0.0",
-    "google-genai >= 1.0.0, < 2.0.0",
+    "bedrock-agentcore[a2a] >= 1.19.0",
+    "google-adk[a2a] >= 2.5.0, < 3.0.0",
+    "google-genai >= 2.9.0, < 3.0.0",
 ]
 
 [tool.hatch.build.targets.wheel]
@@ -1577,11 +1583,11 @@ import os
 from langchain_core.tools import tool
 from langgraph.prebuilt import create_react_agent
 from opentelemetry.instrumentation.langchain import LangchainInstrumentor
+from a2a.helpers import new_task_from_user_message
 from a2a.server.agent_execution import AgentExecutor, RequestContext
 from a2a.server.events import EventQueue
 from a2a.server.tasks import TaskUpdater
-from a2a.types import AgentCapabilities, AgentCard, AgentSkill, Part, TextPart
-from a2a.utils import new_task
+from a2a.types import AgentCapabilities, AgentCard, AgentInterface, AgentSkill, Part
 from bedrock_agentcore.runtime import serve_a2a
 from model.load import load_model
 
@@ -1673,7 +1679,7 @@ class LangGraphA2AExecutor(AgentExecutor):
         self.graph = graph
 
     async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:
-        task = context.current_task or new_task(context.message)
+        task = context.current_task or new_task_from_user_message(context.message)
         if not context.current_task:
             await event_queue.enqueue_event(task)
         updater = TaskUpdater(event_queue, task.id, task.context_id)
@@ -1682,7 +1688,7 @@ class LangGraphA2AExecutor(AgentExecutor):
         result = await self.graph.ainvoke({"messages": [("user", user_text)]})
         response = result["messages"][-1].content
 
-        await updater.add_artifact([Part(root=TextPart(text=response))])
+        await updater.add_artifact([Part(text=response)])
         await updater.complete()
 
     async def cancel(self, context: RequestContext, event_queue: EventQueue) -> None:
@@ -1692,7 +1698,6 @@ class LangGraphA2AExecutor(AgentExecutor):
 card = AgentCard(
     name="{{ name }}",
     description="A LangGraph agent on Bedrock AgentCore",
-    url="http://localhost:9000/",
     version="0.1.0",
     capabilities=AgentCapabilities(streaming=True),
     skills=[
@@ -1705,6 +1710,13 @@ card = AgentCard(
     ],
     default_input_modes=["text"],
     default_output_modes=["text"],
+    supported_interfaces=[
+        AgentInterface(
+            protocol_binding="JSONRPC",
+            protocol_version="1.0",
+            url="http://localhost:9000/",
+        )
+    ],
 )
 
 if __name__ == "__main__":
@@ -1856,7 +1868,7 @@ description = "AgentCore A2A Agent using LangChain + LangGraph"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "a2a-sdk >= 0.2.0, < 1.0.0",
+    "a2a-sdk[http-server] >= 1.0.1, < 2.0.0",
     {{#if (eq modelProvider "Anthropic")}}"langchain-anthropic >= 0.3.0",
     {{/if}}{{#if (eq modelProvider "Bedrock")}}"langchain-aws >= 0.2.0",
     {{/if}}{{#if (eq modelProvider "Gemini")}}"langchain-google-genai >= 2.0.0",
@@ -1864,7 +1876,7 @@ dependencies = [
     {{/if}}{{#if (eq modelProvider "OpenAI")}}"langchain-openai >= 0.2.0",
     {{/if}}"aws-opentelemetry-distro",
     "opentelemetry-instrumentation-langchain >= 0.59.0",
-    "bedrock-agentcore[a2a] >= 1.8.0",
+    "bedrock-agentcore[a2a] >= 1.19.0",
     "botocore[crt] >= 1.35.0",
     "langgraph >= 0.2.0",
 ]
@@ -1947,7 +1959,11 @@ Thumbs.db
 
 exports[`Assets Directory Snapshots > Python framework assets > python/python/a2a/strands/base/main.py should match snapshot 1`] = `
 "from strands import Agent, tool
-from strands.multiagent.a2a.executor import StrandsA2AExecutor
+from a2a.helpers import new_task_from_user_message
+from a2a.server.agent_execution import AgentExecutor, RequestContext
+from a2a.server.events import EventQueue
+from a2a.server.tasks import TaskUpdater
+from a2a.types import AgentCapabilities, AgentCard, AgentInterface, AgentSkill, Part
 from bedrock_agentcore.runtime import serve_a2a
 from model.load import load_model
 {{#if hasMemory}}
@@ -2057,8 +2073,53 @@ agent = Agent(
 )
 {{/if}}
 
+
+class StrandsAgentExecutor(AgentExecutor):
+    """Wraps a Strands Agent as an a2a-sdk v1 AgentExecutor."""
+
+    def __init__(self, agent):
+        self.agent = agent
+
+    async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:
+        task = context.current_task or new_task_from_user_message(context.message)
+        if not context.current_task:
+            await event_queue.enqueue_event(task)
+        updater = TaskUpdater(event_queue, task.id, task.context_id)
+
+        result = await self.agent.invoke_async(context.get_user_input())
+        await updater.add_artifact([Part(text=str(result))])
+        await updater.complete()
+
+    async def cancel(self, context: RequestContext, event_queue: EventQueue) -> None:
+        pass
+
+
+card = AgentCard(
+    name="{{ name }}",
+    description="A Strands agent on Bedrock AgentCore",
+    version="0.1.0",
+    capabilities=AgentCapabilities(streaming=True),
+    skills=[
+        AgentSkill(
+            id="tools",
+            name="tools",
+            description="Use tools to help answer questions",
+            tags=["tools"],
+        )
+    ],
+    default_input_modes=["text"],
+    default_output_modes=["text"],
+    supported_interfaces=[
+        AgentInterface(
+            protocol_binding="JSONRPC",
+            protocol_version="1.0",
+            url="http://localhost:9000/",
+        )
+    ],
+)
+
 if __name__ == "__main__":
-    serve_a2a(StrandsA2AExecutor(agent))
+    serve_a2a(StrandsAgentExecutor(agent), card)
 "
 `;
 
@@ -2207,9 +2268,9 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     {{#if (eq modelProvider "Anthropic")}}"anthropic >= 0.30.0",
-    {{/if}}"a2a-sdk[all] >= 0.2.0, < 1.0.0",
+    {{/if}}"a2a-sdk[http-server] >= 1.0.1, < 2.0.0",
     "aws-opentelemetry-distro",
-    "bedrock-agentcore[a2a] >= 1.9.1",
+    "bedrock-agentcore[a2a] >= 1.19.0",
     "botocore[crt] >= 1.35.0",
     {{#if (eq modelProvider "Gemini")}}"google-genai >= 1.0.0",
     {{/if}}{{#if (eq modelProvider "OpenAI")}}"openai >= 1.0.0",

--- a/src/assets/python/a2a/googleadk/base/main.py
+++ b/src/assets/python/a2a/googleadk/base/main.py
@@ -5,7 +5,7 @@ from google.adk.agents import Agent
 from google.adk.a2a.executor.a2a_agent_executor import A2aAgentExecutor
 from google.adk.runners import Runner
 from google.adk.sessions import InMemorySessionService
-from a2a.types import AgentCapabilities, AgentCard, AgentSkill
+from a2a.types import AgentCapabilities, AgentCard, AgentInterface, AgentSkill
 from bedrock_agentcore.runtime import serve_a2a
 from model.load import load_model
 
@@ -99,7 +99,6 @@ runner = Runner(
 card = AgentCard(
     name=agent.name,
     description=agent.description,
-    url="http://localhost:9000/",
     version="0.1.0",
     capabilities=AgentCapabilities(streaming=True),
     skills=[
@@ -112,6 +111,13 @@ card = AgentCard(
     ],
     default_input_modes=["text"],
     default_output_modes=["text"],
+    supported_interfaces=[
+        AgentInterface(
+            protocol_binding="JSONRPC",
+            protocol_version="1.0",
+            url="http://localhost:9000/",
+        )
+    ],
 )
 
 if __name__ == "__main__":

--- a/src/assets/python/a2a/googleadk/base/pyproject.toml
+++ b/src/assets/python/a2a/googleadk/base/pyproject.toml
@@ -9,11 +9,11 @@ description = "AgentCore A2A Agent using Google ADK"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "a2a-sdk >= 0.2.0, < 1.0.0",
+    "a2a-sdk[http-server] >= 1.0.1, < 2.0.0",
     "aws-opentelemetry-distro",
-    "bedrock-agentcore[a2a] >= 1.0.3",
-    "google-adk >= 1.0.0, < 2.0.0",
-    "google-genai >= 1.0.0, < 2.0.0",
+    "bedrock-agentcore[a2a] >= 1.19.0",
+    "google-adk[a2a] >= 2.5.0, < 3.0.0",
+    "google-genai >= 2.9.0, < 3.0.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/assets/python/a2a/langchain_langgraph/base/main.py
+++ b/src/assets/python/a2a/langchain_langgraph/base/main.py
@@ -4,11 +4,11 @@ import os
 from langchain_core.tools import tool
 from langgraph.prebuilt import create_react_agent
 from opentelemetry.instrumentation.langchain import LangchainInstrumentor
+from a2a.helpers import new_task_from_user_message
 from a2a.server.agent_execution import AgentExecutor, RequestContext
 from a2a.server.events import EventQueue
 from a2a.server.tasks import TaskUpdater
-from a2a.types import AgentCapabilities, AgentCard, AgentSkill, Part, TextPart
-from a2a.utils import new_task
+from a2a.types import AgentCapabilities, AgentCard, AgentInterface, AgentSkill, Part
 from bedrock_agentcore.runtime import serve_a2a
 from model.load import load_model
 
@@ -100,7 +100,7 @@ class LangGraphA2AExecutor(AgentExecutor):
         self.graph = graph
 
     async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:
-        task = context.current_task or new_task(context.message)
+        task = context.current_task or new_task_from_user_message(context.message)
         if not context.current_task:
             await event_queue.enqueue_event(task)
         updater = TaskUpdater(event_queue, task.id, task.context_id)
@@ -109,7 +109,7 @@ class LangGraphA2AExecutor(AgentExecutor):
         result = await self.graph.ainvoke({"messages": [("user", user_text)]})
         response = result["messages"][-1].content
 
-        await updater.add_artifact([Part(root=TextPart(text=response))])
+        await updater.add_artifact([Part(text=response)])
         await updater.complete()
 
     async def cancel(self, context: RequestContext, event_queue: EventQueue) -> None:
@@ -119,7 +119,6 @@ class LangGraphA2AExecutor(AgentExecutor):
 card = AgentCard(
     name="{{ name }}",
     description="A LangGraph agent on Bedrock AgentCore",
-    url="http://localhost:9000/",
     version="0.1.0",
     capabilities=AgentCapabilities(streaming=True),
     skills=[
@@ -132,6 +131,13 @@ card = AgentCard(
     ],
     default_input_modes=["text"],
     default_output_modes=["text"],
+    supported_interfaces=[
+        AgentInterface(
+            protocol_binding="JSONRPC",
+            protocol_version="1.0",
+            url="http://localhost:9000/",
+        )
+    ],
 )
 
 if __name__ == "__main__":

--- a/src/assets/python/a2a/langchain_langgraph/base/pyproject.toml
+++ b/src/assets/python/a2a/langchain_langgraph/base/pyproject.toml
@@ -9,7 +9,7 @@ description = "AgentCore A2A Agent using LangChain + LangGraph"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "a2a-sdk >= 0.2.0, < 1.0.0",
+    "a2a-sdk[http-server] >= 1.0.1, < 2.0.0",
     {{#if (eq modelProvider "Anthropic")}}"langchain-anthropic >= 0.3.0",
     {{/if}}{{#if (eq modelProvider "Bedrock")}}"langchain-aws >= 0.2.0",
     {{/if}}{{#if (eq modelProvider "Gemini")}}"langchain-google-genai >= 2.0.0",
@@ -17,7 +17,7 @@ dependencies = [
     {{/if}}{{#if (eq modelProvider "OpenAI")}}"langchain-openai >= 0.2.0",
     {{/if}}"aws-opentelemetry-distro",
     "opentelemetry-instrumentation-langchain >= 0.59.0",
-    "bedrock-agentcore[a2a] >= 1.8.0",
+    "bedrock-agentcore[a2a] >= 1.19.0",
     "botocore[crt] >= 1.35.0",
     "langgraph >= 0.2.0",
 ]

--- a/src/assets/python/a2a/strands/base/main.py
+++ b/src/assets/python/a2a/strands/base/main.py
@@ -1,5 +1,9 @@
 from strands import Agent, tool
-from strands.multiagent.a2a.executor import StrandsA2AExecutor
+from a2a.helpers import new_task_from_user_message
+from a2a.server.agent_execution import AgentExecutor, RequestContext
+from a2a.server.events import EventQueue
+from a2a.server.tasks import TaskUpdater
+from a2a.types import AgentCapabilities, AgentCard, AgentInterface, AgentSkill, Part
 from bedrock_agentcore.runtime import serve_a2a
 from model.load import load_model
 {{#if hasMemory}}
@@ -109,5 +113,50 @@ agent = Agent(
 )
 {{/if}}
 
+
+class StrandsAgentExecutor(AgentExecutor):
+    """Wraps a Strands Agent as an a2a-sdk v1 AgentExecutor."""
+
+    def __init__(self, agent):
+        self.agent = agent
+
+    async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:
+        task = context.current_task or new_task_from_user_message(context.message)
+        if not context.current_task:
+            await event_queue.enqueue_event(task)
+        updater = TaskUpdater(event_queue, task.id, task.context_id)
+
+        result = await self.agent.invoke_async(context.get_user_input())
+        await updater.add_artifact([Part(text=str(result))])
+        await updater.complete()
+
+    async def cancel(self, context: RequestContext, event_queue: EventQueue) -> None:
+        pass
+
+
+card = AgentCard(
+    name="{{ name }}",
+    description="A Strands agent on Bedrock AgentCore",
+    version="0.1.0",
+    capabilities=AgentCapabilities(streaming=True),
+    skills=[
+        AgentSkill(
+            id="tools",
+            name="tools",
+            description="Use tools to help answer questions",
+            tags=["tools"],
+        )
+    ],
+    default_input_modes=["text"],
+    default_output_modes=["text"],
+    supported_interfaces=[
+        AgentInterface(
+            protocol_binding="JSONRPC",
+            protocol_version="1.0",
+            url="http://localhost:9000/",
+        )
+    ],
+)
+
 if __name__ == "__main__":
-    serve_a2a(StrandsA2AExecutor(agent))
+    serve_a2a(StrandsAgentExecutor(agent), card)

--- a/src/assets/python/a2a/strands/base/pyproject.toml
+++ b/src/assets/python/a2a/strands/base/pyproject.toml
@@ -10,9 +10,9 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     {{#if (eq modelProvider "Anthropic")}}"anthropic >= 0.30.0",
-    {{/if}}"a2a-sdk[all] >= 0.2.0, < 1.0.0",
+    {{/if}}"a2a-sdk[http-server] >= 1.0.1, < 2.0.0",
     "aws-opentelemetry-distro",
-    "bedrock-agentcore[a2a] >= 1.9.1",
+    "bedrock-agentcore[a2a] >= 1.19.0",
     "botocore[crt] >= 1.35.0",
     {{#if (eq modelProvider "Gemini")}}"google-genai >= 1.0.0",
     {{/if}}{{#if (eq modelProvider "OpenAI")}}"openai >= 1.0.0",

--- a/src/cli/operations/dev/__tests__/invoke-a2a.test.ts
+++ b/src/cli/operations/dev/__tests__/invoke-a2a.test.ts
@@ -1,5 +1,5 @@
 import { DevServerError } from '../../../../lib/errors/types';
-import { invokeA2AStreaming } from '../invoke-a2a';
+import { fetchA2AAgentCard, invokeA2AStreaming } from '../invoke-a2a';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockFetch = vi.fn();
@@ -208,5 +208,37 @@ describe('invokeA2AStreaming', () => {
 
     // Should yield the stringified result as fallback
     expect(chunks.length).toBeGreaterThan(0);
+  });
+});
+
+describe('fetchA2AAgentCard', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('uses the v1 agent card endpoint', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ name: 'v1-agent' }),
+    });
+
+    const card = await fetchA2AAgentCard(9000);
+
+    expect(card?.name).toBe('v1-agent');
+    expect(mockFetch.mock.calls[0]![0]).toBe('http://localhost:9000/.well-known/agent-card.json');
+  });
+
+  it('falls back to the v0.3 agent card endpoint', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404 }).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ name: 'legacy-agent' }),
+    });
+
+    const card = await fetchA2AAgentCard(9000);
+
+    expect(card?.name).toBe('legacy-agent');
+    expect(mockFetch.mock.calls[1]![0]).toBe('http://localhost:9000/.well-known/agent.json');
   });
 });

--- a/src/cli/operations/dev/invoke-a2a.ts
+++ b/src/cli/operations/dev/invoke-a2a.ts
@@ -10,6 +10,7 @@ export interface A2AAgentCard {
   description?: string;
   version?: string;
   url?: string;
+  supportedInterfaces?: { protocolBinding?: string; protocolVersion?: string; url?: string }[];
   skills?: { id?: string; name?: string; description?: string; tags?: string[] }[];
   capabilities?: { streaming?: boolean };
   defaultInputModes?: string[];
@@ -17,7 +18,7 @@ export interface A2AAgentCard {
 }
 
 /**
- * Fetch the A2A agent card from /.well-known/agent.json.
+ * Fetch the A2A agent card, falling back to the v0.3 endpoint.
  * Returns null if not available (retries on connection errors).
  */
 export async function fetchA2AAgentCard(port: number, logger?: SSELogger): Promise<A2AAgentCard | null> {
@@ -26,19 +27,23 @@ export async function fetchA2AAgentCard(port: number, logger?: SSELogger): Promi
 
   for (let attempt = 0; attempt < maxRetries; attempt++) {
     try {
-      const res = await fetch(`http://localhost:${port}/.well-known/agent.json`, {
-        method: 'GET',
-        headers: { Accept: 'application/json' },
-      });
+      for (const path of ['/.well-known/agent-card.json', '/.well-known/agent.json']) {
+        const res = await fetch(`http://localhost:${port}${path}`, {
+          method: 'GET',
+          headers: { Accept: 'application/json' },
+        });
 
-      if (!res.ok) {
-        logger?.log?.('warn', `Agent card not available (${res.status})`);
-        return null;
+        if (!res.ok) {
+          if (res.status === 404 && path === '/.well-known/agent-card.json') continue;
+          logger?.log?.('warn', `Agent card not available (${res.status})`);
+          return null;
+        }
+
+        const card = (await res.json()) as A2AAgentCard;
+        logger?.log?.('system', `A2A agent card: ${card.name ?? 'unnamed'}`);
+        return card;
       }
-
-      const card = (await res.json()) as A2AAgentCard;
-      logger?.log?.('system', `A2A agent card: ${card.name ?? 'unnamed'}`);
-      return card;
+      return null;
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err));
       if (isConnectionError(error) && attempt < maxRetries - 1) {

--- a/src/cli/operations/dev/web-ui/api-types.ts
+++ b/src/cli/operations/dev/web-ui/api-types.ts
@@ -420,12 +420,13 @@ export interface A2AAgentSkill {
   tags?: string[];
 }
 
-/** A2A agent card returned by /.well-known/agent.json */
+/** A2A agent card returned by /.well-known/agent-card.json */
 export interface A2AAgentCard {
   name?: string;
   description?: string;
   version?: string;
   url?: string;
+  supportedInterfaces?: { protocolBinding?: string; protocolVersion?: string; url?: string }[];
   skills?: A2AAgentSkill[];
   capabilities?: { streaming?: boolean };
   defaultInputModes?: string[];

--- a/src/cli/operations/dev/web-ui/handlers/a2a-proxy.ts
+++ b/src/cli/operations/dev/web-ui/handlers/a2a-proxy.ts
@@ -27,10 +27,16 @@ export async function handleA2AAgentCard(
   }
 
   try {
-    const cardRes = await fetch(`http://localhost:${running.port}/.well-known/agent.json`, {
+    let cardRes = await fetch(`http://localhost:${running.port}/.well-known/agent-card.json`, {
       method: 'GET',
       headers: { Accept: 'application/json' },
     });
+    if (cardRes.status === 404) {
+      cardRes = await fetch(`http://localhost:${running.port}/.well-known/agent.json`, {
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+      });
+    }
 
     if (!cardRes.ok) {
       res.writeHead(502, { 'Content-Type': 'application/json' });


### PR DESCRIPTION
## Summary
- migrate the Google ADK and LangGraph A2A templates to a2a-sdk v1 types and agent cards
- use the opt-in `bedrock-agentcore[a2a-v1]` dependency path introduced by aws/bedrock-agentcore-sdk-python#591
- preserve the Strands template on its supported a2a-sdk 0.3 path and native `StrandsA2AExecutor`
- discover the v1 agent-card endpoint with a fallback for existing v0.3 agents
- add unit coverage for both CLI and web UI endpoint fallback paths

## Release coordination
This PR depends on aws/bedrock-agentcore-sdk-python#591 and publication of `bedrock-agentcore >= 1.19.0`, which provides the `a2a-v1` extra. **Do not release a CLI version containing these Google ADK and LangGraph template changes until that SDK version is available on PyPI.** The Strands template is not gated on that release and continues to use the currently published `[a2a]` / a2a-sdk 0.3 path.

## Validation
- full unit suite: 5,983 passed
- focused A2A and asset snapshot suite: 139 passed
- TypeScript typecheck, ESLint, Prettier, secretlint, and pre-commit hooks pass
- asset snapshots regenerated after merging current `main`

Closes #1146