### PR TITLE
fix(project): refuse nested project creation and model embedded-asset error

### DIFF
--- a/src/core/project/manager.test.ts
+++ b/src/core/project/manager.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtemp, readdir, rm } from "node:fs/promises";
 import { join, relative } from "node:path";
 import { tmpdir } from "node:os";
-import { FsProjectManager } from "./manager";
+import { FsProjectManager, NestedProjectError } from "./manager";
 import { ProjectFileExistsError } from "./tree";
 import { PROJECT_TEMPLATES } from "../../handlers/project/types";
 import { createSilentLogger } from "../../testing";
@@ -68,5 +68,15 @@ describe("FsProjectManager.create", () => {
 
     await manager().create(input);
     await expect(manager().create(input)).rejects.toBeInstanceOf(ProjectFileExistsError);
+  });
+
+  test("refuses to create a project inside an existing project", async () => {
+    const directory = await inTempDirectory();
+    await manager().create({ name: "root", template: PROJECT_TEMPLATES.HELLO_WORLD_PYTHON });
+
+    process.chdir(join(directory, "root"));
+    await expect(
+      manager().create({ name: "child", template: PROJECT_TEMPLATES.HELLO_WORLD_PYTHON }),
+    ).rejects.toBeInstanceOf(NestedProjectError);
   });
 });

--- a/src/core/project/manager.tsx
+++ b/src/core/project/manager.tsx
@@ -1,4 +1,6 @@
-import { join } from "node:path";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { AgentCoreCLIError, ERROR_SOURCE } from "../../errors";
 import type {
   CreateProjectInput,
   ResolveProjectInput,
@@ -9,6 +11,28 @@ import type { Logger } from "../../logging";
 import { projectTree } from "./compose";
 import { defaultSource, type AssetSource } from "./source";
 import { writeTree } from "./tree";
+
+/** Thrown when scaffolding would nest a new project inside an existing AgentCore project. */
+export class NestedProjectError extends AgentCoreCLIError {
+  constructor(public readonly projectRoot: string) {
+    super(
+      `cannot create a project inside an existing AgentCore project (found ${join(projectRoot, "agentcore", "agentcore.json")})`,
+      { source: ERROR_SOURCE.USER, meta: { projectRoot } },
+    );
+  }
+}
+
+/** Walks up from directory looking for the agentcore/agentcore.json project marker. */
+function enclosingProjectRoot(directory: string): string | undefined {
+  for (let current = directory; ; current = dirname(current)) {
+    if (existsSync(join(current, "agentcore", "agentcore.json"))) {
+      return current;
+    }
+    if (dirname(current) === current) {
+      return undefined;
+    }
+  }
+}
 
 type ProjectManagerConfig = {
   logger: Logger;
@@ -32,7 +56,11 @@ export class FsProjectManager implements ProjectManager {
   }
 
   public async create(input: CreateProjectInput): Promise<Project> {
-    // Scaffold into a fresh directory.
+    // Scaffold into a fresh directory, refusing to nest inside an existing project.
+    const enclosing = enclosingProjectRoot(process.cwd());
+    if (enclosing) {
+      throw new NestedProjectError(enclosing);
+    }
     const destination = join(process.cwd(), input.name);
     this.logger.debug(`scaffolding project "${input.name}" from template "${input.template}"`);
 

--- a/src/core/project/source.test.ts
+++ b/src/core/project/source.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { EmbeddedAssetSource } from "./source";
+import { EmbeddedAssetNotFoundError, EmbeddedAssetSource } from "./source";
 
 describe("EmbeddedAssetSource", () => {
-  test("throws when the asset is not embedded", () => {
-    expect(new EmbeddedAssetSource().read("cdk/package.json")).rejects.toThrow(
-      /Embedded asset not found/,
+  test("throws a modeled error when the asset is not embedded", () => {
+    expect(new EmbeddedAssetSource().read("cdk/package.json")).rejects.toBeInstanceOf(
+      EmbeddedAssetNotFoundError,
     );
   });
 });

--- a/src/core/project/source.ts
+++ b/src/core/project/source.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { readFile, readdir } from "node:fs/promises";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { AgentCoreCLIError } from "../../errors";
 
 /**
  * Reads and lists asset files by path relative to the asset root.
@@ -20,6 +21,13 @@ const EMBEDDED_PREFIX = "agentcore-assets/src/assets/";
 // Embedded files carry a name property that Bun's types widen to Blob.
 type NamedBlob = Blob & { readonly name: string };
 
+/** Thrown when an asset is missing from the compiled executable, indicating a packaging bug. */
+export class EmbeddedAssetNotFoundError extends AgentCoreCLIError {
+  constructor(public readonly assetPath: string) {
+    super(`Embedded asset not found: ${assetPath}`, { meta: { assetPath } });
+  }
+}
+
 /** Reads assets embedded in the compiled standalone executable. */
 export class EmbeddedAssetSource implements AssetSource {
   private blobs(): readonly NamedBlob[] {
@@ -30,7 +38,7 @@ export class EmbeddedAssetSource implements AssetSource {
     const name = `${EMBEDDED_PREFIX}${assetPath}`;
     const blob = this.blobs().find((f) => f.name === name);
     if (!blob) {
-      throw new Error(`Embedded asset not found: ${assetPath}`);
+      throw new EmbeddedAssetNotFoundError(assetPath);
     }
     return blob.text();
   }


### PR DESCRIPTION
## Summary

Post-review follow-ups from #1809 

- **Modeled error for missing embedded assets** — `EmbeddedAssetSource.read` now throws `EmbeddedAssetNotFoundError` (extends `AgentCoreCLIError`, internal source, `assetPath` in meta) instead of a bare `Error`.
- **Refuse nested project creation** — `FsProjectManager.create` now walks up from the working directory looking for the `agentcore/agentcore.json` project marker and throws a modeled `NestedProjectError` (user source) if one is found, instead of scaffolding a project inside an existing one.

The "child lifted to root" behavior seen with `bun run start` is a `bun run` artifact — bun chdirs to the package root before running the script, so the child was created next to `root` rather than inside it. A compiled/linked binary would have nested the child inside `root`. Either way, nesting a project inside a project would confuse project resolution, so `create` now refuses it explicitly.

## Testing

- New test: creating a project from inside an existing project rejects with `NestedProjectError`.
- Updated test: missing embedded asset rejects with `EmbeddedAssetNotFoundError`.
- Full suite: 509 pass, 0 fail. `tsc --noEmit` and Prettier clean.
- Manual: `project create --project-name child` from inside a scaffolded `root` project prints `Error: cannot create a project inside an existing AgentCore project (found .../root/agentcore/agentcore.json)` and exits 1.