### PR TITLE
fix(ci): provision review Python with uv on CodeBuild

### DIFF
--- a/.github/workflows/pr-ai-review.yml
+++ b/.github/workflows/pr-ai-review.yml
@@ -134,16 +134,14 @@ jobs:
           role-to-assume: ${{ secrets.HARNESS_AWS_ROLE_ARN }}
           aws-region: us-east-1
 
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v7
+      - name: Set up Python 3.12 with uv
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: '3.12'
-
-      - name: Install uv and dependencies
-        uses: astral-sh/setup-uv@v7
+          activate-environment: true
 
       - name: Install boto3
-        run: uv pip install --system boto3
+        run: uv pip install boto3
 
       - name: Run AI review
         env:


### PR DESCRIPTION
## Summary

- replace `actions/setup-python` in the harness review workflow because it has no Amazon Linux 2023 Python builds
- use `setup-uv` to download Python 3.12 and activate a virtual environment
- install `boto3` into the activated environment

## Verification

- `npm run typecheck` (via pre-commit hook)
- Prettier and secretlint (via lint-staged)
- Full workflow dispatch on the CodeBuild runner: https://github.com/aws/agentcore-cli/actions/runs/30049510856
  - downloaded and activated CPython 3.12.13
  - installed boto3 successfully
  - completed the harness review and cleanup successfully
