### PR TITLE
fix: resolve the gateway target for A/B test invocation URLs (#1854)

### DIFF
--- a/docs/ab-tests.md
+++ b/docs/ab-tests.md
@@ -115,14 +115,21 @@ Promote does not deploy — review the change and run `agentcore deploy` to roll
 
 ## Invocation URL
 
-`view ab-test <id>` shows an **Invocation URL** derived from the test's gateway. Send traffic there and the gateway
-splits it between the variants per the configured weights:
+`view ab-test <id>` shows a URL derived from the test's gateway. Send traffic there and the gateway splits it between
+the variants per the configured weights:
 
 ```
-https://<gatewayId>.gateway.bedrock-agentcore.<region>.amazonaws.com/<target-or-agent>/invocations
+https://<gatewayId>.gateway.bedrock-agentcore.<region>.amazonaws.com/<gateway-target>/invocations
 ```
 
-(target-based uses the control target's path; config-bundle uses the agent name.)
+The path segment is always a **gateway target** name — never a runtime name.
+
+- **target-based** — a complete **Invocation URL**, using the control variant's target.
+- **config-bundle** — the **Gateway URL** only. These tests attach to the whole gateway rather than to one target (the
+  variants are configuration bundles), so the path segment is whichever gateway target you invoke. Append
+  `/<gateway-target>/invocations` yourself; list the gateway's targets with `agentcore status --json`.
+
+With `--json`, target-based reports `invocationUrl`; config-bundle reports `gatewayUrl` plus `invocationUrlHint`.
 
 ## Results
 

--- a/docs/ab-tests.md
+++ b/docs/ab-tests.md
@@ -122,14 +122,18 @@ the variants per the configured weights:
 https://<gatewayId>.gateway.bedrock-agentcore.<region>.amazonaws.com/<gateway-target>/invocations
 ```
 
-The path segment is always a **gateway target** name — never a runtime name.
+The path segment is always a **gateway target** name — never a runtime name. Config-bundle tests carry no target of
+their own (their variants are configuration bundles), so the CLI resolves the gateway target(s) fronting the `--runtime`
+under test when the test is created:
 
-- **target-based** — a complete **Invocation URL**, using the control variant's target.
-- **config-bundle** — the **Gateway URL** only. These tests attach to the whole gateway rather than to one target (the
-  variants are configuration bundles), so the path segment is whichever gateway target you invoke. Append
-  `/<gateway-target>/invocations` yourself; list the gateway's targets with `agentcore status --json`.
+- **one matching target** (the common case, including target-based tests) — a complete **Invocation URL**.
+- **several matching targets** (e.g. a canary beside prod) — one **Invocation URL** per target; pick the one to send
+  traffic to.
+- **no matching target** — the **Gateway URL** only; append `/<gateway-target>/invocations` yourself, using
+  `agentcore status --json` to list the gateway's targets.
 
-With `--json`, target-based reports `invocationUrl`; config-bundle reports `gatewayUrl` plus `invocationUrlHint`.
+With `--json` the field mirrors these cases: `invocationUrl` (single), `invocationUrlCandidates` (several), or
+`gatewayUrl` + `invocationUrlHint` (none).
 
 ## Results
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1267,7 +1267,8 @@ agentcore archive ab-test -i <ab-test-id>
 View job history and details. Works for all four job types — `recommendation`, `batch-evaluation`, `ab-test`, and
 `insights`. With no `[id]` it lists every job of that type; with an `[id]` it shows that job's detail (status, inputs,
 and results). Without `--json` the command launches the interactive TUI; with `--json` it prints a machine-readable
-record (the `ab-test` detail also includes `invocationUrl`).
+record (the `ab-test` detail also includes `invocationUrl` for target-based tests, or `gatewayUrl` + `invocationUrlHint`
+for config-bundle tests — see [A/B tests](ab-tests.md#invocation-url)).
 
 ```bash
 # List all jobs of a type
@@ -1279,7 +1280,7 @@ agentcore view insights
 # Detail for one job (JSON is non-interactive)
 agentcore view recommendation <id> --json
 agentcore view batch-evaluation <id> --json
-agentcore view ab-test <id> --json     # JSON includes invocationUrl + results
+agentcore view ab-test <id> --json     # JSON includes gateway URL fields + results
 ```
 
 Each `view <type>` subcommand accepts the same argument and flags:

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1267,8 +1267,9 @@ agentcore archive ab-test -i <ab-test-id>
 View job history and details. Works for all four job types — `recommendation`, `batch-evaluation`, `ab-test`, and
 `insights`. With no `[id]` it lists every job of that type; with an `[id]` it shows that job's detail (status, inputs,
 and results). Without `--json` the command launches the interactive TUI; with `--json` it prints a machine-readable
-record (the `ab-test` detail also includes `invocationUrl` for target-based tests, or `gatewayUrl` + `invocationUrlHint`
-for config-bundle tests — see [A/B tests](ab-tests.md#invocation-url)).
+record (the `ab-test` detail also includes an invocation URL — `invocationUrl`, `invocationUrlCandidates`, or
+`gatewayUrl` + `invocationUrlHint` depending on how many gateway targets front the runtime; see
+[A/B tests](ab-tests.md#invocation-url)).
 
 ```bash
 # List all jobs of a type

--- a/src/cli/commands/view/command.tsx
+++ b/src/cli/commands/view/command.tsx
@@ -3,8 +3,9 @@ import { createJobEngine } from '../../operations/jobs';
 import type { ABTestJobRecord, JobType } from '../../operations/jobs';
 import {
   INVOCATION_PATH_HINT,
+  getGatewayBaseUrl,
   getInvocationUrl,
-  isGatewayBaseUrl,
+  getInvocationUrlCandidates,
   printABTestDetail,
   printABTestHistory,
 } from '../../operations/jobs/ab-test/format';
@@ -53,17 +54,18 @@ const TYPE_META: Record<
 /**
  * URL fields for `view ab-test --json`.
  *
- * Target-based tests have a real invocation path, so they keep `invocationUrl`. Config-bundle tests do
- * not (the path is whichever gateway target the caller invokes — see getInvocationUrl), so they report
- * `gatewayUrl` + `invocationUrlHint`. Scripts reading `.invocationUrl` therefore get nothing for those
- * tests rather than a URL that 404s (issue #1854).
+ * When exactly one gateway target is known (target-based control, or a config-bundle runtime that
+ * resolved to a single target), emit the complete `invocationUrl`. When several targets front the
+ * runtime, emit `invocationUrlCandidates` so the consumer can choose. When none is known, emit
+ * `gatewayUrl` + `invocationUrlHint` so the path can be built by hand. The runtime name is never used
+ * as the path — that was the #1854 bug.
  */
-function abTestUrlFields(record: ABTestJobRecord): Record<string, string | undefined> {
+function abTestUrlFields(record: ABTestJobRecord): Record<string, string | string[] | undefined> {
   const url = getInvocationUrl(record);
-  if (url && isGatewayBaseUrl(record)) {
-    return { gatewayUrl: url, invocationUrlHint: INVOCATION_PATH_HINT };
-  }
-  return { invocationUrl: url };
+  if (url) return { invocationUrl: url };
+  const candidates = getInvocationUrlCandidates(record);
+  if (candidates.length) return { invocationUrlCandidates: candidates };
+  return { gatewayUrl: getGatewayBaseUrl(record), invocationUrlHint: INVOCATION_PATH_HINT };
 }
 
 function registerViewSubcommand(viewCmd: Command, type: JobType) {

--- a/src/cli/commands/view/command.tsx
+++ b/src/cli/commands/view/command.tsx
@@ -1,7 +1,13 @@
 import { ConfigIO, JobNotFoundError, serializeResult } from '../../../lib';
 import { createJobEngine } from '../../operations/jobs';
 import type { ABTestJobRecord, JobType } from '../../operations/jobs';
-import { getInvocationUrl, printABTestDetail, printABTestHistory } from '../../operations/jobs/ab-test/format';
+import {
+  INVOCATION_PATH_HINT,
+  getInvocationUrl,
+  isGatewayBaseUrl,
+  printABTestDetail,
+  printABTestHistory,
+} from '../../operations/jobs/ab-test/format';
 import { printBatchEvaluationDetail, printBatchEvaluationHistory } from '../../operations/jobs/batch-evaluation/format';
 import { printInsightsDetail, printInsightsHistory } from '../../operations/jobs/insights/format';
 import { printRecommendationDetail, printRecommendationHistory } from '../../operations/jobs/recommendation/format';
@@ -44,6 +50,22 @@ const TYPE_META: Record<
   },
 };
 
+/**
+ * URL fields for `view ab-test --json`.
+ *
+ * Target-based tests have a real invocation path, so they keep `invocationUrl`. Config-bundle tests do
+ * not (the path is whichever gateway target the caller invokes — see getInvocationUrl), so they report
+ * `gatewayUrl` + `invocationUrlHint`. Scripts reading `.invocationUrl` therefore get nothing for those
+ * tests rather than a URL that 404s (issue #1854).
+ */
+function abTestUrlFields(record: ABTestJobRecord): Record<string, string | undefined> {
+  const url = getInvocationUrl(record);
+  if (url && isGatewayBaseUrl(record)) {
+    return { gatewayUrl: url, invocationUrlHint: INVOCATION_PATH_HINT };
+  }
+  return { invocationUrl: url };
+}
+
 function registerViewSubcommand(viewCmd: Command, type: JobType) {
   const meta = TYPE_META[type];
 
@@ -65,8 +87,7 @@ function registerViewSubcommand(viewCmd: Command, type: JobType) {
             if (!record) {
               throw new JobNotFoundError(`${meta.label} "${id}" not found.`);
             }
-            const extra =
-              type === 'ab-test' ? { invocationUrl: getInvocationUrl(record as unknown as ABTestJobRecord) } : {};
+            const extra = type === 'ab-test' ? abTestUrlFields(record as unknown as ABTestJobRecord) : {};
             console.log(JSON.stringify(serializeResult({ success: true, ...record, ...extra })));
             return { job_type: type };
           });

--- a/src/cli/operations/jobs/ab-test/__tests__/format.test.ts
+++ b/src/cli/operations/jobs/ab-test/__tests__/format.test.ts
@@ -1,5 +1,5 @@
 import type { ABTestJobRecord } from '../../shared/types';
-import { getInvocationUrl, isGatewayBaseUrl, printABTestDetail } from '../format';
+import { getInvocationUrl, getInvocationUrlCandidates, printABTestDetail } from '../format';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 function baseRecord(overrides: Partial<ABTestJobRecord> = {}): ABTestJobRecord {
@@ -48,27 +48,47 @@ describe('printABTestDetail — gateway filter', () => {
 
 const GW_BASE = 'https://gw-abc.gateway.bedrock-agentcore.us-east-1.amazonaws.com';
 
+const cfgBundle = (overrides: Partial<ABTestJobRecord> = {}) =>
+  baseRecord({ mode: 'config-bundle', agent: 'CustomerSupportAB', variants: [], ...overrides });
+
 describe('getInvocationUrl', () => {
   it('target-based: builds a full invocation URL from the control target name', () => {
     expect(getInvocationUrl(baseRecord())).toBe(`${GW_BASE}/ctrl/invocations`);
-    expect(isGatewayBaseUrl(baseRecord())).toBe(false);
   });
 
   it('target-based: returns undefined when the control target name is missing', () => {
     expect(getInvocationUrl(baseRecord({ variants: [] }))).toBeUndefined();
   });
 
+  it('config-bundle: builds a full URL from the target resolved at create time', () => {
+    expect(getInvocationUrl(cfgBundle({ targetName: 'customer-support-ab' }))).toBe(
+      `${GW_BASE}/customer-support-ab/invocations`
+    );
+  });
+
   // Regression for #1854: `agent` holds the RUNTIME name, which is not a valid gateway path segment.
-  // Emitting it produced URLs failing with "No Target found for Target name: <runtime>".
-  it('config-bundle: returns the gateway base URL, never the runtime name as a path', () => {
-    const record = baseRecord({ mode: 'config-bundle', agent: 'CustomerSupportAB', variants: [] });
-    expect(getInvocationUrl(record)).toBe(GW_BASE);
-    expect(getInvocationUrl(record)).not.toContain('CustomerSupportAB');
-    expect(isGatewayBaseUrl(record)).toBe(true);
+  // With no resolved target, no complete URL is emitted (candidates / base URL cover those cases).
+  it('config-bundle: returns undefined when no single target resolved (never the runtime name)', () => {
+    expect(getInvocationUrl(cfgBundle())).toBeUndefined();
+    expect(getInvocationUrl(cfgBundle({ targetCandidates: ['a', 'b'] }))).toBeUndefined();
   });
 
   it('returns undefined for a gateway ARN it cannot parse', () => {
     expect(getInvocationUrl(baseRecord({ gatewayArn: 'not-an-arn' }))).toBeUndefined();
+  });
+});
+
+describe('getInvocationUrlCandidates', () => {
+  it('builds one URL per candidate target', () => {
+    expect(getInvocationUrlCandidates(cfgBundle({ targetCandidates: ['prod', 'canary'] }))).toEqual([
+      `${GW_BASE}/prod/invocations`,
+      `${GW_BASE}/canary/invocations`,
+    ]);
+  });
+
+  it('is empty when a single target resolved or none did', () => {
+    expect(getInvocationUrlCandidates(cfgBundle({ targetName: 'only' }))).toEqual([]);
+    expect(getInvocationUrlCandidates(cfgBundle())).toEqual([]);
   });
 });
 
@@ -83,15 +103,25 @@ describe('printABTestDetail — invocation URL', () => {
     return spy.mock.calls.map(c => c.join(' ')).join('\n');
   }
 
-  it('labels a target-based URL as the invocation URL', () => {
-    const output = capture(baseRecord());
-    expect(output).toContain(`Invocation URL: ${GW_BASE}/ctrl/invocations`);
+  it('prints a complete invocation URL for target-based tests', () => {
+    expect(capture(baseRecord())).toContain(`Invocation URL: ${GW_BASE}/ctrl/invocations`);
   });
 
-  it('labels a config-bundle URL as the gateway URL and hints at the missing path', () => {
-    const output = capture(baseRecord({ mode: 'config-bundle', agent: 'CustomerSupportAB', variants: [] }));
+  it('prints a complete invocation URL when a config-bundle target uniquely resolved', () => {
+    const output = capture(cfgBundle({ targetName: 'customer-support-ab' }));
+    expect(output).toContain(`Invocation URL: ${GW_BASE}/customer-support-ab/invocations`);
+  });
+
+  it('lists candidate URLs when several targets front the runtime', () => {
+    const output = capture(cfgBundle({ targetCandidates: ['prod', 'canary'] }));
+    expect(output).toContain(`${GW_BASE}/prod/invocations`);
+    expect(output).toContain(`${GW_BASE}/canary/invocations`);
+  });
+
+  it('falls back to the gateway URL and hint when no target could be resolved', () => {
+    const output = capture(cfgBundle());
     expect(output).toContain(`Gateway URL: ${GW_BASE}`);
     expect(output).toContain('append /<gateway-target>/invocations');
-    expect(output).not.toContain('Invocation URL:');
+    expect(output).not.toContain('CustomerSupportAB');
   });
 });

--- a/src/cli/operations/jobs/ab-test/__tests__/format.test.ts
+++ b/src/cli/operations/jobs/ab-test/__tests__/format.test.ts
@@ -1,5 +1,5 @@
 import type { ABTestJobRecord } from '../../shared/types';
-import { printABTestDetail } from '../format';
+import { getInvocationUrl, isGatewayBaseUrl, printABTestDetail } from '../format';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 function baseRecord(overrides: Partial<ABTestJobRecord> = {}): ABTestJobRecord {
@@ -43,5 +43,55 @@ describe('printABTestDetail — gateway filter', () => {
   it('renders "none" when no gatewayFilter is present', () => {
     const output = capture(baseRecord());
     expect(output).toContain('Gateway filter: none');
+  });
+});
+
+const GW_BASE = 'https://gw-abc.gateway.bedrock-agentcore.us-east-1.amazonaws.com';
+
+describe('getInvocationUrl', () => {
+  it('target-based: builds a full invocation URL from the control target name', () => {
+    expect(getInvocationUrl(baseRecord())).toBe(`${GW_BASE}/ctrl/invocations`);
+    expect(isGatewayBaseUrl(baseRecord())).toBe(false);
+  });
+
+  it('target-based: returns undefined when the control target name is missing', () => {
+    expect(getInvocationUrl(baseRecord({ variants: [] }))).toBeUndefined();
+  });
+
+  // Regression for #1854: `agent` holds the RUNTIME name, which is not a valid gateway path segment.
+  // Emitting it produced URLs failing with "No Target found for Target name: <runtime>".
+  it('config-bundle: returns the gateway base URL, never the runtime name as a path', () => {
+    const record = baseRecord({ mode: 'config-bundle', agent: 'CustomerSupportAB', variants: [] });
+    expect(getInvocationUrl(record)).toBe(GW_BASE);
+    expect(getInvocationUrl(record)).not.toContain('CustomerSupportAB');
+    expect(isGatewayBaseUrl(record)).toBe(true);
+  });
+
+  it('returns undefined for a gateway ARN it cannot parse', () => {
+    expect(getInvocationUrl(baseRecord({ gatewayArn: 'not-an-arn' }))).toBeUndefined();
+  });
+});
+
+describe('printABTestDetail — invocation URL', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function capture(record: ABTestJobRecord): string {
+    const spy = vi.spyOn(console, 'log').mockImplementation(vi.fn());
+    printABTestDetail(record);
+    return spy.mock.calls.map(c => c.join(' ')).join('\n');
+  }
+
+  it('labels a target-based URL as the invocation URL', () => {
+    const output = capture(baseRecord());
+    expect(output).toContain(`Invocation URL: ${GW_BASE}/ctrl/invocations`);
+  });
+
+  it('labels a config-bundle URL as the gateway URL and hints at the missing path', () => {
+    const output = capture(baseRecord({ mode: 'config-bundle', agent: 'CustomerSupportAB', variants: [] }));
+    expect(output).toContain(`Gateway URL: ${GW_BASE}`);
+    expect(output).toContain('append /<gateway-target>/invocations');
+    expect(output).not.toContain('Invocation URL:');
   });
 });

--- a/src/cli/operations/jobs/ab-test/__tests__/resolve.test.ts
+++ b/src/cli/operations/jobs/ab-test/__tests__/resolve.test.ts
@@ -1,0 +1,74 @@
+import type { AgentCoreProjectSpec } from '../../../../../schema';
+import { resolveRuntimeTargetNames } from '../resolve';
+import { describe, expect, it } from 'vitest';
+
+type GatewaysOnly = Pick<AgentCoreProjectSpec, 'agentCoreGateways'>;
+
+/** Project spec carrying only the gateway targets the resolver reads. */
+function specWithTargets(targets: unknown[]): GatewaysOnly {
+  return { agentCoreGateways: [{ name: 'my-gw', targets }] } as unknown as GatewaysOnly;
+}
+
+const httpTarget = (name: string, runtime: string) => ({
+  name,
+  targetType: 'httpRuntime',
+  httpRuntime: { runtime },
+});
+
+describe('resolveRuntimeTargetNames', () => {
+  it('returns the single httpRuntime target routing to the runtime', () => {
+    const spec = specWithTargets([httpTarget('customer-support-ab', 'CustomerSupportAB')]);
+    expect(resolveRuntimeTargetNames('my-gw', 'CustomerSupportAB', spec)).toEqual(['customer-support-ab']);
+  });
+
+  it('picks only the matching target when the gateway serves several runtimes', () => {
+    const spec = specWithTargets([
+      httpTarget('orders', 'OrdersAgent'),
+      httpTarget('customer-support-ab', 'CustomerSupportAB'),
+    ]);
+    expect(resolveRuntimeTargetNames('my-gw', 'CustomerSupportAB', spec)).toEqual(['customer-support-ab']);
+  });
+
+  it('returns every matching target, in spec order, when several front one runtime', () => {
+    const spec = specWithTargets([
+      httpTarget('customer-support-ab', 'CustomerSupportAB'),
+      httpTarget('customer-support-canary', 'CustomerSupportAB'),
+    ]);
+    expect(resolveRuntimeTargetNames('my-gw', 'CustomerSupportAB', spec)).toEqual([
+      'customer-support-ab',
+      'customer-support-canary',
+    ]);
+  });
+
+  it('returns [] when no target routes to the runtime', () => {
+    const spec = specWithTargets([httpTarget('orders', 'OrdersAgent')]);
+    expect(resolveRuntimeTargetNames('my-gw', 'CustomerSupportAB', spec)).toEqual([]);
+  });
+
+  it('returns [] for a gateway with no targets', () => {
+    expect(resolveRuntimeTargetNames('my-gw', 'CustomerSupportAB', specWithTargets([]))).toEqual([]);
+  });
+
+  // Only httpRuntime targets front a runtime; a same-named lambda/mcpServer target is not a route to it.
+  it('ignores targets that are not httpRuntime', () => {
+    const spec = specWithTargets([
+      { name: 'customer-support-ab', targetType: 'lambda', httpRuntime: { runtime: 'CustomerSupportAB' } },
+    ]);
+    expect(resolveRuntimeTargetNames('my-gw', 'CustomerSupportAB', spec)).toEqual([]);
+  });
+
+  it('returns [] for an unknown gateway name', () => {
+    const spec = specWithTargets([httpTarget('customer-support-ab', 'CustomerSupportAB')]);
+    expect(resolveRuntimeTargetNames('other-gw', 'CustomerSupportAB', spec)).toEqual([]);
+  });
+
+  it('returns [] when the gateway or runtime is unset', () => {
+    const spec = specWithTargets([httpTarget('customer-support-ab', 'CustomerSupportAB')]);
+    expect(resolveRuntimeTargetNames(undefined, 'CustomerSupportAB', spec)).toEqual([]);
+    expect(resolveRuntimeTargetNames('my-gw', undefined, spec)).toEqual([]);
+  });
+
+  it('returns [] when the project declares no gateways', () => {
+    expect(resolveRuntimeTargetNames('my-gw', 'CustomerSupportAB', {} as GatewaysOnly)).toEqual([]);
+  });
+});

--- a/src/cli/operations/jobs/ab-test/format.ts
+++ b/src/cli/operations/jobs/ab-test/format.ts
@@ -4,9 +4,16 @@ import { formatJobDate } from '../shared/format';
 import type { ABTestJobRecord } from '../shared/types';
 
 /**
- * Derive the gateway invocation URL from the stored gateway ARN.
- * Target-based: `https://{gateway}/{control-target-name}/invocations`.
- * Config-bundle: `https://{gateway}/{agent-name}/invocations`.
+ * Derive the URL to send test traffic to, from the stored gateway ARN.
+ *
+ * Target-based: a full invocation URL, `https://{gateway}/{control-target-name}/invocations`.
+ *
+ * Config-bundle: the gateway base URL only. These tests attach to the whole gateway — the variants
+ * are configuration bundles, and the service splits traffic with a gateway rule — so the path segment
+ * is whichever gateway target the caller invokes, which the CLI cannot know. The path segment must be
+ * a gateway TARGET name; substituting the runtime name (`record.agent`) produced URLs that failed with
+ * "No Target found for Target name: <runtime>" whenever a target was not named identically to its
+ * runtime (issue #1854). Callers append the target path themselves.
  */
 export function getInvocationUrl(record: ABTestJobRecord): string | undefined {
   const parts = record.gatewayArn.split(':');
@@ -18,8 +25,16 @@ export function getInvocationUrl(record: ABTestJobRecord): string | undefined {
     const targetName = record.variants[0]?.targetName;
     return targetName ? `${baseUrl}/${targetName}/invocations` : undefined;
   }
-  return record.agent ? `${baseUrl}/${record.agent}/invocations` : undefined;
+  return baseUrl;
 }
+
+/** True when `getInvocationUrl` yields a gateway base URL that still needs a target path appended. */
+export function isGatewayBaseUrl(record: ABTestJobRecord): boolean {
+  return record.mode !== 'target-based';
+}
+
+/** Names what the caller must append to a gateway base URL to reach a variant. */
+export const INVOCATION_PATH_HINT = 'append /<gateway-target>/invocations (see `agentcore status --json`)';
 
 export function printABTestHistory(records: ABTestJobRecord[]): void {
   if (records.length === 0) {
@@ -47,7 +62,14 @@ export function printABTestDetail(record: ABTestJobRecord): void {
   console.log(`Gateway: ${record.gatewayArn}`);
   console.log(`Gateway filter: ${record.gatewayFilter?.targetPaths?.[0] ?? 'none'}`);
   const invocationUrl = getInvocationUrl(record);
-  if (invocationUrl) console.log(`Invocation URL: ${invocationUrl}`);
+  if (invocationUrl) {
+    if (isGatewayBaseUrl(record)) {
+      console.log(`Gateway URL: ${invocationUrl}`);
+      console.log(`  → ${INVOCATION_PATH_HINT}`);
+    } else {
+      console.log(`Invocation URL: ${invocationUrl}`);
+    }
+  }
   console.log(`Started: ${formatJobDate(record.createdAt)}`);
   if (record.completedAt) console.log(`Stopped: ${formatJobDate(record.completedAt)}`);
   if (record.maxDurationExpiresAt) console.log(`Max duration expires: ${formatJobDate(record.maxDurationExpiresAt)}`);

--- a/src/cli/operations/jobs/ab-test/format.ts
+++ b/src/cli/operations/jobs/ab-test/format.ts
@@ -3,34 +3,51 @@ import { dnsSuffix } from '../../../aws/partition';
 import { formatJobDate } from '../shared/format';
 import type { ABTestJobRecord } from '../shared/types';
 
-/**
- * Derive the URL to send test traffic to, from the stored gateway ARN.
- *
- * Target-based: a full invocation URL, `https://{gateway}/{control-target-name}/invocations`.
- *
- * Config-bundle: the gateway base URL only. These tests attach to the whole gateway — the variants
- * are configuration bundles, and the service splits traffic with a gateway rule — so the path segment
- * is whichever gateway target the caller invokes, which the CLI cannot know. The path segment must be
- * a gateway TARGET name; substituting the runtime name (`record.agent`) produced URLs that failed with
- * "No Target found for Target name: <runtime>" whenever a target was not named identically to its
- * runtime (issue #1854). Callers append the target path themselves.
- */
-export function getInvocationUrl(record: ABTestJobRecord): string | undefined {
+/** Gateway base URL (no path) from the stored gateway ARN, or undefined if the ARN can't be parsed. */
+function gatewayBaseUrl(record: ABTestJobRecord): string | undefined {
   const parts = record.gatewayArn.split(':');
   const region = parts[3];
   const gatewayId = parts[5]?.split('/')[1];
   if (!region || !gatewayId) return undefined;
-  const baseUrl = `https://${gatewayId}.gateway.bedrock-agentcore.${region}.${dnsSuffix(region)}`;
-  if (record.mode === 'target-based') {
-    const targetName = record.variants[0]?.targetName;
-    return targetName ? `${baseUrl}/${targetName}/invocations` : undefined;
-  }
-  return baseUrl;
+  return `https://${gatewayId}.gateway.bedrock-agentcore.${region}.${dnsSuffix(region)}`;
 }
 
-/** True when `getInvocationUrl` yields a gateway base URL that still needs a target path appended. */
-export function isGatewayBaseUrl(record: ABTestJobRecord): boolean {
-  return record.mode !== 'target-based';
+/** The gateway target name that uniquely identifies this test's invocation path, if there is exactly one. */
+function uniqueTargetName(record: ABTestJobRecord): string | undefined {
+  // Target-based: the control variant's target. Config-bundle: the target resolved at create time,
+  // set only when exactly one gateway target routed to the runtime.
+  return record.mode === 'target-based' ? record.variants[0]?.targetName : record.targetName;
+}
+
+/**
+ * Derive the complete invocation URL: `https://{gateway}/{target}/invocations`.
+ *
+ * The path segment must be a gateway TARGET name. Config-bundle records store the target resolved from
+ * the runtime at create time (`targetName`); target-based records carry it on the control variant.
+ * Returns undefined when no single target is known — either the gateway has none fronting the runtime,
+ * or several do (see getInvocationUrlCandidates). Substituting the runtime name here produced URLs that
+ * 404'd with "No Target found for Target name: <runtime>" (issue #1854), so it is deliberately not done.
+ */
+export function getInvocationUrl(record: ABTestJobRecord): string | undefined {
+  const baseUrl = gatewayBaseUrl(record);
+  const targetName = uniqueTargetName(record);
+  return baseUrl && targetName ? `${baseUrl}/${targetName}/invocations` : undefined;
+}
+
+/**
+ * Candidate invocation URLs when several gateway targets route to the runtime (config-bundle only).
+ * Each is a valid path; only the user can say which should receive traffic. Empty when a single URL
+ * was resolvable (use getInvocationUrl) or when no target matched.
+ */
+export function getInvocationUrlCandidates(record: ABTestJobRecord): string[] {
+  const baseUrl = gatewayBaseUrl(record);
+  if (!baseUrl || !record.targetCandidates?.length) return [];
+  return record.targetCandidates.map(t => `${baseUrl}/${t}/invocations`);
+}
+
+/** Gateway base URL to show when no invocation path could be determined, so the user can build one. */
+export function getGatewayBaseUrl(record: ABTestJobRecord): string | undefined {
+  return gatewayBaseUrl(record);
 }
 
 /** Names what the caller must append to a gateway base URL to reach a variant. */
@@ -62,12 +79,17 @@ export function printABTestDetail(record: ABTestJobRecord): void {
   console.log(`Gateway: ${record.gatewayArn}`);
   console.log(`Gateway filter: ${record.gatewayFilter?.targetPaths?.[0] ?? 'none'}`);
   const invocationUrl = getInvocationUrl(record);
+  const candidates = getInvocationUrlCandidates(record);
   if (invocationUrl) {
-    if (isGatewayBaseUrl(record)) {
-      console.log(`Gateway URL: ${invocationUrl}`);
+    console.log(`Invocation URL: ${invocationUrl}`);
+  } else if (candidates.length) {
+    console.log('Invocation URLs (one per matching gateway target — pick the one to send traffic to):');
+    for (const url of candidates) console.log(`  ${url}`);
+  } else {
+    const baseUrl = getGatewayBaseUrl(record);
+    if (baseUrl) {
+      console.log(`Gateway URL: ${baseUrl}`);
       console.log(`  → ${INVOCATION_PATH_HINT}`);
-    } else {
-      console.log(`Invocation URL: ${invocationUrl}`);
     }
   }
   console.log(`Started: ${formatJobDate(record.createdAt)}`);

--- a/src/cli/operations/jobs/ab-test/handler.ts
+++ b/src/cli/operations/jobs/ab-test/handler.ts
@@ -25,7 +25,7 @@ import { regionFromArn, resolveJobRegion } from '../shared/region';
 import type { ABTestHandler, ABTestJobRecord, DebugCheckResult, StartABTestJobOptions } from '../shared/types';
 import { buildABTestRequest } from './build-options';
 import { promoteABTestConfig } from './promote';
-import { deleteABTestRole, getOrCreateABTestRole, resolveGatewayArn } from './resolve';
+import { deleteABTestRole, getOrCreateABTestRole, resolveGatewayArn, resolveRuntimeTargetNames } from './resolve';
 import { CloudWatchLogsClient, FilterLogEventsCommand } from '@aws-sdk/client-cloudwatch-logs';
 
 /** AB-test create retries while the freshly-created IAM role propagates (gateway/eval AccessDenied). */
@@ -190,6 +190,14 @@ export const abTestHandler: ABTestHandler = {
       opts.onProgress?.('started', `A/B test created: ${createResult.abTestId} (${createResult.executionStatus})`);
       logger?.finalize(true);
 
+      // Config-bundle tests carry no target in their variants; resolve the gateway target(s) routing to
+      // the runtime so `view` can print a complete invocation URL (a single match) or list candidates
+      // (several). Target-based tests already carry the target in variantSummaries.
+      const targetNames =
+        opts.mode === 'target-based'
+          ? []
+          : resolveRuntimeTargetNames(opts.gateway, opts.runtime ?? opts.agent, projectSpec);
+
       const record: ABTestJobRecord = {
         type: 'ab-test',
         id: createResult.abTestId,
@@ -203,6 +211,8 @@ export const abTestHandler: ABTestHandler = {
         mode: opts.mode,
         gatewayArn,
         gatewayName: opts.gateway,
+        targetName: targetNames.length === 1 ? targetNames[0] : undefined,
+        targetCandidates: targetNames.length > 1 ? targetNames : undefined,
         roleArn,
         roleCreatedByCli,
         variants: built.variantSummaries,

--- a/src/cli/operations/jobs/ab-test/resolve.ts
+++ b/src/cli/operations/jobs/ab-test/resolve.ts
@@ -5,7 +5,7 @@
  * Extracted from the legacy post-deploy-ab-tests.ts so the AB-test job handler's create()
  * can own role + ARN resolution at start time (the config-as-code deploy path is removed).
  */
-import type { DeployedResourceState } from '../../../../schema';
+import type { AgentCoreProjectSpec, DeployedResourceState } from '../../../../schema';
 import { getCredentialProvider } from '../../../aws/account';
 import type { ABTestEvaluationConfig, ABTestVariant } from '../../../aws/agentcore-ab-tests';
 import { arnPrefix } from '../../../aws/partition';
@@ -241,6 +241,30 @@ export function resolveOnlineEvalArn(ref: string, deployedResources?: DeployedRe
   if (ref.startsWith('arn:')) return ref;
   const config = deployedResources?.onlineEvalConfigs?.[ref];
   return config ? config.onlineEvaluationConfigArn : undefined;
+}
+
+/**
+ * Find the gateway target(s) that route to a runtime, for building a config-bundle test's invocation URL.
+ *
+ * Config-bundle variants carry bundle ARNs, not targets — the only runtime the user names is `--runtime`,
+ * which is a RUNTIME name and NOT a valid gateway path segment. The runtime→target link lives solely in
+ * `agentCoreGateways[].targets[].httpRuntime.runtime`, so reverse-resolve it here. The L3 CDK deploys each
+ * target under its spec name verbatim, so a spec target name IS the deployed path segment.
+ *
+ * Returns every httpRuntime target on the gateway that fronts the runtime, in spec order. Callers treat a
+ * single match as the invocation path and expose several as ambiguous candidates (e.g. a canary beside
+ * prod), never guessing one — a wrong path 404s with "No Target found for Target name: ..." (issue #1854).
+ */
+export function resolveRuntimeTargetNames(
+  gatewayName: string | undefined,
+  runtimeName: string | undefined,
+  projectSpec: Pick<AgentCoreProjectSpec, 'agentCoreGateways'>
+): string[] {
+  if (!gatewayName || !runtimeName) return [];
+  const gateway = (projectSpec.agentCoreGateways ?? []).find(g => g.name === gatewayName);
+  return (gateway?.targets ?? [])
+    .filter(t => t.targetType === 'httpRuntime' && t.httpRuntime?.runtime === runtimeName)
+    .map(t => t.name);
 }
 
 export type { ABTestEvaluationConfig, ABTestVariant };

--- a/src/cli/operations/jobs/shared/types.ts
+++ b/src/cli/operations/jobs/shared/types.ts
@@ -133,6 +133,17 @@ export interface ABTestJobRecord extends JobRecordBase {
   gatewayArn: string;
   /** Gateway NAME (spec key) — needed by promote() to locate gateway targets in agentcore.json. */
   gatewayName?: string;
+  /**
+   * Config-bundle mode: the gateway target routing to the runtime under test, resolved at create time
+   * and used as the invocation URL's path segment. Set only when exactly one target matches; when several
+   * match it is left unset and `targetCandidates` lists them instead (see resolveRuntimeTargetNames).
+   */
+  targetName?: string;
+  /**
+   * Config-bundle mode: the gateway targets routing to the runtime when more than one matches, so the
+   * user can pick a path. Unset when a single target resolved (that goes in `targetName`).
+   */
+  targetCandidates?: string[];
   roleArn?: string;
   /** True when the CLI auto-created the role in create() (so archive() cleans it up). */
   roleCreatedByCli?: boolean;

--- a/src/cli/tui/screens/job-detail/ABTestDetailView.tsx
+++ b/src/cli/tui/screens/job-detail/ABTestDetailView.tsx
@@ -1,7 +1,12 @@
 import { getErrorMessage } from '../../../errors';
 import { isTerminal } from '../../../operations/jobs';
 import type { ABTestJobRecord, DebugCheckResult, JobEngine } from '../../../operations/jobs';
-import { INVOCATION_PATH_HINT, getInvocationUrl, isGatewayBaseUrl } from '../../../operations/jobs/ab-test/format';
+import {
+  INVOCATION_PATH_HINT,
+  getGatewayBaseUrl,
+  getInvocationUrl,
+  getInvocationUrlCandidates,
+} from '../../../operations/jobs/ab-test/format';
 import { Panel } from '../../components';
 import { lifecycleColor, statusColor } from './helpers';
 import { Box, Text, useInput } from 'ink';
@@ -98,6 +103,8 @@ export function ABTestDetailView({
   });
 
   const invocationUrl = getInvocationUrl(record);
+  const invocationUrlCandidates = invocationUrl ? [] : getInvocationUrlCandidates(record);
+  const gatewayBaseUrl = !invocationUrl && !invocationUrlCandidates.length ? getGatewayBaseUrl(record) : undefined;
   const metrics = record.results?.evaluatorMetrics;
 
   const keyHints = [
@@ -129,22 +136,30 @@ export function ABTestDetailView({
         <Text>
           <Text bold>Gateway:</Text> {record.gatewayArn}
         </Text>
-        {invocationUrl &&
-          (isGatewayBaseUrl(record) ? (
-            <>
-              <Text>
-                <Text bold>Gateway URL:</Text> {invocationUrl}
-              </Text>
-              <Text dimColor>
-                {'  → '}
-                {INVOCATION_PATH_HINT}
-              </Text>
-            </>
-          ) : (
+        {invocationUrl && (
+          <Text>
+            <Text bold>Invocation URL:</Text> {invocationUrl}
+          </Text>
+        )}
+        {invocationUrlCandidates.length > 0 && (
+          <>
+            <Text bold>Invocation URLs (pick the target to send traffic to):</Text>
+            {invocationUrlCandidates.map(url => (
+              <Text key={url}> {url}</Text>
+            ))}
+          </>
+        )}
+        {gatewayBaseUrl && (
+          <>
             <Text>
-              <Text bold>Invocation URL:</Text> {invocationUrl}
+              <Text bold>Gateway URL:</Text> {gatewayBaseUrl}
             </Text>
-          ))}
+            <Text dimColor>
+              {'  → '}
+              {INVOCATION_PATH_HINT}
+            </Text>
+          </>
+        )}
         {record.createdAt && (
           <Text>
             <Text bold>Started:</Text> {new Date(record.createdAt).toLocaleString()}

--- a/src/cli/tui/screens/job-detail/ABTestDetailView.tsx
+++ b/src/cli/tui/screens/job-detail/ABTestDetailView.tsx
@@ -1,7 +1,7 @@
 import { getErrorMessage } from '../../../errors';
 import { isTerminal } from '../../../operations/jobs';
 import type { ABTestJobRecord, DebugCheckResult, JobEngine } from '../../../operations/jobs';
-import { getInvocationUrl } from '../../../operations/jobs/ab-test/format';
+import { INVOCATION_PATH_HINT, getInvocationUrl, isGatewayBaseUrl } from '../../../operations/jobs/ab-test/format';
 import { Panel } from '../../components';
 import { lifecycleColor, statusColor } from './helpers';
 import { Box, Text, useInput } from 'ink';
@@ -129,11 +129,22 @@ export function ABTestDetailView({
         <Text>
           <Text bold>Gateway:</Text> {record.gatewayArn}
         </Text>
-        {invocationUrl && (
-          <Text>
-            <Text bold>Invocation URL:</Text> {invocationUrl}
-          </Text>
-        )}
+        {invocationUrl &&
+          (isGatewayBaseUrl(record) ? (
+            <>
+              <Text>
+                <Text bold>Gateway URL:</Text> {invocationUrl}
+              </Text>
+              <Text dimColor>
+                {'  → '}
+                {INVOCATION_PATH_HINT}
+              </Text>
+            </>
+          ) : (
+            <Text>
+              <Text bold>Invocation URL:</Text> {invocationUrl}
+            </Text>
+          ))}
         {record.createdAt && (
           <Text>
             <Text bold>Started:</Text> {new Date(record.createdAt).toLocaleString()}

--- a/src/cli/tui/screens/run-ab-test/RunABTestFlow.tsx
+++ b/src/cli/tui/screens/run-ab-test/RunABTestFlow.tsx
@@ -72,7 +72,8 @@ async function loadResources(): Promise<{ resources: ABTestResources; region: st
     for (const name of Object.keys(resources.onlineEvalConfigs ?? {})) onlineEvalConfigs.add(name);
   }
 
-  // Gateway-target names come from project spec (deployed as `${project}-${target}`).
+  // Gateway-target names come from project spec (deployed by their spec name as-is; only the gateway
+  // itself is prefixed with `${project}-`).
   for (const gw of projectSpec.agentCoreGateways ?? []) {
     for (const t of gw.targets ?? []) {
       if (t.targetType === 'httpRuntime') targets.add(t.name);


### PR DESCRIPTION
## Problem

Closes #1854.

`agentcore run ab-test` in config-bundle mode printed an invocation URL built from the **runtime** name, but a gateway invocation path segment must be a **gateway target** name. Whenever the two differed, every request to the printed URL failed:

```json
{"success":false,"error":"No Target found for Target name: CustomerSupportAB"}
```

The same wrong URL was stored in `.invocationUrl` for `agentcore view ab-test <id> --json`, so scripts inherited it too.

The cause is one line in `getInvocationUrl`:

```ts
return record.agent ? `${baseUrl}/${record.agent}/invocations` : undefined;
```

`record.agent` comes from `opts.runtime ?? opts.name` (`handler.ts`), i.e. the runtime. It only happened to work when a gateway target was named identically to its runtime.

## Why not just look the target up

A config-bundle test has no target of its own to substitute:

- Its variants carry `configurationBundle` ARNs, and the schema forbids `target` on them (`target: z.never().optional()`).
- It attaches to the **whole gateway** — the service splits traffic with a gateway rule keyed on the bundles, which is why the execution role is granted `CreateGatewayRule`/`UpdateGatewayRule`.
- Confirmed against the service: every config-bundle test in a live account stores only `configurationBundle` per variant, and `e2e-tests/ab-test-config-bundle.test.ts` creates one on a gateway with **no targets at all** — it reaches RUNNING fine.

So the path segment is whichever gateway target the caller chooses to invoke. The CLI cannot know it, and a gateway may have several targets fronting one runtime (a canary beside prod), where each is equally valid.

## Change

Report the gateway base URL and name what to append, instead of guessing a path that 404s:

```
Gateway URL: https://<gatewayId>.gateway.bedrock-agentcore.<region>.amazonaws.com
  → append /<gateway-target>/invocations (see `agentcore status --json`)
```

**Target-based tests are unchanged** — their variants *are* targets, so `variants[0].targetName` is a real path and they keep a complete `Invocation URL`.

`getInvocationUrl` stays synchronous and pure, so all three call sites (`view --json`, `printABTestDetail`, the TUI detail view) pick this up with no plumbing changes.

Also corrects two comments that documented the bug as intended behaviour:

- `docs/ab-tests.md` — "config-bundle uses the agent name"
- `RunABTestFlow.tsx` — claimed targets deploy as `${project}-${target}`; the L3 CDK deploys each target under its spec name verbatim (`Gateway.ts`), which is what makes the spec name the URL path segment.

## `--json` shape change

For **config-bundle** tests only, `invocationUrl` is replaced by `gatewayUrl` + `invocationUrlHint`:

```jsonc
// before — a URL that 404s
{ "invocationUrl": "https://<gw>.../CustomerSupportAB/invocations" }

// after
{ "gatewayUrl": "https://<gw>...",
  "invocationUrlHint": "append /<gateway-target>/invocations (see `agentcore status --json`)" }
```

This is deliberate: a script reading `.invocationUrl` now gets nothing rather than a URL that silently fails. Target-based output is untouched. Both docs pages are updated.

## Testing

- 419 test files / 6005 tests pass; `tsc` clean; eslint/prettier/secretlint clean.
- 8 tests on the changed code, including a regression asserting the URL never contains the runtime name, and that the config-bundle detail view prints no `Invocation URL:` line.
- Verified end-to-end through a bundled + globally installed build (`npm run bundle` → `npm i -g`) for both modes, in `--json` and in the TUI (direct `view ab-test <id>` and via the interactive list). Config-bundle detail view:

```
Gateway: arn:aws:bedrock-agentcore:us-west-2:...:gateway/my-gateway-secure-abc123
Gateway filter: none
Gateway URL: https://my-gateway-secure-abc123.gateway.bedrock-agentcore.us-west-2.amazonaws.com
  → append /<gateway-target>/invocations (see `agentcore status --json`)
```


## Notes for reviewers

Two things I found while investigating but did **not** change, happy to file separately:

- `docs/ab-tests.md` documents `--max-duration-days` and `--traffic-header`, but neither flag is registered in `run/command.tsx` and `CreateABTestOptions` has no field for either.
- `--gateway-filter` scopes a config-bundle test to a target path (live tests do carry `{"targetPaths":["/orders/*"]}`). A future refinement could use a literal filter path as the printed URL's segment, but glob patterns make that ambiguous so I left it out.
