### PR TITLE
fix: preserve wrapped CLI help in API docs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,6 +43,9 @@ jobs:
         uses: astral-sh/setup-uv@v7
       - run: npm ci
       - run: npm run build --if-present
+      - name: Test API docs generator
+        if: matrix.node-version == '20.x'
+        run: npm run test:docs
       - name: Pack tarball
         if: matrix.node-version == '20.x'
         run: npm pack

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "prepare": "husky",
     "test": "vitest run --project unit",
     "test:all": "vitest run",
+    "test:docs": "node --test scripts/*.test.mjs && python3 -m unittest scripts/test_render_adoc.py",
     "test:watch": "vitest --project unit",
     "test:integ": "npm run build && vitest run --project integ",
     "test:unit": "vitest run --project unit --coverage",

--- a/scripts/extract-cli-model.mjs
+++ b/scripts/extract-cli-model.mjs
@@ -19,6 +19,7 @@
 import { execFileSync } from 'node:child_process';
 import { writeFileSync } from 'node:fs';
 import { argv } from 'node:process';
+import { pathToFileURL } from 'node:url';
 
 // Command grouping (arranged properly, per the request). Mirrors the sections
 // in agentcore-cli/docs/commands.md. Any command discovered from the binary but
@@ -85,10 +86,11 @@ function help(args) {
 }
 
 // Parse a Commander.js help blob into { summary, signature, params, options }.
-function parseHelp(text, name) {
+export function parseHelp(text) {
   const lines = text.split('\n');
   const out = { summary: '', signature: '', args: [], options: [] };
   let section = 'head';
+  let currentItem = null;
   const descLines = [];
 
   for (const raw of lines) {
@@ -96,18 +98,22 @@ function parseHelp(text, name) {
     if (/^Usage:/.test(line)) {
       out.signature = line.replace(/^Usage:\s*/, '').trim();
       section = 'desc';
+      currentItem = null;
       continue;
     }
     if (/^Arguments:/.test(line)) {
       section = 'args';
+      currentItem = null;
       continue;
     }
     if (/^Options:/.test(line)) {
       section = 'options';
+      currentItem = null;
       continue;
     }
     if (/^Commands:/.test(line)) {
       section = 'commands';
+      currentItem = null;
       continue;
     }
 
@@ -115,10 +121,22 @@ function parseHelp(text, name) {
       if (line.trim()) descLines.push(line.trim());
     } else if (section === 'args') {
       const m = line.match(/^\s+(\S+)\s{2,}(.*)$/);
-      if (m) out.args.push({ name: m[1], type: null, required: true, description: m[2].trim() });
+      if (m) {
+        currentItem = { name: m[1], type: null, required: true, description: m[2].trim() };
+        out.args.push(currentItem);
+      } else if (currentItem && /^\s+\S/.test(line)) {
+        currentItem.description += ` ${line.trim()}`;
+      }
     } else if (section === 'options') {
       const m = line.match(/^\s+(-[^\s].*?)\s{2,}(.*)$/);
-      if (m) out.options.push({ name: m[1].trim(), type: null, required: false, description: m[2].trim() });
+      if (m) {
+        currentItem = { name: m[1].trim(), type: null, required: false, description: m[2].trim() };
+        out.options.push(currentItem);
+      } else if (currentItem && /^\s+\S/.test(line)) {
+        currentItem.description += ` ${line.trim()}`;
+      } else if (line.trim()) {
+        currentItem = null;
+      }
     }
   }
   out.summary = descLines.join(' ');
@@ -138,7 +156,7 @@ function entryForCommand(name) {
         `not a real CLI command (phantom/renamed). Remove it from GROUPS or fix the name.`
     );
   }
-  const parsed = parseHelp(raw, name);
+  const parsed = parseHelp(raw);
   // subcommands (e.g. `add agent`, `remove tool`) show under "Commands:"—
   // we surface the top-level command; nested ones can be expanded later.
   return {
@@ -225,4 +243,6 @@ function main() {
   process.stderr.write(`Wrote doc-model: ${groups.length} groups, version ${version}\n`);
 }
 
-main();
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/extract-cli-model.mjs
+++ b/scripts/extract-cli-model.mjs
@@ -85,6 +85,27 @@ function help(args) {
   }
 }
 
+const PARAMETER_DESCRIPTION_OVERRIDES = new Map([
+  [
+    'bedrock, open_ai, or gemini',
+    'The model provider. Valid values: `bedrock`, `open_ai`, or `gemini`.',
+  ],
+  [
+    'Override LiteLLM API base URL (harness only, lite_llm) [non-interactive]',
+    'The LiteLLM API base URL override for harness invocations. ' +
+      'Available only with `lite_llm` in non-interactive mode.',
+  ],
+  [
+    'Override LiteLLM additional params as a JSON object (harness only, lite_llm) [non-interactive]',
+    'The additional LiteLLM parameters, as a JSON object, for harness invocations. ' +
+      'Available only with `lite_llm` in non-interactive mode.',
+  ],
+]);
+
+export function normalizeParameterDescription(description) {
+  return PARAMETER_DESCRIPTION_OVERRIDES.get(description) || description;
+}
+
 // Parse a Commander.js help blob into { summary, signature, params, options }.
 export function parseHelp(text) {
   const lines = text.split('\n');
@@ -168,7 +189,12 @@ function entryForCommand(name) {
     // reuse params for both positional args and flags, flagged by required.
     // The renderer already wraps param names in backticks, so don't add our
     // own (that produced double-backticks). Drop the ubiquitous help flag.
-    params: [...parsed.args, ...parsed.options.filter(o => !/^-h,?\s|--help\b/.test(o.name))],
+    params: [...parsed.args, ...parsed.options.filter(o => !/^-h,?\s|--help\b/.test(o.name))].map(
+      param => ({
+        ...param,
+        description: normalizeParameterDescription(param.description),
+      })
+    ),
     returns: null,
     raises: [],
     examples: [],

--- a/scripts/extract-cli-model.mjs
+++ b/scripts/extract-cli-model.mjs
@@ -86,10 +86,7 @@ function help(args) {
 }
 
 const PARAMETER_DESCRIPTION_OVERRIDES = new Map([
-  [
-    'bedrock, open_ai, or gemini',
-    'The model provider. Valid values: `bedrock`, `open_ai`, or `gemini`.',
-  ],
+  ['bedrock, open_ai, or gemini', 'The model provider. Valid values: `bedrock`, `open_ai`, or `gemini`.'],
   [
     'Override LiteLLM API base URL (harness only, lite_llm) [non-interactive]',
     'The LiteLLM API base URL override for harness invocations. ' +
@@ -189,12 +186,10 @@ function entryForCommand(name) {
     // reuse params for both positional args and flags, flagged by required.
     // The renderer already wraps param names in backticks, so don't add our
     // own (that produced double-backticks). Drop the ubiquitous help flag.
-    params: [...parsed.args, ...parsed.options.filter(o => !/^-h,?\s|--help\b/.test(o.name))].map(
-      param => ({
-        ...param,
-        description: normalizeParameterDescription(param.description),
-      })
-    ),
+    params: [...parsed.args, ...parsed.options.filter(o => !/^-h,?\s|--help\b/.test(o.name))].map(param => ({
+      ...param,
+      description: normalizeParameterDescription(param.description),
+    })),
     returns: null,
     raises: [],
     examples: [],

--- a/scripts/extract-cli-model.test.mjs
+++ b/scripts/extract-cli-model.test.mjs
@@ -1,9 +1,8 @@
-import assert from "node:assert/strict";
-import test from "node:test";
+import { normalizeParameterDescription, parseHelp } from './extract-cli-model.mjs';
+import assert from 'node:assert/strict';
+import test from 'node:test';
 
-import { normalizeParameterDescription, parseHelp } from "./extract-cli-model.mjs";
-
-test("parseHelp preserves wrapped argument and option descriptions", () => {
+test('parseHelp preserves wrapped argument and option descriptions', () => {
   const parsed = parseHelp(`Usage: agentcore invoke [options] [prompt]
 
 Invoke an agent.
@@ -22,25 +21,23 @@ Output
 
   assert.equal(
     parsed.args[0].description,
-    "Prompt to send to the agent. Also accepts piped stdin when no prompt is provided",
+    'Prompt to send to the agent. Also accepts piped stdin when no prompt is provided'
   );
   assert.equal(
     parsed.options[0].description,
-    "Read the prompt from a file (for long or structured payloads that exceed shell limits)",
+    'Read the prompt from a file (for long or structured payloads that exceed shell limits)'
   );
-  assert.equal(parsed.options[1].description, "Output as JSON");
+  assert.equal(parsed.options[1].description, 'Output as JSON');
 });
 
-test("normalizeParameterDescription expands model provider and LiteLLM fragments", () => {
+test('normalizeParameterDescription expands model provider and LiteLLM fragments', () => {
   assert.equal(
-    normalizeParameterDescription("bedrock, open_ai, or gemini"),
-    "The model provider. Valid values: `bedrock`, `open_ai`, or `gemini`.",
+    normalizeParameterDescription('bedrock, open_ai, or gemini'),
+    'The model provider. Valid values: `bedrock`, `open_ai`, or `gemini`.'
   );
   assert.equal(
-    normalizeParameterDescription(
-      "Override LiteLLM API base URL (harness only, lite_llm) [non-interactive]",
-    ),
-    "The LiteLLM API base URL override for harness invocations. " +
-      "Available only with `lite_llm` in non-interactive mode.",
+    normalizeParameterDescription('Override LiteLLM API base URL (harness only, lite_llm) [non-interactive]'),
+    'The LiteLLM API base URL override for harness invocations. ' +
+      'Available only with `lite_llm` in non-interactive mode.'
   );
 });

--- a/scripts/extract-cli-model.test.mjs
+++ b/scripts/extract-cli-model.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { parseHelp } from "./extract-cli-model.mjs";
+import { normalizeParameterDescription, parseHelp } from "./extract-cli-model.mjs";
 
 test("parseHelp preserves wrapped argument and option descriptions", () => {
   const parsed = parseHelp(`Usage: agentcore invoke [options] [prompt]
@@ -29,4 +29,18 @@ Output
     "Read the prompt from a file (for long or structured payloads that exceed shell limits)",
   );
   assert.equal(parsed.options[1].description, "Output as JSON");
+});
+
+test("normalizeParameterDescription expands model provider and LiteLLM fragments", () => {
+  assert.equal(
+    normalizeParameterDescription("bedrock, open_ai, or gemini"),
+    "The model provider. Valid values: `bedrock`, `open_ai`, or `gemini`.",
+  );
+  assert.equal(
+    normalizeParameterDescription(
+      "Override LiteLLM API base URL (harness only, lite_llm) [non-interactive]",
+    ),
+    "The LiteLLM API base URL override for harness invocations. " +
+      "Available only with `lite_llm` in non-interactive mode.",
+  );
 });

--- a/scripts/extract-cli-model.test.mjs
+++ b/scripts/extract-cli-model.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseHelp } from "./extract-cli-model.mjs";
+
+test("parseHelp preserves wrapped argument and option descriptions", () => {
+  const parsed = parseHelp(`Usage: agentcore invoke [options] [prompt]
+
+Invoke an agent.
+
+Arguments:
+  prompt                 Prompt to send to the agent. Also accepts piped
+                         stdin when no prompt is provided
+
+Options:
+  --prompt-file <path>   Read the prompt from a file (for long or
+                         structured payloads that exceed shell limits)
+
+Output
+  --json                 Output as JSON
+`);
+
+  assert.equal(
+    parsed.args[0].description,
+    "Prompt to send to the agent. Also accepts piped stdin when no prompt is provided",
+  );
+  assert.equal(
+    parsed.options[0].description,
+    "Read the prompt from a file (for long or structured payloads that exceed shell limits)",
+  );
+  assert.equal(parsed.options[1].description, "Output as JSON");
+});

--- a/scripts/render_adoc.py
+++ b/scripts/render_adoc.py
@@ -68,6 +68,12 @@ def normalize_style(text):
     )
     text = re.sub(r"\bAWS Bedrock AgentCore\b", "Amazon Bedrock AgentCore", text)
     text = re.sub(r"\bAWS Bedrock\b", "Amazon Bedrock", text)
+    text = re.sub(
+        r"(?<!Amazon )(?<!AWS )\bBedrock AgentCore\b",
+        "Amazon Bedrock AgentCore",
+        text,
+    )
+    text = re.sub(r"\bAWS region\b", "AWS Region", text, flags=re.IGNORECASE)
     text = re.sub(r"\bAgentCore Memory\b", "AgentCore memory", text)
     text = re.sub(r"\bAgentCore Runtime\b", "AgentCore runtime", text)
     text = text.replace(
@@ -97,8 +103,9 @@ def normalize_param_description(text):
     }
     if text in exact_substitutions:
         return exact_substitutions[text]
+    optional_replacement = "Optional" if _starts_with_plural_noun(text) else "An optional"
     substitutions = (
-        (r"^Optional\b", "An optional"),
+        (r"^Optional\b", optional_replacement),
         (r"^(?:\{aws\}|AWS)\s+region\b", "The {aws} Region"),
         (r"^id of\b", "The ID of"),
         (r"^Behaviour\b", "The behavior"),
@@ -110,6 +117,15 @@ def normalize_param_description(text):
     for pattern, replacement in substitutions:
         text = re.sub(pattern, replacement, text, count=1, flags=re.IGNORECASE)
     return text
+
+
+def _starts_with_plural_noun(text):
+    """Return whether an Optional description starts with a likely plural noun."""
+    match = re.match(r"^Optional\s+([A-Za-z]+)\b", text, flags=re.IGNORECASE)
+    if not match:
+        return False
+    noun = match.group(1)
+    return noun.islower() and noun.endswith("s") and not noun.endswith(("is", "ss", "us"))
 
 
 def esc(text):

--- a/scripts/render_adoc.py
+++ b/scripts/render_adoc.py
@@ -55,15 +55,44 @@ import textwrap
 SCHEMA_VERSION = 1
 
 
+def normalize_style(text):
+    """Apply style-safe substitutions to generated prose."""
+    if not text:
+        return ""
+    text = re.sub(r"\be\.g\.(?:,)?", "for example,", text, flags=re.IGNORECASE)
+    text = text.replace(
+        "This feature is in preview and may change in future releases.",
+        "This feature is in preview and might change in future releases.",
+    )
+    return re.sub(r"\bAWS\b", "{aws}", text)
+
+
+def normalize_param_description(text):
+    """Normalize recurring parameter-description style issues."""
+    text = normalize_style(text).strip()
+    substitutions = (
+        (r"^Optional\b", "An optional"),
+        (r"^(?:\{aws\}|AWS)\s+region\b", "The {aws} Region"),
+        (r"^id of\b", "The ID of"),
+        (r"^Behaviour\b", "The behavior"),
+        (r"^Behavior\b", "The behavior"),
+        (r"^Memory resource ID\b", "The memory resource ID"),
+        (r"^Strategy name\b", "The name of the memory strategy"),
+        (r"^Strategy ID\b", "The ID of the memory strategy"),
+    )
+    for pattern, replacement in substitutions:
+        text = re.sub(pattern, replacement, text, count=1, flags=re.IGNORECASE)
+    return text
+
+
 def esc(text):
     """Escape AsciiDoc-significant characters in inline text."""
     if not text:
         return ""
     # Guard the couple of chars that start AsciiDoc markup in running prose.
-    return (
-        text.replace("|", "\\|")
-        .replace("{", "\\{")
-    )
+    marker = "\0AWS_ENTITY\0"
+    text = normalize_style(text).replace("{aws}", marker)
+    return text.replace("|", "\\|").replace("{", "\\{").replace(marker, "{aws}")
 
 
 # Match markdown code fences that may be indented (reST/Google docstrings often
@@ -116,7 +145,7 @@ def render_params(params, out):
         req = "" if p.get("required") else " _(optional)_"
         typ = f"`{p['type']}`" if p.get("type") else ""
         out.append(f"`{p['name']}`{req} {typ}::")
-        out.append(esc(p.get("description", "")) or "_No description._")
+        out.append(esc(normalize_param_description(p.get("description", ""))) or "_No description._")
     out.append("")
 
 

--- a/scripts/render_adoc.py
+++ b/scripts/render_adoc.py
@@ -60,16 +60,43 @@ def normalize_style(text):
     if not text:
         return ""
     text = re.sub(r"\be\.g\.(?:,)?", "for example,", text, flags=re.IGNORECASE)
+    text = re.sub(
+        r"\bAWS Bedrock(?: AgentCore)? Code\s*Interpreter\b",
+        "AgentCore Code Interpreter",
+        text,
+        flags=re.IGNORECASE,
+    )
+    text = re.sub(r"\bAWS Bedrock AgentCore\b", "Amazon Bedrock AgentCore", text)
+    text = re.sub(r"\bAWS Bedrock\b", "Amazon Bedrock", text)
+    text = re.sub(r"\bAgentCore Memory\b", "AgentCore memory", text)
+    text = re.sub(r"\bAgentCore Runtime\b", "AgentCore runtime", text)
     text = text.replace(
         "This feature is in preview and may change in future releases.",
         "This feature is in preview and might change in future releases.",
     )
+    text = text.replace("validation will ensure", "validation ensures")
     return re.sub(r"\bAWS\b", "{aws}", text)
 
 
 def normalize_param_description(text):
     """Normalize recurring parameter-description style issues."""
     text = normalize_style(text).strip()
+    exact_substitutions = {
+        "bedrock, open_ai, or gemini": (
+            "The model provider. Valid values: `bedrock`, `open_ai`, or `gemini`."
+        ),
+        "Override LiteLLM API base URL (harness only, lite_llm) [non-interactive]": (
+            "The LiteLLM API base URL override for harness invocations. "
+            "Available only with `lite_llm` in non-interactive mode."
+        ),
+        "Override LiteLLM additional params as a JSON object (harness only, lite_llm) "
+        "[non-interactive]": (
+            "The additional LiteLLM parameters, as a JSON object, for harness invocations. "
+            "Available only with `lite_llm` in non-interactive mode."
+        ),
+    }
+    if text in exact_substitutions:
+        return exact_substitutions[text]
     substitutions = (
         (r"^Optional\b", "An optional"),
         (r"^(?:\{aws\}|AWS)\s+region\b", "The {aws} Region"),

--- a/scripts/render_adoc.py
+++ b/scripts/render_adoc.py
@@ -62,7 +62,7 @@ def normalize_style(text):
     text = re.sub(r"\be\.g\.(?:,)?", "for example,", text, flags=re.IGNORECASE)
     text = re.sub(
         r"\bAWS (?:Bedrock(?: AgentCore)? )?Code\s*Interpreter\b",
-        "AgentCore Code Interpreter",
+        "Amazon Bedrock AgentCore Code Interpreter",
         text,
         flags=re.IGNORECASE,
     )
@@ -71,6 +71,16 @@ def normalize_style(text):
     text = re.sub(
         r"(?<!Amazon )(?<!AWS )\bBedrock AgentCore\b",
         "Amazon Bedrock AgentCore",
+        text,
+    )
+    text = re.sub(
+        r"(?<!Amazon Bedrock )\bAgentCore Code Interpreter\b",
+        "Amazon Bedrock AgentCore Code Interpreter",
+        text,
+    )
+    text = re.sub(
+        r"(?<!Amazon Bedrock )\bAgentCore runtime\b",
+        "Amazon Bedrock AgentCore runtime",
         text,
     )
     text = re.sub(r"\bAWS region\b", "AWS Region", text, flags=re.IGNORECASE)

--- a/scripts/render_adoc.py
+++ b/scripts/render_adoc.py
@@ -61,7 +61,7 @@ def normalize_style(text):
         return ""
     text = re.sub(r"\be\.g\.(?:,)?", "for example,", text, flags=re.IGNORECASE)
     text = re.sub(
-        r"\bAWS Bedrock(?: AgentCore)? Code\s*Interpreter\b",
+        r"\bAWS (?:Bedrock(?: AgentCore)? )?Code\s*Interpreter\b",
         "AgentCore Code Interpreter",
         text,
         flags=re.IGNORECASE,

--- a/scripts/render_adoc.py
+++ b/scripts/render_adoc.py
@@ -103,9 +103,8 @@ def normalize_param_description(text):
     }
     if text in exact_substitutions:
         return exact_substitutions[text]
-    optional_replacement = "Optional" if _starts_with_plural_noun(text) else "An optional"
     substitutions = (
-        (r"^Optional\b", optional_replacement),
+        (r"^Optional\b", "The optional"),
         (r"^(?:\{aws\}|AWS)\s+region\b", "The {aws} Region"),
         (r"^id of\b", "The ID of"),
         (r"^Behaviour\b", "The behavior"),
@@ -117,17 +116,6 @@ def normalize_param_description(text):
     for pattern, replacement in substitutions:
         text = re.sub(pattern, replacement, text, count=1, flags=re.IGNORECASE)
     return text
-
-
-def _starts_with_plural_noun(text):
-    """Return whether an Optional description starts with a likely plural noun."""
-    match = re.match(r"^Optional\s+([A-Za-z]+)\b", text, flags=re.IGNORECASE)
-    if not match:
-        return False
-    noun = match.group(1)
-    return noun.islower() and noun.endswith("s") and not noun.endswith(("is", "ss", "us"))
-
-
 def esc(text):
     """Escape AsciiDoc-significant characters in inline text."""
     if not text:

--- a/scripts/render_adoc.py
+++ b/scripts/render_adoc.py
@@ -83,6 +83,12 @@ def normalize_style(text):
         "Amazon Bedrock AgentCore runtime",
         text,
     )
+    text = re.sub(
+        r"(?<!Amazon Bedrock )\bAgentCore Identity\b",
+        "Amazon Bedrock AgentCore Identity",
+        text,
+    )
+    text = text.replace(", allowing applications to", " so applications can")
     text = re.sub(r"\bAWS region\b", "AWS Region", text, flags=re.IGNORECASE)
     text = re.sub(r"\bAgentCore Memory\b", "AgentCore memory", text)
     text = re.sub(r"\bAgentCore Runtime\b", "AgentCore runtime", text)

--- a/scripts/test_render_adoc.py
+++ b/scripts/test_render_adoc.py
@@ -1,0 +1,20 @@
+import unittest
+
+from scripts.render_adoc import normalize_param_description
+
+
+class NormalizeParamDescriptionTest(unittest.TestCase):
+    def test_optional_descriptions_support_singular_plural_and_mass_nouns(self):
+        cases = {
+            "Optional session name.": "The optional session name.",
+            "Optional tags.": "The optional tags.",
+            "Optional additional task metadata.": "The optional additional task metadata.",
+        }
+
+        for description, expected in cases.items():
+            with self.subTest(description=description):
+                self.assertEqual(normalize_param_description(description), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_render_adoc.py
+++ b/scripts/test_render_adoc.py
@@ -24,6 +24,14 @@ class NormalizeParamDescriptionTest(unittest.TestCase):
             normalize_style("Client for the AgentCore Code Interpreter sandbox service."),
             "Client for the Amazon Bedrock AgentCore Code Interpreter sandbox service.",
         )
+        self.assertEqual(
+            normalize_style("Retrieves an API key from AgentCore Identity."),
+            "Retrieves an API key from Amazon Bedrock AgentCore Identity.",
+        )
+        self.assertEqual(
+            normalize_style("Provides credentials, allowing applications to connect."),
+            "Provides credentials so applications can connect.",
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/test_render_adoc.py
+++ b/scripts/test_render_adoc.py
@@ -1,6 +1,6 @@
 import unittest
 
-from scripts.render_adoc import normalize_param_description
+from scripts.render_adoc import normalize_param_description, normalize_style
 
 
 class NormalizeParamDescriptionTest(unittest.TestCase):
@@ -14,6 +14,16 @@ class NormalizeParamDescriptionTest(unittest.TestCase):
         for description, expected in cases.items():
             with self.subTest(description=description):
                 self.assertEqual(normalize_param_description(description), expected)
+
+    def test_service_names_are_fully_qualified(self):
+        self.assertEqual(
+            normalize_style("Client for AgentCore runtime."),
+            "Client for Amazon Bedrock AgentCore runtime.",
+        )
+        self.assertEqual(
+            normalize_style("Client for the AgentCore Code Interpreter sandbox service."),
+            "Client for the Amazon Bedrock AgentCore Code Interpreter sandbox service.",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- join wrapped Commander argument and option descriptions during extraction
- normalize generated AsciiDoc for AWS style and China rebranding checks
- add a regression test for wrapped help output

Addresses generated documentation feedback from Amazon CR-290947859.

## Testing
- `node --test scripts/extract-cli-model.test.mjs`
- regenerated the v0.24.2 CLI reference