### PR TITLE
fix(deps): update react-router to 8.3.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
         "lodash": "^4.18.1",
         "react": "^19.2.7",
         "react-devtools-core": "^7.0.1",
-        "react-router": "^8.1.0",
+        "react-router": "^8.3.0",
         "winston": "^3.19.0",
         "winston-daily-rotate-file": "^5.0.0",
         "zod": "^4.4.3",
@@ -262,7 +262,7 @@
 
     "react-reconciler": ["react-reconciler@0.33.0", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA=="],
 
-    "react-router": ["react-router@8.2.0", "", { "dependencies": { "cookie-es": "^3.1.1" }, "peerDependencies": { "react": ">=19.2.7", "react-dom": ">=19.2.7" }, "optionalPeers": ["react-dom"] }, "sha512-uP1LgGNHyilL1u+ZkecQk74DJOKOb6q4NLNYLRJcD/fjoogftNb5/Rj/07o/QBFsY/5MbAKPm1peTCQuVPv9cQ=="],
+    "react-router": ["react-router@8.3.0", "", { "dependencies": { "cookie-es": "^3.1.1" }, "peerDependencies": { "react": ">=19.2.7", "react-dom": ">=19.2.7" }, "optionalPeers": ["react-dom"] }, "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ=="],
 
     "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "lodash": "^4.18.1",
     "react": "^19.2.7",
     "react-devtools-core": "^7.0.1",
-    "react-router": "^8.1.0",
+    "react-router": "^8.3.0",
     "winston": "^3.19.0",
     "winston-daily-rotate-file": "^5.0.0",
     "zod": "^4.4.3"


### PR DESCRIPTION
## Description

Updates React Router from `8.2.0` to `8.3.0` and raises the manifest minimum to `^8.3.0`.

This resolves [GHSA-qwww-vcr4-c8h2](https://github.com/advisories/GHSA-qwww-vcr4-c8h2), which currently causes `bun audit` to fail on the `refactor` branch and its dependent pull requests.

## Related Issue

N/A - this is a targeted dependency remediation for an existing CI failure.

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe): Security dependency update

## Testing

How have you tested the change?

- [x] I ran `bun audit` (no vulnerabilities found)
- [x] I ran `bun test` (331 passed, 0 failed)
- [x] I ran `bun run typecheck`
- [x] I ran `bun run lint:check`
- [x] I ran `bun run format:check`
- [x] I ran `bun run build`
- [x] `src/assets/` was not modified, so snapshots do not require updates

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] No additional tests are required for this lockfile-only package upgrade
- [x] No documentation changes are required
- [x] My changes generate no new warnings
- [x] No dependent package changes are required

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
