### PR TITLE
fix(errors): define new custom errors for failures. 

### DIFF
--- a/src/errors/index.tsx
+++ b/src/errors/index.tsx
@@ -1,1 +1,2 @@
-export { AgentCoreCLIError, InputValidationError } from "./errors";
+export { AgentCoreCLIError, InputValidationError, type AgentCoreCLIErrorOptions } from "./errors";
+export { ERROR_SOURCE } from "./types";

--- a/src/globalConfig/accessor.tsx
+++ b/src/globalConfig/accessor.tsx
@@ -8,7 +8,8 @@ import type { ReadWriteJson } from "../io";
 import type { Logger } from "../logging";
 import { globalConfigFileSchema } from "./types";
 import { DEFAULT_GLOBAL_CONFIG, applyOverrides } from "./config";
-import { AgentCoreCLIError, ERROR_SOURCE, type AgentCoreCLIErrorOptions } from "../errors";
+import z from "zod";
+import { InputValidationError } from "../errors";
 
 type DefaultGlobalConfigAccessorConfig = {
   logger: Logger;
@@ -76,7 +77,7 @@ export class DefaultGlobalConfigAccessor implements GlobalConfigAccessor {
   private async writeToConfigFile(data: GlobalConfigFileData): Promise<GlobalConfigFileData> {
     const dataParseResult = globalConfigFileSchema.safeParse(data);
     if (!dataParseResult.success) {
-      throw new InternalValidationError("failed to validate config data before writing to file", {
+      throw new InputValidationError(z.prettifyError(dataParseResult.error), {
         cause: dataParseResult.error,
       });
     }
@@ -127,11 +128,4 @@ function diff<T extends Record<string, unknown>>(a: T, b: T): DeepPartial<T> {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-/** Error raised by invalid data coming from internal sources **/
-export class InternalValidationError extends AgentCoreCLIError {
-  constructor(message?: string, options?: Omit<AgentCoreCLIErrorOptions, "source">) {
-    super(message, { ...options, source: ERROR_SOURCE.INTERNAL });
-  }
 }

--- a/src/globalConfig/accessor.tsx
+++ b/src/globalConfig/accessor.tsx
@@ -76,7 +76,7 @@ export class DefaultGlobalConfigAccessor implements GlobalConfigAccessor {
   private async writeToConfigFile(data: GlobalConfigFileData): Promise<GlobalConfigFileData> {
     const dataParseResult = globalConfigFileSchema.safeParse(data);
     if (!dataParseResult.success) {
-      throw new InternalValidationError("failed to valide config data before writing to file", {
+      throw new InternalValidationError("failed to validate config data before writing to file", {
         cause: dataParseResult.error,
       });
     }

--- a/src/globalConfig/accessor.tsx
+++ b/src/globalConfig/accessor.tsx
@@ -6,9 +6,9 @@ import {
 } from "./types";
 import type { ReadWriteJson } from "../io";
 import type { Logger } from "../logging";
-import z from "zod";
 import { globalConfigFileSchema } from "./types";
 import { DEFAULT_GLOBAL_CONFIG, applyOverrides } from "./config";
+import { AgentCoreCLIError, ERROR_SOURCE, type AgentCoreCLIErrorOptions } from "../errors";
 
 type DefaultGlobalConfigAccessorConfig = {
   logger: Logger;
@@ -76,8 +76,9 @@ export class DefaultGlobalConfigAccessor implements GlobalConfigAccessor {
   private async writeToConfigFile(data: GlobalConfigFileData): Promise<GlobalConfigFileData> {
     const dataParseResult = globalConfigFileSchema.safeParse(data);
     if (!dataParseResult.success) {
-      // TODO: mark this as a client-source error.
-      throw new TypeError(z.prettifyError(dataParseResult.error));
+      throw new InternalValidationError("failed to valide config data before writing to file", {
+        cause: dataParseResult.error,
+      });
     }
 
     await this.json.write(this.filePath, dataParseResult.data);
@@ -126,4 +127,11 @@ function diff<T extends Record<string, unknown>>(a: T, b: T): DeepPartial<T> {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Error raised by invalid data coming from internal sources **/
+export class InternalValidationError extends AgentCoreCLIError {
+  constructor(message?: string, options?: Omit<AgentCoreCLIErrorOptions, "source">) {
+    super(message, { ...options, source: ERROR_SOURCE.INTERNAL });
+  }
 }

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -11,6 +11,7 @@ import {
 import type { AppIO } from "../io";
 import type { Core } from "../handlers/types";
 import { JsonKey } from "../handlers/keys";
+import { AgentCoreCLIError, ERROR_SOURCE, type AgentCoreCLIErrorOptions } from "../errors";
 
 // renderJson pretty-prints a value as indented JSON. It is the output
 // counterpart to renderTui: handlers call it to emit machine-readable results
@@ -43,7 +44,7 @@ export async function renderTuiAt(
   io: AppIO,
 ): Promise<void> {
   if (!io.stdin.isTTY || !io.stdout.isTTY) {
-    throw new TypeError("interactive mode requires a TTY on stdin and stdout");
+    throw new InvalidEnvironmentError("interactive mode requires a TTY on stdin and stdout");
   }
 
   // alternateScreen switches the terminal to its alternate buffer so the TUI
@@ -73,4 +74,11 @@ export function renderTui(core: Core, io: AppIO): DefaultHandle {
 
     await renderTuiAt(ctx.require(PathKey), ctx, core, io);
   };
+}
+
+/** Error raised when detecting an invalid environment */
+export class InvalidEnvironmentError extends AgentCoreCLIError {
+  constructor(message?: string, options?: Omit<AgentCoreCLIErrorOptions, "source">) {
+    super(message, { ...options, source: ERROR_SOURCE.USER });
+  }
 }

--- a/src/tui/tui.test.tsx
+++ b/src/tui/tui.test.tsx
@@ -1,6 +1,6 @@
 import { test, expect, describe } from "bun:test";
 import { createRootHandler } from "../handlers";
-import { renderJson } from "./index";
+import { InvalidEnvironmentError, renderJson } from "./index";
 import {
   createSilentLogger,
   TestCoreClient,
@@ -89,9 +89,7 @@ describe("TUI stream boundary", () => {
         globalConfigAccessor: new TestGlobalConfigAccessor(),
       });
 
-      await expect(root.route(["node", "agentcore"])).rejects.toThrow(
-        "interactive mode requires a TTY on stdin and stdout",
-      );
+      await expect(root.route(["node", "agentcore"])).rejects.toThrow(InvalidEnvironmentError);
     },
   );
 


### PR DESCRIPTION
### Problem 
There are a few errors that are not yet migrated to the custom errors types. This PR does not aim to migrate all of them, but migrates a few that were raised in a previous PR. 

https://github.com/aws/agentcore-cli/pull/1848#issuecomment-5110918879

### Solution 
- define `InputValidationError` for when data passed internally fails validation in the config. 
- define `invalidEnvironmentError` for when tty is missing on stdin and stdout. 

### Testing
- updated tests to assert on error type instead of error message.  