### PR TITLE
feat(traces): compare two AgentCore traces from the CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ These options are available on all commands:
 - `logs evals` - Stream or search online eval logs
 - `traces list` - List recent traces for a deployed agent
 - `traces get` - Download a trace to a JSON file
+- `traces compare` - Compare latency and token metrics of two traces
 - `package` - Package agent artifacts without deploying (zip for CodeZip, container image build for Container)
 - `validate` - Validate configuration files
 - `update` - Check for CLI updates

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -974,9 +974,61 @@ agentcore traces compare abc123 def456 --since 2h --json
 
 Reports end-to-end, LLM, and tool latency, LLM/tool call counts, and token usage for each trace, with absolute and
 percentage deltas. Nested provider spans (e.g. a framework LLM span wrapping a Bedrock client span) are counted once.
-End-to-end latency comes from the `POST /invocations` server span; when that span is missing, the earliest/latest span
-times are used instead and a warning is shown. Comparability warnings flag differing LLM/tool call counts or token
-usage. `--json` returns the same data as structured output suitable for CI benchmarking.
+
+Behavior details:
+
+- Both traces must belong to the selected runtime — a trace from a different runtime in the same account is rejected.
+- Application spans are fetched from the endpoint-specific runtime log group, detected per trace from the runtime
+  span's `aws.endpoint.name` attribute. Baseline and candidate may come from different endpoints (e.g. `DEFAULT` vs a
+  named test endpoint).
+- End-to-end latency comes from the `POST /invocations` server span; when that span is missing, the earliest/latest
+  span times are used instead and a warning is shown.
+- When only service-side spans are found for a trace, LLM/tool/token metrics are reported as unavailable (omitted from
+  JSON, shown as `-` in the table) with a warning — never as zero.
+- Comparability warnings flag differing LLM/tool call counts, and input/output/total token usage that differs by more
+  than 20% relative to the baseline (or changes from zero). The CLI cannot prove the two invocations ran equivalent
+  workloads.
+
+`--json` returns stable structured output suitable for CI benchmarking:
+
+```json
+{
+  "success": true,
+  "agentName": "MyAgent",
+  "targetName": "default",
+  "consoleUrl": "https://...",
+  "baseline": {
+    "traceId": "abc123",
+    "spanCount": 12,
+    "endToEndMs": 6600,
+    "timingSource": "invocation-span",
+    "llmMs": 3620,
+    "llmCalls": 2,
+    "toolMs": 2850,
+    "toolCalls": 1,
+    "inputTokens": 2849,
+    "outputTokens": 315,
+    "totalTokens": 3164
+  },
+  "candidate": { "traceId": "def456", "...": "same shape as baseline" },
+  "deltas": {
+    "endToEndMs": { "baseline": 6600, "candidate": 5120, "delta": -1480, "deltaPercent": -22.4 },
+    "llmMs": { "...": "same shape" },
+    "toolMs": { "...": "same shape" },
+    "llmCalls": { "...": "same shape" },
+    "toolCalls": { "...": "same shape" },
+    "inputTokens": { "...": "same shape" },
+    "outputTokens": { "...": "same shape" },
+    "totalTokens": { "...": "same shape" }
+  },
+  "warnings": []
+}
+```
+
+Field notes: `timingSource` is `invocation-span` or `span-envelope` (labeled fallback). `deltaPercent` is `null` when
+the baseline value is zero. Unavailable metrics are omitted from `baseline`/`candidate`, and the corresponding delta
+entries carry only the sides that exist. On failure the output is `{ "success": false, "error": "<message>" }` with
+`errorName`/`errorSource` for typed errors.
 
 ---
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -977,9 +977,14 @@ percentage deltas. Nested provider spans (e.g. a framework LLM span wrapping a B
 
 Behavior details:
 
-- Both traces must belong to the selected runtime — a trace from a different runtime in the same account is rejected.
-- Application spans are fetched from the endpoint-specific runtime log group, detected per trace from the runtime
-  span's `aws.endpoint.name` attribute. Baseline and candidate may come from different endpoints (e.g. `DEFAULT` vs a
+- LLM and tool spans are recognized via OTel GenAI attributes (`gen_ai.operation.name`), Traceloop/OpenLLMetry
+  (`traceloop.span.kind`, used by LangGraph), OpenInference (`openinference.span.kind`), and span-name fallbacks
+  (`chat …`, `execute_tool …`, `….tool`).
+- Both traces must belong to the selected runtime — spans are matched via `aws.agent.id` / `cloud.resource_id`, other
+  runtimes' spans in a distributed trace are excluded, and a trace whose identified spans all belong to a different
+  runtime is rejected.
+- Application spans are fetched from the endpoint-specific runtime log group, detected per trace from this runtime's
+  span `aws.endpoint.name` attribute. Baseline and candidate may come from different endpoints (e.g. `DEFAULT` vs a
   named test endpoint).
 - End-to-end latency comes from the `POST /invocations` server span; when that span is missing, the earliest/latest
   span times are used instead and a warning is shown.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1030,9 +1030,11 @@ Behavior details:
 }
 ```
 
-Field notes: `timingSource` is `invocation-span` or `span-envelope` (labeled fallback). `deltaPercent` is `null` when
-the baseline value is zero. Unavailable metrics are omitted from `baseline`/`candidate`, and the corresponding delta
-entries carry only the sides that exist. On failure the output is `{ "success": false, "error": "<message>" }` with
+Field notes: latency fields (`endToEndMs`, `llmMs`, `toolMs`, and each delta's `delta`) and all `deltaPercent` values
+are rounded to one decimal place, so runs diff cleanly in CI; token and call-count fields are integers.
+`timingSource` is `invocation-span` or `span-envelope` (labeled fallback). `deltaPercent` is `null` when the baseline
+value is zero. Unavailable metrics are omitted from `baseline`/`candidate`, and the corresponding delta entries carry
+only the sides that exist. On failure the output is `{ "success": false, "error": "<message>" }` with
 `errorName`/`errorSource` for typed errors.
 
 ---

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -953,6 +953,31 @@ agentcore traces get abc123 --runtime MyAgent --json
 | `--until <time>`   | End time (defaults to now)       |
 | `--json`           | Output as JSON                   |
 
+#### traces compare
+
+Compare latency and token metrics of two traces from the same runtime.
+
+```bash
+agentcore traces compare <baselineTraceId> <candidateTraceId>
+agentcore traces compare abc123 def456 --runtime MyAgent
+agentcore traces compare abc123 def456 --since 2h --json
+```
+
+| Flag                 | Description                                                                 |
+| -------------------- | --------------------------------------------------------------------------- |
+| `<baselineTraceId>`  | Baseline trace ID (required)                                                |
+| `<candidateTraceId>` | Candidate trace ID (required)                                               |
+| `--runtime <name>`   | Select specific runtime                                                     |
+| `--since <time>`     | Start time (defaults to 12h ago; e.g. `5m`, `1h`, `2d`, ISO 8601, epoch ms) |
+| `--until <time>`     | End time (defaults to now; e.g. `now`, `1h`, ISO 8601, epoch ms)            |
+| `--json`             | Output as JSON                                                              |
+
+Reports end-to-end, LLM, and tool latency, LLM/tool call counts, and token usage for each trace, with absolute and
+percentage deltas. Nested provider spans (e.g. a framework LLM span wrapping a Bedrock client span) are counted once.
+End-to-end latency comes from the `POST /invocations` server span; when that span is missing, the earliest/latest span
+times are used instead and a warning is shown. Comparability warnings flag differing LLM/tool call counts or token
+usage. `--json` returns the same data as structured output suitable for CI benchmarking.
+
 ---
 
 ## Evaluations

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -990,9 +990,11 @@ Behavior details:
   span times are used instead and a warning is shown.
 - When only service-side spans are found for a trace, LLM/tool/token metrics are reported as unavailable (omitted from
   JSON, shown as `-` in the table) with a warning — never as zero.
-- Comparability warnings flag differing LLM/tool call counts, and input/output/total token usage that differs by more
-  than 20% relative to the baseline (or changes from zero). The CLI cannot prove the two invocations ran equivalent
-  workloads.
+- The distinct LLM models used in each trace are reported (from `gen_ai.response.model`, falling back to
+  `gen_ai.request.model`).
+- Comparability warnings flag differing models, differing LLM/tool call counts, and input/output/total token usage that
+  differs by more than 20% relative to the baseline (or changes from zero). The CLI cannot prove the two invocations ran
+  equivalent workloads.
 
 `--json` returns stable structured output suitable for CI benchmarking:
 
@@ -1013,7 +1015,8 @@ Behavior details:
     "toolCalls": 1,
     "inputTokens": 2849,
     "outputTokens": 315,
-    "totalTokens": 3164
+    "totalTokens": 3164,
+    "models": ["claude-3-5-sonnet-20241022-v2:0"]
   },
   "candidate": { "traceId": "def456", "...": "same shape as baseline" },
   "deltas": {
@@ -1032,9 +1035,9 @@ Behavior details:
 
 Field notes: latency fields (`endToEndMs`, `llmMs`, `toolMs`, and each delta's `delta`) and all `deltaPercent` values
 are rounded to one decimal place, so runs diff cleanly in CI; token and call-count fields are integers.
-`timingSource` is `invocation-span` or `span-envelope` (labeled fallback). `deltaPercent` is `null` when the baseline
-value is zero. Unavailable metrics are omitted from `baseline`/`candidate`, and the corresponding delta entries carry
-only the sides that exist. On failure the output is `{ "success": false, "error": "<message>" }` with
+`timingSource` is `invocation-span` or `span-envelope` (labeled fallback). `models` is the sorted list of distinct LLM
+models used, omitted when none are reported. `deltaPercent` is `null` when the baseline value is zero. Unavailable
+metrics are omitted from `baseline`/`candidate`, and the corresponding delta entries carry only the sides that exist. On failure the output is `{ "success": false, "error": "<message>" }` with
 `errorName`/`errorSource` for typed errors.
 
 ---

--- a/src/cli/commands/traces/__tests__/command.test.ts
+++ b/src/cli/commands/traces/__tests__/command.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
   mockGetProjectRootMismatch,
+  mockHandleTracesCompare,
   mockHandleTracesGet,
   mockHandleTracesList,
   mockLoadConfig,
@@ -12,6 +13,7 @@ const {
   mockRequireProject,
 } = vi.hoisted(() => ({
   mockGetProjectRootMismatch: vi.fn(),
+  mockHandleTracesCompare: vi.fn(),
   mockHandleTracesGet: vi.fn(),
   mockHandleTracesList: vi.fn(),
   mockLoadConfig: vi.fn(),
@@ -21,8 +23,13 @@ const {
 }));
 
 vi.mock('../action', () => ({
+  handleTracesCompare: (...args: unknown[]) => mockHandleTracesCompare(...args),
   handleTracesGet: (...args: unknown[]) => mockHandleTracesGet(...args),
   handleTracesList: (...args: unknown[]) => mockHandleTracesList(...args),
+}));
+
+vi.mock('../../../telemetry/cli-command-run.js', () => ({
+  withCommandRunTelemetry: vi.fn((_command: unknown, _attrs: unknown, run: () => unknown) => run()),
 }));
 
 vi.mock('../../../operations/resolve-agent', () => ({
@@ -153,6 +160,84 @@ describe('traces JSON output', () => {
     expect(mockExit).toHaveBeenCalledWith(1);
     expect(mockLoadConfig).not.toHaveBeenCalled();
     expect(mockRender).not.toHaveBeenCalled();
+  });
+
+  it('emits trace compare results as JSON', async () => {
+    const baseline = { traceId: 'trace-1', spanCount: 3, endToEndMs: 6600, timingSource: 'invocation-span' };
+    const candidate = { traceId: 'trace-2', spanCount: 3, endToEndMs: 5120, timingSource: 'invocation-span' };
+    mockHandleTracesCompare.mockResolvedValue({
+      success: true,
+      agentName: 'runtime-one',
+      targetName: 'default',
+      baseline,
+      candidate,
+      deltas: { endToEndMs: { baseline: 6600, candidate: 5120, delta: -1480, deltaPercent: -22.4 } },
+      warnings: [],
+    });
+
+    await program.parseAsync(['traces', 'compare', 'trace-1', 'trace-2', '--runtime', 'runtime-one', '--json'], {
+      from: 'user',
+    });
+
+    expect(JSON.parse(mockLog.mock.calls[0]![0])).toEqual({
+      success: true,
+      agentName: 'runtime-one',
+      targetName: 'default',
+      baseline,
+      candidate,
+      deltas: { endToEndMs: { baseline: 6600, candidate: 5120, delta: -1480, deltaPercent: -22.4 } },
+      warnings: [],
+    });
+    expect(mockHandleTracesCompare).toHaveBeenCalledWith(
+      expect.anything(),
+      'trace-1',
+      'trace-2',
+      expect.objectContaining({ runtime: 'runtime-one', json: true })
+    );
+    expect(mockRender).not.toHaveBeenCalled();
+  });
+
+  it('emits trace compare failures as JSON and exits 1', async () => {
+    mockHandleTracesCompare.mockResolvedValue({
+      success: false,
+      error: new Error('No spans found for baseline trace trace-1'),
+    });
+
+    await program.parseAsync(['traces', 'compare', 'trace-1', 'trace-2', '--json'], { from: 'user' });
+
+    expect(JSON.parse(mockLog.mock.calls[0]![0])).toEqual({
+      success: false,
+      error: 'No spans found for baseline trace trace-1',
+    });
+    expect(mockExit).toHaveBeenCalledWith(1);
+    expect(mockRender).not.toHaveBeenCalled();
+  });
+
+  it('renders trace compare output with Ink for non-JSON runs', async () => {
+    mockHandleTracesCompare.mockResolvedValue({
+      success: true,
+      agentName: 'runtime-one',
+      targetName: 'default',
+      baseline: { traceId: 'trace-1', spanCount: 3, endToEndMs: 6600, timingSource: 'invocation-span' },
+      candidate: { traceId: 'trace-2', spanCount: 3, endToEndMs: 5120, timingSource: 'invocation-span' },
+      deltas: {
+        endToEndMs: { baseline: 6600, candidate: 5120, delta: -1480, deltaPercent: -22.4 },
+        llmMs: { baseline: 3620, candidate: 3040, delta: -580, deltaPercent: -16.0 },
+        toolMs: { baseline: 2850, candidate: 1710, delta: -1140, deltaPercent: -40.0 },
+        llmCalls: { baseline: 2, candidate: 2, delta: 0, deltaPercent: 0 },
+        toolCalls: { baseline: 1, candidate: 1, delta: 0, deltaPercent: 0 },
+        inputTokens: { baseline: 2849, candidate: 1912, delta: -937, deltaPercent: -32.9 },
+        outputTokens: { baseline: 315, candidate: 237, delta: -78, deltaPercent: -24.8 },
+        totalTokens: {},
+      },
+      warnings: ['LLM call counts differ (baseline 1, candidate 2); traces may not be directly comparable'],
+    });
+
+    await program.parseAsync(['traces', 'compare', 'trace-1', 'trace-2'], { from: 'user' });
+
+    expect(mockRender).toHaveBeenCalledOnce();
+    expect(mockLog).not.toHaveBeenCalled();
+    expect(mockExit).not.toHaveBeenCalled();
   });
 
   it('keeps Ink rendering for non-JSON output', async () => {

--- a/src/cli/commands/traces/action.ts
+++ b/src/cli/commands/traces/action.ts
@@ -3,8 +3,22 @@ import type { Result } from '../../../lib/result';
 import { parseTimeString } from '../../../lib/utils';
 import type { DeployedProjectConfig } from '../../operations/resolve-agent';
 import { resolveAgent } from '../../operations/resolve-agent';
-import { buildTraceConsoleUrl, getTrace, listTraces } from '../../operations/traces';
-import type { TracesGetOptions, TracesListOptions } from './types';
+import { buildTraceConsoleUrl, compareTraces, getTrace, listTraces } from '../../operations/traces';
+import type { TraceComparisonDeltas, TraceMetrics } from '../../operations/traces';
+import type { TracesCompareOptions, TracesGetOptions, TracesListOptions } from './types';
+
+/** Traces are only supported for Python agents. */
+function requirePythonRuntime(context: DeployedProjectConfig, agentName: string): ValidationError | undefined {
+  const runtimeSpec = context.project.runtimes.find(r => r.name === agentName);
+  const isPython =
+    (runtimeSpec?.entrypoint?.endsWith('.py') ?? false) || (runtimeSpec?.entrypoint?.includes('.py:') ?? false);
+  if (!isPython) {
+    return new ValidationError(
+      'Traces are only supported for Python agents. TypeScript agents do not support observability traces.'
+    );
+  }
+  return undefined;
+}
 
 export type TracesListResult = Result<{
   agentName?: string;
@@ -23,17 +37,9 @@ export async function handleTracesList(
 
   const { agent } = resolved;
 
-  // Traces are only supported for Python agents
-  const runtimeSpec = context.project.runtimes.find(r => r.name === agent.agentName);
-  const isPython =
-    (runtimeSpec?.entrypoint?.endsWith('.py') ?? false) || (runtimeSpec?.entrypoint?.includes('.py:') ?? false);
-  if (!isPython) {
-    return {
-      success: false,
-      error: new ValidationError(
-        'Traces are only supported for Python agents. TypeScript agents do not support observability traces.'
-      ),
-    };
+  const pythonError = requirePythonRuntime(context, agent.agentName);
+  if (pythonError) {
+    return { success: false, error: pythonError };
   }
 
   const consoleUrl = buildTraceConsoleUrl({
@@ -98,17 +104,9 @@ export async function handleTracesGet(
 
   const { agent } = resolved;
 
-  // Traces are only supported for Python agents
-  const runtimeSpec = context.project.runtimes.find(r => r.name === agent.agentName);
-  const isPython =
-    (runtimeSpec?.entrypoint?.endsWith('.py') ?? false) || (runtimeSpec?.entrypoint?.includes('.py:') ?? false);
-  if (!isPython) {
-    return {
-      success: false,
-      error: new ValidationError(
-        'Traces are only supported for Python agents. TypeScript agents do not support observability traces.'
-      ),
-    };
+  const pythonError = requirePythonRuntime(context, agent.agentName);
+  if (pythonError) {
+    return { success: false, error: pythonError };
   }
 
   const consoleUrl = buildTraceConsoleUrl({
@@ -148,5 +146,74 @@ export async function handleTracesGet(
     targetName: agent.targetName,
     consoleUrl,
     filePath: result.filePath,
+  };
+}
+
+export type TracesCompareResult = Result<{
+  agentName?: string;
+  targetName?: string;
+  baseline: TraceMetrics;
+  candidate: TraceMetrics;
+  deltas: TraceComparisonDeltas;
+  warnings: string[];
+}> & { consoleUrl?: string };
+
+export async function handleTracesCompare(
+  context: DeployedProjectConfig,
+  baselineTraceId: string,
+  candidateTraceId: string,
+  options: TracesCompareOptions
+): Promise<TracesCompareResult> {
+  const resolved = resolveAgent(context, options);
+  if (!resolved.success) {
+    return { success: false, error: new ResourceNotFoundError(resolved.error) };
+  }
+
+  const { agent } = resolved;
+
+  const pythonError = requirePythonRuntime(context, agent.agentName);
+  if (pythonError) {
+    return { success: false, error: pythonError };
+  }
+
+  const consoleUrl = buildTraceConsoleUrl({
+    region: agent.region,
+    accountId: agent.accountId,
+    runtimeId: agent.runtimeId,
+    agentName: agent.agentName,
+  });
+
+  // Parse time options
+  let startTime: number | undefined;
+  let endTime: number | undefined;
+  if (options.since) {
+    startTime = parseTimeString(options.since);
+  }
+  if (options.until) {
+    endTime = parseTimeString(options.until);
+  }
+
+  const result = await compareTraces({
+    region: agent.region,
+    runtimeId: agent.runtimeId,
+    baselineTraceId,
+    candidateTraceId,
+    startTime,
+    endTime,
+  });
+
+  if (!result.success) {
+    return { success: false, error: result.error, consoleUrl };
+  }
+
+  return {
+    success: true,
+    agentName: agent.agentName,
+    targetName: agent.targetName,
+    consoleUrl,
+    baseline: result.baseline,
+    candidate: result.candidate,
+    deltas: result.deltas,
+    warnings: result.warnings,
   };
 }

--- a/src/cli/commands/traces/command.tsx
+++ b/src/cli/commands/traces/command.tsx
@@ -2,9 +2,11 @@ import { serializeResult } from '../../../lib';
 import { COMMAND_DESCRIPTIONS } from '../../constants';
 import { getErrorMessage } from '../../errors';
 import { loadDeployedProjectConfig } from '../../operations/resolve-agent';
+import type { MetricDelta, TraceComparisonDeltas } from '../../operations/traces';
+import { withCommandRunTelemetry } from '../../telemetry/cli-command-run.js';
 import { getProjectRootMismatch, projectExists, requireProject } from '../../tui/guards';
-import { handleTracesGet, handleTracesList } from './action';
-import type { TracesGetOptions, TracesListOptions } from './types';
+import { handleTracesCompare, handleTracesGet, handleTracesList } from './action';
+import type { TracesCompareOptions, TracesGetOptions, TracesListOptions } from './types';
 import type { Command } from '@commander-js/extra-typings';
 import { Box, Text, render } from 'ink';
 
@@ -16,6 +18,45 @@ function formatTimestamp(ts: string): string {
     .toISOString()
     .replace('T', ' ')
     .replace(/\.\d+Z$/, 'Z');
+}
+
+function formatSeconds(value: number): string {
+  return `${(value / 1000).toFixed(2)}s`;
+}
+
+function formatCount(value: number): string {
+  return String(value);
+}
+
+function formatTokens(value: number): string {
+  return value.toLocaleString('en-US');
+}
+
+function formatSide(value: number | undefined, format: (value: number) => string): string {
+  return value === undefined ? '-' : format(value);
+}
+
+function formatDelta(entry: MetricDelta, format: (value: number) => string): string {
+  if (entry.delta === undefined) return '-';
+  const sign = entry.delta > 0 ? '+' : '';
+  const percent =
+    entry.deltaPercent === null || entry.deltaPercent === undefined
+      ? ''
+      : ` (${entry.deltaPercent > 0 ? '+' : ''}${entry.deltaPercent.toFixed(1)}%)`;
+  return `${sign}${format(entry.delta)}${percent}`;
+}
+
+function buildComparisonRows(deltas: TraceComparisonDeltas) {
+  return [
+    { label: 'End-to-end latency', entry: deltas.endToEndMs, format: formatSeconds },
+    { label: 'LLM latency', entry: deltas.llmMs, format: formatSeconds },
+    { label: 'Tool latency', entry: deltas.toolMs, format: formatSeconds },
+    { label: 'LLM calls', entry: deltas.llmCalls, format: formatCount },
+    { label: 'Tool calls', entry: deltas.toolCalls, format: formatCount },
+    { label: 'Input tokens', entry: deltas.inputTokens, format: formatTokens },
+    { label: 'Output tokens', entry: deltas.outputTokens, format: formatTokens },
+    { label: 'Total tokens', entry: deltas.totalTokens, format: formatTokens },
+  ].filter(row => row.entry.baseline !== undefined || row.entry.candidate !== undefined);
 }
 
 function requireTracesProject(json?: boolean): boolean {
@@ -170,6 +211,98 @@ export const registerTraces = (program: Command) => {
         render(
           <Box flexDirection="column">
             <Text color="green">Trace saved to: {result.filePath}</Text>
+            {result.consoleUrl && <Text color="gray">Console: {result.consoleUrl}</Text>}
+          </Box>
+        );
+      } catch (error) {
+        if (cliOptions.json) {
+          console.log(JSON.stringify({ success: false, error: getErrorMessage(error) }));
+        } else {
+          render(<Text color="red">Error: {getErrorMessage(error)}</Text>);
+        }
+        process.exit(1);
+      }
+    });
+
+  traces
+    .command('compare <baselineTraceId> <candidateTraceId>')
+    .description('Compare latency and token metrics of two traces')
+    .option('--runtime <name>', 'Select specific runtime')
+    .option('--since <time>', 'Start time — defaults to 12h ago (e.g. 5m, 1h, 2d, ISO 8601, epoch ms)')
+    .option('--until <time>', 'End time — defaults to now (e.g. now, 1h, ISO 8601, epoch ms)')
+    .option('--json', 'Output as JSON')
+    .action(async (baselineTraceId: string, candidateTraceId: string, cliOptions: TracesCompareOptions) => {
+      try {
+        if (!requireTracesProject(cliOptions.json)) return;
+        const context = await loadDeployedProjectConfig();
+        const result = await withCommandRunTelemetry('traces.compare', {}, () =>
+          handleTracesCompare(context, baselineTraceId, candidateTraceId, cliOptions)
+        );
+
+        if (!result.success) {
+          if (cliOptions.json) {
+            console.log(JSON.stringify(serializeResult(result)));
+          } else {
+            render(
+              <Box flexDirection="column">
+                <Text color="red">Error: {result.error.message}</Text>
+                {result.consoleUrl && <Text color="gray">Console: {result.consoleUrl}</Text>}
+              </Box>
+            );
+          }
+          process.exit(1);
+          return;
+        }
+
+        if (cliOptions.json) {
+          console.log(JSON.stringify(serializeResult(result)));
+          return;
+        }
+
+        const rows = buildComparisonRows(result.deltas);
+        render(
+          <Box flexDirection="column">
+            <Text bold>
+              Trace comparison: baseline {result.baseline.traceId} → candidate {result.candidate.traceId}
+            </Text>
+            <Text> </Text>
+            <Box>
+              <Box width={22}>
+                <Text bold>Metric</Text>
+              </Box>
+              <Box width={14} justifyContent="flex-end">
+                <Text bold>Baseline</Text>
+              </Box>
+              <Box width={14} justifyContent="flex-end">
+                <Text bold>Candidate</Text>
+              </Box>
+              <Box width={24} justifyContent="flex-end">
+                <Text bold>Delta</Text>
+              </Box>
+            </Box>
+            {rows.map(row => (
+              <Box key={row.label}>
+                <Box width={22}>
+                  <Text>{row.label}</Text>
+                </Box>
+                <Box width={14} justifyContent="flex-end">
+                  <Text>{formatSide(row.entry.baseline, row.format)}</Text>
+                </Box>
+                <Box width={14} justifyContent="flex-end">
+                  <Text>{formatSide(row.entry.candidate, row.format)}</Text>
+                </Box>
+                <Box width={24} justifyContent="flex-end">
+                  <Text color="cyan">{formatDelta(row.entry, row.format)}</Text>
+                </Box>
+              </Box>
+            ))}
+            {result.warnings.length > 0 && <Text> </Text>}
+            {result.warnings.map(warning => (
+              <Text key={warning} color="yellow">
+                Warning: {warning}
+              </Text>
+            ))}
+            <Text> </Text>
             {result.consoleUrl && <Text color="gray">Console: {result.consoleUrl}</Text>}
           </Box>
         );

--- a/src/cli/commands/traces/command.tsx
+++ b/src/cli/commands/traces/command.tsx
@@ -2,10 +2,10 @@ import { serializeResult } from '../../../lib';
 import { COMMAND_DESCRIPTIONS } from '../../constants';
 import { getErrorMessage } from '../../errors';
 import { loadDeployedProjectConfig } from '../../operations/resolve-agent';
-import type { MetricDelta, TraceComparisonDeltas } from '../../operations/traces';
 import { withCommandRunTelemetry } from '../../telemetry/cli-command-run.js';
 import { getProjectRootMismatch, projectExists, requireProject } from '../../tui/guards';
 import { handleTracesCompare, handleTracesGet, handleTracesList } from './action';
+import { TraceComparisonView } from './comparison-view';
 import type { TracesCompareOptions, TracesGetOptions, TracesListOptions } from './types';
 import type { Command } from '@commander-js/extra-typings';
 import { Box, Text, render } from 'ink';
@@ -18,45 +18,6 @@ function formatTimestamp(ts: string): string {
     .toISOString()
     .replace('T', ' ')
     .replace(/\.\d+Z$/, 'Z');
-}
-
-function formatSeconds(value: number): string {
-  return `${(value / 1000).toFixed(2)}s`;
-}
-
-function formatCount(value: number): string {
-  return String(value);
-}
-
-function formatTokens(value: number): string {
-  return value.toLocaleString('en-US');
-}
-
-function formatSide(value: number | undefined, format: (value: number) => string): string {
-  return value === undefined ? '-' : format(value);
-}
-
-function formatDelta(entry: MetricDelta, format: (value: number) => string): string {
-  if (entry.delta === undefined) return '-';
-  const sign = entry.delta > 0 ? '+' : '';
-  const percent =
-    entry.deltaPercent === null || entry.deltaPercent === undefined
-      ? ''
-      : ` (${entry.deltaPercent > 0 ? '+' : ''}${entry.deltaPercent.toFixed(1)}%)`;
-  return `${sign}${format(entry.delta)}${percent}`;
-}
-
-function buildComparisonRows(deltas: TraceComparisonDeltas) {
-  return [
-    { label: 'End-to-end latency', entry: deltas.endToEndMs, format: formatSeconds },
-    { label: 'LLM latency', entry: deltas.llmMs, format: formatSeconds },
-    { label: 'Tool latency', entry: deltas.toolMs, format: formatSeconds },
-    { label: 'LLM calls', entry: deltas.llmCalls, format: formatCount },
-    { label: 'Tool calls', entry: deltas.toolCalls, format: formatCount },
-    { label: 'Input tokens', entry: deltas.inputTokens, format: formatTokens },
-    { label: 'Output tokens', entry: deltas.outputTokens, format: formatTokens },
-    { label: 'Total tokens', entry: deltas.totalTokens, format: formatTokens },
-  ].filter(row => row.entry.baseline !== undefined || row.entry.candidate !== undefined);
 }
 
 function requireTracesProject(json?: boolean): boolean {
@@ -259,52 +220,14 @@ export const registerTraces = (program: Command) => {
           return;
         }
 
-        const rows = buildComparisonRows(result.deltas);
         render(
-          <Box flexDirection="column">
-            <Text bold>
-              Trace comparison: baseline {result.baseline.traceId} → candidate {result.candidate.traceId}
-            </Text>
-            <Text> </Text>
-            <Box>
-              <Box width={22}>
-                <Text bold>Metric</Text>
-              </Box>
-              <Box width={14} justifyContent="flex-end">
-                <Text bold>Baseline</Text>
-              </Box>
-              <Box width={14} justifyContent="flex-end">
-                <Text bold>Candidate</Text>
-              </Box>
-              <Box width={24} justifyContent="flex-end">
-                <Text bold>Delta</Text>
-              </Box>
-            </Box>
-            {rows.map(row => (
-              <Box key={row.label}>
-                <Box width={22}>
-                  <Text>{row.label}</Text>
-                </Box>
-                <Box width={14} justifyContent="flex-end">
-                  <Text>{formatSide(row.entry.baseline, row.format)}</Text>
-                </Box>
-                <Box width={14} justifyContent="flex-end">
-                  <Text>{formatSide(row.entry.candidate, row.format)}</Text>
-                </Box>
-                <Box width={24} justifyContent="flex-end">
-                  <Text color="cyan">{formatDelta(row.entry, row.format)}</Text>
-                </Box>
-              </Box>
-            ))}
-            {result.warnings.length > 0 && <Text> </Text>}
-            {result.warnings.map(warning => (
-              <Text key={warning} color="yellow">
-                Warning: {warning}
-              </Text>
-            ))}
-            <Text> </Text>
-            {result.consoleUrl && <Text color="gray">Console: {result.consoleUrl}</Text>}
-          </Box>
+          <TraceComparisonView
+            baseline={result.baseline}
+            candidate={result.candidate}
+            deltas={result.deltas}
+            warnings={result.warnings}
+            consoleUrl={result.consoleUrl}
+          />
         );
       } catch (error) {
         if (cliOptions.json) {

--- a/src/cli/commands/traces/comparison-view.tsx
+++ b/src/cli/commands/traces/comparison-view.tsx
@@ -1,0 +1,99 @@
+import type { MetricDelta, TraceComparisonDeltas, TraceMetrics } from '../../operations/traces';
+import { Box, Text } from 'ink';
+
+function formatSeconds(value: number): string {
+  return `${(value / 1000).toFixed(2)}s`;
+}
+
+function formatCount(value: number): string {
+  return String(value);
+}
+
+function formatTokens(value: number): string {
+  return value.toLocaleString('en-US');
+}
+
+function formatSide(value: number | undefined, format: (value: number) => string): string {
+  return value === undefined ? '-' : format(value);
+}
+
+function formatDelta(entry: MetricDelta, format: (value: number) => string): string {
+  if (entry.delta === undefined) return '-';
+  const sign = entry.delta > 0 ? '+' : '';
+  const percent =
+    entry.deltaPercent === null || entry.deltaPercent === undefined
+      ? ''
+      : ` (${entry.deltaPercent > 0 ? '+' : ''}${entry.deltaPercent.toFixed(1)}%)`;
+  return `${sign}${format(entry.delta)}${percent}`;
+}
+
+function buildComparisonRows(deltas: TraceComparisonDeltas) {
+  return [
+    { label: 'End-to-end latency', entry: deltas.endToEndMs, format: formatSeconds },
+    { label: 'LLM latency', entry: deltas.llmMs, format: formatSeconds },
+    { label: 'Tool latency', entry: deltas.toolMs, format: formatSeconds },
+    { label: 'LLM calls', entry: deltas.llmCalls, format: formatCount },
+    { label: 'Tool calls', entry: deltas.toolCalls, format: formatCount },
+    { label: 'Input tokens', entry: deltas.inputTokens, format: formatTokens },
+    { label: 'Output tokens', entry: deltas.outputTokens, format: formatTokens },
+    { label: 'Total tokens', entry: deltas.totalTokens, format: formatTokens },
+  ].filter(row => row.entry.baseline !== undefined || row.entry.candidate !== undefined);
+}
+
+export interface TraceComparisonViewProps {
+  baseline: TraceMetrics;
+  candidate: TraceMetrics;
+  deltas: TraceComparisonDeltas;
+  warnings: string[];
+  consoleUrl?: string;
+}
+
+export function TraceComparisonView({ baseline, candidate, deltas, warnings, consoleUrl }: TraceComparisonViewProps) {
+  const rows = buildComparisonRows(deltas);
+  return (
+    <Box flexDirection="column">
+      <Text bold>
+        Trace comparison: baseline {baseline.traceId} → candidate {candidate.traceId}
+      </Text>
+      <Text> </Text>
+      <Box>
+        <Box width={22}>
+          <Text bold>Metric</Text>
+        </Box>
+        <Box width={14} justifyContent="flex-end">
+          <Text bold>Baseline</Text>
+        </Box>
+        <Box width={14} justifyContent="flex-end">
+          <Text bold>Candidate</Text>
+        </Box>
+        <Box width={24} justifyContent="flex-end">
+          <Text bold>Delta</Text>
+        </Box>
+      </Box>
+      {rows.map(row => (
+        <Box key={row.label}>
+          <Box width={22}>
+            <Text>{row.label}</Text>
+          </Box>
+          <Box width={14} justifyContent="flex-end">
+            <Text>{formatSide(row.entry.baseline, row.format)}</Text>
+          </Box>
+          <Box width={14} justifyContent="flex-end">
+            <Text>{formatSide(row.entry.candidate, row.format)}</Text>
+          </Box>
+          <Box width={24} justifyContent="flex-end">
+            <Text color="cyan">{formatDelta(row.entry, row.format)}</Text>
+          </Box>
+        </Box>
+      ))}
+      {warnings.length > 0 && <Text> </Text>}
+      {warnings.map(warning => (
+        <Text key={warning} color="yellow">
+          Warning: {warning}
+        </Text>
+      ))}
+      <Text> </Text>
+      {consoleUrl && <Text color="gray">Console: {consoleUrl}</Text>}
+    </Box>
+  );
+}

--- a/src/cli/commands/traces/comparison-view.tsx
+++ b/src/cli/commands/traces/comparison-view.tsx
@@ -86,6 +86,17 @@ export function TraceComparisonView({ baseline, candidate, deltas, warnings, con
           </Box>
         </Box>
       ))}
+      {(baseline.models ?? candidate.models) && (
+        <>
+          <Text> </Text>
+          <Text>
+            Baseline model(s): <Text color="magenta">{baseline.models?.join(', ') ?? '-'}</Text>
+          </Text>
+          <Text>
+            Candidate model(s): <Text color="magenta">{candidate.models?.join(', ') ?? '-'}</Text>
+          </Text>
+        </>
+      )}
       {warnings.length > 0 && <Text> </Text>}
       {warnings.map(warning => (
         <Text key={warning} color="yellow">

--- a/src/cli/commands/traces/types.ts
+++ b/src/cli/commands/traces/types.ts
@@ -13,3 +13,10 @@ export interface TracesGetOptions {
   until?: string;
   json?: boolean;
 }
+
+export interface TracesCompareOptions {
+  runtime?: string;
+  since?: string;
+  until?: string;
+  json?: boolean;
+}

--- a/src/cli/operations/traces/__tests__/compare-traces.test.ts
+++ b/src/cli/operations/traces/__tests__/compare-traces.test.ts
@@ -324,6 +324,38 @@ describe('aggregateSpans', () => {
     expect(result.warnings).toEqual([expect.stringContaining('application spans unavailable')]);
   });
 
+  it('rounds latency metrics to one decimal place', () => {
+    const spans = [
+      span({
+        spanId: 'root',
+        name: 'POST /invocations',
+        kind: 'SERVER',
+        durationNano: String(6_334_894_566),
+      }),
+      span({
+        spanId: 'llm1',
+        parentSpanId: 'root',
+        genAiOperation: 'chat',
+        name: 'chat claude-3',
+        durationNano: String(3_671_294_691),
+      }),
+      span({
+        spanId: 'tool1',
+        parentSpanId: 'root',
+        genAiOperation: 'execute_tool',
+        name: 'execute_tool weather',
+        durationNano: String(2_578_348_746),
+      }),
+    ];
+
+    const result = aggregateSpans('trace-a', spans);
+
+    assert(result.success);
+    expect(result.metrics.endToEndMs).toBe(6334.9);
+    expect(result.metrics.llmMs).toBe(3671.3);
+    expect(result.metrics.toolMs).toBe(2578.3);
+  });
+
   it('classifies LangGraph traceloop tool spans', () => {
     const spans = [
       span({
@@ -477,6 +509,16 @@ describe('buildTraceComparison', () => {
     });
     expect(deltas.llmMs.delta).toBe(-580);
     expect(deltas.toolMs.delta).toBe(-1140);
+  });
+
+  it('rounds delta and percentage to one decimal place', () => {
+    const baseline = metrics({ endToEndMs: 6334.9 });
+    const candidate = metrics({ traceId: 'trace-b', endToEndMs: 5701.9 });
+
+    const { deltas } = buildTraceComparison(baseline, candidate);
+
+    expect(deltas.endToEndMs.delta).toBe(-633);
+    expect(deltas.endToEndMs.deltaPercent).toBe(-10);
   });
 
   it('returns null percentage for a zero baseline', () => {

--- a/src/cli/operations/traces/__tests__/compare-traces.test.ts
+++ b/src/cli/operations/traces/__tests__/compare-traces.test.ts
@@ -324,6 +324,88 @@ describe('aggregateSpans', () => {
     expect(result.warnings).toEqual([expect.stringContaining('application spans unavailable')]);
   });
 
+  it('classifies LangGraph traceloop tool spans', () => {
+    const spans = [
+      span({
+        spanId: 'root',
+        name: 'POST /invocations',
+        kind: 'SERVER',
+        startTimeUnixNano: nano(0),
+        endTimeUnixNano: nano(6000),
+      }),
+      span({
+        spanId: 'tool1',
+        parentSpanId: 'root',
+        name: 'get_word_frequency.tool',
+        traceloopSpanKind: 'tool',
+        durationNano: String(1_500_000_000),
+      }),
+    ];
+
+    const result = aggregateSpans('trace-a', spans);
+
+    assert(result.success);
+    expect(result.metrics.toolCalls).toBe(1);
+    expect(result.metrics.toolMs).toBe(1500);
+  });
+
+  it('classifies OpenInference LLM and tool spans', () => {
+    const spans = [
+      span({
+        spanId: 'root',
+        name: 'POST /invocations',
+        kind: 'SERVER',
+        startTimeUnixNano: nano(0),
+        endTimeUnixNano: nano(6000),
+      }),
+      span({
+        spanId: 'llm1',
+        parentSpanId: 'root',
+        name: 'ChatBedrock',
+        openinferenceSpanKind: 'LLM',
+        durationNano: String(2_000_000_000),
+      }),
+      span({
+        spanId: 'tool1',
+        parentSpanId: 'root',
+        name: 'get_weather',
+        openinferenceSpanKind: 'TOOL',
+        durationNano: String(1_000_000_000),
+      }),
+    ];
+
+    const result = aggregateSpans('trace-a', spans);
+
+    assert(result.success);
+    expect(result.metrics.llmCalls).toBe(1);
+    expect(result.metrics.llmMs).toBe(2000);
+    expect(result.metrics.toolCalls).toBe(1);
+    expect(result.metrics.toolMs).toBe(1000);
+  });
+
+  it('classifies tool spans by .tool name suffix when kind attributes are absent', () => {
+    const spans = [
+      span({
+        spanId: 'root',
+        name: 'POST /invocations',
+        kind: 'SERVER',
+        startTimeUnixNano: nano(0),
+        endTimeUnixNano: nano(6000),
+      }),
+      span({
+        spanId: 'tool1',
+        parentSpanId: 'root',
+        name: 'get_word_frequency.tool',
+        durationNano: String(1_500_000_000),
+      }),
+    ];
+
+    const result = aggregateSpans('trace-a', spans);
+
+    assert(result.success);
+    expect(result.metrics.toolCalls).toBe(1);
+  });
+
   it('counts tool spans and de-duplicates nested tool spans', () => {
     const spans = [
       span({
@@ -585,6 +667,94 @@ describe('compareTraces', () => {
     expect(result.candidate.llmCalls).toBe(1);
     expect(result.warnings).toEqual([]);
     expect(mockQuerySpanRecords).toHaveBeenCalledWith(expect.objectContaining({ logGroupName: TEST_LOG_GROUP }));
+  });
+
+  it('scopes ownership, endpoint, and metrics to spans matching the runtime id', async () => {
+    primeSpanQueries({
+      'trace-a': {
+        [SPANS_LOG_GROUP]: [
+          // A distributed trace: another runtime's invocation span appears first
+          // with a different endpoint — it must not drive endpoint selection or timing.
+          serviceSpan('trace-a', 9000, {
+            spanId: 'root-other',
+            cloudResourceId: undefined,
+            agentId: 'other-runtime',
+            endpointName: 'DEFAULT',
+          }),
+          serviceSpan('trace-a', 6600, {
+            cloudResourceId: undefined,
+            agentId: 'runtime-123',
+            endpointName: 'test',
+          }),
+        ],
+        [TEST_LOG_GROUP]: [chatSpan('trace-a')],
+      },
+      'trace-b': {
+        [SPANS_LOG_GROUP]: [serviceSpan('trace-b', 5120)],
+        [DEFAULT_LOG_GROUP]: [chatSpan('trace-b')],
+      },
+    });
+
+    const result = await compareTraces(options);
+
+    assert(result.success);
+    expect(result.baseline.endToEndMs).toBe(6600);
+    expect(result.baseline.spanCount).toBe(2);
+    expect(mockQuerySpanRecords).toHaveBeenCalledWith(
+      expect.objectContaining({ traceId: 'trace-a', logGroupName: TEST_LOG_GROUP })
+    );
+  });
+
+  it('rejects a trace whose agent ids all belong to other runtimes', async () => {
+    primeSpanQueries({
+      'trace-a': {
+        [SPANS_LOG_GROUP]: [
+          serviceSpan('trace-a', 6600, { cloudResourceId: undefined, agentId: 'other-runtime' }),
+        ],
+      },
+      'trace-b': {
+        [SPANS_LOG_GROUP]: [serviceSpan('trace-b', 5120)],
+        [DEFAULT_LOG_GROUP]: [chatSpan('trace-b')],
+      },
+    });
+
+    const result = await compareTraces(options);
+
+    assert(!result.success);
+    expect(result.error.message).toContain('belongs to a different runtime');
+  });
+
+  it('merges duplicate span records preferring defined runtime log fields', async () => {
+    primeSpanQueries({
+      'trace-a': {
+        // Shared log group has a partial record: no tokens, no parent link.
+        [SPANS_LOG_GROUP]: [
+          serviceSpan('trace-a', 6600),
+          chatSpan('trace-a', {
+            durationNano: undefined,
+            genAiOperation: undefined,
+            parentSpanId: undefined,
+          }),
+        ],
+        // Runtime log group has the richer record for the same span ID.
+        [DEFAULT_LOG_GROUP]: [
+          chatSpan('trace-a', { inputTokens: 2849, outputTokens: 315, totalTokens: 3164 }),
+        ],
+      },
+      'trace-b': {
+        [SPANS_LOG_GROUP]: [serviceSpan('trace-b', 5120)],
+        [DEFAULT_LOG_GROUP]: [chatSpan('trace-b', { inputTokens: 2500, outputTokens: 300, totalTokens: 2800 })],
+      },
+    });
+
+    const result = await compareTraces(options);
+
+    assert(result.success);
+    expect(result.baseline.spanCount).toBe(2);
+    expect(result.baseline.llmCalls).toBe(1);
+    expect(result.baseline.llmMs).toBe(2000);
+    expect(result.baseline.totalTokens).toBe(3164);
+    expect(result.baseline.inputTokens).toBe(2849);
   });
 
   it('rejects a trace that belongs to a different runtime', async () => {

--- a/src/cli/operations/traces/__tests__/compare-traces.test.ts
+++ b/src/cli/operations/traces/__tests__/compare-traces.test.ts
@@ -356,6 +356,83 @@ describe('aggregateSpans', () => {
     expect(result.metrics.toolMs).toBe(2578.3);
   });
 
+  it('collects the distinct set of LLM models used in the trace', () => {
+    const spans = [
+      span({
+        spanId: 'root',
+        name: 'POST /invocations',
+        kind: 'SERVER',
+        startTimeUnixNano: nano(0),
+        endTimeUnixNano: nano(6000),
+      }),
+      span({
+        spanId: 'llm1',
+        parentSpanId: 'root',
+        genAiOperation: 'chat',
+        name: 'chat',
+        durationNano: String(1_000_000_000),
+        responseModel: 'claude-3-5-sonnet-20241022-v2:0',
+      }),
+      span({
+        spanId: 'llm2',
+        parentSpanId: 'root',
+        genAiOperation: 'chat',
+        name: 'chat',
+        durationNano: String(1_000_000_000),
+        requestModel: 'claude-3-5-sonnet-20241022-v2:0',
+      }),
+    ];
+
+    const result = aggregateSpans('trace-a', spans);
+
+    assert(result.success);
+    expect(result.metrics.models).toEqual(['claude-3-5-sonnet-20241022-v2:0']);
+  });
+
+  it('captures a model reported only on a nested provider span, preferring response model', () => {
+    const spans = [
+      span({
+        spanId: 'root',
+        name: 'POST /invocations',
+        kind: 'SERVER',
+        startTimeUnixNano: nano(0),
+        endTimeUnixNano: nano(6000),
+      }),
+      span({ spanId: 'llm1', parentSpanId: 'root', genAiOperation: 'chat', name: 'chat', durationNano: String(1e9) }),
+      span({
+        spanId: 'bedrock1',
+        parentSpanId: 'llm1',
+        name: 'Bedrock Runtime.InvokeModel',
+        durationNano: String(9e8),
+        requestModel: 'anthropic.claude-3-haiku',
+        responseModel: 'anthropic.claude-3-haiku-20240307-v1:0',
+      }),
+    ];
+
+    const result = aggregateSpans('trace-a', spans);
+
+    assert(result.success);
+    expect(result.metrics.models).toEqual(['anthropic.claude-3-haiku-20240307-v1:0']);
+  });
+
+  it('leaves models undefined when no span reports a model', () => {
+    const spans = [
+      span({
+        spanId: 'root',
+        name: 'POST /invocations',
+        kind: 'SERVER',
+        startTimeUnixNano: nano(0),
+        endTimeUnixNano: nano(6000),
+      }),
+      span({ spanId: 'llm1', parentSpanId: 'root', genAiOperation: 'chat', name: 'chat', durationNano: String(1e9) }),
+    ];
+
+    const result = aggregateSpans('trace-a', spans);
+
+    assert(result.success);
+    expect(result.metrics.models).toBeUndefined();
+  });
+
   it('classifies LangGraph traceloop tool spans', () => {
     const spans = [
       span({
@@ -565,6 +642,24 @@ describe('buildTraceComparison', () => {
     const { warnings } = buildTraceComparison(baseline, candidate);
 
     expect(warnings).toEqual([expect.stringContaining('token usage differs')]);
+  });
+
+  it('warns when the traces used different models', () => {
+    const baseline = metrics({ models: ['claude-3-5-sonnet-20241022-v2:0'] });
+    const candidate = metrics({ traceId: 'trace-b', models: ['claude-3-7-sonnet-20250219-v1:0'] });
+
+    const { warnings } = buildTraceComparison(baseline, candidate);
+
+    expect(warnings).toEqual([expect.stringContaining('Models differ')]);
+  });
+
+  it('does not warn when the traces used the same models', () => {
+    const baseline = metrics({ models: ['claude-3-5-sonnet-20241022-v2:0'] });
+    const candidate = metrics({ traceId: 'trace-b', models: ['claude-3-5-sonnet-20241022-v2:0'] });
+
+    const { warnings } = buildTraceComparison(baseline, candidate);
+
+    expect(warnings).toEqual([]);
   });
 
   it('does not warn on matching characteristics', () => {

--- a/src/cli/operations/traces/__tests__/compare-traces.test.ts
+++ b/src/cli/operations/traces/__tests__/compare-traces.test.ts
@@ -1,14 +1,15 @@
+import { ResourceNotFoundError } from '../../../../lib';
 import { aggregateSpans, buildTraceComparison, compareTraces } from '../compare-traces';
-import type { CloudWatchSpanRecord, TraceMetrics } from '../types';
+import type { CloudWatchSpanRecord, QuerySpanRecordsOptions, TraceMetrics } from '../types';
 import assert from 'node:assert';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-const { mockFetchSpans } = vi.hoisted(() => ({
-  mockFetchSpans: vi.fn(),
+const { mockQuerySpanRecords } = vi.hoisted(() => ({
+  mockQuerySpanRecords: vi.fn(),
 }));
 
 vi.mock('../get-trace', () => ({
-  fetchSpans: (...args: unknown[]) => mockFetchSpans(...args),
+  querySpanRecords: (options: unknown) => mockQuerySpanRecords(options),
 }));
 
 // Base timestamp: divisible by 256 so nano values stay exactly representable as doubles.
@@ -264,6 +265,65 @@ describe('aggregateSpans', () => {
     expect(result.metrics.totalTokens).toBeUndefined();
   });
 
+  it('de-duplicates each token field independently across nested spans', () => {
+    const spans = [
+      span({
+        spanId: 'root',
+        name: 'POST /invocations',
+        kind: 'SERVER',
+        startTimeUnixNano: nano(0),
+        endTimeUnixNano: nano(6000),
+      }),
+      // Parent reports only the total; the nested provider span carries the split.
+      span({
+        spanId: 'llm1',
+        parentSpanId: 'root',
+        genAiOperation: 'chat',
+        name: 'chat claude-3',
+        durationNano: String(2_000_000_000),
+        totalTokens: 3164,
+      }),
+      span({
+        spanId: 'bedrock1',
+        parentSpanId: 'llm1',
+        name: 'Bedrock Runtime.InvokeModel',
+        durationNano: String(1_900_000_000),
+        inputTokens: 2849,
+        outputTokens: 315,
+      }),
+    ];
+
+    const result = aggregateSpans('trace-a', spans);
+
+    assert(result.success);
+    expect(result.metrics.inputTokens).toBe(2849);
+    expect(result.metrics.outputTokens).toBe(315);
+    expect(result.metrics.totalTokens).toBe(3164);
+  });
+
+  it('marks LLM, tool, and token metrics unavailable when application spans are missing', () => {
+    const spans = [
+      span({
+        spanId: 'root',
+        name: 'POST /invocations',
+        kind: 'SERVER',
+        startTimeUnixNano: nano(0),
+        endTimeUnixNano: nano(6000),
+      }),
+    ];
+
+    const result = aggregateSpans('trace-a', spans, false);
+
+    assert(result.success);
+    expect(result.metrics.endToEndMs).toBe(6000);
+    expect(result.metrics.llmCalls).toBeUndefined();
+    expect(result.metrics.llmMs).toBeUndefined();
+    expect(result.metrics.toolCalls).toBeUndefined();
+    expect(result.metrics.toolMs).toBeUndefined();
+    expect(result.metrics.totalTokens).toBeUndefined();
+    expect(result.warnings).toEqual([expect.stringContaining('application spans unavailable')]);
+  });
+
   it('counts tool spans and de-duplicates nested tool spans', () => {
     const spans = [
       span({
@@ -391,6 +451,33 @@ describe('buildTraceComparison', () => {
 
     expect(warnings).toEqual([]);
   });
+
+  it('warns on input/output token differences beyond the threshold', () => {
+    const baseline = metrics({ inputTokens: 1000, outputTokens: 100 });
+    const candidate = metrics({ traceId: 'trace-b', inputTokens: 1500, outputTokens: 105 });
+
+    const { warnings } = buildTraceComparison(baseline, candidate);
+
+    expect(warnings).toEqual([expect.stringContaining('Input token usage differs')]);
+  });
+
+  it('warns on a zero-to-nonzero token change', () => {
+    const baseline = metrics({ totalTokens: 0 });
+    const candidate = metrics({ traceId: 'trace-b', totalTokens: 500 });
+
+    const { warnings } = buildTraceComparison(baseline, candidate);
+
+    expect(warnings).toEqual([expect.stringContaining('Total token usage differs')]);
+  });
+
+  it('skips count warnings when metrics are unavailable on one side', () => {
+    const baseline = metrics({ llmCalls: undefined, llmMs: undefined, toolCalls: undefined, toolMs: undefined });
+    const candidate = metrics({ traceId: 'trace-b', llmCalls: 2, toolCalls: 1 });
+
+    const { warnings } = buildTraceComparison(baseline, candidate);
+
+    expect(warnings).toEqual([]);
+  });
 });
 
 describe('compareTraces', () => {
@@ -403,39 +490,193 @@ describe('compareTraces', () => {
     candidateTraceId: 'trace-b',
   };
 
-  function invocationTrace(traceId: string, endMs: number): CloudWatchSpanRecord[] {
-    return [
-      {
-        traceId,
-        spanId: 'root',
-        name: 'POST /invocations',
-        kind: 'SERVER',
-        startTimeUnixNano: nano(0),
-        endTimeUnixNano: nano(endMs),
-      },
-    ];
+  const RESOURCE_ID = 'arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/runtime-123/runtime-endpoint/DEFAULT';
+  const SPANS_LOG_GROUP = 'aws/spans';
+  const DEFAULT_LOG_GROUP = '/aws/bedrock-agentcore/runtimes/runtime-123-DEFAULT';
+  const TEST_LOG_GROUP = '/aws/bedrock-agentcore/runtimes/runtime-123-test';
+
+  function serviceSpan(traceId: string, endMs: number, overrides: Partial<CloudWatchSpanRecord> = {}) {
+    return {
+      traceId,
+      spanId: 'root',
+      name: 'POST /invocations',
+      kind: 'SERVER',
+      startTimeUnixNano: nano(0),
+      endTimeUnixNano: nano(endMs),
+      cloudResourceId: RESOURCE_ID,
+      ...overrides,
+    };
+  }
+
+  function chatSpan(traceId: string, overrides: Partial<CloudWatchSpanRecord> = {}) {
+    return {
+      traceId,
+      spanId: 'llm1',
+      parentSpanId: 'root',
+      name: 'chat claude-3',
+      genAiOperation: 'chat',
+      durationNano: String(2_000_000_000),
+      ...overrides,
+    };
+  }
+
+  /** Configures mockQuerySpanRecords per (traceId, logGroupName); unspecified queries return no spans. */
+  function primeSpanQueries(spansByTraceAndGroup: Record<string, Record<string, CloudWatchSpanRecord[]>>) {
+    mockQuerySpanRecords.mockImplementation((queryOptions: QuerySpanRecordsOptions) =>
+      Promise.resolve({
+        success: true,
+        spans: spansByTraceAndGroup[queryOptions.traceId]?.[queryOptions.logGroupName] ?? [],
+      })
+    );
   }
 
   it('compares two traces and returns metrics, deltas, and warnings', async () => {
-    mockFetchSpans
-      .mockResolvedValueOnce({ success: true, spans: invocationTrace('trace-a', 6600) })
-      .mockResolvedValueOnce({ success: true, spans: invocationTrace('trace-b', 5120) });
+    primeSpanQueries({
+      'trace-a': {
+        [SPANS_LOG_GROUP]: [serviceSpan('trace-a', 6600)],
+        [DEFAULT_LOG_GROUP]: [chatSpan('trace-a')],
+      },
+      'trace-b': {
+        [SPANS_LOG_GROUP]: [serviceSpan('trace-b', 5120)],
+        [DEFAULT_LOG_GROUP]: [chatSpan('trace-b')],
+      },
+    });
 
     const result = await compareTraces(options);
 
     assert(result.success);
     expect(result.baseline.endToEndMs).toBe(6600);
     expect(result.candidate.endToEndMs).toBe(5120);
+    expect(result.baseline.llmCalls).toBe(1);
     expect(result.deltas.endToEndMs.delta).toBe(-1480);
     expect(result.warnings).toEqual([]);
-    expect(mockFetchSpans).toHaveBeenCalledWith('us-west-2', 'runtime-123', 'trace-a', undefined, undefined);
-    expect(mockFetchSpans).toHaveBeenCalledWith('us-west-2', 'runtime-123', 'trace-b', undefined, undefined);
+    expect(mockQuerySpanRecords).toHaveBeenCalledWith({
+      region: 'us-west-2',
+      logGroupName: SPANS_LOG_GROUP,
+      traceId: 'trace-a',
+      startTime: undefined,
+      endTime: undefined,
+    });
+    expect(mockQuerySpanRecords).toHaveBeenCalledWith({
+      region: 'us-west-2',
+      logGroupName: DEFAULT_LOG_GROUP,
+      traceId: 'trace-b',
+      startTime: undefined,
+      endTime: undefined,
+    });
+  });
+
+  it('fetches application spans from the endpoint-specific log group per trace', async () => {
+    primeSpanQueries({
+      'trace-a': {
+        [SPANS_LOG_GROUP]: [serviceSpan('trace-a', 6600, { endpointName: 'test' })],
+        [TEST_LOG_GROUP]: [chatSpan('trace-a')],
+      },
+      'trace-b': {
+        [SPANS_LOG_GROUP]: [serviceSpan('trace-b', 5120)],
+        [DEFAULT_LOG_GROUP]: [chatSpan('trace-b')],
+      },
+    });
+
+    const result = await compareTraces(options);
+
+    assert(result.success);
+    expect(result.baseline.llmCalls).toBe(1);
+    expect(result.candidate.llmCalls).toBe(1);
+    expect(result.warnings).toEqual([]);
+    expect(mockQuerySpanRecords).toHaveBeenCalledWith(expect.objectContaining({ logGroupName: TEST_LOG_GROUP }));
+  });
+
+  it('rejects a trace that belongs to a different runtime', async () => {
+    primeSpanQueries({
+      'trace-a': {
+        [SPANS_LOG_GROUP]: [
+          serviceSpan('trace-a', 6600, {
+            cloudResourceId: 'arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/other-runtime/x',
+          }),
+        ],
+      },
+      'trace-b': {
+        [SPANS_LOG_GROUP]: [serviceSpan('trace-b', 5120)],
+        [DEFAULT_LOG_GROUP]: [chatSpan('trace-b')],
+      },
+    });
+
+    const result = await compareTraces(options);
+
+    assert(!result.success);
+    expect(result.error.message).toContain('belongs to a different runtime');
+    expect(result.error.message).toContain('trace-a');
+  });
+
+  it('reports metrics as unavailable instead of zero when application spans are missing', async () => {
+    primeSpanQueries({
+      'trace-a': {
+        [SPANS_LOG_GROUP]: [serviceSpan('trace-a', 6600)],
+      },
+      'trace-b': {
+        [SPANS_LOG_GROUP]: [serviceSpan('trace-b', 5120)],
+        [DEFAULT_LOG_GROUP]: [chatSpan('trace-b')],
+      },
+    });
+
+    const result = await compareTraces(options);
+
+    assert(result.success);
+    expect(result.baseline.llmCalls).toBeUndefined();
+    expect(result.baseline.toolCalls).toBeUndefined();
+    expect(result.deltas.llmMs.delta).toBeUndefined();
+    expect(result.warnings).toEqual([expect.stringContaining('application spans unavailable')]);
+  });
+
+  it('treats a missing endpoint log group as unavailable application spans', async () => {
+    mockQuerySpanRecords.mockImplementation((queryOptions: QuerySpanRecordsOptions) => {
+      if (queryOptions.logGroupName === SPANS_LOG_GROUP) {
+        return Promise.resolve({
+          success: true,
+          spans: [serviceSpan(queryOptions.traceId, queryOptions.traceId === 'trace-a' ? 6600 : 5120)],
+        });
+      }
+      return Promise.resolve({ success: false, error: new ResourceNotFoundError('Log group not found') });
+    });
+
+    const result = await compareTraces(options);
+
+    assert(result.success);
+    expect(result.baseline.llmCalls).toBeUndefined();
+    expect(result.candidate.llmCalls).toBeUndefined();
+    expect(result.warnings).toEqual([
+      expect.stringContaining('trace-a'),
+      expect.stringContaining('trace-b'),
+    ]);
+  });
+
+  it('de-duplicates spans that appear in both log groups', async () => {
+    primeSpanQueries({
+      'trace-a': {
+        [SPANS_LOG_GROUP]: [serviceSpan('trace-a', 6600), chatSpan('trace-a')],
+        [DEFAULT_LOG_GROUP]: [chatSpan('trace-a')],
+      },
+      'trace-b': {
+        [SPANS_LOG_GROUP]: [serviceSpan('trace-b', 5120)],
+        [DEFAULT_LOG_GROUP]: [chatSpan('trace-b')],
+      },
+    });
+
+    const result = await compareTraces(options);
+
+    assert(result.success);
+    expect(result.baseline.spanCount).toBe(2);
+    expect(result.baseline.llmCalls).toBe(1);
   });
 
   it('fails clearly when the baseline trace has no spans', async () => {
-    mockFetchSpans
-      .mockResolvedValueOnce({ success: true, spans: [] })
-      .mockResolvedValueOnce({ success: true, spans: invocationTrace('trace-b', 5120) });
+    primeSpanQueries({
+      'trace-b': {
+        [SPANS_LOG_GROUP]: [serviceSpan('trace-b', 5120)],
+        [DEFAULT_LOG_GROUP]: [chatSpan('trace-b')],
+      },
+    });
 
     const result = await compareTraces(options);
 
@@ -444,9 +685,12 @@ describe('compareTraces', () => {
   });
 
   it('fails clearly when the candidate trace has no spans', async () => {
-    mockFetchSpans
-      .mockResolvedValueOnce({ success: true, spans: invocationTrace('trace-a', 6600) })
-      .mockResolvedValueOnce({ success: true, spans: [] });
+    primeSpanQueries({
+      'trace-a': {
+        [SPANS_LOG_GROUP]: [serviceSpan('trace-a', 6600)],
+        [DEFAULT_LOG_GROUP]: [chatSpan('trace-a')],
+      },
+    });
 
     const result = await compareTraces(options);
 
@@ -455,9 +699,12 @@ describe('compareTraces', () => {
   });
 
   it('propagates fetch failures', async () => {
-    mockFetchSpans
-      .mockResolvedValueOnce({ success: false, error: new Error('Query failed') })
-      .mockResolvedValueOnce({ success: true, spans: invocationTrace('trace-b', 5120) });
+    mockQuerySpanRecords.mockImplementation((queryOptions: QuerySpanRecordsOptions) => {
+      if (queryOptions.traceId === 'trace-a' && queryOptions.logGroupName === SPANS_LOG_GROUP) {
+        return Promise.resolve({ success: false, error: new Error('Query failed') });
+      }
+      return Promise.resolve({ success: true, spans: [serviceSpan('trace-b', 5120)] });
+    });
 
     const result = await compareTraces(options);
 
@@ -465,36 +712,93 @@ describe('compareTraces', () => {
     expect(result.error.message).toBe('Query failed');
   });
 
+  it('produces the documented JSON contract shape', async () => {
+    function toolSpan(traceId: string, durationNano: string) {
+      return {
+        traceId,
+        spanId: 'tool1',
+        parentSpanId: 'root',
+        name: 'execute_tool weather',
+        genAiOperation: 'execute_tool',
+        durationNano,
+      };
+    }
+    primeSpanQueries({
+      'trace-a': {
+        [SPANS_LOG_GROUP]: [serviceSpan('trace-a', 6600)],
+        [DEFAULT_LOG_GROUP]: [
+          chatSpan('trace-a', { inputTokens: 2849, outputTokens: 315, totalTokens: 3164 }),
+          toolSpan('trace-a', String(2_850_000_000)),
+        ],
+      },
+      'trace-b': {
+        [SPANS_LOG_GROUP]: [serviceSpan('trace-b', 5120)],
+        [DEFAULT_LOG_GROUP]: [
+          chatSpan('trace-b', {
+            durationNano: String(1_710_000_000),
+            inputTokens: 2500,
+            outputTokens: 300,
+            totalTokens: 2800,
+          }),
+          toolSpan('trace-b', String(1_000_000_000)),
+        ],
+      },
+    });
+
+    const result = await compareTraces(options);
+
+    expect(JSON.parse(JSON.stringify(result))).toEqual({
+      success: true,
+      baseline: {
+        traceId: 'trace-a',
+        spanCount: 3,
+        endToEndMs: 6600,
+        timingSource: 'invocation-span',
+        llmMs: 2000,
+        llmCalls: 1,
+        toolMs: 2850,
+        toolCalls: 1,
+        inputTokens: 2849,
+        outputTokens: 315,
+        totalTokens: 3164,
+      },
+      candidate: {
+        traceId: 'trace-b',
+        spanCount: 3,
+        endToEndMs: 5120,
+        timingSource: 'invocation-span',
+        llmMs: 1710,
+        llmCalls: 1,
+        toolMs: 1000,
+        toolCalls: 1,
+        inputTokens: 2500,
+        outputTokens: 300,
+        totalTokens: 2800,
+      },
+      deltas: {
+        endToEndMs: { baseline: 6600, candidate: 5120, delta: -1480, deltaPercent: expect.closeTo(-22.4, 1) as number },
+        llmMs: { baseline: 2000, candidate: 1710, delta: -290, deltaPercent: expect.closeTo(-14.5, 1) as number },
+        toolMs: { baseline: 2850, candidate: 1000, delta: -1850, deltaPercent: expect.closeTo(-64.9, 1) as number },
+        llmCalls: { baseline: 1, candidate: 1, delta: 0, deltaPercent: 0 },
+        toolCalls: { baseline: 1, candidate: 1, delta: 0, deltaPercent: 0 },
+        inputTokens: { baseline: 2849, candidate: 2500, delta: -349, deltaPercent: expect.closeTo(-12.2, 1) as number },
+        outputTokens: { baseline: 315, candidate: 300, delta: -15, deltaPercent: expect.closeTo(-4.8, 1) as number },
+        totalTokens: { baseline: 3164, candidate: 2800, delta: -364, deltaPercent: expect.closeTo(-11.5, 1) as number },
+      },
+      warnings: [],
+    });
+  });
+
   it('surfaces per-trace fallback-timing warnings', async () => {
-    mockFetchSpans
-      .mockResolvedValueOnce({
-        success: true,
-        spans: [
-          {
-            traceId: 'trace-a',
-            spanId: 'llm1',
-            name: 'chat claude-3',
-            genAiOperation: 'chat',
-            startTimeUnixNano: nano(0),
-            endTimeUnixNano: nano(1000),
-          },
-        ],
-      })
-      .mockResolvedValueOnce({
-        success: true,
-        spans: [
-          ...invocationTrace('trace-b', 1000),
-          {
-            traceId: 'trace-b',
-            spanId: 'llm1',
-            parentSpanId: 'root',
-            name: 'chat claude-3',
-            genAiOperation: 'chat',
-            startTimeUnixNano: nano(0),
-            endTimeUnixNano: nano(900),
-          },
-        ],
-      });
+    primeSpanQueries({
+      'trace-a': {
+        [DEFAULT_LOG_GROUP]: [chatSpan('trace-a', { startTimeUnixNano: nano(0), endTimeUnixNano: nano(1000) })],
+      },
+      'trace-b': {
+        [SPANS_LOG_GROUP]: [serviceSpan('trace-b', 1000)],
+        [DEFAULT_LOG_GROUP]: [chatSpan('trace-b')],
+      },
+    });
 
     const result = await compareTraces(options);
 

--- a/src/cli/operations/traces/__tests__/compare-traces.test.ts
+++ b/src/cli/operations/traces/__tests__/compare-traces.test.ts
@@ -1,0 +1,504 @@
+import { aggregateSpans, buildTraceComparison, compareTraces } from '../compare-traces';
+import type { CloudWatchSpanRecord, TraceMetrics } from '../types';
+import assert from 'node:assert';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { mockFetchSpans } = vi.hoisted(() => ({
+  mockFetchSpans: vi.fn(),
+}));
+
+vi.mock('../get-trace', () => ({
+  fetchSpans: (...args: unknown[]) => mockFetchSpans(...args),
+}));
+
+// Base timestamp: divisible by 256 so nano values stay exactly representable as doubles.
+const T0 = 1_700_000_000_000_000_000;
+
+function nano(offsetMs: number): string {
+  return String(T0 + offsetMs * 1_000_000);
+}
+
+function span(overrides: Partial<CloudWatchSpanRecord> & { spanId: string }): CloudWatchSpanRecord {
+  return { traceId: 'trace-a', ...overrides };
+}
+
+function metrics(overrides: Partial<TraceMetrics>): TraceMetrics {
+  return {
+    traceId: 'trace-a',
+    spanCount: 3,
+    endToEndMs: 1000,
+    timingSource: 'invocation-span',
+    llmMs: 500,
+    llmCalls: 1,
+    toolMs: 200,
+    toolCalls: 1,
+    ...overrides,
+  };
+}
+
+describe('aggregateSpans', () => {
+  it('uses the POST /invocations server span for end-to-end latency', () => {
+    const spans = [
+      span({
+        spanId: 'root',
+        name: 'POST /invocations',
+        kind: 'SERVER',
+        startTimeUnixNano: nano(0),
+        endTimeUnixNano: nano(6600),
+      }),
+      span({
+        spanId: 'llm1',
+        parentSpanId: 'root',
+        name: 'chat claude-3',
+        genAiOperation: 'chat',
+        startTimeUnixNano: nano(100),
+        endTimeUnixNano: nano(3720),
+      }),
+    ];
+
+    const result = aggregateSpans('trace-a', spans);
+
+    assert(result.success);
+    expect(result.metrics.endToEndMs).toBe(6600);
+    expect(result.metrics.timingSource).toBe('invocation-span');
+    expect(result.metrics.spanCount).toBe(2);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('falls back to the span envelope with a warning when no invocation span exists', () => {
+    const spans = [
+      span({
+        spanId: 'llm1',
+        name: 'chat claude-3',
+        genAiOperation: 'chat',
+        startTimeUnixNano: nano(100),
+        endTimeUnixNano: nano(3100),
+      }),
+      span({
+        spanId: 'tool1',
+        name: 'execute_tool weather',
+        genAiOperation: 'execute_tool',
+        startTimeUnixNano: nano(3200),
+        endTimeUnixNano: nano(5200),
+      }),
+    ];
+
+    const result = aggregateSpans('trace-a', spans);
+
+    assert(result.success);
+    expect(result.metrics.endToEndMs).toBe(5100);
+    expect(result.metrics.timingSource).toBe('span-envelope');
+    expect(result.warnings).toEqual([
+      expect.stringContaining('no POST /invocations server span found'),
+    ]);
+  });
+
+  it('fails when no span has usable timing data', () => {
+    const spans = [span({ spanId: 'a', name: 'chat claude-3' }), span({ spanId: 'b', name: 'execute_tool weather' })];
+
+    const result = aggregateSpans('trace-a', spans);
+
+    assert(!result.success);
+    expect(result.error.message).toContain('no spans with timing data');
+  });
+
+  it('counts a nested provider LLM span as a single model call', () => {
+    const spans = [
+      span({
+        spanId: 'root',
+        name: 'POST /invocations',
+        kind: 'SERVER',
+        startTimeUnixNano: nano(0),
+        endTimeUnixNano: nano(6000),
+      }),
+      span({
+        spanId: 'llm1',
+        parentSpanId: 'root',
+        name: 'chat claude-3',
+        genAiOperation: 'chat',
+        durationNano: String(3_000_000_000),
+        startTimeUnixNano: nano(100),
+        endTimeUnixNano: nano(3100),
+      }),
+      // Nested Bedrock client span for the same model call — must not double-count.
+      span({
+        spanId: 'bedrock1',
+        parentSpanId: 'llm1',
+        name: 'Bedrock Runtime.InvokeModel',
+        kind: 'CLIENT',
+        durationNano: String(2_800_000_000),
+        startTimeUnixNano: nano(200),
+        endTimeUnixNano: nano(3000),
+      }),
+    ];
+
+    const result = aggregateSpans('trace-a', spans);
+
+    assert(result.success);
+    expect(result.metrics.llmCalls).toBe(1);
+    expect(result.metrics.llmMs).toBe(3000);
+  });
+
+  it('counts sibling LLM calls separately', () => {
+    const spans = [
+      span({
+        spanId: 'root',
+        name: 'POST /invocations',
+        kind: 'SERVER',
+        startTimeUnixNano: nano(0),
+        endTimeUnixNano: nano(6000),
+      }),
+      span({
+        spanId: 'llm1',
+        parentSpanId: 'root',
+        genAiOperation: 'chat',
+        name: 'chat claude-3',
+        durationNano: String(2_000_000_000),
+      }),
+      span({
+        spanId: 'llm2',
+        parentSpanId: 'root',
+        genAiOperation: 'chat',
+        name: 'chat claude-3',
+        durationNano: String(1_620_000_000),
+      }),
+    ];
+
+    const result = aggregateSpans('trace-a', spans);
+
+    assert(result.success);
+    expect(result.metrics.llmCalls).toBe(2);
+    expect(result.metrics.llmMs).toBe(3620);
+  });
+
+  it('aggregates tokens from the outermost token-bearing span only', () => {
+    const spans = [
+      span({
+        spanId: 'root',
+        name: 'POST /invocations',
+        kind: 'SERVER',
+        startTimeUnixNano: nano(0),
+        endTimeUnixNano: nano(6000),
+      }),
+      span({
+        spanId: 'llm1',
+        parentSpanId: 'root',
+        genAiOperation: 'chat',
+        name: 'chat claude-3',
+        durationNano: String(2_000_000_000),
+        inputTokens: 2849,
+        outputTokens: 315,
+        totalTokens: 3164,
+      }),
+      // Nested provider span reporting the same usage — must not double-count.
+      span({
+        spanId: 'bedrock1',
+        parentSpanId: 'llm1',
+        name: 'Bedrock Runtime.InvokeModel',
+        durationNano: String(1_900_000_000),
+        inputTokens: 2849,
+        outputTokens: 315,
+        totalTokens: 3164,
+      }),
+    ];
+
+    const result = aggregateSpans('trace-a', spans);
+
+    assert(result.success);
+    expect(result.metrics.inputTokens).toBe(2849);
+    expect(result.metrics.outputTokens).toBe(315);
+    expect(result.metrics.totalTokens).toBe(3164);
+  });
+
+  it('picks up tokens reported only on a nested provider span', () => {
+    const spans = [
+      span({
+        spanId: 'root',
+        name: 'POST /invocations',
+        kind: 'SERVER',
+        startTimeUnixNano: nano(0),
+        endTimeUnixNano: nano(6000),
+      }),
+      span({
+        spanId: 'llm1',
+        parentSpanId: 'root',
+        genAiOperation: 'chat',
+        name: 'chat claude-3',
+        durationNano: String(2_000_000_000),
+      }),
+      span({
+        spanId: 'bedrock1',
+        parentSpanId: 'llm1',
+        name: 'Bedrock Runtime.InvokeModel',
+        durationNano: String(1_900_000_000),
+        inputTokens: 1912,
+        outputTokens: 237,
+        totalTokens: 2149,
+      }),
+    ];
+
+    const result = aggregateSpans('trace-a', spans);
+
+    assert(result.success);
+    expect(result.metrics.inputTokens).toBe(1912);
+    expect(result.metrics.outputTokens).toBe(237);
+    expect(result.metrics.totalTokens).toBe(2149);
+  });
+
+  it('leaves token fields undefined when no span reports usage', () => {
+    const spans = [
+      span({
+        spanId: 'root',
+        name: 'POST /invocations',
+        kind: 'SERVER',
+        startTimeUnixNano: nano(0),
+        endTimeUnixNano: nano(6000),
+      }),
+    ];
+
+    const result = aggregateSpans('trace-a', spans);
+
+    assert(result.success);
+    expect(result.metrics.inputTokens).toBeUndefined();
+    expect(result.metrics.outputTokens).toBeUndefined();
+    expect(result.metrics.totalTokens).toBeUndefined();
+  });
+
+  it('counts tool spans and de-duplicates nested tool spans', () => {
+    const spans = [
+      span({
+        spanId: 'root',
+        name: 'POST /invocations',
+        kind: 'SERVER',
+        startTimeUnixNano: nano(0),
+        endTimeUnixNano: nano(6000),
+      }),
+      span({
+        spanId: 'tool1',
+        parentSpanId: 'root',
+        genAiOperation: 'execute_tool',
+        name: 'execute_tool weather',
+        durationNano: String(2_850_000_000),
+      }),
+      span({
+        spanId: 'tool1-inner',
+        parentSpanId: 'tool1',
+        name: 'execute_tool weather',
+        durationNano: String(2_700_000_000),
+      }),
+    ];
+
+    const result = aggregateSpans('trace-a', spans);
+
+    assert(result.success);
+    expect(result.metrics.toolCalls).toBe(1);
+    expect(result.metrics.toolMs).toBe(2850);
+  });
+
+  it('treats spans with unknown parents as top-level', () => {
+    const spans = [
+      span({
+        spanId: 'root',
+        name: 'POST /invocations',
+        kind: 'SERVER',
+        startTimeUnixNano: nano(0),
+        endTimeUnixNano: nano(6000),
+      }),
+      span({
+        spanId: 'llm1',
+        parentSpanId: 'missing-span',
+        genAiOperation: 'chat',
+        name: 'chat claude-3',
+        durationNano: String(1_000_000_000),
+      }),
+    ];
+
+    const result = aggregateSpans('trace-a', spans);
+
+    assert(result.success);
+    expect(result.metrics.llmCalls).toBe(1);
+  });
+});
+
+describe('buildTraceComparison', () => {
+  it('computes absolute and percentage deltas', () => {
+    const baseline = metrics({ endToEndMs: 6600, llmMs: 3620, toolMs: 2850, totalTokens: 3164 });
+    const candidate = metrics({ traceId: 'trace-b', endToEndMs: 5120, llmMs: 3040, toolMs: 1710, totalTokens: 3000 });
+
+    const { deltas } = buildTraceComparison(baseline, candidate);
+
+    expect(deltas.endToEndMs).toEqual({
+      baseline: 6600,
+      candidate: 5120,
+      delta: -1480,
+      deltaPercent: expect.closeTo(-22.42, 1) as number,
+    });
+    expect(deltas.llmMs.delta).toBe(-580);
+    expect(deltas.toolMs.delta).toBe(-1140);
+  });
+
+  it('returns null percentage for a zero baseline', () => {
+    const baseline = metrics({ toolMs: 0, toolCalls: 0 });
+    const candidate = metrics({ traceId: 'trace-b', toolMs: 500, toolCalls: 1 });
+
+    const { deltas } = buildTraceComparison(baseline, candidate);
+
+    expect(deltas.toolMs.delta).toBe(500);
+    expect(deltas.toolMs.deltaPercent).toBeNull();
+  });
+
+  it('omits values for token metrics missing on both sides', () => {
+    const baseline = metrics({});
+    const candidate = metrics({ traceId: 'trace-b' });
+
+    const { deltas } = buildTraceComparison(baseline, candidate);
+
+    expect(deltas.totalTokens).toEqual({});
+  });
+
+  it('warns when LLM call counts differ', () => {
+    const baseline = metrics({ llmCalls: 2 });
+    const candidate = metrics({ traceId: 'trace-b', llmCalls: 3 });
+
+    const { warnings } = buildTraceComparison(baseline, candidate);
+
+    expect(warnings).toEqual([expect.stringContaining('LLM call counts differ')]);
+  });
+
+  it('warns when tool call counts differ', () => {
+    const baseline = metrics({ toolCalls: 1 });
+    const candidate = metrics({ traceId: 'trace-b', toolCalls: 0 });
+
+    const { warnings } = buildTraceComparison(baseline, candidate);
+
+    expect(warnings).toEqual([expect.stringContaining('Tool call counts differ')]);
+  });
+
+  it('warns when total token usage differs beyond the comparability threshold', () => {
+    const baseline = metrics({ totalTokens: 1000 });
+    const candidate = metrics({ traceId: 'trace-b', totalTokens: 1500 });
+
+    const { warnings } = buildTraceComparison(baseline, candidate);
+
+    expect(warnings).toEqual([expect.stringContaining('token usage differs')]);
+  });
+
+  it('does not warn on matching characteristics', () => {
+    const baseline = metrics({ totalTokens: 1000 });
+    const candidate = metrics({ traceId: 'trace-b', endToEndMs: 900, totalTokens: 1050 });
+
+    const { warnings } = buildTraceComparison(baseline, candidate);
+
+    expect(warnings).toEqual([]);
+  });
+});
+
+describe('compareTraces', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  const options = {
+    region: 'us-west-2',
+    runtimeId: 'runtime-123',
+    baselineTraceId: 'trace-a',
+    candidateTraceId: 'trace-b',
+  };
+
+  function invocationTrace(traceId: string, endMs: number): CloudWatchSpanRecord[] {
+    return [
+      {
+        traceId,
+        spanId: 'root',
+        name: 'POST /invocations',
+        kind: 'SERVER',
+        startTimeUnixNano: nano(0),
+        endTimeUnixNano: nano(endMs),
+      },
+    ];
+  }
+
+  it('compares two traces and returns metrics, deltas, and warnings', async () => {
+    mockFetchSpans
+      .mockResolvedValueOnce({ success: true, spans: invocationTrace('trace-a', 6600) })
+      .mockResolvedValueOnce({ success: true, spans: invocationTrace('trace-b', 5120) });
+
+    const result = await compareTraces(options);
+
+    assert(result.success);
+    expect(result.baseline.endToEndMs).toBe(6600);
+    expect(result.candidate.endToEndMs).toBe(5120);
+    expect(result.deltas.endToEndMs.delta).toBe(-1480);
+    expect(result.warnings).toEqual([]);
+    expect(mockFetchSpans).toHaveBeenCalledWith('us-west-2', 'runtime-123', 'trace-a', undefined, undefined);
+    expect(mockFetchSpans).toHaveBeenCalledWith('us-west-2', 'runtime-123', 'trace-b', undefined, undefined);
+  });
+
+  it('fails clearly when the baseline trace has no spans', async () => {
+    mockFetchSpans
+      .mockResolvedValueOnce({ success: true, spans: [] })
+      .mockResolvedValueOnce({ success: true, spans: invocationTrace('trace-b', 5120) });
+
+    const result = await compareTraces(options);
+
+    assert(!result.success);
+    expect(result.error.message).toContain('baseline trace trace-a');
+  });
+
+  it('fails clearly when the candidate trace has no spans', async () => {
+    mockFetchSpans
+      .mockResolvedValueOnce({ success: true, spans: invocationTrace('trace-a', 6600) })
+      .mockResolvedValueOnce({ success: true, spans: [] });
+
+    const result = await compareTraces(options);
+
+    assert(!result.success);
+    expect(result.error.message).toContain('candidate trace trace-b');
+  });
+
+  it('propagates fetch failures', async () => {
+    mockFetchSpans
+      .mockResolvedValueOnce({ success: false, error: new Error('Query failed') })
+      .mockResolvedValueOnce({ success: true, spans: invocationTrace('trace-b', 5120) });
+
+    const result = await compareTraces(options);
+
+    assert(!result.success);
+    expect(result.error.message).toBe('Query failed');
+  });
+
+  it('surfaces per-trace fallback-timing warnings', async () => {
+    mockFetchSpans
+      .mockResolvedValueOnce({
+        success: true,
+        spans: [
+          {
+            traceId: 'trace-a',
+            spanId: 'llm1',
+            name: 'chat claude-3',
+            genAiOperation: 'chat',
+            startTimeUnixNano: nano(0),
+            endTimeUnixNano: nano(1000),
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        spans: [
+          ...invocationTrace('trace-b', 1000),
+          {
+            traceId: 'trace-b',
+            spanId: 'llm1',
+            parentSpanId: 'root',
+            name: 'chat claude-3',
+            genAiOperation: 'chat',
+            startTimeUnixNano: nano(0),
+            endTimeUnixNano: nano(900),
+          },
+        ],
+      });
+
+    const result = await compareTraces(options);
+
+    assert(result.success);
+    expect(result.warnings).toEqual([expect.stringContaining('trace-a')]);
+  });
+});

--- a/src/cli/operations/traces/__tests__/get-trace.test.ts
+++ b/src/cli/operations/traces/__tests__/get-trace.test.ts
@@ -1,4 +1,4 @@
-import { fetchTraceRecords, getTrace } from '../get-trace';
+import { fetchSpans, fetchTraceRecords, getTrace } from '../get-trace';
 import type { FetchTraceRecordsOptions } from '../types';
 import assert from 'node:assert';
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
@@ -176,6 +176,61 @@ describe('fetchTraceRecords', () => {
     assert(!result.success);
     expect(result.error.message).toContain('Log group');
     expect(result.error.message).toContain('not found');
+  });
+});
+
+describe('fetchSpans', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('maps span rows including the gen_ai operation name', async () => {
+    const startedQueries: { logGroupName: string; queryString: string }[] = [];
+    mockSend.mockImplementation((cmd: { input: Record<string, string> }) => {
+      if (cmd.input.queryString) {
+        startedQueries.push({ logGroupName: cmd.input.logGroupName!, queryString: cmd.input.queryString });
+        return Promise.resolve({ queryId: cmd.input.logGroupName === 'aws/spans' ? 'q-spans' : 'q-runtime' });
+      }
+      if (cmd.input.queryId === 'q-spans') {
+        return Promise.resolve({
+          status: 'Complete',
+          results: [
+            [
+              { field: 'traceId', value: 'abc123def456' },
+              { field: 'spanId', value: 'span-1' },
+              { field: 'name', value: 'chat claude' },
+              { field: 'kind', value: 'CLIENT' },
+              { field: 'startTimeUnixNano', value: '1700000000000000000' },
+              { field: 'endTimeUnixNano', value: '1700000001000000000' },
+              { field: 'inputTokens', value: '120' },
+              { field: 'genAiOperation', value: 'chat' },
+            ],
+          ],
+        });
+      }
+      return Promise.resolve({ status: 'Complete', results: [] });
+    });
+
+    const result = await fetchSpans('us-west-2', 'runtime-123', 'abc123def456', 1000000, 2000000);
+
+    assert(result.success);
+    expect(result.spans).toHaveLength(1);
+    expect(result.spans[0]).toMatchObject({
+      traceId: 'abc123def456',
+      spanId: 'span-1',
+      name: 'chat claude',
+      kind: 'CLIENT',
+      inputTokens: 120,
+      genAiOperation: 'chat',
+    });
+    const spansQuery = startedQueries.find(q => q.logGroupName === 'aws/spans');
+    expect(spansQuery?.queryString).toContain('attributes.gen_ai.operation.name as genAiOperation');
+  });
+
+  it('returns error for invalid trace ID format', async () => {
+    const result = await fetchSpans('us-west-2', 'runtime-123', 'not$valid');
+
+    assert(!result.success);
+    expect(result.error.message).toContain('Invalid trace ID format');
+    expect(mockSend).not.toHaveBeenCalled();
   });
 });
 

--- a/src/cli/operations/traces/__tests__/get-trace.test.ts
+++ b/src/cli/operations/traces/__tests__/get-trace.test.ts
@@ -202,6 +202,8 @@ describe('querySpanRecords', () => {
             { field: 'agentId', value: 'runtime-123' },
             { field: 'traceloopSpanKind', value: 'tool' },
             { field: 'openinferenceSpanKind', value: 'TOOL' },
+            { field: 'requestModel', value: 'claude-3-5-sonnet' },
+            { field: 'responseModel', value: 'claude-3-5-sonnet-20241022-v2:0' },
           ],
         ],
       });
@@ -222,6 +224,8 @@ describe('querySpanRecords', () => {
       agentId: 'runtime-123',
       traceloopSpanKind: 'tool',
       openinferenceSpanKind: 'TOOL',
+      requestModel: 'claude-3-5-sonnet',
+      responseModel: 'claude-3-5-sonnet-20241022-v2:0',
     });
     expect(startedQueries).toHaveLength(1);
     expect(startedQueries[0]!.logGroupName).toBe('/aws/bedrock-agentcore/runtimes/runtime-123-test');
@@ -230,6 +234,8 @@ describe('querySpanRecords', () => {
     expect(startedQueries[0]!.queryString).toContain('attributes.aws.agent.id as agentId');
     expect(startedQueries[0]!.queryString).toContain('attributes.traceloop.span.kind as traceloopSpanKind');
     expect(startedQueries[0]!.queryString).toContain('attributes.openinference.span.kind as openinferenceSpanKind');
+    expect(startedQueries[0]!.queryString).toContain('attributes.gen_ai.request.model as requestModel');
+    expect(startedQueries[0]!.queryString).toContain('attributes.gen_ai.response.model as responseModel');
   });
 
   it('returns error for invalid trace ID format', async () => {

--- a/src/cli/operations/traces/__tests__/get-trace.test.ts
+++ b/src/cli/operations/traces/__tests__/get-trace.test.ts
@@ -1,4 +1,4 @@
-import { fetchSpans, fetchTraceRecords, getTrace } from '../get-trace';
+import { fetchSpans, fetchTraceRecords, getTrace, querySpanRecords } from '../get-trace';
 import type { FetchTraceRecordsOptions } from '../types';
 import assert from 'node:assert';
 import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
@@ -176,6 +176,63 @@ describe('fetchTraceRecords', () => {
     assert(!result.success);
     expect(result.error.message).toContain('Log group');
     expect(result.error.message).toContain('not found');
+  });
+});
+
+describe('querySpanRecords', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('queries a single log group and maps resource/endpoint attributes', async () => {
+    const startedQueries: { logGroupName: string; queryString: string }[] = [];
+    mockSend.mockImplementation((cmd: { input: Record<string, string> }) => {
+      if (cmd.input.queryString) {
+        startedQueries.push({ logGroupName: cmd.input.logGroupName!, queryString: cmd.input.queryString });
+        return Promise.resolve({ queryId: 'q-1' });
+      }
+      return Promise.resolve({
+        status: 'Complete',
+        results: [
+          [
+            { field: 'traceId', value: 'abc123def456' },
+            { field: 'spanId', value: 'span-1' },
+            { field: 'name', value: 'POST /invocations' },
+            { field: 'kind', value: 'SERVER' },
+            { field: 'cloudResourceId', value: 'arn:aws:bedrock-agentcore:us-west-2:123:runtime/runtime-123/x' },
+            { field: 'endpointName', value: 'test' },
+          ],
+        ],
+      });
+    });
+
+    const result = await querySpanRecords({
+      region: 'us-west-2',
+      logGroupName: '/aws/bedrock-agentcore/runtimes/runtime-123-test',
+      traceId: 'abc123def456',
+    });
+
+    assert(result.success);
+    expect(result.spans).toHaveLength(1);
+    expect(result.spans[0]).toMatchObject({
+      spanId: 'span-1',
+      cloudResourceId: 'arn:aws:bedrock-agentcore:us-west-2:123:runtime/runtime-123/x',
+      endpointName: 'test',
+    });
+    expect(startedQueries).toHaveLength(1);
+    expect(startedQueries[0]!.logGroupName).toBe('/aws/bedrock-agentcore/runtimes/runtime-123-test');
+    expect(startedQueries[0]!.queryString).toContain('resource.attributes.cloud.resource_id as cloudResourceId');
+    expect(startedQueries[0]!.queryString).toContain('attributes.aws.endpoint.name as endpointName');
+  });
+
+  it('returns error for invalid trace ID format', async () => {
+    const result = await querySpanRecords({
+      region: 'us-west-2',
+      logGroupName: 'aws/spans',
+      traceId: 'not$valid',
+    });
+
+    assert(!result.success);
+    expect(result.error.message).toContain('Invalid trace ID format');
+    expect(mockSend).not.toHaveBeenCalled();
   });
 });
 

--- a/src/cli/operations/traces/__tests__/get-trace.test.ts
+++ b/src/cli/operations/traces/__tests__/get-trace.test.ts
@@ -199,6 +199,9 @@ describe('querySpanRecords', () => {
             { field: 'kind', value: 'SERVER' },
             { field: 'cloudResourceId', value: 'arn:aws:bedrock-agentcore:us-west-2:123:runtime/runtime-123/x' },
             { field: 'endpointName', value: 'test' },
+            { field: 'agentId', value: 'runtime-123' },
+            { field: 'traceloopSpanKind', value: 'tool' },
+            { field: 'openinferenceSpanKind', value: 'TOOL' },
           ],
         ],
       });
@@ -216,11 +219,17 @@ describe('querySpanRecords', () => {
       spanId: 'span-1',
       cloudResourceId: 'arn:aws:bedrock-agentcore:us-west-2:123:runtime/runtime-123/x',
       endpointName: 'test',
+      agentId: 'runtime-123',
+      traceloopSpanKind: 'tool',
+      openinferenceSpanKind: 'TOOL',
     });
     expect(startedQueries).toHaveLength(1);
     expect(startedQueries[0]!.logGroupName).toBe('/aws/bedrock-agentcore/runtimes/runtime-123-test');
     expect(startedQueries[0]!.queryString).toContain('resource.attributes.cloud.resource_id as cloudResourceId');
     expect(startedQueries[0]!.queryString).toContain('attributes.aws.endpoint.name as endpointName');
+    expect(startedQueries[0]!.queryString).toContain('attributes.aws.agent.id as agentId');
+    expect(startedQueries[0]!.queryString).toContain('attributes.traceloop.span.kind as traceloopSpanKind');
+    expect(startedQueries[0]!.queryString).toContain('attributes.openinference.span.kind as openinferenceSpanKind');
   });
 
   it('returns error for invalid trace ID format', async () => {

--- a/src/cli/operations/traces/compare-traces.ts
+++ b/src/cli/operations/traces/compare-traces.ts
@@ -1,6 +1,9 @@
 import { ResourceNotFoundError, ValidationError } from '../../../lib';
 import type { Result } from '../../../lib/result';
-import { fetchSpans } from './get-trace';
+import { runtimeLogGroup } from '../../aws/cloudwatch';
+import { DEFAULT_ENDPOINT_NAME } from '../../constants';
+import { SPANS_LOG_GROUP } from './constants';
+import { querySpanRecords } from './get-trace';
 import type {
   CloudWatchSpanRecord,
   CompareTracesOptions,
@@ -17,8 +20,16 @@ const TOOL_OPERATIONS = new Set(['execute_tool']);
 const LLM_NAME_PATTERN = /^chat\b|^invoke_model\b|^text_completion\b|^generate_content\b|InvokeModel|^Model invoke$/i;
 const TOOL_NAME_PATTERN = /^execute_tool\b|^Tool: /i;
 const INVOCATION_PATH = '/invocations';
-// Relative total-token difference above which the traces are flagged as possibly incomparable.
+// Relative per-field token difference above which the traces are flagged as possibly incomparable.
 const TOKEN_COMPARABILITY_THRESHOLD = 0.2;
+// Extracts the runtime resource ID from resource.attributes.cloud.resource_id (".../runtime/<id>/...").
+const RUNTIME_RESOURCE_ID_PATTERN = /runtime\/([^/]+)/;
+
+const TOKEN_FIELDS = [
+  ['inputTokens', 'Input token'],
+  ['outputTokens', 'Output token'],
+  ['totalTokens', 'Total token'],
+] as const;
 
 type SpanCategory = 'llm' | 'tool' | 'other';
 
@@ -91,21 +102,24 @@ function sumDefined(
   return total;
 }
 
-function hasTokenUsage(span: CloudWatchSpanRecord): boolean {
-  return span.inputTokens !== undefined || span.outputTokens !== undefined || span.totalTokens !== undefined;
-}
-
 /**
  * Computes latency and token metrics for a single trace.
  *
  * Nested spans of the same category are de-duplicated via parent links: a
  * framework LLM span and its nested provider client span (e.g. a Strands chat
- * span wrapping a Bedrock InvokeModel span) count as one model call. Token
- * usage is likewise summed only from the outermost token-bearing spans.
+ * span wrapping a Bedrock InvokeModel span) count as one model call. Each token
+ * field is likewise summed only from the outermost span reporting that field,
+ * so complementary parent/child fields (total on one, input/output on the
+ * other) are all preserved.
+ *
+ * When `appSpansAvailable` is false, only end-to-end timing is computed and
+ * LLM/tool/token metrics stay undefined — absent application spans mean the
+ * data is unavailable, not zero.
  */
 export function aggregateSpans(
   traceId: string,
-  spans: CloudWatchSpanRecord[]
+  spans: CloudWatchSpanRecord[],
+  appSpansAvailable = true
 ): Result<{ metrics: TraceMetrics; warnings: string[] }> {
   const warnings: string[] = [];
   const byId = new Map(spans.map(span => [span.spanId, span]));
@@ -135,6 +149,17 @@ export function aggregateSpans(
     return { success: false, error: new ValidationError(`Trace ${traceId} has no spans with timing data`) };
   }
 
+  if (!appSpansAvailable) {
+    warnings.push(
+      `Trace ${traceId}: application spans unavailable (only service spans found); LLM, tool, and token metrics were not computed`
+    );
+    return {
+      success: true,
+      metrics: { traceId, spanCount: spans.length, endToEndMs, timingSource },
+      warnings,
+    };
+  }
+
   const topLevelOfCategory = (category: SpanCategory): CloudWatchSpanRecord[] =>
     spans.filter(
       span =>
@@ -143,9 +168,17 @@ export function aggregateSpans(
 
   const llmSpans = topLevelOfCategory('llm');
   const toolSpans = topLevelOfCategory('tool');
-  const tokenSpans = spans.filter(
-    span => hasTokenUsage(span) && !hasAncestorMatching(span, byId, hasTokenUsage)
-  );
+
+  // De-duplicate each token field independently: a span's field counts only if
+  // no ancestor reports that same field, so a parent carrying totalTokens does
+  // not suppress a child carrying the input/output split.
+  const sumTokenField = (field: 'inputTokens' | 'outputTokens' | 'totalTokens'): number | undefined =>
+    sumDefined(
+      spans.filter(
+        span => span[field] !== undefined && !hasAncestorMatching(span, byId, ancestor => ancestor[field] !== undefined)
+      ),
+      span => span[field]
+    );
 
   return {
     success: true,
@@ -158,9 +191,9 @@ export function aggregateSpans(
       llmCalls: llmSpans.length,
       toolMs: sumDefined(toolSpans, spanDurationMs) ?? 0,
       toolCalls: toolSpans.length,
-      inputTokens: sumDefined(tokenSpans, span => span.inputTokens),
-      outputTokens: sumDefined(tokenSpans, span => span.outputTokens),
-      totalTokens: sumDefined(tokenSpans, span => span.totalTokens),
+      inputTokens: sumTokenField('inputTokens'),
+      outputTokens: sumTokenField('outputTokens'),
+      totalTokens: sumTokenField('totalTokens'),
     },
     warnings,
   };
@@ -198,26 +231,98 @@ export function buildTraceComparison(
   };
 
   const warnings: string[] = [];
-  if (baseline.llmCalls !== candidate.llmCalls) {
+  if (baseline.llmCalls !== undefined && candidate.llmCalls !== undefined && baseline.llmCalls !== candidate.llmCalls) {
     warnings.push(
       `LLM call counts differ (baseline ${baseline.llmCalls}, candidate ${candidate.llmCalls}); traces may not be directly comparable`
     );
   }
-  if (baseline.toolCalls !== candidate.toolCalls) {
+  if (
+    baseline.toolCalls !== undefined &&
+    candidate.toolCalls !== undefined &&
+    baseline.toolCalls !== candidate.toolCalls
+  ) {
     warnings.push(
       `Tool call counts differ (baseline ${baseline.toolCalls}, candidate ${candidate.toolCalls}); traces may not be directly comparable`
     );
   }
-  if (baseline.totalTokens !== undefined && candidate.totalTokens !== undefined && baseline.totalTokens > 0) {
-    const relativeDiff = Math.abs(candidate.totalTokens - baseline.totalTokens) / baseline.totalTokens;
-    if (relativeDiff > TOKEN_COMPARABILITY_THRESHOLD) {
+  for (const [field, label] of TOKEN_FIELDS) {
+    const baselineTokens = baseline[field];
+    const candidateTokens = candidate[field];
+    if (baselineTokens === undefined || candidateTokens === undefined) continue;
+    if (baselineTokens > 0) {
+      const relativeDiff = Math.abs(candidateTokens - baselineTokens) / baselineTokens;
+      if (relativeDiff > TOKEN_COMPARABILITY_THRESHOLD) {
+        warnings.push(
+          `${label} usage differs by ${Math.round(relativeDiff * 100)}% (baseline ${baselineTokens}, candidate ${candidateTokens}); traces may not be directly comparable`
+        );
+      }
+    } else if (candidateTokens > 0) {
       warnings.push(
-        `Total token usage differs by ${Math.round(relativeDiff * 100)}% (baseline ${baseline.totalTokens}, candidate ${candidate.totalTokens}); traces may not be directly comparable`
+        `${label} usage differs (baseline ${baselineTokens}, candidate ${candidateTokens}); traces may not be directly comparable`
       );
     }
   }
 
   return { deltas, warnings };
+}
+
+/**
+ * Fetches all span records for one trace: service-side spans from the shared
+ * `aws/spans` log group, then application spans from the endpoint-specific
+ * runtime log group. The endpoint is detected per trace from the service
+ * span's `aws.endpoint.name` attribute (baseline and candidate may use
+ * different endpoints), and ownership is validated against the runtime's
+ * resource ID so a trace from another runtime is rejected rather than
+ * silently producing empty metrics.
+ */
+async function fetchComparisonSpans(
+  region: string,
+  runtimeId: string,
+  traceId: string,
+  startTime?: number,
+  endTime?: number
+): Promise<Result<{ spans: CloudWatchSpanRecord[]; appSpansAvailable: boolean }>> {
+  const queryOpts = { region, traceId, startTime, endTime };
+
+  const serviceResult = await querySpanRecords({ ...queryOpts, logGroupName: SPANS_LOG_GROUP });
+  let serviceSpans: CloudWatchSpanRecord[] = [];
+  if (serviceResult.success) {
+    serviceSpans = serviceResult.spans;
+  } else if (!(serviceResult.error instanceof ResourceNotFoundError)) {
+    return serviceResult;
+  }
+
+  const ownerRuntimeIds = serviceSpans
+    .map(span => (span.cloudResourceId ? RUNTIME_RESOURCE_ID_PATTERN.exec(span.cloudResourceId)?.[1] : undefined))
+    .filter((id): id is string => id !== undefined);
+  if (ownerRuntimeIds.length > 0 && !ownerRuntimeIds.includes(runtimeId)) {
+    return {
+      success: false,
+      error: new ValidationError(`Trace ${traceId} belongs to a different runtime (expected ${runtimeId})`),
+    };
+  }
+
+  const endpointName = serviceSpans.find(span => span.endpointName)?.endpointName ?? DEFAULT_ENDPOINT_NAME;
+
+  const appResult = await querySpanRecords({ ...queryOpts, logGroupName: runtimeLogGroup(runtimeId, endpointName) });
+  let appSpans: CloudWatchSpanRecord[] = [];
+  if (appResult.success) {
+    appSpans = appResult.spans;
+  } else if (!(appResult.error instanceof ResourceNotFoundError)) {
+    return appResult;
+  }
+
+  const merged = new Map<string, CloudWatchSpanRecord>();
+  for (const span of [...serviceSpans, ...appSpans]) {
+    if (!merged.has(span.spanId)) merged.set(span.spanId, span);
+  }
+
+  // Application spans may arrive via the runtime log group or (with transaction
+  // search) directly in aws/spans; either way, anything beyond the service-side
+  // invocation span counts as application data.
+  const appSpansAvailable = appSpans.length > 0 || serviceSpans.some(span => !isInvocationSpan(span));
+
+  return { success: true, spans: [...merged.values()], appSpansAvailable };
 }
 
 /**
@@ -228,8 +333,8 @@ export async function compareTraces(options: CompareTracesOptions): Promise<Comp
   const { region, runtimeId, baselineTraceId, candidateTraceId, startTime, endTime } = options;
 
   const [baselineFetch, candidateFetch] = await Promise.all([
-    fetchSpans(region, runtimeId, baselineTraceId, startTime, endTime),
-    fetchSpans(region, runtimeId, candidateTraceId, startTime, endTime),
+    fetchComparisonSpans(region, runtimeId, baselineTraceId, startTime, endTime),
+    fetchComparisonSpans(region, runtimeId, candidateTraceId, startTime, endTime),
   ]);
 
   if (!baselineFetch.success) return baselineFetch;
@@ -249,9 +354,9 @@ export async function compareTraces(options: CompareTracesOptions): Promise<Comp
     }
   }
 
-  const baselineAgg = aggregateSpans(baselineTraceId, baselineFetch.spans);
+  const baselineAgg = aggregateSpans(baselineTraceId, baselineFetch.spans, baselineFetch.appSpansAvailable);
   if (!baselineAgg.success) return baselineAgg;
-  const candidateAgg = aggregateSpans(candidateTraceId, candidateFetch.spans);
+  const candidateAgg = aggregateSpans(candidateTraceId, candidateFetch.spans, candidateFetch.appSpansAvailable);
   if (!candidateAgg.success) return candidateAgg;
 
   const comparison = buildTraceComparison(baselineAgg.metrics, candidateAgg.metrics);

--- a/src/cli/operations/traces/compare-traces.ts
+++ b/src/cli/operations/traces/compare-traces.ts
@@ -50,6 +50,17 @@ function categorize(span: CloudWatchSpanRecord): SpanCategory {
   return 'other';
 }
 
+/**
+ * Rounds to one decimal place. Applied to latency (ms) and percentage fields at
+ * the output boundary so the JSON contract stays stable — sub-millisecond
+ * precision from nanosecond conversion is measurement noise, and rounding
+ * removes float-arithmetic artifacts (e.g. 2847.0795900000003) that would make
+ * two otherwise-equal runs diff in CI.
+ */
+function roundTo1(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
 function nanoToMs(value?: string): number | undefined {
   if (!value) return undefined;
   const ns = Number(value);
@@ -155,6 +166,7 @@ export function aggregateSpans(
   if (endToEndMs === undefined) {
     return { success: false, error: new ValidationError(`Trace ${traceId} has no spans with timing data`) };
   }
+  endToEndMs = roundTo1(endToEndMs);
 
   if (!appSpansAvailable) {
     warnings.push(
@@ -194,9 +206,9 @@ export function aggregateSpans(
       spanCount: spans.length,
       endToEndMs,
       timingSource,
-      llmMs: sumDefined(llmSpans, spanDurationMs) ?? 0,
+      llmMs: roundTo1(sumDefined(llmSpans, spanDurationMs) ?? 0),
       llmCalls: llmSpans.length,
-      toolMs: sumDefined(toolSpans, spanDurationMs) ?? 0,
+      toolMs: roundTo1(sumDefined(toolSpans, spanDurationMs) ?? 0),
       toolCalls: toolSpans.length,
       inputTokens: sumTokenField('inputTokens'),
       outputTokens: sumTokenField('outputTokens'),
@@ -211,8 +223,8 @@ function metricDelta(baseline?: number, candidate?: number): MetricDelta {
   if (baseline !== undefined) entry.baseline = baseline;
   if (candidate !== undefined) entry.candidate = candidate;
   if (baseline !== undefined && candidate !== undefined) {
-    entry.delta = candidate - baseline;
-    entry.deltaPercent = baseline > 0 ? ((candidate - baseline) / baseline) * 100 : null;
+    entry.delta = roundTo1(candidate - baseline);
+    entry.deltaPercent = baseline > 0 ? roundTo1(((candidate - baseline) / baseline) * 100) : null;
   }
   return entry;
 }

--- a/src/cli/operations/traces/compare-traces.ts
+++ b/src/cli/operations/traces/compare-traces.ts
@@ -16,7 +16,7 @@ const TOOL_OPERATIONS = new Set(['execute_tool']);
 // Fallbacks for spans that predate the operation attribute (framework/provider span names).
 const LLM_NAME_PATTERN = /^chat\b|^invoke_model\b|^text_completion\b|^generate_content\b|InvokeModel|^Model invoke$/i;
 const TOOL_NAME_PATTERN = /^execute_tool\b|^Tool: /i;
-const INVOCATION_NAME_PATTERN = /\/invocations/;
+const INVOCATION_PATH = '/invocations';
 // Relative total-token difference above which the traces are flagged as possibly incomparable.
 const TOKEN_COMPARABILITY_THRESHOLD = 0.2;
 
@@ -50,7 +50,7 @@ function spanDurationMs(span: CloudWatchSpanRecord): number | undefined {
 
 function isInvocationSpan(span: CloudWatchSpanRecord): boolean {
   const name = span.name ?? '';
-  if (!INVOCATION_NAME_PATTERN.test(name)) return false;
+  if (!name.includes(INVOCATION_PATH)) return false;
   // CloudWatch parent/child data can be incomplete, so match kind when present
   // and fall back to the conventional server-span name otherwise.
   if (span.kind) return span.kind.toUpperCase().includes('SERVER');

--- a/src/cli/operations/traces/compare-traces.ts
+++ b/src/cli/operations/traces/compare-traces.ts
@@ -1,0 +1,266 @@
+import { ResourceNotFoundError, ValidationError } from '../../../lib';
+import type { Result } from '../../../lib/result';
+import { fetchSpans } from './get-trace';
+import type {
+  CloudWatchSpanRecord,
+  CompareTracesOptions,
+  CompareTracesResult,
+  MetricDelta,
+  TraceComparisonDeltas,
+  TraceMetrics,
+} from './types';
+
+// OTel GenAI semantic-convention operation names (attributes.gen_ai.operation.name).
+const LLM_OPERATIONS = new Set(['chat', 'text_completion', 'generate_content', 'embeddings', 'invoke_model']);
+const TOOL_OPERATIONS = new Set(['execute_tool']);
+// Fallbacks for spans that predate the operation attribute (framework/provider span names).
+const LLM_NAME_PATTERN = /^chat\b|^invoke_model\b|^text_completion\b|^generate_content\b|InvokeModel|^Model invoke$/i;
+const TOOL_NAME_PATTERN = /^execute_tool\b|^Tool: /i;
+const INVOCATION_NAME_PATTERN = /\/invocations/;
+// Relative total-token difference above which the traces are flagged as possibly incomparable.
+const TOKEN_COMPARABILITY_THRESHOLD = 0.2;
+
+type SpanCategory = 'llm' | 'tool' | 'other';
+
+function categorize(span: CloudWatchSpanRecord): SpanCategory {
+  const operation = span.genAiOperation?.toLowerCase();
+  if (operation && LLM_OPERATIONS.has(operation)) return 'llm';
+  if (operation && TOOL_OPERATIONS.has(operation)) return 'tool';
+  const name = span.name ?? '';
+  if (LLM_NAME_PATTERN.test(name)) return 'llm';
+  if (TOOL_NAME_PATTERN.test(name)) return 'tool';
+  return 'other';
+}
+
+function nanoToMs(value?: string): number | undefined {
+  if (!value) return undefined;
+  const ns = Number(value);
+  if (!Number.isFinite(ns)) return undefined;
+  return ns / 1e6;
+}
+
+function spanDurationMs(span: CloudWatchSpanRecord): number | undefined {
+  const duration = nanoToMs(span.durationNano);
+  if (duration !== undefined) return duration;
+  const start = nanoToMs(span.startTimeUnixNano);
+  const end = nanoToMs(span.endTimeUnixNano);
+  if (start === undefined || end === undefined) return undefined;
+  return end - start;
+}
+
+function isInvocationSpan(span: CloudWatchSpanRecord): boolean {
+  const name = span.name ?? '';
+  if (!INVOCATION_NAME_PATTERN.test(name)) return false;
+  // CloudWatch parent/child data can be incomplete, so match kind when present
+  // and fall back to the conventional server-span name otherwise.
+  if (span.kind) return span.kind.toUpperCase().includes('SERVER');
+  return name.startsWith('POST ');
+}
+
+/**
+ * Walks the parent chain looking for an ancestor matching the predicate.
+ * Unknown parents end the walk (parent links may be incomplete); a visited
+ * set guards against cyclic references in malformed data.
+ */
+function hasAncestorMatching(
+  span: CloudWatchSpanRecord,
+  byId: Map<string, CloudWatchSpanRecord>,
+  predicate: (ancestor: CloudWatchSpanRecord) => boolean
+): boolean {
+  const visited = new Set<string>([span.spanId]);
+  let parentId = span.parentSpanId;
+  while (parentId && !visited.has(parentId)) {
+    const parent = byId.get(parentId);
+    if (!parent) return false;
+    if (predicate(parent)) return true;
+    visited.add(parentId);
+    parentId = parent.parentSpanId;
+  }
+  return false;
+}
+
+function sumDefined(
+  spans: CloudWatchSpanRecord[],
+  pick: (span: CloudWatchSpanRecord) => number | undefined
+): number | undefined {
+  let total: number | undefined;
+  for (const span of spans) {
+    const value = pick(span);
+    if (value !== undefined) total = (total ?? 0) + value;
+  }
+  return total;
+}
+
+function hasTokenUsage(span: CloudWatchSpanRecord): boolean {
+  return span.inputTokens !== undefined || span.outputTokens !== undefined || span.totalTokens !== undefined;
+}
+
+/**
+ * Computes latency and token metrics for a single trace.
+ *
+ * Nested spans of the same category are de-duplicated via parent links: a
+ * framework LLM span and its nested provider client span (e.g. a Strands chat
+ * span wrapping a Bedrock InvokeModel span) count as one model call. Token
+ * usage is likewise summed only from the outermost token-bearing spans.
+ */
+export function aggregateSpans(
+  traceId: string,
+  spans: CloudWatchSpanRecord[]
+): Result<{ metrics: TraceMetrics; warnings: string[] }> {
+  const warnings: string[] = [];
+  const byId = new Map(spans.map(span => [span.spanId, span]));
+
+  let endToEndMs: number | undefined;
+  let timingSource: TraceMetrics['timingSource'] = 'invocation-span';
+
+  const invocationSpan = spans
+    .filter(span => isInvocationSpan(span) && spanDurationMs(span) !== undefined)
+    .sort((a, b) => (nanoToMs(a.startTimeUnixNano) ?? Infinity) - (nanoToMs(b.startTimeUnixNano) ?? Infinity))[0];
+
+  if (invocationSpan) {
+    endToEndMs = spanDurationMs(invocationSpan);
+  } else {
+    const starts = spans.map(span => nanoToMs(span.startTimeUnixNano)).filter((v): v is number => v !== undefined);
+    const ends = spans.map(span => nanoToMs(span.endTimeUnixNano)).filter((v): v is number => v !== undefined);
+    if (starts.length > 0 && ends.length > 0) {
+      endToEndMs = Math.max(...ends) - Math.min(...starts);
+      timingSource = 'span-envelope';
+      warnings.push(
+        `Trace ${traceId}: end-to-end latency derived from earliest/latest span times (no POST /invocations server span found)`
+      );
+    }
+  }
+
+  if (endToEndMs === undefined) {
+    return { success: false, error: new ValidationError(`Trace ${traceId} has no spans with timing data`) };
+  }
+
+  const topLevelOfCategory = (category: SpanCategory): CloudWatchSpanRecord[] =>
+    spans.filter(
+      span =>
+        categorize(span) === category && !hasAncestorMatching(span, byId, ancestor => categorize(ancestor) === category)
+    );
+
+  const llmSpans = topLevelOfCategory('llm');
+  const toolSpans = topLevelOfCategory('tool');
+  const tokenSpans = spans.filter(
+    span => hasTokenUsage(span) && !hasAncestorMatching(span, byId, hasTokenUsage)
+  );
+
+  return {
+    success: true,
+    metrics: {
+      traceId,
+      spanCount: spans.length,
+      endToEndMs,
+      timingSource,
+      llmMs: sumDefined(llmSpans, spanDurationMs) ?? 0,
+      llmCalls: llmSpans.length,
+      toolMs: sumDefined(toolSpans, spanDurationMs) ?? 0,
+      toolCalls: toolSpans.length,
+      inputTokens: sumDefined(tokenSpans, span => span.inputTokens),
+      outputTokens: sumDefined(tokenSpans, span => span.outputTokens),
+      totalTokens: sumDefined(tokenSpans, span => span.totalTokens),
+    },
+    warnings,
+  };
+}
+
+function metricDelta(baseline?: number, candidate?: number): MetricDelta {
+  const entry: MetricDelta = {};
+  if (baseline !== undefined) entry.baseline = baseline;
+  if (candidate !== undefined) entry.candidate = candidate;
+  if (baseline !== undefined && candidate !== undefined) {
+    entry.delta = candidate - baseline;
+    entry.deltaPercent = baseline > 0 ? ((candidate - baseline) / baseline) * 100 : null;
+  }
+  return entry;
+}
+
+/**
+ * Builds per-metric deltas and comparability warnings for two traces.
+ * Warnings flag observable differences (call counts, token usage) — the CLI
+ * cannot prove the two invocations ran equivalent workloads.
+ */
+export function buildTraceComparison(
+  baseline: TraceMetrics,
+  candidate: TraceMetrics
+): { deltas: TraceComparisonDeltas; warnings: string[] } {
+  const deltas: TraceComparisonDeltas = {
+    endToEndMs: metricDelta(baseline.endToEndMs, candidate.endToEndMs),
+    llmMs: metricDelta(baseline.llmMs, candidate.llmMs),
+    toolMs: metricDelta(baseline.toolMs, candidate.toolMs),
+    llmCalls: metricDelta(baseline.llmCalls, candidate.llmCalls),
+    toolCalls: metricDelta(baseline.toolCalls, candidate.toolCalls),
+    inputTokens: metricDelta(baseline.inputTokens, candidate.inputTokens),
+    outputTokens: metricDelta(baseline.outputTokens, candidate.outputTokens),
+    totalTokens: metricDelta(baseline.totalTokens, candidate.totalTokens),
+  };
+
+  const warnings: string[] = [];
+  if (baseline.llmCalls !== candidate.llmCalls) {
+    warnings.push(
+      `LLM call counts differ (baseline ${baseline.llmCalls}, candidate ${candidate.llmCalls}); traces may not be directly comparable`
+    );
+  }
+  if (baseline.toolCalls !== candidate.toolCalls) {
+    warnings.push(
+      `Tool call counts differ (baseline ${baseline.toolCalls}, candidate ${candidate.toolCalls}); traces may not be directly comparable`
+    );
+  }
+  if (baseline.totalTokens !== undefined && candidate.totalTokens !== undefined && baseline.totalTokens > 0) {
+    const relativeDiff = Math.abs(candidate.totalTokens - baseline.totalTokens) / baseline.totalTokens;
+    if (relativeDiff > TOKEN_COMPARABILITY_THRESHOLD) {
+      warnings.push(
+        `Total token usage differs by ${Math.round(relativeDiff * 100)}% (baseline ${baseline.totalTokens}, candidate ${candidate.totalTokens}); traces may not be directly comparable`
+      );
+    }
+  }
+
+  return { deltas, warnings };
+}
+
+/**
+ * Fetches span records for two traces from CloudWatch and compares their
+ * latency and token metrics.
+ */
+export async function compareTraces(options: CompareTracesOptions): Promise<CompareTracesResult> {
+  const { region, runtimeId, baselineTraceId, candidateTraceId, startTime, endTime } = options;
+
+  const [baselineFetch, candidateFetch] = await Promise.all([
+    fetchSpans(region, runtimeId, baselineTraceId, startTime, endTime),
+    fetchSpans(region, runtimeId, candidateTraceId, startTime, endTime),
+  ]);
+
+  if (!baselineFetch.success) return baselineFetch;
+  if (!candidateFetch.success) return candidateFetch;
+
+  for (const [role, traceId, spans] of [
+    ['baseline', baselineTraceId, baselineFetch.spans],
+    ['candidate', candidateTraceId, candidateFetch.spans],
+  ] as const) {
+    if (spans.length === 0) {
+      return {
+        success: false,
+        error: new ResourceNotFoundError(
+          `No spans found for ${role} trace ${traceId}. Traces may take 2-3 minutes to appear in CloudWatch.`
+        ),
+      };
+    }
+  }
+
+  const baselineAgg = aggregateSpans(baselineTraceId, baselineFetch.spans);
+  if (!baselineAgg.success) return baselineAgg;
+  const candidateAgg = aggregateSpans(candidateTraceId, candidateFetch.spans);
+  if (!candidateAgg.success) return candidateAgg;
+
+  const comparison = buildTraceComparison(baselineAgg.metrics, candidateAgg.metrics);
+
+  return {
+    success: true,
+    baseline: baselineAgg.metrics,
+    candidate: candidateAgg.metrics,
+    deltas: comparison.deltas,
+    warnings: [...baselineAgg.warnings, ...candidateAgg.warnings, ...comparison.warnings],
+  };
+}

--- a/src/cli/operations/traces/compare-traces.ts
+++ b/src/cli/operations/traces/compare-traces.ts
@@ -16,9 +16,12 @@ import type {
 // OTel GenAI semantic-convention operation names (attributes.gen_ai.operation.name).
 const LLM_OPERATIONS = new Set(['chat', 'text_completion', 'generate_content', 'embeddings', 'invoke_model']);
 const TOOL_OPERATIONS = new Set(['execute_tool']);
+// Framework span-kind attributes: Traceloop/OpenLLMetry (LangGraph et al.) and OpenInference.
+const OPENINFERENCE_LLM_KINDS = new Set(['llm', 'embedding']);
 // Fallbacks for spans that predate the operation attribute (framework/provider span names).
+// The `.tool` suffix matches Traceloop-instrumented tool spans (e.g. "get_word_frequency.tool").
 const LLM_NAME_PATTERN = /^chat\b|^invoke_model\b|^text_completion\b|^generate_content\b|InvokeModel|^Model invoke$/i;
-const TOOL_NAME_PATTERN = /^execute_tool\b|^Tool: /i;
+const TOOL_NAME_PATTERN = /^execute_tool\b|^Tool: |\.tool$/i;
 const INVOCATION_PATH = '/invocations';
 // Relative per-field token difference above which the traces are flagged as possibly incomparable.
 const TOKEN_COMPARABILITY_THRESHOLD = 0.2;
@@ -37,6 +40,10 @@ function categorize(span: CloudWatchSpanRecord): SpanCategory {
   const operation = span.genAiOperation?.toLowerCase();
   if (operation && LLM_OPERATIONS.has(operation)) return 'llm';
   if (operation && TOOL_OPERATIONS.has(operation)) return 'tool';
+  if (span.traceloopSpanKind?.toLowerCase() === 'tool') return 'tool';
+  const openinferenceKind = span.openinferenceSpanKind?.toLowerCase();
+  if (openinferenceKind && OPENINFERENCE_LLM_KINDS.has(openinferenceKind)) return 'llm';
+  if (openinferenceKind === 'tool') return 'tool';
   const name = span.name ?? '';
   if (LLM_NAME_PATTERN.test(name)) return 'llm';
   if (TOOL_NAME_PATTERN.test(name)) return 'tool';
@@ -266,14 +273,35 @@ export function buildTraceComparison(
   return { deltas, warnings };
 }
 
+/** Runtime identity of a span, from `aws.agent.id` or parsed from `cloud.resource_id`. */
+function spanRuntimeId(span: CloudWatchSpanRecord): string | undefined {
+  if (span.agentId) return span.agentId;
+  if (span.cloudResourceId) return RUNTIME_RESOURCE_ID_PATTERN.exec(span.cloudResourceId)?.[1];
+  return undefined;
+}
+
+/** Merges two records for the same span ID; `primary`'s defined fields win. */
+function mergeSpanRecords(primary: CloudWatchSpanRecord, fallback: CloudWatchSpanRecord): CloudWatchSpanRecord {
+  const merged: Record<string, unknown> = { ...fallback };
+  for (const [key, value] of Object.entries(primary)) {
+    if (value !== undefined) merged[key] = value;
+  }
+  return merged as unknown as CloudWatchSpanRecord;
+}
+
 /**
  * Fetches all span records for one trace: service-side spans from the shared
  * `aws/spans` log group, then application spans from the endpoint-specific
- * runtime log group. The endpoint is detected per trace from the service
- * span's `aws.endpoint.name` attribute (baseline and candidate may use
- * different endpoints), and ownership is validated against the runtime's
- * resource ID so a trace from another runtime is rejected rather than
- * silently producing empty metrics.
+ * runtime log group.
+ *
+ * A distributed trace may span multiple runtimes, so everything is scoped to
+ * the selected runtime: spans identified (via `aws.agent.id` or
+ * `cloud.resource_id`) as belonging to other runtimes are excluded from
+ * metrics, the endpoint is derived only from this runtime's spans (baseline
+ * and candidate may use different endpoints), and a trace whose identified
+ * spans all belong to other runtimes is rejected rather than silently
+ * producing empty metrics. Duplicate records for the same span ID are merged
+ * field by field, preferring defined runtime-log values.
  */
 async function fetchComparisonSpans(
   region: string,
@@ -292,17 +320,23 @@ async function fetchComparisonSpans(
     return serviceResult;
   }
 
-  const ownerRuntimeIds = serviceSpans
-    .map(span => (span.cloudResourceId ? RUNTIME_RESOURCE_ID_PATTERN.exec(span.cloudResourceId)?.[1] : undefined))
-    .filter((id): id is string => id !== undefined);
-  if (ownerRuntimeIds.length > 0 && !ownerRuntimeIds.includes(runtimeId)) {
+  const identified = serviceSpans.filter(span => spanRuntimeId(span) !== undefined);
+  const matched = identified.filter(span => spanRuntimeId(span) === runtimeId);
+  if (identified.length > 0 && matched.length === 0) {
     return {
       success: false,
       error: new ValidationError(`Trace ${traceId} belongs to a different runtime (expected ${runtimeId})`),
     };
   }
 
-  const endpointName = serviceSpans.find(span => span.endpointName)?.endpointName ?? DEFAULT_ENDPOINT_NAME;
+  // Keep this runtime's spans plus spans with no runtime identity; drop other runtimes' spans.
+  const scopedServiceSpans = serviceSpans.filter(span => {
+    const owner = spanRuntimeId(span);
+    return owner === undefined || owner === runtimeId;
+  });
+
+  const endpointSource = matched.length > 0 ? matched : scopedServiceSpans;
+  const endpointName = endpointSource.find(span => span.endpointName)?.endpointName ?? DEFAULT_ENDPOINT_NAME;
 
   const appResult = await querySpanRecords({ ...queryOpts, logGroupName: runtimeLogGroup(runtimeId, endpointName) });
   let appSpans: CloudWatchSpanRecord[] = [];
@@ -313,14 +347,18 @@ async function fetchComparisonSpans(
   }
 
   const merged = new Map<string, CloudWatchSpanRecord>();
-  for (const span of [...serviceSpans, ...appSpans]) {
-    if (!merged.has(span.spanId)) merged.set(span.spanId, span);
+  for (const span of scopedServiceSpans) {
+    merged.set(span.spanId, span);
+  }
+  for (const span of appSpans) {
+    const existing = merged.get(span.spanId);
+    merged.set(span.spanId, existing ? mergeSpanRecords(span, existing) : span);
   }
 
   // Application spans may arrive via the runtime log group or (with transaction
   // search) directly in aws/spans; either way, anything beyond the service-side
   // invocation span counts as application data.
-  const appSpansAvailable = appSpans.length > 0 || serviceSpans.some(span => !isInvocationSpan(span));
+  const appSpansAvailable = appSpans.length > 0 || scopedServiceSpans.some(span => !isInvocationSpan(span));
 
   return { success: true, spans: [...merged.values()], appSpansAvailable };
 }

--- a/src/cli/operations/traces/compare-traces.ts
+++ b/src/cli/operations/traces/compare-traces.ts
@@ -188,6 +188,16 @@ export function aggregateSpans(
   const llmSpans = topLevelOfCategory('llm');
   const toolSpans = topLevelOfCategory('tool');
 
+  // Collect the distinct LLM models seen anywhere in the trace. The model
+  // attribute may sit on the framework span or its nested provider span, so
+  // scan every span; prefer the response model (what actually served) over the
+  // requested model.
+  const models = [
+    ...new Set(
+      spans.map(span => span.responseModel ?? span.requestModel).filter((model): model is string => model !== undefined)
+    ),
+  ].sort();
+
   // De-duplicate each token field independently: a span's field counts only if
   // no ancestor reports that same field, so a parent carrying totalTokens does
   // not suppress a child carrying the input/output split.
@@ -213,6 +223,7 @@ export function aggregateSpans(
       inputTokens: sumTokenField('inputTokens'),
       outputTokens: sumTokenField('outputTokens'),
       totalTokens: sumTokenField('totalTokens'),
+      models: models.length > 0 ? models : undefined,
     },
     warnings,
   };
@@ -250,6 +261,11 @@ export function buildTraceComparison(
   };
 
   const warnings: string[] = [];
+  if (baseline.models && candidate.models && baseline.models.join(',') !== candidate.models.join(',')) {
+    warnings.push(
+      `Models differ (baseline ${baseline.models.join(', ')}, candidate ${candidate.models.join(', ')}); traces may not be directly comparable`
+    );
+  }
   if (baseline.llmCalls !== undefined && candidate.llmCalls !== undefined && baseline.llmCalls !== candidate.llmCalls) {
     warnings.push(
       `LLM call counts differ (baseline ${baseline.llmCalls}, candidate ${candidate.llmCalls}); traces may not be directly comparable`

--- a/src/cli/operations/traces/constants.ts
+++ b/src/cli/operations/traces/constants.ts
@@ -1,0 +1,4 @@
+/** Shared CloudWatch log group holding OTel spans for all runtimes in a region. */
+export const SPANS_LOG_GROUP = 'aws/spans';
+
+export const TRACE_ID_PATTERN = /^[a-fA-F0-9-]+$/;

--- a/src/cli/operations/traces/get-trace.ts
+++ b/src/cli/operations/traces/get-trace.ts
@@ -41,7 +41,10 @@ export async function querySpanRecords(
   attributes.http.status_code as httpStatusCode,
   attributes.session.id as sessionId,
   attributes.gen_ai.operation.name as genAiOperation,
-  attributes.aws.endpoint.name as endpointName
+  attributes.aws.endpoint.name as endpointName,
+  attributes.aws.agent.id as agentId,
+  attributes.traceloop.span.kind as traceloopSpanKind,
+  attributes.openinference.span.kind as openinferenceSpanKind
 | filter ispresent(traceId) and ispresent(resource.attributes.service.name)
 | filter resource.attributes.aws.service.type = "gen_ai_agent"
 | filter ispresent(kind)
@@ -74,6 +77,9 @@ export async function querySpanRecords(
       sessionId: row.sessionId ?? undefined,
       genAiOperation: row.genAiOperation ?? undefined,
       endpointName: row.endpointName ?? undefined,
+      agentId: row.agentId ?? undefined,
+      traceloopSpanKind: row.traceloopSpanKind ?? undefined,
+      openinferenceSpanKind: row.openinferenceSpanKind ?? undefined,
     }));
 
   return { success: true, spans };

--- a/src/cli/operations/traces/get-trace.ts
+++ b/src/cli/operations/traces/get-trace.ts
@@ -1,6 +1,7 @@
 import { ResourceNotFoundError, ValidationError } from '../../../lib';
 import type { Result } from '../../../lib/result';
 import { runtimeLogGroup } from '../../aws/cloudwatch';
+import { SPANS_LOG_GROUP, TRACE_ID_PATTERN } from './constants';
 import { runInsightsQuery } from './insights-query';
 import type {
   CloudWatchSpanRecord,
@@ -9,12 +10,74 @@ import type {
   FetchTraceRecordsResult,
   GetTraceOptions,
   GetTraceResult,
+  QuerySpanRecordsOptions,
 } from './types';
 import fs from 'node:fs';
 import path from 'node:path';
 
-const SPANS_LOG_GROUP = 'aws/spans';
-const TRACE_ID_PATTERN = /^[a-fA-F0-9-]+$/;
+/**
+ * Queries structured span records for one trace from a single CloudWatch log group.
+ */
+export async function querySpanRecords(
+  options: QuerySpanRecordsOptions
+): Promise<Result<{ spans: CloudWatchSpanRecord[] }>> {
+  const { region, logGroupName, traceId, startTime, endTime } = options;
+
+  if (!TRACE_ID_PATTERN.test(traceId)) {
+    return {
+      success: false,
+      error: new ValidationError('Invalid trace ID format. Expected a hex string (e.g., abc123def456).'),
+    };
+  }
+
+  const queryString = `fields traceId, spanId, parentSpanId, name, kind,
+  startTimeUnixNano, endTimeUnixNano, durationNano,
+  status.code as statusCode,
+  resource.attributes.service.name as serviceName,
+  resource.attributes.cloud.resource_id as cloudResourceId,
+  attributes.gen_ai.usage.input_tokens as inputTokens,
+  attributes.gen_ai.usage.output_tokens as outputTokens,
+  attributes.gen_ai.usage.total_tokens as totalTokens,
+  attributes.http.status_code as httpStatusCode,
+  attributes.session.id as sessionId,
+  attributes.gen_ai.operation.name as genAiOperation,
+  attributes.aws.endpoint.name as endpointName
+| filter ispresent(traceId) and ispresent(resource.attributes.service.name)
+| filter resource.attributes.aws.service.type = "gen_ai_agent"
+| filter ispresent(kind)
+| filter traceId = '${traceId}'
+| sort startTimeUnixNano asc`;
+
+  const result = await runInsightsQuery({ region, logGroupName, queryString, startTime, endTime });
+  if (!result.success) {
+    return result;
+  }
+
+  const spans: CloudWatchSpanRecord[] = result.rows
+    .filter(row => row.traceId && row.spanId)
+    .map(row => ({
+      traceId: row.traceId!,
+      spanId: row.spanId!,
+      parentSpanId: row.parentSpanId ?? undefined,
+      name: row.name ?? undefined,
+      kind: row.kind ?? undefined,
+      startTimeUnixNano: row.startTimeUnixNano ?? undefined,
+      endTimeUnixNano: row.endTimeUnixNano ?? undefined,
+      durationNano: row.durationNano ?? undefined,
+      statusCode: row.statusCode ?? undefined,
+      serviceName: row.serviceName ?? undefined,
+      cloudResourceId: row.cloudResourceId ?? undefined,
+      inputTokens: row.inputTokens ? Number(row.inputTokens) : undefined,
+      outputTokens: row.outputTokens ? Number(row.outputTokens) : undefined,
+      totalTokens: row.totalTokens ? Number(row.totalTokens) : undefined,
+      httpStatusCode: row.httpStatusCode ? Number(row.httpStatusCode) : undefined,
+      sessionId: row.sessionId ?? undefined,
+      genAiOperation: row.genAiOperation ?? undefined,
+      endpointName: row.endpointName ?? undefined,
+    }));
+
+  return { success: true, spans };
+}
 
 export async function fetchSpans(
   region: string,
@@ -30,59 +93,22 @@ export async function fetchSpans(
     };
   }
 
-  const queryString = `fields traceId, spanId, parentSpanId, name, kind,
-  startTimeUnixNano, endTimeUnixNano, durationNano,
-  status.code as statusCode,
-  resource.attributes.service.name as serviceName,
-  attributes.gen_ai.usage.input_tokens as inputTokens,
-  attributes.gen_ai.usage.output_tokens as outputTokens,
-  attributes.gen_ai.usage.total_tokens as totalTokens,
-  attributes.http.status_code as httpStatusCode,
-  attributes.session.id as sessionId,
-  attributes.gen_ai.operation.name as genAiOperation
-| filter ispresent(traceId) and ispresent(resource.attributes.service.name)
-| filter resource.attributes.aws.service.type = "gen_ai_agent"
-| filter ispresent(kind)
-| filter traceId = '${traceId}'
-| sort startTimeUnixNano asc`;
-
-  const queryOpts = { region, queryString, startTime, endTime };
+  const queryOpts = { region, traceId, startTime, endTime };
   const results = await Promise.all([
-    runInsightsQuery({ ...queryOpts, logGroupName: SPANS_LOG_GROUP }),
-    runInsightsQuery({ ...queryOpts, logGroupName: runtimeLogGroup(runtimeId) }),
+    querySpanRecords({ ...queryOpts, logGroupName: SPANS_LOG_GROUP }),
+    querySpanRecords({ ...queryOpts, logGroupName: runtimeLogGroup(runtimeId) }),
   ]);
 
-  const allRows: Record<string, string>[] = [];
+  const spans: CloudWatchSpanRecord[] = [];
   for (const result of results) {
     if (result.success) {
-      allRows.push(...result.rows);
+      spans.push(...result.spans);
     } else if (result.error instanceof ResourceNotFoundError) {
       continue;
     } else {
       return { success: false, error: result.error };
     }
   }
-
-  const spans: CloudWatchSpanRecord[] = allRows
-    .filter(row => row.traceId && row.spanId)
-    .map(row => ({
-      traceId: row.traceId!,
-      spanId: row.spanId!,
-      parentSpanId: row.parentSpanId ?? undefined,
-      name: row.name ?? undefined,
-      kind: row.kind ?? undefined,
-      startTimeUnixNano: row.startTimeUnixNano ?? undefined,
-      endTimeUnixNano: row.endTimeUnixNano ?? undefined,
-      durationNano: row.durationNano ?? undefined,
-      statusCode: row.statusCode ?? undefined,
-      serviceName: row.serviceName ?? undefined,
-      inputTokens: row.inputTokens ? Number(row.inputTokens) : undefined,
-      outputTokens: row.outputTokens ? Number(row.outputTokens) : undefined,
-      totalTokens: row.totalTokens ? Number(row.totalTokens) : undefined,
-      httpStatusCode: row.httpStatusCode ? Number(row.httpStatusCode) : undefined,
-      sessionId: row.sessionId ?? undefined,
-      genAiOperation: row.genAiOperation ?? undefined,
-    }));
 
   return { success: true, spans };
 }

--- a/src/cli/operations/traces/get-trace.ts
+++ b/src/cli/operations/traces/get-trace.ts
@@ -44,7 +44,9 @@ export async function querySpanRecords(
   attributes.aws.endpoint.name as endpointName,
   attributes.aws.agent.id as agentId,
   attributes.traceloop.span.kind as traceloopSpanKind,
-  attributes.openinference.span.kind as openinferenceSpanKind
+  attributes.openinference.span.kind as openinferenceSpanKind,
+  attributes.gen_ai.request.model as requestModel,
+  attributes.gen_ai.response.model as responseModel
 | filter ispresent(traceId) and ispresent(resource.attributes.service.name)
 | filter resource.attributes.aws.service.type = "gen_ai_agent"
 | filter ispresent(kind)
@@ -80,6 +82,8 @@ export async function querySpanRecords(
       agentId: row.agentId ?? undefined,
       traceloopSpanKind: row.traceloopSpanKind ?? undefined,
       openinferenceSpanKind: row.openinferenceSpanKind ?? undefined,
+      requestModel: row.requestModel ?? undefined,
+      responseModel: row.responseModel ?? undefined,
     }));
 
   return { success: true, spans };

--- a/src/cli/operations/traces/get-trace.ts
+++ b/src/cli/operations/traces/get-trace.ts
@@ -16,7 +16,7 @@ import path from 'node:path';
 const SPANS_LOG_GROUP = 'aws/spans';
 const TRACE_ID_PATTERN = /^[a-fA-F0-9-]+$/;
 
-async function fetchSpans(
+export async function fetchSpans(
   region: string,
   runtimeId: string,
   traceId: string,
@@ -38,7 +38,8 @@ async function fetchSpans(
   attributes.gen_ai.usage.output_tokens as outputTokens,
   attributes.gen_ai.usage.total_tokens as totalTokens,
   attributes.http.status_code as httpStatusCode,
-  attributes.session.id as sessionId
+  attributes.session.id as sessionId,
+  attributes.gen_ai.operation.name as genAiOperation
 | filter ispresent(traceId) and ispresent(resource.attributes.service.name)
 | filter resource.attributes.aws.service.type = "gen_ai_agent"
 | filter ispresent(kind)
@@ -80,6 +81,7 @@ async function fetchSpans(
       totalTokens: row.totalTokens ? Number(row.totalTokens) : undefined,
       httpStatusCode: row.httpStatusCode ? Number(row.httpStatusCode) : undefined,
       sessionId: row.sessionId ?? undefined,
+      genAiOperation: row.genAiOperation ?? undefined,
     }));
 
   return { success: true, spans };

--- a/src/cli/operations/traces/index.ts
+++ b/src/cli/operations/traces/index.ts
@@ -1,6 +1,6 @@
 export { buildTraceConsoleUrl } from './trace-url';
 export { listTraces } from './list-traces';
-export { fetchTraceRecords, getTrace } from './get-trace';
+export { fetchSpans, fetchTraceRecords, getTrace } from './get-trace';
 export { runInsightsQuery, type InsightsQueryOptions, type InsightsQueryResult } from './insights-query';
 export type {
   CloudWatchSpanRecord,

--- a/src/cli/operations/traces/index.ts
+++ b/src/cli/operations/traces/index.ts
@@ -1,6 +1,6 @@
 export { buildTraceConsoleUrl } from './trace-url';
 export { listTraces } from './list-traces';
-export { fetchSpans, fetchTraceRecords, getTrace } from './get-trace';
+export { fetchSpans, fetchTraceRecords, getTrace, querySpanRecords } from './get-trace';
 export { aggregateSpans, buildTraceComparison, compareTraces } from './compare-traces';
 export { runInsightsQuery, type InsightsQueryOptions, type InsightsQueryResult } from './insights-query';
 export type {

--- a/src/cli/operations/traces/index.ts
+++ b/src/cli/operations/traces/index.ts
@@ -1,15 +1,22 @@
 export { buildTraceConsoleUrl } from './trace-url';
 export { listTraces } from './list-traces';
 export { fetchSpans, fetchTraceRecords, getTrace } from './get-trace';
+export { aggregateSpans, buildTraceComparison, compareTraces } from './compare-traces';
 export { runInsightsQuery, type InsightsQueryOptions, type InsightsQueryResult } from './insights-query';
 export type {
   CloudWatchSpanRecord,
   CloudWatchTraceRecord,
+  CompareTracesOptions,
+  CompareTracesResult,
   FetchTraceRecordsOptions,
   FetchTraceRecordsResult,
   GetTraceOptions,
   GetTraceResult,
   ListTracesOptions,
   ListTracesResult,
+  MetricDelta,
+  TraceComparisonDeltas,
+  TraceComparisonMetricKey,
   TraceEntry,
+  TraceMetrics,
 } from './types';

--- a/src/cli/operations/traces/types.ts
+++ b/src/cli/operations/traces/types.ts
@@ -23,6 +23,16 @@ export interface CloudWatchSpanRecord {
   httpStatusCode?: number;
   sessionId?: string;
   genAiOperation?: string;
+  cloudResourceId?: string;
+  endpointName?: string;
+}
+
+export interface QuerySpanRecordsOptions {
+  region: string;
+  logGroupName: string;
+  traceId: string;
+  startTime?: number;
+  endTime?: number;
 }
 
 export interface FetchTraceRecordsOptions {
@@ -65,10 +75,11 @@ export interface TraceMetrics {
   endToEndMs: number;
   /** 'invocation-span' when derived from the POST /invocations server span; 'span-envelope' is the labeled fallback. */
   timingSource: 'invocation-span' | 'span-envelope';
-  llmMs: number;
-  llmCalls: number;
-  toolMs: number;
-  toolCalls: number;
+  /** LLM/tool/token fields are undefined (not zero) when application spans are unavailable for the trace. */
+  llmMs?: number;
+  llmCalls?: number;
+  toolMs?: number;
+  toolCalls?: number;
   inputTokens?: number;
   outputTokens?: number;
   totalTokens?: number;

--- a/src/cli/operations/traces/types.ts
+++ b/src/cli/operations/traces/types.ts
@@ -22,6 +22,7 @@ export interface CloudWatchSpanRecord {
   totalTokens?: number;
   httpStatusCode?: number;
   sessionId?: string;
+  genAiOperation?: string;
 }
 
 export interface FetchTraceRecordsOptions {

--- a/src/cli/operations/traces/types.ts
+++ b/src/cli/operations/traces/types.ts
@@ -28,6 +28,8 @@ export interface CloudWatchSpanRecord {
   agentId?: string;
   traceloopSpanKind?: string;
   openinferenceSpanKind?: string;
+  requestModel?: string;
+  responseModel?: string;
 }
 
 export interface QuerySpanRecordsOptions {
@@ -86,6 +88,8 @@ export interface TraceMetrics {
   inputTokens?: number;
   outputTokens?: number;
   totalTokens?: number;
+  /** Distinct LLM models observed in the trace (from gen_ai.response/request.model); undefined when none reported. */
+  models?: string[];
 }
 
 export interface MetricDelta {

--- a/src/cli/operations/traces/types.ts
+++ b/src/cli/operations/traces/types.ts
@@ -25,6 +25,9 @@ export interface CloudWatchSpanRecord {
   genAiOperation?: string;
   cloudResourceId?: string;
   endpointName?: string;
+  agentId?: string;
+  traceloopSpanKind?: string;
+  openinferenceSpanKind?: string;
 }
 
 export interface QuerySpanRecordsOptions {

--- a/src/cli/operations/traces/types.ts
+++ b/src/cli/operations/traces/types.ts
@@ -58,6 +58,58 @@ export interface TraceEntry {
   spanCount?: string;
 }
 
+/** Aggregated latency/token metrics computed from one trace's spans. */
+export interface TraceMetrics {
+  traceId: string;
+  spanCount: number;
+  endToEndMs: number;
+  /** 'invocation-span' when derived from the POST /invocations server span; 'span-envelope' is the labeled fallback. */
+  timingSource: 'invocation-span' | 'span-envelope';
+  llmMs: number;
+  llmCalls: number;
+  toolMs: number;
+  toolCalls: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+}
+
+export interface MetricDelta {
+  baseline?: number;
+  candidate?: number;
+  delta?: number;
+  /** Percentage change relative to baseline; null when the baseline is zero or absent. */
+  deltaPercent?: number | null;
+}
+
+export type TraceComparisonMetricKey =
+  | 'endToEndMs'
+  | 'llmMs'
+  | 'toolMs'
+  | 'llmCalls'
+  | 'toolCalls'
+  | 'inputTokens'
+  | 'outputTokens'
+  | 'totalTokens';
+
+export type TraceComparisonDeltas = Record<TraceComparisonMetricKey, MetricDelta>;
+
+export interface CompareTracesOptions {
+  region: string;
+  runtimeId: string;
+  baselineTraceId: string;
+  candidateTraceId: string;
+  startTime?: number;
+  endTime?: number;
+}
+
+export type CompareTracesResult = Result<{
+  baseline: TraceMetrics;
+  candidate: TraceMetrics;
+  deltas: TraceComparisonDeltas;
+  warnings: string[];
+}>;
+
 export interface ListTracesOptions {
   region: string;
   runtimeId: string;

--- a/src/cli/telemetry/schemas/command-run.ts
+++ b/src/cli/telemetry/schemas/command-run.ts
@@ -270,6 +270,7 @@ export const COMMAND_SCHEMAS = {
   'resume.online-insights': PauseResumeOnlineEvalAttrs,
   'traces.list': NoAttrs,
   'traces.get': NoAttrs,
+  'traces.compare': NoAttrs,
   'evals.history': NoAttrs,
   import: NoAttrs,
   'import.runtime': NoAttrs,


### PR DESCRIPTION
## Summary

## Problem

  AgentCore traces can contain runtime, model, and tool spans across the shared
  `aws/spans` log group and endpoint-specific application log groups. CloudWatch
  does not currently provide a practical way to compare two invocations side by side, and its
  trace view may show the invocation as one span containing many events.

  Diagnosing a latency regression therefore requires manually exporting both
  traces, correlating endpoint log groups, de-duplicating spans, and calculating
  latency and token differences.

  ## Solution

  Adds `agentcore traces compare` to compare two AgentCore runtime traces using CloudWatch telemetry.

  The command reports:

  - End-to-end duration
  - LLM time and call count
  - Tool time and call count
  - Input, output, and total tokens
  - Absolute and percentage deltas
  - Comparability warnings
  - Human-readable and JSON output

  It supports traces from named runtime endpoints and validates the selected runtime.

  ## Example

  ```bash
 agentcore traces compare 6a650d4d5967b68b44a9ac2f71c20cf0 6a650d27066bdda15a10a0991e47b730
Trace comparison: baseline 6a650d4d5967b68b44a9ac2f71c20cf0 → candidate 6a650d27066bdda15a10a0991e47b730

Metric                      Baseline     Candidate                   Delta
End-to-end latency             6.33s         5.70s         -0.63s (-10.0%)
LLM latency                    3.67s         2.85s         -0.82s (-22.4%)
Tool latency                   2.58s         2.77s          +0.19s (+7.3%)
LLM calls                          2             2                0 (0.0%)
Tool calls                         1             1                0 (0.0%)
Input tokens                   2,848         2,829             -19 (-0.7%)
Output tokens                    300           248            -52 (-17.3%)
Total tokens                   3,148         3,077             -71 (-2.3%)

Baseline model(s): us.anthropic.claude-haiku-4-5-20251001-v1:0
Candidate model(s): us.anthropic.claude-haiku-4-5-20251001-v1:0


  agentcore traces compare \
    --agent githubagent \
    --baseline-trace-id <baseline-trace-id> \
    --candidate-trace-id <candidate-trace-id> \
    --json | jq .

{
  "success": true,
  "agentName": "githubagent",
  "targetName": "default",
  "consoleUrl": "https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#/gen-ai-observability/agent-core/agent-alias/alias/endpoint/DEFAULT/agent/githubagent?start=-43200000&resourceId=arn%3Aaws%3Abedrock-agentcore%3Aus-east-1%3A801945369277%3Aruntime%2FRuntime-f0DXUN7T-is%2Fruntime-endpoint%2FDEFAULT%3ADEFAULT&serviceName=service.DEFAULT&tabId=traces",
  "baseline": {
    "traceId": "6a650d4d5967b68b44a9ac2f71c20cf0",
    "spanCount": 12,
    "endToEndMs": 6334.9,
    "timingSource": "invocation-span",
    "llmMs": 3671.3,
    "llmCalls": 2,
    "toolMs": 2578.3,
    "toolCalls": 1,
    "inputTokens": 2848,
    "outputTokens": 300,
    "totalTokens": 3148,
    "models": [
      "us.anthropic.claude-haiku-4-5-20251001-v1:0"
    ]
  },
  "candidate": {
    "traceId": "6a650d27066bdda15a10a0991e47b730",
    "spanCount": 12,
    "endToEndMs": 5701.9,
    "timingSource": "invocation-span",
    "llmMs": 2847.1,
    "llmCalls": 2,
    "toolMs": 2766.3,
    "toolCalls": 1,
    "inputTokens": 2829,
    "outputTokens": 248,
    "totalTokens": 3077,
    "models": [
      "us.anthropic.claude-haiku-4-5-20251001-v1:0"
    ]
  },
  "deltas": {
    "endToEndMs": {
      "baseline": 6334.9,
      "candidate": 5701.9,
      "delta": -633,
      "deltaPercent": -10
    },
    "llmMs": {
      "baseline": 3671.3,
      "candidate": 2847.1,
      "delta": -824.2,
      "deltaPercent": -22.4
    },
    "toolMs": {
      "baseline": 2578.3,
      "candidate": 2766.3,
      "delta": 188,
      "deltaPercent": 7.3
    },
    "llmCalls": {
      "baseline": 2,
      "candidate": 2,
      "delta": 0,
      "deltaPercent": 0
    },
    "toolCalls": {
      "baseline": 1,
      "candidate": 1,
      "delta": 0,
      "deltaPercent": 0
    },
    "inputTokens": {
      "baseline": 2848,
      "candidate": 2829,
      "delta": -19,
      "deltaPercent": -0.7
    },
    "outputTokens": {
      "baseline": 300,
      "candidate": 248,
      "delta": -52,
      "deltaPercent": -17.3
    },
    "totalTokens": {
      "baseline": 3148,
      "candidate": 3077,
      "delta": -71,
      "deltaPercent": -2.3
    }
  },
  "warnings": []
}
    

  ## Validation

  - [v] Lint passes
  - [v] Tested against DEFAULT and named runtime endpoints
  Closes #1830