### PR TITLE
feat(project): scaffold add/remove/dev/deploy/status/build commands

### DIFF
--- a/src/errors/errors.tsx
+++ b/src/errors/errors.tsx
@@ -64,3 +64,10 @@ export class InputValidationError extends AgentCoreCLIError {
     super(message, { ...options, source: ERROR_SOURCE.USER });
   }
 }
+
+/** Error raised when a command or operation has not been implemented yet. */
+export class NotImplementedError extends AgentCoreCLIError {
+  constructor(message?: string, options?: Omit<AgentCoreCLIErrorOptions, "source">) {
+    super(message ?? "not implemented yet", { ...options, source: ERROR_SOURCE.INTERNAL });
+  }
+}

--- a/src/errors/index.tsx
+++ b/src/errors/index.tsx
@@ -1,2 +1,7 @@
-export { AgentCoreCLIError, InputValidationError, type AgentCoreCLIErrorOptions } from "./errors";
+export {
+  AgentCoreCLIError,
+  InputValidationError,
+  NotImplementedError,
+  type AgentCoreCLIErrorOptions,
+} from "./errors";
 export { ERROR_SOURCE } from "./types";

--- a/src/handlers/project/add/index.ts
+++ b/src/handlers/project/add/index.ts
@@ -1,0 +1,11 @@
+import { createHandler } from "../../../router";
+import { NotImplementedError } from "../../../errors";
+
+export const createAddProjectHandler = () =>
+  createHandler({
+    name: "add",
+    description: "add a resource to the project",
+    handle: async () => {
+      throw new NotImplementedError("agentcore project add is not implemented yet");
+    },
+  });

--- a/src/handlers/project/build/index.ts
+++ b/src/handlers/project/build/index.ts
@@ -1,0 +1,11 @@
+import { createHandler } from "../../../router";
+import { NotImplementedError } from "../../../errors";
+
+export const createBuildProjectHandler = () =>
+  createHandler({
+    name: "build",
+    description: "build the project's deployable artifacts",
+    handle: async () => {
+      throw new NotImplementedError("agentcore project build is not implemented yet");
+    },
+  });

--- a/src/handlers/project/deploy/index.ts
+++ b/src/handlers/project/deploy/index.ts
@@ -1,0 +1,11 @@
+import { createHandler } from "../../../router";
+import { NotImplementedError } from "../../../errors";
+
+export const createDeployProjectHandler = () =>
+  createHandler({
+    name: "deploy",
+    description: "deploy the project to AWS",
+    handle: async () => {
+      throw new NotImplementedError("agentcore project deploy is not implemented yet");
+    },
+  });

--- a/src/handlers/project/dev/index.ts
+++ b/src/handlers/project/dev/index.ts
@@ -1,0 +1,11 @@
+import { createHandler } from "../../../router";
+import { NotImplementedError } from "../../../errors";
+
+export const createDevProjectHandler = () =>
+  createHandler({
+    name: "dev",
+    description: "run the project locally for development",
+    handle: async () => {
+      throw new NotImplementedError("agentcore project dev is not implemented yet");
+    },
+  });

--- a/src/handlers/project/index.ts
+++ b/src/handlers/project/index.ts
@@ -1,5 +1,11 @@
 import { Router } from "../../router";
 import { createCreateProjectHandler } from "./create";
+import { createAddProjectHandler } from "./add";
+import { createRemoveProjectHandler } from "./remove";
+import { createDevProjectHandler } from "./dev";
+import { createDeployProjectHandler } from "./deploy";
+import { createStatusProjectHandler } from "./status";
+import { createBuildProjectHandler } from "./build";
 import type { ProjectManager } from "./types";
 
 type ProjectHandlerConfig = {
@@ -10,6 +16,12 @@ export function createProjectHandler(config: ProjectHandlerConfig): Router {
   const project = new Router("project", "manage an AgentCore project");
 
   project.handler(createCreateProjectHandler({ projectManager: config.projectManager }));
+  project.handler(createAddProjectHandler());
+  project.handler(createRemoveProjectHandler());
+  project.handler(createDevProjectHandler());
+  project.handler(createDeployProjectHandler());
+  project.handler(createStatusProjectHandler());
+  project.handler(createBuildProjectHandler());
 
   return project;
 }

--- a/src/handlers/project/project.test.ts
+++ b/src/handlers/project/project.test.ts
@@ -17,6 +17,12 @@ async function run(args: string[]): Promise<void> {
   await root.route(["node", "agentcore", "project", ...args]);
 }
 
+describe.each(["add", "remove", "dev", "deploy", "status", "build"])("project %s", (command) => {
+  test("throws because it is not implemented yet", async () => {
+    await expect(run([command])).rejects.toThrow(/not implemented/);
+  });
+});
+
 describe("project create", () => {
   test("throws because it is not implemented yet", async () => {
     await expect(run(["create"])).rejects.toThrow(/not implemented/);

--- a/src/handlers/project/remove/index.ts
+++ b/src/handlers/project/remove/index.ts
@@ -1,0 +1,11 @@
+import { createHandler } from "../../../router";
+import { NotImplementedError } from "../../../errors";
+
+export const createRemoveProjectHandler = () =>
+  createHandler({
+    name: "remove",
+    description: "remove a resource from the project",
+    handle: async () => {
+      throw new NotImplementedError("agentcore project remove is not implemented yet");
+    },
+  });

--- a/src/handlers/project/status/index.ts
+++ b/src/handlers/project/status/index.ts
@@ -1,0 +1,11 @@
+import { createHandler } from "../../../router";
+import { NotImplementedError } from "../../../errors";
+
+export const createStatusProjectHandler = () =>
+  createHandler({
+    name: "status",
+    description: "show the status of the project's deployed resources",
+    handle: async () => {
+      throw new NotImplementedError("agentcore project status is not implemented yet");
+    },
+  });


### PR DESCRIPTION
## What

Scaffolds six `agentcore project` subcommands: `add`, `remove`, `dev`, `deploy`, `status`, `build`.

- Each handler follows the directory-per-command layout with a `create<Name>ProjectHandler()` factory and throws `NotImplementedError`.
- Adds `NotImplementedError` to `src/errors`, a subclass of `AgentCoreCLIError` with `INTERNAL` source.
- No flags, screens, or Core interfaces yet; those land with the real implementations.

## Testing

- Parameterized test in `project.test.ts` asserts each command throws `not implemented` through the real root handler.
- Full suite: 424 pass, 0 fail. `tsc --noEmit` and Prettier clean.