### PR TITLE
fix(typescript): enable ADOT instrumentation for TypeScript agents

### DIFF
--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -7957,6 +7957,7 @@ exports[`Assets Directory Snapshots > TypeScript assets > typescript/typescript/
     {{#if (eq modelProvider "Gemini")}}
     "@google/genai": "^1.40.0",
     {{/if}}
+    "@aws/aws-distro-opentelemetry-node-autoinstrumentation": "^0.12.0",
     "@modelcontextprotocol/sdk": "^1.25.2",
     "@opentelemetry/api": "^1.9.0",
     "@strands-agents/sdk": "^1.5.0",
@@ -8132,6 +8133,15 @@ const SYSTEM_PROMPT = \`You are a helpful assistant.\`;
 
 const HISTORY_LIMIT = 128;
 
+// Emit OpenTelemetry spans for model calls (token usage, latency, GenAI
+// attributes) when observability is enabled. ADOT registers a global tracer at
+// startup that these spans flow to. Set here rather than relying on the ADOT
+// Vercel-AI auto-instrumentation, which patches the \`ai\` module at import time:
+// that never fires under CodeZip, where esbuild inlines \`ai\` into the bundle so
+// there is no import to intercept. Toggling the SDK's own telemetry works
+// regardless of bundling. Enabled whenever the runtime turns on observability.
+const AI_TELEMETRY = { isEnabled: process.env.AGENT_OBSERVABILITY_ENABLED === 'true' };
+
 // Keeps one message history per sessionId so each session remembers its own
 // turns (best-effort; resets on cold start). A Map preserves insertion order,
 // so it doubles as an LRU bounded to 128 sessions — a local dev process serving
@@ -8168,6 +8178,7 @@ const app = new BedrockAgentCoreApp({
         model,
         system: SYSTEM_PROMPT,
         messages: [...history, userMessage],
+        experimental_telemetry: AI_TELEMETRY,
       });
 
       let assistant = '';
@@ -8329,6 +8340,7 @@ exports[`Assets Directory Snapshots > TypeScript assets > typescript/typescript/
     "dev": "tsx watch main.ts"
   },
   "dependencies": {
+    "@aws/aws-distro-opentelemetry-node-autoinstrumentation": "^0.12.0",
     "ai": "^6.0.0",
     {{#if (eq modelProvider "Bedrock")}}
     "@ai-sdk/amazon-bedrock": "^4.0.0",

--- a/src/assets/__tests__/__snapshots__/dockerfile-render.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/dockerfile-render.test.ts.snap
@@ -79,3 +79,67 @@ EXPOSE 8080 8000 9000
 CMD ["python", "-m", "main"]
 "
 `;
+
+exports[`TypeScript Dockerfile enableOtel rendering > omits instrumentation when enableOtel is false > Dockerfile-ts-enableOtel-false 1`] = `
+"FROM public.ecr.aws/docker/library/node:22-slim
+
+WORKDIR /app
+
+ENV NODE_ENV=production \\
+    DOCKER_CONTAINER=1
+
+RUN userdel -r node 2>/dev/null || true
+RUN useradd -m -u 1000 bedrock_agentcore
+
+COPY package.json package-lock.json* ./
+RUN npm ci --omit=dev || npm install --omit=dev
+
+COPY --chown=bedrock_agentcore:bedrock_agentcore . .
+
+USER bedrock_agentcore
+
+# AgentCore Runtime service contract ports
+# https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-service-contract.html
+# 8080: HTTP Mode
+# 8000: MCP Mode
+# 9000: A2A Mode
+EXPOSE 8080 8000 9000
+
+CMD ["npx", "tsx", "main.ts"]
+"
+`;
+
+exports[`TypeScript Dockerfile enableOtel rendering > preloads the ADOT Node distro when enableOtel is true > Dockerfile-ts-enableOtel-true 1`] = `
+"FROM public.ecr.aws/docker/library/node:22-slim
+
+WORKDIR /app
+
+ENV NODE_ENV=production \\
+    DOCKER_CONTAINER=1
+
+RUN userdel -r node 2>/dev/null || true
+RUN useradd -m -u 1000 bedrock_agentcore
+
+COPY package.json package-lock.json* ./
+RUN npm ci --omit=dev || npm install --omit=dev
+
+COPY --chown=bedrock_agentcore:bedrock_agentcore . .
+
+USER bedrock_agentcore
+
+# AgentCore Runtime service contract ports
+# https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-service-contract.html
+# 8080: HTTP Mode
+# 8000: MCP Mode
+# 9000: A2A Mode
+EXPOSE 8080 8000 9000
+
+# Node has no \`opentelemetry-instrument\` equivalent, so the ADOT distro is
+# preloaded instead. This registers the global tracer/meter providers before
+# agent code runs, so spans from any third-party instrumentation library are
+# exported rather than silently dropped.
+ENV NODE_OPTIONS="--require @aws/aws-distro-opentelemetry-node-autoinstrumentation/register"
+
+CMD ["npx", "tsx", "main.ts"]
+"
+`;

--- a/src/assets/__tests__/dockerfile-render.test.ts
+++ b/src/assets/__tests__/dockerfile-render.test.ts
@@ -4,6 +4,9 @@ import * as path from 'path';
 import { describe, expect, it } from 'vitest';
 
 const DOCKERFILE_PATH = path.resolve(__dirname, '..', 'container', 'python', 'Dockerfile');
+const TS_DOCKERFILE_PATH = path.resolve(__dirname, '..', 'container', 'typescript', 'Dockerfile');
+
+const ADOT_NODE_PRELOAD = '--require @aws/aws-distro-opentelemetry-node-autoinstrumentation/register';
 
 describe('Dockerfile enableOtel rendering', () => {
   const template = Handlebars.compile(fs.readFileSync(DOCKERFILE_PATH, 'utf-8'));
@@ -20,5 +23,28 @@ describe('Dockerfile enableOtel rendering', () => {
     expect(rendered).toMatchSnapshot('Dockerfile-enableOtel-false');
     expect(rendered).toContain('CMD ["python", "-m"');
     expect(rendered).not.toContain('opentelemetry-instrument');
+  });
+});
+
+describe('TypeScript Dockerfile enableOtel rendering', () => {
+  const template = Handlebars.compile(fs.readFileSync(TS_DOCKERFILE_PATH, 'utf-8'));
+
+  it('preloads the ADOT Node distro when enableOtel is true', () => {
+    const rendered = template({ entrypoint: 'main', enableOtel: true });
+    expect(rendered).toMatchSnapshot('Dockerfile-ts-enableOtel-true');
+    expect(rendered).toContain(ADOT_NODE_PRELOAD);
+    // Node instruments via preload, never the Python console-script wrapper.
+    // Asserted against the CMD line so the explanatory comment above it, which
+    // names `opentelemetry-instrument`, does not trip this.
+    expect(rendered).toContain('CMD ["npx", "tsx", "main.ts"]');
+    expect(rendered).not.toMatch(/CMD \[[^\]]*opentelemetry-instrument/);
+  });
+
+  it('omits instrumentation when enableOtel is false', () => {
+    const rendered = template({ entrypoint: 'main', enableOtel: false });
+    expect(rendered).toMatchSnapshot('Dockerfile-ts-enableOtel-false');
+    expect(rendered).not.toContain('NODE_OPTIONS');
+    expect(rendered).not.toContain('aws-distro-opentelemetry');
+    expect(rendered).toContain('CMD ["npx", "tsx", "main.ts"]');
   });
 });

--- a/src/assets/container/typescript/Dockerfile
+++ b/src/assets/container/typescript/Dockerfile
@@ -22,4 +22,12 @@ USER bedrock_agentcore
 # 9000: A2A Mode
 EXPOSE 8080 8000 9000
 
+{{#if enableOtel}}
+# Node has no `opentelemetry-instrument` equivalent, so the ADOT distro is
+# preloaded instead. This registers the global tracer/meter providers before
+# agent code runs, so spans from any third-party instrumentation library are
+# exported rather than silently dropped.
+ENV NODE_OPTIONS="--require @aws/aws-distro-opentelemetry-node-autoinstrumentation/register"
+
+{{/if}}
 CMD ["npx", "tsx", "main.ts"]

--- a/src/assets/typescript/http/strands/base/package.json
+++ b/src/assets/typescript/http/strands/base/package.json
@@ -19,6 +19,7 @@
     {{#if (eq modelProvider "Gemini")}}
     "@google/genai": "^1.40.0",
     {{/if}}
+    "@aws/aws-distro-opentelemetry-node-autoinstrumentation": "^0.12.0",
     "@modelcontextprotocol/sdk": "^1.25.2",
     "@opentelemetry/api": "^1.9.0",
     "@strands-agents/sdk": "^1.5.0",

--- a/src/assets/typescript/http/vercelai/base/main.ts
+++ b/src/assets/typescript/http/vercelai/base/main.ts
@@ -6,6 +6,15 @@ const SYSTEM_PROMPT = `You are a helpful assistant.`;
 
 const HISTORY_LIMIT = 128;
 
+// Emit OpenTelemetry spans for model calls (token usage, latency, GenAI
+// attributes) when observability is enabled. ADOT registers a global tracer at
+// startup that these spans flow to. Set here rather than relying on the ADOT
+// Vercel-AI auto-instrumentation, which patches the `ai` module at import time:
+// that never fires under CodeZip, where esbuild inlines `ai` into the bundle so
+// there is no import to intercept. Toggling the SDK's own telemetry works
+// regardless of bundling. Enabled whenever the runtime turns on observability.
+const AI_TELEMETRY = { isEnabled: process.env.AGENT_OBSERVABILITY_ENABLED === 'true' };
+
 // Keeps one message history per sessionId so each session remembers its own
 // turns (best-effort; resets on cold start). A Map preserves insertion order,
 // so it doubles as an LRU bounded to 128 sessions — a local dev process serving
@@ -42,6 +51,7 @@ const app = new BedrockAgentCoreApp({
         model,
         system: SYSTEM_PROMPT,
         messages: [...history, userMessage],
+        experimental_telemetry: AI_TELEMETRY,
       });
 
       let assistant = '';

--- a/src/assets/typescript/http/vercelai/base/package.json
+++ b/src/assets/typescript/http/vercelai/base/package.json
@@ -10,6 +10,7 @@
     "dev": "tsx watch main.ts"
   },
   "dependencies": {
+    "@aws/aws-distro-opentelemetry-node-autoinstrumentation": "^0.12.0",
     "ai": "^6.0.0",
     {{#if (eq modelProvider "Bedrock")}}
     "@ai-sdk/amazon-bedrock": "^4.0.0",

--- a/src/cli/operations/agent/generate/schema-mapper.ts
+++ b/src/cli/operations/agent/generate/schema-mapper.ts
@@ -281,7 +281,7 @@ export async function mapGenerateConfigToRenderConfig(
 ): Promise<AgentRenderConfig> {
   const isMcp = config.protocol === 'MCP';
   const gatewayProviders = isMcp ? [] : await mapGatewaysToGatewayProviders();
-  const enableOtel = !isMcp && config.language !== 'TypeScript';
+  const enableOtel = !isMcp;
 
   return {
     name: config.projectName,


### PR DESCRIPTION
Fixes #1892
Depends on aws/agentcore-l3-cdk-constructs#311 (CodeZip path)

## Problem

`agentcore deploy` sets up no ADOT/OpenTelemetry instrumentation for TypeScript agents. Spans from any third-party instrumentation library are silently dropped and nothing appears in CloudWatch. Three independent gaps, each sufficient on its own:

1. **`enableOtel` hardcoded off for TypeScript** — `schema-mapper.ts`:
   ```ts
   const enableOtel = !isMcp && config.language !== 'TypeScript';
   ```
2. **The TypeScript Dockerfile had no instrumentation branch at all.** The Python one branches on `{{#if enableOtel}}`; the TS one ended unconditionally at `CMD ["npx", "tsx", "main.ts"]`. So setting `instrumentation.enableOtel: true` on a TS agent was a **silent no-op** — there was nothing for it to render — while the schema documents it as wrapping the entrypoint.
3. **No OTel SDK in either TS template.** Strands carried only `@opentelemetry/api` (the no-op API surface, which discards spans unless a provider is registered); Vercel AI carried nothing.

## This is a regression

580cd10b — *"fix(templates): remove OTEL, session storage, and gateway from TS templates"*, merged in #981 — deleted the working implementation: both `otel-register.ts` files, their imports from `main.ts`, seven `@opentelemetry/*` dependencies, and it flipped `schema-mapper.ts` to exclude TypeScript. The OTel removal was one commit inside a broader TS template PR, so it isn't visible from the PR title.

## Changes

- `schema-mapper.ts` — stop excluding TypeScript from `enableOtel`
- `container/typescript/Dockerfile` — add the `{{#if enableOtel}}` branch. Node has no `opentelemetry-instrument` equivalent, so it preloads the ADOT distro via `NODE_OPTIONS` rather than wrapping the entrypoint
- both TS templates — add `@aws/aws-distro-opentelemetry-node-autoinstrumentation`
- `vercelai/base/main.ts` — force-enable the Vercel AI SDK's own telemetry (see below)
- `dockerfile-render.test.ts` — extend to cover TypeScript

The CodeZip path needs a different mechanism (no Dockerfile to hook) and lives in aws/agentcore-l3-cdk-constructs#311.

## Why the Vercel template needs an explicit telemetry toggle

Turning on ADOT was necessary but not sufficient for Vercel AI. With instrumentation loaded and traces flowing, Vercel agents still produced **only network-level spans** — no model spans, no `gen_ai.*` attributes — while Strands produced a full GenAI tree from the same runtime.

Two compounding causes:

- ADOT's Vercel instrumentation patches the `ai` module at import time. Both templates are `"type": "module"` and load instrumentation via `--require` (a CJS hook), which never observes an ESM `import ... from 'ai'`.
- Under CodeZip it cannot work at all: esbuild **inlines `ai` into the bundle**, so there is no module resolution event left to intercept. An ESM loader hook would have fixed Container and silently missed CodeZip.

Setting `experimental_telemetry` on the call site sidesteps both. `ai@6` resolves the **global** tracer (`trace.getTracer('ai')` from `@opentelemetry/api`, shared via `globalThis`), which ADOT registers at startup — so it works regardless of bundling or module system. Gated on `AGENT_OBSERVABILITY_ENABLED === 'true'`, matching ADOT's own gate.

Strands needs no equivalent: its template self-instruments via `@opentelemetry/api`.

## Verification

Deployed all four TypeScript agent shapes to a live account, invoked each 5 times, waited for ingestion, and queried X-Ray.

All four log `AWS Distro of OpenTelemetry automatic instrumentation started successfully` and produce X-Ray spans including downstream Bedrock calls.

Vercel AI, before vs after:

```
before:  SdkVercelZip.DEFAULT
           - bedrock-runtime.us-east-1.amazonaws.com:443
           - 169.254.169.254:80

after:   SdkVercelZip.DEFAULT
           - chat us.anthropic.claude-sonnet-4-5-20250929-v1:0
             - chat us.anthropic.claude-sonnet-4-5-...
               - bedrock-runtime.us-east-1.amazonaws.com:443
```

Attributes now present: `gen_ai.request.model`, `gen_ai.response.model`, `gen_ai.response.finish_reasons`, `gen_ai.operation.name`, `gen_ai.provider.name`, `gen_ai.system`. Confirmed on **both** CodeZip and Container.

Tests: asset suite green (141), including the new TS Dockerfile render cases.

## Known cosmetic issue, not addressed here

Runtime logs show `@aws/...-instrumentation-vercel-ai Failed to register VercelAISpanProcessor`. It is harmless and unrelated: ADOT's `setTracerProvider` is called once before the real provider exists (logged at `warn`) and again after, when it succeeds (logged at `debug`, so invisible in production). It also appears for Strands agents, which have no `ai` package installed at all. Worth an upstream log-level fix on `aws-observability/aws-otel-js-instrumentation`; nothing is lost.

## Follow-up

If LangChain or OpenAI-Agents TypeScript templates are added later, they will hit the same ESM/bundling wall — their ADOT instrumentation patches modules identically and will be equally inert. Each will need a per-SDK telemetry toggle, or an `--import`-based ESM loader hook on the Container path.
