### PR TITLE
fix: exclude broken GCP resource detector release

### DIFF
--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -1492,8 +1492,8 @@ dependencies = [
     "bedrock-agentcore[a2a] >= 1.0.3",
     "google-adk >= 1.0.0, < 2.0.0",
     "google-genai >= 1.0.0, < 2.0.0",
-    # 1.13.0 was yanked for broken imports; pin the latest usable wheel explicitly.
-    "opentelemetry-resourcedetector-gcp == 1.12.0a0",
+    # 1.13.0 was yanked for broken imports.
+    "opentelemetry-resourcedetector-gcp >= 1.9.0a0, < 2.0.0, != 1.13.0",
 ]
 
 [tool.hatch.build.targets.wheel]
@@ -2520,8 +2520,8 @@ dependencies = [
     "fastapi >= 0.115.12",
     "google-adk >= 1.16.0, < 2.0.0",
     "google-genai >= 1.0.0, < 2.0.0",
-    # 1.13.0 was yanked for broken imports; pin the latest usable wheel explicitly.
-    "opentelemetry-resourcedetector-gcp == 1.12.0a0",
+    # 1.13.0 was yanked for broken imports.
+    "opentelemetry-resourcedetector-gcp >= 1.9.0a0, < 2.0.0, != 1.13.0",
     "aws-opentelemetry-distro >= 0.17.0",
     "uvicorn >= 0.34.3",
 ]
@@ -4204,8 +4204,8 @@ dependencies = [
     "aws-opentelemetry-distro >= 0.17.0",
     "google-adk >= 1.35.0, < 2.0.0",
     "google-genai >= 1.0.0, < 2.0.0",
-    # 1.13.0 was yanked for broken imports; pin the latest usable wheel explicitly.
-    "opentelemetry-resourcedetector-gcp == 1.12.0a0",
+    # 1.13.0 was yanked for broken imports.
+    "opentelemetry-resourcedetector-gcp >= 1.9.0a0, < 2.0.0, != 1.13.0",
     "bedrock-agentcore >= 1.0.3",
     "botocore[crt] >= 1.35.0",
     {{#if hasGateway}}{{#if (includes gatewayAuthTypes "AWS_IAM")}}"mcp-proxy-for-aws >= 1.1.0",

--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -1492,6 +1492,8 @@ dependencies = [
     "bedrock-agentcore[a2a] >= 1.0.3",
     "google-adk >= 1.0.0, < 2.0.0",
     "google-genai >= 1.0.0, < 2.0.0",
+    # 1.13.0 was yanked for broken imports; pin the latest usable wheel explicitly.
+    "opentelemetry-resourcedetector-gcp == 1.12.0a0",
 ]
 
 [tool.hatch.build.targets.wheel]
@@ -2518,6 +2520,8 @@ dependencies = [
     "fastapi >= 0.115.12",
     "google-adk >= 1.16.0, < 2.0.0",
     "google-genai >= 1.0.0, < 2.0.0",
+    # 1.13.0 was yanked for broken imports; pin the latest usable wheel explicitly.
+    "opentelemetry-resourcedetector-gcp == 1.12.0a0",
     "aws-opentelemetry-distro >= 0.17.0",
     "uvicorn >= 0.34.3",
 ]
@@ -4200,6 +4204,8 @@ dependencies = [
     "aws-opentelemetry-distro >= 0.17.0",
     "google-adk >= 1.35.0, < 2.0.0",
     "google-genai >= 1.0.0, < 2.0.0",
+    # 1.13.0 was yanked for broken imports; pin the latest usable wheel explicitly.
+    "opentelemetry-resourcedetector-gcp == 1.12.0a0",
     "bedrock-agentcore >= 1.0.3",
     "botocore[crt] >= 1.35.0",
     {{#if hasGateway}}{{#if (includes gatewayAuthTypes "AWS_IAM")}}"mcp-proxy-for-aws >= 1.1.0",

--- a/src/assets/__tests__/googleadk-observability.test.ts
+++ b/src/assets/__tests__/googleadk-observability.test.ts
@@ -8,7 +8,6 @@ const EXPECTED_DEPENDENCIES = [
   ['agui', '"aws-opentelemetry-distro >= 0.17.0"'],
   ['a2a', '"aws-opentelemetry-distro"'],
 ] as const;
-const GCP_RESOURCE_DETECTOR_PIN = '"opentelemetry-resourcedetector-gcp == 1.12.0a0"';
 
 describe('Google ADK observability dependencies', () => {
   it.each(EXPECTED_DEPENDENCIES)('%s uses the AWS OpenTelemetry distro', (protocol, expectedDependency) => {
@@ -20,14 +19,5 @@ describe('Google ADK observability dependencies', () => {
     expect(pyproject).toContain(expectedDependency);
     expect(pyproject).not.toMatch(/^\s*"opentelemetry-distro",?$/m);
     expect(pyproject).not.toMatch(/^\s*"opentelemetry-exporter-otlp",?$/m);
-  });
-
-  it.each(EXPECTED_DEPENDENCIES)('%s pins the GCP resource detector to a usable wheel', protocol => {
-    const pyproject = fs.readFileSync(
-      path.join(ASSETS_DIR, protocol, 'googleadk', 'base', 'pyproject.toml'),
-      'utf-8'
-    );
-
-    expect(pyproject).toContain(GCP_RESOURCE_DETECTOR_PIN);
   });
 });

--- a/src/assets/__tests__/googleadk-observability.test.ts
+++ b/src/assets/__tests__/googleadk-observability.test.ts
@@ -8,6 +8,7 @@ const EXPECTED_DEPENDENCIES = [
   ['agui', '"aws-opentelemetry-distro >= 0.17.0"'],
   ['a2a', '"aws-opentelemetry-distro"'],
 ] as const;
+const GCP_RESOURCE_DETECTOR_PIN = '"opentelemetry-resourcedetector-gcp == 1.12.0a0"';
 
 describe('Google ADK observability dependencies', () => {
   it.each(EXPECTED_DEPENDENCIES)('%s uses the AWS OpenTelemetry distro', (protocol, expectedDependency) => {
@@ -19,5 +20,14 @@ describe('Google ADK observability dependencies', () => {
     expect(pyproject).toContain(expectedDependency);
     expect(pyproject).not.toMatch(/^\s*"opentelemetry-distro",?$/m);
     expect(pyproject).not.toMatch(/^\s*"opentelemetry-exporter-otlp",?$/m);
+  });
+
+  it.each(EXPECTED_DEPENDENCIES)('%s pins the GCP resource detector to a usable wheel', protocol => {
+    const pyproject = fs.readFileSync(
+      path.join(ASSETS_DIR, protocol, 'googleadk', 'base', 'pyproject.toml'),
+      'utf-8'
+    );
+
+    expect(pyproject).toContain(GCP_RESOURCE_DETECTOR_PIN);
   });
 });

--- a/src/assets/python/a2a/googleadk/base/pyproject.toml
+++ b/src/assets/python/a2a/googleadk/base/pyproject.toml
@@ -14,8 +14,8 @@ dependencies = [
     "bedrock-agentcore[a2a] >= 1.0.3",
     "google-adk >= 1.0.0, < 2.0.0",
     "google-genai >= 1.0.0, < 2.0.0",
-    # 1.13.0 was yanked for broken imports; pin the latest usable wheel explicitly.
-    "opentelemetry-resourcedetector-gcp == 1.12.0a0",
+    # 1.13.0 was yanked for broken imports.
+    "opentelemetry-resourcedetector-gcp >= 1.9.0a0, < 2.0.0, != 1.13.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/assets/python/a2a/googleadk/base/pyproject.toml
+++ b/src/assets/python/a2a/googleadk/base/pyproject.toml
@@ -14,6 +14,8 @@ dependencies = [
     "bedrock-agentcore[a2a] >= 1.0.3",
     "google-adk >= 1.0.0, < 2.0.0",
     "google-genai >= 1.0.0, < 2.0.0",
+    # 1.13.0 was yanked for broken imports; pin the latest usable wheel explicitly.
+    "opentelemetry-resourcedetector-gcp == 1.12.0a0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/assets/python/agui/googleadk/base/pyproject.toml
+++ b/src/assets/python/agui/googleadk/base/pyproject.toml
@@ -15,8 +15,8 @@ dependencies = [
     "fastapi >= 0.115.12",
     "google-adk >= 1.16.0, < 2.0.0",
     "google-genai >= 1.0.0, < 2.0.0",
-    # 1.13.0 was yanked for broken imports; pin the latest usable wheel explicitly.
-    "opentelemetry-resourcedetector-gcp == 1.12.0a0",
+    # 1.13.0 was yanked for broken imports.
+    "opentelemetry-resourcedetector-gcp >= 1.9.0a0, < 2.0.0, != 1.13.0",
     "aws-opentelemetry-distro >= 0.17.0",
     "uvicorn >= 0.34.3",
 ]

--- a/src/assets/python/agui/googleadk/base/pyproject.toml
+++ b/src/assets/python/agui/googleadk/base/pyproject.toml
@@ -15,6 +15,8 @@ dependencies = [
     "fastapi >= 0.115.12",
     "google-adk >= 1.16.0, < 2.0.0",
     "google-genai >= 1.0.0, < 2.0.0",
+    # 1.13.0 was yanked for broken imports; pin the latest usable wheel explicitly.
+    "opentelemetry-resourcedetector-gcp == 1.12.0a0",
     "aws-opentelemetry-distro >= 0.17.0",
     "uvicorn >= 0.34.3",
 ]

--- a/src/assets/python/http/googleadk/base/pyproject.toml
+++ b/src/assets/python/http/googleadk/base/pyproject.toml
@@ -12,8 +12,8 @@ dependencies = [
     "aws-opentelemetry-distro >= 0.17.0",
     "google-adk >= 1.35.0, < 2.0.0",
     "google-genai >= 1.0.0, < 2.0.0",
-    # 1.13.0 was yanked for broken imports; pin the latest usable wheel explicitly.
-    "opentelemetry-resourcedetector-gcp == 1.12.0a0",
+    # 1.13.0 was yanked for broken imports.
+    "opentelemetry-resourcedetector-gcp >= 1.9.0a0, < 2.0.0, != 1.13.0",
     "bedrock-agentcore >= 1.0.3",
     "botocore[crt] >= 1.35.0",
     {{#if hasGateway}}{{#if (includes gatewayAuthTypes "AWS_IAM")}}"mcp-proxy-for-aws >= 1.1.0",

--- a/src/assets/python/http/googleadk/base/pyproject.toml
+++ b/src/assets/python/http/googleadk/base/pyproject.toml
@@ -12,6 +12,8 @@ dependencies = [
     "aws-opentelemetry-distro >= 0.17.0",
     "google-adk >= 1.35.0, < 2.0.0",
     "google-genai >= 1.0.0, < 2.0.0",
+    # 1.13.0 was yanked for broken imports; pin the latest usable wheel explicitly.
+    "opentelemetry-resourcedetector-gcp == 1.12.0a0",
     "bedrock-agentcore >= 1.0.3",
     "botocore[crt] >= 1.35.0",
     {{#if hasGateway}}{{#if (includes gatewayAuthTypes "AWS_IAM")}}"mcp-proxy-for-aws >= 1.1.0",


### PR DESCRIPTION
## Summary

- exclude yanked `opentelemetry-resourcedetector-gcp==1.13.0` in every Google ADK template
- retain the existing supported range so future fixed releases remain eligible
- update the affected asset snapshots

## Root cause

Google ADK requires `opentelemetry-resourcedetector-gcp >=1.9.0a0,<2`. PyPI yanked `1.13.0` with the reason `breaks imports`. During wheel-only Python packaging, uv attempted that release and CDK synth failed. Adding the direct exclusion causes the current resolver to select `1.12.0a0` while allowing later releases.

Evidence:
- https://pypi.org/pypi/google-adk/1.35.0/json
- https://pypi.org/pypi/opentelemetry-resourcedetector-gcp/json
- https://github.com/aws/agentcore-cli/actions/runs/29957552477/job/89271829887

## Testing

- exact Python 3.14 ARM64 `uv --only-binary :all:` resolution selects `1.12.0a0` with the exclusion range
- `npm run typecheck`
- `npx vitest run --project unit src/assets/__tests__/assets.snapshot.test.ts` (128 tests)
- `npm run lint -- --no-fix` (0 errors; existing warnings only)
- [E2E Tests (Full Suite)](https://github.com/aws/agentcore-cli/actions/runs/30032069443): browser tests and all five E2E shards passed
- Google ADK/Gemini deploy, invoke, status, logs, traces, and teardown passed in shard 3