### PR TITLE
feat(memory): add read-only event and record commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,13 @@ agentcore                          # interactive TUI
 │       └── list                   # list a Runtime's endpoints
 ├── memory                         # inspect AgentCore Memories
 │   ├── get                        # fetch a Memory by id
-│   └── list                       # list Memories (server-side paginated)
+│   ├── list                       # list Memories (server-side paginated)
+│   ├── event
+│   │   ├── get                    # get an Event from a Memory session
+│   │   └── list                   # list Events from a Memory session
+│   └── record
+│       ├── get                    # get a long-term Memory record
+│       └── list                   # list long-term Memory records
 ├── gateway                        # inspect AgentCore Gateways
 │   ├── get                        # get a Gateway by id
 │   ├── list                       # list Gateways (server-side paginated)

--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ agentcore runtime endpoint list --id <runtimeId> --max-results 20
 agentcore memory get --id <memoryId>
 agentcore memory get --id <memoryId> --view without_decryption
 agentcore memory list --max-results 20
+agentcore memory event get --memory <memoryId> --actor-id <actorId> --session-id <sessionId> --event-id <eventId>
+agentcore memory event list --memory <memoryId> --actor-id <actorId> --session-id <sessionId> --max-results 20
+agentcore memory record get --memory <memoryId> --record-id <recordId>
+agentcore memory record list --memory <memoryId> --namespace <namespace> --max-results 20
 
 # Inspect Gateway resources without project configuration or deployment
 agentcore gateway get --id <gatewayId>
@@ -279,10 +283,14 @@ accept ARNs, `--version`, `--interactive`, cross-account targets, or custom
 request paths. All requests use the Runtime `/invocations` route, including MCP
 Runtimes.
 
-Bare Runtime and Memory branches and leaves require a TTY on stdin and stdout.
+Bare Runtime branches and leaves, plus `memory`, `memory get`, and `memory list`,
+require a TTY on stdin and stdout.
 For Runtime Invoke, supplying a payload or headless-only request or output flags
 runs headlessly; `--session-id` can instead seed the persistent console.
-`--json` always suppresses TUI rendering.
+Supplying Memory operation flags runs those commands headlessly, and `--json`
+always suppresses TUI rendering. The `memory event` and `memory record` groups
+are headless: invoking a group without a leaf prints help, and their leaves
+require resource selectors.
 
 ```bash
 agentcore runtime
@@ -293,6 +301,8 @@ agentcore runtime endpoint list
 agentcore memory
 agentcore memory list
 agentcore memory get
+agentcore memory event
+agentcore memory record
 ```
 
 ---
@@ -704,8 +714,9 @@ A Husky pre-commit hook runs Prettier (via lint-staged) on staged files automati
 
 - **Cover more AgentCore resources.** The harness surface (CRUD, versions,
   endpoints, invoke, exec) is fully implemented in both the CLI and the TUI;
-  the same patterns extend naturally to gateways, Memory mutations and
-  data-plane operations, browser profiles, and the other AgentCore resources.
+  the same patterns extend naturally to gateways, the remaining read-only
+  Memory data-plane operations, browser profiles, and the other AgentCore
+  resources.
 - **Implement `config`.** The `config` command is currently a stub — it should
   read/write real global settings (telemetry, log level, ...) through an
   injected config accessor.

--- a/src/core/core.test.ts
+++ b/src/core/core.test.ts
@@ -5,9 +5,13 @@ import {
 } from "@aws-sdk/client-bedrock-agentcore-control";
 import type { IAMClient } from "@aws-sdk/client-iam";
 import {
+  GetEventCommand,
+  GetMemoryRecordCommand,
   InvokeAgentRuntimeCommand,
   InvokeAgentRuntimeCommandCommand,
   InvokeHarnessCommand,
+  ListEventsCommand,
+  ListMemoryRecordsCommand,
   type BedrockAgentCoreClient,
 } from "@aws-sdk/client-bedrock-agentcore";
 import type { RuntimeInvokeRequest } from "../handlers/runtime/types";
@@ -192,6 +196,95 @@ test("exposes feature sub-clients", () => {
   expect(core.harness).toBeDefined();
   expect(core.memory).toBeDefined();
   expect(core.gateway).toBeDefined();
+});
+
+test("getEvent sends a GetEventCommand on the data client", async () => {
+  const sent: unknown[] = [];
+  const response = { event: undefined };
+  const core = coreWithDataSend(async (command) => {
+    sent.push(command);
+    return response;
+  });
+  const input = {
+    memoryId: "memory-123",
+    actorId: "actor-123",
+    sessionId: "session-123",
+    eventId: "event-123",
+  };
+
+  const result = await core.memory.getEvent(input, { region: "us-east-1" });
+
+  expect(result).toBe(response);
+  expect(sent).toHaveLength(1);
+  expect(sent[0]).toBeInstanceOf(GetEventCommand);
+  expect((sent[0] as GetEventCommand).input).toEqual(input);
+});
+
+test("listEvents sends a ListEventsCommand on the data client", async () => {
+  const sent: unknown[] = [];
+  const response = { events: [], nextToken: "next" };
+  const core = coreWithDataSend(async (command) => {
+    sent.push(command);
+    return response;
+  });
+  const input = {
+    memoryId: "memory-123",
+    actorId: "actor-123",
+    sessionId: "session-123",
+    includePayloads: true,
+    maxResults: 25,
+    nextToken: "current",
+  };
+
+  const result = await core.memory.listEvents(input, { region: "us-east-1" });
+
+  expect(result).toBe(response);
+  expect(sent).toHaveLength(1);
+  expect(sent[0]).toBeInstanceOf(ListEventsCommand);
+  expect((sent[0] as ListEventsCommand).input).toEqual(input);
+});
+
+test("getMemoryRecord sends a GetMemoryRecordCommand on the data client", async () => {
+  const sent: unknown[] = [];
+  const response = { memoryRecord: undefined };
+  const core = coreWithDataSend(async (command) => {
+    sent.push(command);
+    return response;
+  });
+  const input = {
+    memoryId: "memory-123",
+    memoryRecordId: "record-123",
+  };
+
+  const result = await core.memory.getMemoryRecord(input, { region: "us-east-1" });
+
+  expect(result).toBe(response);
+  expect(sent).toHaveLength(1);
+  expect(sent[0]).toBeInstanceOf(GetMemoryRecordCommand);
+  expect((sent[0] as GetMemoryRecordCommand).input).toEqual(input);
+});
+
+test("listMemoryRecords sends a ListMemoryRecordsCommand on the data client", async () => {
+  const sent: unknown[] = [];
+  const response = { memoryRecordSummaries: [], nextToken: "next" };
+  const core = coreWithDataSend(async (command) => {
+    sent.push(command);
+    return response;
+  });
+  const input = {
+    memoryId: "memory-123",
+    namespace: "/customers/acme",
+    memoryStrategyId: "strategy-123",
+    maxResults: 25,
+    nextToken: "current",
+  };
+
+  const result = await core.memory.listMemoryRecords(input, { region: "us-east-1" });
+
+  expect(result).toBe(response);
+  expect(sent).toHaveLength(1);
+  expect(sent[0]).toBeInstanceOf(ListMemoryRecordsCommand);
+  expect((sent[0] as ListMemoryRecordsCommand).input).toEqual(input);
 });
 
 test("getRuntime sends the abort signal to the control client", async () => {

--- a/src/core/memory.tsx
+++ b/src/core/memory.tsx
@@ -1,4 +1,18 @@
 import {
+  GetEventCommand,
+  GetMemoryRecordCommand,
+  ListEventsCommand,
+  ListMemoryRecordsCommand,
+  type GetEventInput,
+  type GetEventOutput,
+  type GetMemoryRecordInput,
+  type GetMemoryRecordOutput,
+  type ListEventsInput,
+  type ListEventsOutput,
+  type ListMemoryRecordsInput,
+  type ListMemoryRecordsOutput,
+} from "@aws-sdk/client-bedrock-agentcore";
+import {
   GetMemoryCommand,
   ListMemoriesCommand,
   type GetMemoryOutput,
@@ -26,5 +40,27 @@ export class MemoryClient implements CoreMemoryClient {
     return this.clients
       .control(toClientConfig(options))
       .send(new ListMemoriesCommand({ nextToken, maxResults }));
+  }
+
+  async getEvent(input: GetEventInput, options: CoreOptions): Promise<GetEventOutput> {
+    return this.clients.data(toClientConfig(options)).send(new GetEventCommand(input));
+  }
+
+  async listEvents(input: ListEventsInput, options: CoreOptions): Promise<ListEventsOutput> {
+    return this.clients.data(toClientConfig(options)).send(new ListEventsCommand(input));
+  }
+
+  async getMemoryRecord(
+    input: GetMemoryRecordInput,
+    options: CoreOptions,
+  ): Promise<GetMemoryRecordOutput> {
+    return this.clients.data(toClientConfig(options)).send(new GetMemoryRecordCommand(input));
+  }
+
+  async listMemoryRecords(
+    input: ListMemoryRecordsInput,
+    options: CoreOptions,
+  ): Promise<ListMemoryRecordsOutput> {
+    return this.clients.data(toClientConfig(options)).send(new ListMemoryRecordsCommand(input));
   }
 }

--- a/src/handlers/memory/event/get/index.tsx
+++ b/src/handlers/memory/event/get/index.tsx
@@ -1,4 +1,5 @@
 import z from "zod";
+import { InputValidationError } from "../../../../errors";
 import { createHandler, flag } from "../../../../router";
 import type { Core } from "../../../types";
 import { coreOptsFromCtx } from "../../../utils";
@@ -9,12 +10,25 @@ export const createGetMemoryEventHandler = (core: Core) =>
     name: "get",
     description: "get an AgentCore Memory Event",
     flags: [
-      flag("memory", "the ID of the Memory", z.string()),
-      flag("actor-id", "the ID of the actor", z.string()),
-      flag("event-id", "the event ID", z.string()),
-      flag("session-id", "the session ID", z.string()),
+      flag("memory", "the ID of the Memory", z.string().optional()),
+      flag("actor-id", "the ID of the actor", z.string().optional()),
+      flag("event-id", "the event ID", z.string().optional()),
+      flag("session-id", "the session ID", z.string().optional()),
     ],
     handle: async (ctx, flags) => {
+      if (!flags.memory) {
+        throw new InputValidationError("required option '--memory <memory>' not specified");
+      }
+      if (!flags["actor-id"]) {
+        throw new InputValidationError("required option '--actor-id <actor-id>' not specified");
+      }
+      if (!flags["session-id"]) {
+        throw new InputValidationError("required option '--session-id <session-id>' not specified");
+      }
+      if (!flags["event-id"]) {
+        throw new InputValidationError("required option '--event-id <event-id>' not specified");
+      }
+
       const response = await core.memory.getEvent(
         {
           memoryId: flags.memory,

--- a/src/handlers/memory/event/get/index.tsx
+++ b/src/handlers/memory/event/get/index.tsx
@@ -1,0 +1,30 @@
+import z from "zod";
+import { createHandler, flag } from "../../../../router";
+import type { Core } from "../../../types";
+import { coreOptsFromCtx } from "../../../utils";
+import { JsonRendererKey } from "../../../../tui";
+
+export const createGetMemoryEventHandler = (core: Core) =>
+  createHandler({
+    name: "get",
+    description: "get an AgentCore Memory Event",
+    flags: [
+      flag("memory", "the ID of the Memory", z.string()),
+      flag("actor-id", "the ID of the actor", z.string()),
+      flag("event-id", "the event ID", z.string()),
+      flag("session-id", "the session ID", z.string()),
+    ],
+    handle: async (ctx, flags) => {
+      const response = await core.memory.getEvent(
+        {
+          memoryId: flags.memory,
+          actorId: flags["actor-id"],
+          sessionId: flags["session-id"],
+          eventId: flags["event-id"],
+        },
+        coreOptsFromCtx(ctx),
+      );
+
+      ctx.require(JsonRendererKey).renderJson(response);
+    },
+  });

--- a/src/handlers/memory/event/index.tsx
+++ b/src/handlers/memory/event/index.tsx
@@ -1,0 +1,10 @@
+import { Router } from "../../../router";
+import type { Core } from "../../types";
+import { createGetMemoryEventHandler } from "./get";
+import { createListMemoryEventsHandler } from "./list";
+
+export function createMemoryEventHandler(core: Core): Router {
+  return new Router("event", "inspect AgentCore Memory events")
+    .handler(createGetMemoryEventHandler(core))
+    .handler(createListMemoryEventsHandler(core));
+}

--- a/src/handlers/memory/event/list/index.tsx
+++ b/src/handlers/memory/event/list/index.tsx
@@ -1,19 +1,19 @@
 import z from "zod";
-import type { EventMetadataFilterExpression } from "@aws-sdk/client-bedrock-agentcore";
 import { InputValidationError } from "../../../../errors";
 import { createHandler, flag } from "../../../../router";
 import type { Core } from "../../../types";
-import { coreOptsFromCtx, parseJsonFlag } from "../../../utils";
+import { coreOptsFromCtx } from "../../../utils";
 import { JsonRendererKey } from "../../../../tui";
+import { parseEventMetadataFilters } from "../../metadataFilters";
 
 export const createListMemoryEventsHandler = (core: Core) =>
   createHandler({
     name: "list",
     description: "list AgentCore Memory events",
     flags: [
-      flag("memory", "the ID of the Memory", z.string()),
-      flag("actor-id", "the ID of the actor", z.string()),
-      flag("session-id", "the session ID", z.string()),
+      flag("memory", "the ID of the Memory", z.string().optional()),
+      flag("actor-id", "the ID of the actor", z.string().optional()),
+      flag("session-id", "the session ID", z.string().optional()),
       flag("include-payloads", "includes event payloads in the response", z.boolean().optional()),
       flag("branch", "filter events by branch name", z.string().optional()),
       flag(
@@ -27,14 +27,21 @@ export const createListMemoryEventsHandler = (core: Core) =>
     ],
 
     handle: async (ctx, flags) => {
+      if (!flags.memory) {
+        throw new InputValidationError("required option '--memory <memory>' not specified");
+      }
+      if (!flags["actor-id"]) {
+        throw new InputValidationError("required option '--actor-id <actor-id>' not specified");
+      }
+      if (!flags["session-id"]) {
+        throw new InputValidationError("required option '--session-id <session-id>' not specified");
+      }
+
       if (flags["include-parent-branches"] && !flags.branch) {
         throw new InputValidationError("'--include-parent-branches' requires '--branch'");
       }
 
-      const eventMetadata = parseJsonFlag<EventMetadataFilterExpression[]>(
-        "metadata-filters",
-        flags["metadata-filters"],
-      );
+      const eventMetadata = parseEventMetadataFilters(flags["metadata-filters"]);
       const filter =
         flags.branch || eventMetadata
           ? {

--- a/src/handlers/memory/event/list/index.tsx
+++ b/src/handlers/memory/event/list/index.tsx
@@ -1,0 +1,66 @@
+import z from "zod";
+import type { EventMetadataFilterExpression } from "@aws-sdk/client-bedrock-agentcore";
+import { InputValidationError } from "../../../../errors";
+import { createHandler, flag } from "../../../../router";
+import type { Core } from "../../../types";
+import { coreOptsFromCtx, parseJsonFlag } from "../../../utils";
+import { JsonRendererKey } from "../../../../tui";
+
+export const createListMemoryEventsHandler = (core: Core) =>
+  createHandler({
+    name: "list",
+    description: "list AgentCore Memory events",
+    flags: [
+      flag("memory", "the ID of the Memory", z.string()),
+      flag("actor-id", "the ID of the actor", z.string()),
+      flag("session-id", "the session ID", z.string()),
+      flag("include-payloads", "includes event payloads in the response", z.boolean().optional()),
+      flag("branch", "filter events by branch name", z.string().optional()),
+      flag(
+        "include-parent-branches",
+        "includes parent branches when filtering by branch",
+        z.boolean().optional(),
+      ),
+      flag("metadata-filters", "event metadata filters as JSON", z.string().optional()),
+      flag("max-results", "maximum number of events to return; default 20", z.number().optional()),
+      flag("next-token", "pagination token returned by a previous request", z.string().optional()),
+    ],
+
+    handle: async (ctx, flags) => {
+      if (flags["include-parent-branches"] && !flags.branch) {
+        throw new InputValidationError("'--include-parent-branches' requires '--branch'");
+      }
+
+      const eventMetadata = parseJsonFlag<EventMetadataFilterExpression[]>(
+        "metadata-filters",
+        flags["metadata-filters"],
+      );
+      const filter =
+        flags.branch || eventMetadata
+          ? {
+              branch: flags.branch
+                ? {
+                    name: flags.branch,
+                    includeParentBranches: flags["include-parent-branches"],
+                  }
+                : undefined,
+              eventMetadata,
+            }
+          : undefined;
+
+      const response = await core.memory.listEvents(
+        {
+          memoryId: flags.memory,
+          actorId: flags["actor-id"],
+          sessionId: flags["session-id"],
+          includePayloads: flags["include-payloads"],
+          filter,
+          maxResults: flags["max-results"],
+          nextToken: flags["next-token"],
+        },
+        coreOptsFromCtx(ctx),
+      );
+
+      ctx.require(JsonRendererKey).renderJson(response);
+    },
+  });

--- a/src/handlers/memory/index.tsx
+++ b/src/handlers/memory/index.tsx
@@ -3,6 +3,7 @@ import { Router } from "../../router";
 import { renderTui } from "../../tui";
 import type { AppIO } from "../../io";
 import type { Core } from "../types";
+import { createMemoryEventHandler } from "./event";
 import { createGetMemoryHandler } from "./get";
 import { createListMemoriesHandler } from "./list";
 
@@ -11,5 +12,6 @@ export function createMemoryHandler(core: Core, io: AppIO): Router {
     .use(withTuiOnEmptyFlagsAndArgs(core, io))
     .default(renderTui(core, io))
     .handler(createGetMemoryHandler(core))
-    .handler(createListMemoriesHandler(core));
+    .handler(createListMemoriesHandler(core))
+    .handler(createMemoryEventHandler(core));
 }

--- a/src/handlers/memory/index.tsx
+++ b/src/handlers/memory/index.tsx
@@ -6,6 +6,7 @@ import type { Core } from "../types";
 import { createMemoryEventHandler } from "./event";
 import { createGetMemoryHandler } from "./get";
 import { createListMemoriesHandler } from "./list";
+import { createMemoryRecordHandler } from "./record";
 
 export function createMemoryHandler(core: Core, io: AppIO): Router {
   return new Router("memory", "manage AgentCore Memories")
@@ -13,5 +14,6 @@ export function createMemoryHandler(core: Core, io: AppIO): Router {
     .default(renderTui(core, io))
     .handler(createGetMemoryHandler(core))
     .handler(createListMemoriesHandler(core))
-    .handler(createMemoryEventHandler(core));
+    .handler(createMemoryEventHandler(core))
+    .handler(createMemoryRecordHandler(core));
 }

--- a/src/handlers/memory/memory.test.tsx
+++ b/src/handlers/memory/memory.test.tsx
@@ -4,7 +4,12 @@ import type {
   Event,
   EventMetadataFilterExpression,
   GetEventOutput,
+  GetMemoryRecordOutput,
   ListEventsOutput,
+  ListMemoryRecordsOutput,
+  MemoryMetadataFilterExpression,
+  MemoryRecord,
+  MemoryRecordSummary,
 } from "@aws-sdk/client-bedrock-agentcore";
 import { CoreClient } from "../../core";
 import {
@@ -32,6 +37,7 @@ const EVENT_MEMORY_ID = "memory-1";
 const ACTOR_ID = "actor-1";
 const SESSION_ID = "session-1";
 const EVENT_ID = "event-1";
+const RECORD_ID = "record-1";
 
 const event: Event = {
   memoryId: EVENT_MEMORY_ID,
@@ -41,6 +47,15 @@ const event: Event = {
   eventTimestamp: new Date("2026-08-03T12:00:00.000Z"),
   payload: [],
 };
+
+const memoryRecord: MemoryRecord = {
+  memoryRecordId: RECORD_ID,
+  content: { text: "Customer prefers email notifications." },
+  memoryStrategyId: "strategy-1",
+  namespaces: ["/customers/acme"],
+  createdAt: new Date("2026-08-03T12:00:00.000Z"),
+};
+const memoryRecordSummary: MemoryRecordSummary = memoryRecord;
 
 function createFixtureCore(): CoreClient {
   const { createControlClient, createDataClient, createIamClient } = fixtureFactories(FIXTURES);
@@ -89,10 +104,17 @@ describe("memory command hierarchy", () => {
     });
     const memory = root.children().find((child) => child.name() === "memory");
     const event = memory?.children().find((child) => child.name() === "event");
+    const record = memory?.children().find((child) => child.name() === "record");
 
     expect(memory?.flags().map((flag) => flag.name)).not.toContain("interactive");
-    expect(memory?.children().map((child) => child.name())).toEqual(["get", "list", "event"]);
+    expect(memory?.children().map((child) => child.name())).toEqual([
+      "get",
+      "list",
+      "event",
+      "record",
+    ]);
     expect(event?.children().map((child) => child.name())).toEqual(["get", "list"]);
+    expect(record?.children().map((child) => child.name())).toEqual(["get", "list"]);
   });
 
   test("keeps an omitted get view undefined for empty-flag routing", () => {
@@ -331,6 +353,169 @@ describe("memory event commands", () => {
     await expect(command.route(["memory", "event", "get"])).rejects.toThrow(
       "required option '--memory <memory>' not specified",
     );
+    expect(command.core.memory.calls).toEqual([]);
+  });
+});
+
+describe("memory record commands", () => {
+  test("gets a record and renders the response unchanged", async () => {
+    const response: GetMemoryRecordOutput = { memoryRecord };
+    const core = new TestCoreClient();
+    core.memory.setGetMemoryRecordResponse(response);
+    const command = testMemoryCommand(core);
+
+    await command.route([
+      "memory",
+      "record",
+      "get",
+      "--memory",
+      EVENT_MEMORY_ID,
+      "--record-id",
+      RECORD_ID,
+    ]);
+
+    expect(core.memory.calls).toEqual([
+      {
+        method: "getMemoryRecord",
+        args: [
+          {
+            memoryId: EVENT_MEMORY_ID,
+            memoryRecordId: RECORD_ID,
+          },
+          { region: REGION },
+        ],
+      },
+    ]);
+    expect(JSON.parse(command.stdout())).toEqual(JSON.parse(JSON.stringify(response)));
+  });
+
+  test("rejects missing record selectors without entering the TUI", async () => {
+    const command = testMemoryCommand();
+
+    await expect(command.route(["memory", "record", "get"])).rejects.toThrow(
+      "required option '--memory <memory>' not specified",
+    );
+    expect(command.core.memory.calls).toEqual([]);
+  });
+
+  test("lists records with namespace, metadata, strategy, and pagination options", async () => {
+    const metadataFilter: MemoryMetadataFilterExpression = {
+      left: { metadataKey: "tenant" },
+      operator: "EQUALS_TO",
+      right: { metadataValue: { stringValue: "acme" } },
+    };
+    const response: ListMemoryRecordsOutput = {
+      memoryRecordSummaries: [memoryRecordSummary],
+      nextToken: "page-3",
+    };
+    const core = new TestCoreClient();
+    core.memory.setListMemoryRecordsResponse(response, "page-2");
+    const command = testMemoryCommand(core);
+
+    await command.route([
+      "memory",
+      "record",
+      "list",
+      "--memory",
+      EVENT_MEMORY_ID,
+      "--namespace",
+      "/customers/acme",
+      "--strategy-id",
+      "strategy-1",
+      "--metadata-filters",
+      JSON.stringify([metadataFilter]),
+      "--max-results",
+      "1",
+      "--next-token",
+      "page-2",
+    ]);
+
+    expect(core.memory.calls).toEqual([
+      {
+        method: "listMemoryRecords",
+        args: [
+          {
+            memoryId: EVENT_MEMORY_ID,
+            namespace: "/customers/acme",
+            namespacePath: undefined,
+            memoryStrategyId: "strategy-1",
+            metadataFilters: [metadataFilter],
+            maxResults: 1,
+            nextToken: "page-2",
+          },
+          { region: REGION },
+        ],
+      },
+    ]);
+    expect(JSON.parse(command.stdout())).toEqual(JSON.parse(JSON.stringify(response)));
+  });
+
+  test("lists records by namespace hierarchy", async () => {
+    const response: ListMemoryRecordsOutput = {
+      memoryRecordSummaries: [memoryRecordSummary],
+    };
+    const core = new TestCoreClient();
+    core.memory.setListMemoryRecordsResponse(response);
+    const command = testMemoryCommand(core);
+
+    await command.route([
+      "memory",
+      "record",
+      "list",
+      "--memory",
+      EVENT_MEMORY_ID,
+      "--namespace-path",
+      "/customers/acme/*",
+    ]);
+
+    expect(core.memory.calls).toEqual([
+      {
+        method: "listMemoryRecords",
+        args: [
+          {
+            memoryId: EVENT_MEMORY_ID,
+            namespace: undefined,
+            namespacePath: "/customers/acme/*",
+            memoryStrategyId: undefined,
+            metadataFilters: undefined,
+            maxResults: undefined,
+            nextToken: undefined,
+          },
+          { region: REGION },
+        ],
+      },
+    ]);
+    expect(JSON.parse(command.stdout())).toEqual(JSON.parse(JSON.stringify(response)));
+  });
+
+  test.each([
+    ["neither", []],
+    ["both", ["--namespace", "/customers/acme", "--namespace-path", "/customers/acme/*"]],
+  ] as const)("rejects %s namespace selector", async (_case, selectors) => {
+    const command = testMemoryCommand();
+
+    await expect(
+      command.route(["memory", "record", "list", "--memory", EVENT_MEMORY_ID, ...selectors]),
+    ).rejects.toThrow("exactly one of '--namespace' or '--namespace-path' must be specified");
+    expect(command.core.memory.calls).toEqual([]);
+  });
+
+  test("rejects invalid record metadata filter JSON", async () => {
+    const command = testMemoryCommand();
+
+    await expect(
+      command.route([
+        "memory",
+        "record",
+        "list",
+        "--memory",
+        EVENT_MEMORY_ID,
+        "--namespace",
+        "/customers/acme",
+        "--metadata-filters",
+        "{",
+      ]),
+    ).rejects.toThrow("Invalid JSON for option '--metadata-filters'");
     expect(command.core.memory.calls).toEqual([]);
   });
 });

--- a/src/handlers/memory/memory.test.tsx
+++ b/src/handlers/memory/memory.test.tsx
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import { join } from "node:path";
+import type {
+  Event,
+  EventMetadataFilterExpression,
+  GetEventOutput,
+  ListEventsOutput,
+} from "@aws-sdk/client-bedrock-agentcore";
 import { CoreClient } from "../../core";
 import {
   createSilentLogger,
@@ -13,6 +19,7 @@ import { createRootHandler } from "../index";
 import { createGetMemoryHandler } from "./get";
 
 const REGION = "us-west-2";
+const ENDPOINT = "https://agentcore.example.test";
 const FIXTURES = join(import.meta.dir, "__fixtures__");
 
 // The e2e-test account holds two persistent fixture Memories:
@@ -21,6 +28,19 @@ const FIXTURES = join(import.meta.dir, "__fixtures__");
 // Record with AWS_PROFILE=e2e-test RECORD=1 bun test src/handlers/memory/memory.test.tsx.
 const FIXTURE_MEMORY_ID = "agentcore_cli_memory_read_only_fixture-QZMh466aPK";
 const MISSING_MEMORY_ID = "missing_memory-0000000000";
+const EVENT_MEMORY_ID = "memory-1";
+const ACTOR_ID = "actor-1";
+const SESSION_ID = "session-1";
+const EVENT_ID = "event-1";
+
+const event: Event = {
+  memoryId: EVENT_MEMORY_ID,
+  actorId: ACTOR_ID,
+  sessionId: SESSION_ID,
+  eventId: EVENT_ID,
+  eventTimestamp: new Date("2026-08-03T12:00:00.000Z"),
+  payload: [],
+};
 
 function createFixtureCore(): CoreClient {
   const { createControlClient, createDataClient, createIamClient } = fixtureFactories(FIXTURES);
@@ -33,8 +53,7 @@ function createFixtureCore(): CoreClient {
   });
 }
 
-function testMemoryCommand() {
-  const core = new TestCoreClient();
+function testMemoryCommand(core = new TestCoreClient()) {
   const io = testIO();
   const root = createRootHandler(core, {
     io: io.io,
@@ -45,6 +64,7 @@ function testMemoryCommand() {
   return {
     core,
     route: (args: string[]) => root.route(["node", "agentcore", ...args, "--region", REGION]),
+    stdout: () => io.stdout(),
   };
 }
 
@@ -68,9 +88,11 @@ describe("memory command hierarchy", () => {
       globalConfigAccessor: new TestGlobalConfigAccessor(),
     });
     const memory = root.children().find((child) => child.name() === "memory");
+    const event = memory?.children().find((child) => child.name() === "event");
 
     expect(memory?.flags().map((flag) => flag.name)).not.toContain("interactive");
-    expect(memory?.children().map((child) => child.name())).toEqual(["get", "list"]);
+    expect(memory?.children().map((child) => child.name())).toEqual(["get", "list", "event"]);
+    expect(event?.children().map((child) => child.name())).toEqual(["get", "list"]);
   });
 
   test("keeps an omitted get view undefined for empty-flag routing", () => {
@@ -157,5 +179,158 @@ describe("memory read-only commands", () => {
     await expect(run(["memory", "get", "--id", MISSING_MEMORY_ID])).rejects.toMatchObject({
       name: "ResourceNotFoundException",
     });
+  });
+});
+
+describe("memory event commands", () => {
+  test("gets an event and renders the response unchanged", async () => {
+    const response: GetEventOutput = { event };
+    const core = new TestCoreClient();
+    core.memory.setGetEventResponse(response);
+    const command = testMemoryCommand(core);
+
+    await command.route([
+      "memory",
+      "event",
+      "get",
+      "--memory",
+      EVENT_MEMORY_ID,
+      "--actor-id",
+      ACTOR_ID,
+      "--session-id",
+      SESSION_ID,
+      "--event-id",
+      EVENT_ID,
+      "--endpoint-url",
+      ENDPOINT,
+    ]);
+
+    expect(core.memory.calls).toEqual([
+      {
+        method: "getEvent",
+        args: [
+          {
+            memoryId: EVENT_MEMORY_ID,
+            actorId: ACTOR_ID,
+            sessionId: SESSION_ID,
+            eventId: EVENT_ID,
+          },
+          { region: REGION, endpointUrl: ENDPOINT },
+        ],
+      },
+    ]);
+    expect(JSON.parse(command.stdout())).toEqual(JSON.parse(JSON.stringify(response)));
+  });
+
+  test("lists events with branch, metadata, payload, and pagination options", async () => {
+    const metadataFilter: EventMetadataFilterExpression = {
+      left: { metadataKey: "tenant" },
+      operator: "EQUALS_TO",
+      right: { metadataValue: { stringValue: "acme" } },
+    };
+    const response: ListEventsOutput = {
+      events: [event],
+      nextToken: "page-3",
+    };
+    const core = new TestCoreClient();
+    core.memory.setListEventsResponse(response, "page-2");
+    const command = testMemoryCommand(core);
+
+    await command.route([
+      "memory",
+      "event",
+      "list",
+      "--memory",
+      EVENT_MEMORY_ID,
+      "--actor-id",
+      ACTOR_ID,
+      "--session-id",
+      SESSION_ID,
+      "--include-payloads",
+      "--branch",
+      "feature",
+      "--include-parent-branches",
+      "--metadata-filters",
+      JSON.stringify([metadataFilter]),
+      "--max-results",
+      "1",
+      "--next-token",
+      "page-2",
+    ]);
+
+    expect(core.memory.calls).toEqual([
+      {
+        method: "listEvents",
+        args: [
+          {
+            memoryId: EVENT_MEMORY_ID,
+            actorId: ACTOR_ID,
+            sessionId: SESSION_ID,
+            includePayloads: true,
+            filter: {
+              branch: {
+                name: "feature",
+                includeParentBranches: true,
+              },
+              eventMetadata: [metadataFilter],
+            },
+            maxResults: 1,
+            nextToken: "page-2",
+          },
+          { region: REGION },
+        ],
+      },
+    ]);
+    expect(JSON.parse(command.stdout())).toEqual(JSON.parse(JSON.stringify(response)));
+  });
+
+  test("rejects parent branch inclusion without a branch", async () => {
+    const command = testMemoryCommand();
+
+    await expect(
+      command.route([
+        "memory",
+        "event",
+        "list",
+        "--memory",
+        EVENT_MEMORY_ID,
+        "--actor-id",
+        ACTOR_ID,
+        "--session-id",
+        SESSION_ID,
+        "--include-parent-branches",
+      ]),
+    ).rejects.toThrow("'--include-parent-branches' requires '--branch'");
+    expect(command.core.memory.calls).toEqual([]);
+  });
+
+  test("rejects invalid metadata filter JSON", async () => {
+    const command = testMemoryCommand();
+
+    await expect(
+      command.route([
+        "memory",
+        "event",
+        "list",
+        "--memory",
+        EVENT_MEMORY_ID,
+        "--actor-id",
+        ACTOR_ID,
+        "--session-id",
+        SESSION_ID,
+        "--metadata-filters",
+        "{",
+      ]),
+    ).rejects.toThrow("Invalid JSON for option '--metadata-filters'");
+    expect(command.core.memory.calls).toEqual([]);
+  });
+
+  test("rejects missing event selectors without entering the TUI", async () => {
+    const command = testMemoryCommand();
+
+    await expect(command.route(["memory", "event", "get"])).rejects.toThrow(
+      "required option '--memory <memory>' not specified",
+    );
+    expect(command.core.memory.calls).toEqual([]);
   });
 });

--- a/src/handlers/memory/memory.test.tsx
+++ b/src/handlers/memory/memory.test.tsx
@@ -548,6 +548,54 @@ describe("memory record commands", () => {
     expect(JSON.parse(command.stdout())).toEqual(JSON.parse(JSON.stringify(response)));
   });
 
+  test("converts ISO datetime metadata filters to SDK Dates", async () => {
+    const timestamp = "2026-08-04T16:33:58-04:00";
+    const core = new TestCoreClient();
+    const command = testMemoryCommand(core);
+
+    await command.route([
+      "memory",
+      "record",
+      "list",
+      "--memory",
+      EVENT_MEMORY_ID,
+      "--namespace",
+      "/customers/acme",
+      "--metadata-filters",
+      JSON.stringify([
+        {
+          left: { metadataKey: "createdAt" },
+          operator: "EQUALS_TO",
+          right: { metadataValue: { dateTimeValue: timestamp } },
+        },
+      ]),
+    ]);
+
+    expect(core.memory.calls).toEqual([
+      {
+        method: "listMemoryRecords",
+        args: [
+          {
+            memoryId: EVENT_MEMORY_ID,
+            namespace: "/customers/acme",
+            namespacePath: undefined,
+            memoryStrategyId: undefined,
+            metadataFilters: [
+              {
+                left: { metadataKey: "createdAt" },
+                operator: "EQUALS_TO",
+                right: { metadataValue: { dateTimeValue: new Date(timestamp) } },
+              },
+            ],
+            maxResults: undefined,
+            nextToken: undefined,
+          },
+          { region: REGION },
+        ],
+      },
+    ]);
+  });
+
   test("rejects a missing Memory selector for record list", async () => {
     const command = testMemoryCommand();
 
@@ -597,6 +645,36 @@ describe("memory record commands", () => {
           left: { metadataKey: "tenant" },
           operator: "EQUALS_TO",
           right: { metadataValue: { booleanValue: true } },
+        },
+      ]),
+    ],
+    [
+      "a null datetime",
+      JSON.stringify([
+        {
+          left: { metadataKey: "createdAt" },
+          operator: "EQUALS_TO",
+          right: { metadataValue: { dateTimeValue: null } },
+        },
+      ]),
+    ],
+    [
+      "a numeric datetime",
+      JSON.stringify([
+        {
+          left: { metadataKey: "createdAt" },
+          operator: "EQUALS_TO",
+          right: { metadataValue: { dateTimeValue: 0 } },
+        },
+      ]),
+    ],
+    [
+      "a malformed datetime",
+      JSON.stringify([
+        {
+          left: { metadataKey: "createdAt" },
+          operator: "EQUALS_TO",
+          right: { metadataValue: { dateTimeValue: "not-a-date" } },
         },
       ]),
     ],

--- a/src/handlers/memory/memory.test.tsx
+++ b/src/handlers/memory/memory.test.tsx
@@ -347,12 +347,71 @@ describe("memory event commands", () => {
     expect(command.core.memory.calls).toEqual([]);
   });
 
-  test("rejects missing event selectors without entering the TUI", async () => {
+  test.each([
+    ["memory", ["--json"], "--memory <memory>"],
+    ["actor", ["--memory", EVENT_MEMORY_ID, "--json"], "--actor-id <actor-id>"],
+    [
+      "session",
+      ["--memory", EVENT_MEMORY_ID, "--actor-id", ACTOR_ID, "--json"],
+      "--session-id <session-id>",
+    ],
+    [
+      "event",
+      ["--memory", EVENT_MEMORY_ID, "--actor-id", ACTOR_ID, "--session-id", SESSION_ID, "--json"],
+      "--event-id <event-id>",
+    ],
+  ] as const)("rejects a missing %s selector for event get", async (_name, flags, expected) => {
     const command = testMemoryCommand();
 
-    await expect(command.route(["memory", "event", "get"])).rejects.toThrow(
-      "required option '--memory <memory>' not specified",
-    );
+    await expect(command.route(["memory", "event", "get", ...flags])).rejects.toThrow(expected);
+    expect(command.core.memory.calls).toEqual([]);
+  });
+
+  test.each([
+    ["memory", ["--json"], "--memory <memory>"],
+    ["actor", ["--memory", EVENT_MEMORY_ID, "--json"], "--actor-id <actor-id>"],
+    [
+      "session",
+      ["--memory", EVENT_MEMORY_ID, "--actor-id", ACTOR_ID, "--json"],
+      "--session-id <session-id>",
+    ],
+  ] as const)("rejects a missing %s selector for event list", async (_name, flags, expected) => {
+    const command = testMemoryCommand();
+
+    await expect(command.route(["memory", "event", "list", ...flags])).rejects.toThrow(expected);
+    expect(command.core.memory.calls).toEqual([]);
+  });
+
+  test.each([
+    ["a non-array", "{}"],
+    [
+      "an invalid expression member",
+      JSON.stringify([
+        {
+          left: { metadataKey: "tenant" },
+          operator: "EQUALS_TO",
+          right: { metadataValue: { numberValue: 1 } },
+        },
+      ]),
+    ],
+  ])("rejects %s in event metadata filters", async (_name, metadataFilters) => {
+    const command = testMemoryCommand();
+
+    await expect(
+      command.route([
+        "memory",
+        "event",
+        "list",
+        "--memory",
+        EVENT_MEMORY_ID,
+        "--actor-id",
+        ACTOR_ID,
+        "--session-id",
+        SESSION_ID,
+        "--metadata-filters",
+        metadataFilters,
+      ]),
+    ).rejects.toThrow("Invalid value for option '--metadata-filters'");
     expect(command.core.memory.calls).toEqual([]);
   });
 });
@@ -389,12 +448,13 @@ describe("memory record commands", () => {
     expect(JSON.parse(command.stdout())).toEqual(JSON.parse(JSON.stringify(response)));
   });
 
-  test("rejects missing record selectors without entering the TUI", async () => {
+  test.each([
+    ["memory", ["--json"], "--memory <memory>"],
+    ["record", ["--memory", EVENT_MEMORY_ID, "--json"], "--record-id <record-id>"],
+  ] as const)("rejects a missing %s selector for record get", async (_name, flags, expected) => {
     const command = testMemoryCommand();
 
-    await expect(command.route(["memory", "record", "get"])).rejects.toThrow(
-      "required option '--memory <memory>' not specified",
-    );
+    await expect(command.route(["memory", "record", "get", ...flags])).rejects.toThrow(expected);
     expect(command.core.memory.calls).toEqual([]);
   });
 
@@ -488,6 +548,15 @@ describe("memory record commands", () => {
     expect(JSON.parse(command.stdout())).toEqual(JSON.parse(JSON.stringify(response)));
   });
 
+  test("rejects a missing Memory selector for record list", async () => {
+    const command = testMemoryCommand();
+
+    await expect(
+      command.route(["memory", "record", "list", "--namespace", "/customers/acme", "--json"]),
+    ).rejects.toThrow("--memory <memory>");
+    expect(command.core.memory.calls).toEqual([]);
+  });
+
   test.each([
     ["neither", []],
     ["both", ["--namespace", "/customers/acme", "--namespace-path", "/customers/acme/*"]],
@@ -516,6 +585,37 @@ describe("memory record commands", () => {
         "{",
       ]),
     ).rejects.toThrow("Invalid JSON for option '--metadata-filters'");
+    expect(command.core.memory.calls).toEqual([]);
+  });
+
+  test.each([
+    ["a non-array", "{}"],
+    [
+      "an invalid expression member",
+      JSON.stringify([
+        {
+          left: { metadataKey: "tenant" },
+          operator: "EQUALS_TO",
+          right: { metadataValue: { booleanValue: true } },
+        },
+      ]),
+    ],
+  ])("rejects %s in record metadata filters", async (_name, metadataFilters) => {
+    const command = testMemoryCommand();
+
+    await expect(
+      command.route([
+        "memory",
+        "record",
+        "list",
+        "--memory",
+        EVENT_MEMORY_ID,
+        "--namespace",
+        "/customers/acme",
+        "--metadata-filters",
+        metadataFilters,
+      ]),
+    ).rejects.toThrow("Invalid value for option '--metadata-filters'");
     expect(command.core.memory.calls).toEqual([]);
   });
 });

--- a/src/handlers/memory/metadataFilters.ts
+++ b/src/handlers/memory/metadataFilters.ts
@@ -1,0 +1,75 @@
+import {
+  MemoryRecordOperatorType,
+  OperatorType,
+  type EventMetadataFilterExpression,
+  type MemoryMetadataFilterExpression,
+} from "@aws-sdk/client-bedrock-agentcore";
+import z from "zod";
+import { parseJsonFlagWithSchema } from "../utils";
+
+const eventMetadataValueSchema = z.object({ stringValue: z.string() }).strict();
+
+const eventMetadataFilterExpressionSchema = z
+  .object({
+    left: z.object({ metadataKey: z.string().min(1) }).strict(),
+    operator: z.enum(OperatorType),
+    right: z.object({ metadataValue: eventMetadataValueSchema }).strict().optional(),
+  })
+  .strict()
+  .superRefine((expression, ctx) => {
+    if (expression.operator === OperatorType.EQUALS_TO && expression.right === undefined) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["right"],
+        message: "right is required for EQUALS_TO",
+      });
+    }
+  });
+
+const memoryRecordMetadataValueSchema = z.union([
+  z.object({ stringValue: z.string() }).strict(),
+  z.object({ stringListValue: z.array(z.string()) }).strict(),
+  z.object({ numberValue: z.number() }).strict(),
+  z.object({ dateTimeValue: z.coerce.date() }).strict(),
+]);
+
+const memoryMetadataFilterExpressionSchema = z
+  .object({
+    left: z.object({ metadataKey: z.string().min(1) }).strict(),
+    operator: z.enum(MemoryRecordOperatorType),
+    right: z.object({ metadataValue: memoryRecordMetadataValueSchema }).strict().optional(),
+  })
+  .strict()
+  .superRefine((expression, ctx) => {
+    if (
+      expression.operator !== MemoryRecordOperatorType.EXISTS &&
+      expression.operator !== MemoryRecordOperatorType.NOT_EXISTS &&
+      expression.right === undefined
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["right"],
+        message: `right is required for ${expression.operator}`,
+      });
+    }
+  });
+
+const eventMetadataFiltersSchema: z.ZodType<EventMetadataFilterExpression[]> = z.array(
+  eventMetadataFilterExpressionSchema,
+);
+
+const memoryMetadataFiltersSchema: z.ZodType<MemoryMetadataFilterExpression[]> = z.array(
+  memoryMetadataFilterExpressionSchema,
+);
+
+export function parseEventMetadataFilters(
+  raw: string | undefined,
+): EventMetadataFilterExpression[] | undefined {
+  return parseJsonFlagWithSchema("metadata-filters", raw, eventMetadataFiltersSchema);
+}
+
+export function parseMemoryMetadataFilters(
+  raw: string | undefined,
+): MemoryMetadataFilterExpression[] | undefined {
+  return parseJsonFlagWithSchema("metadata-filters", raw, memoryMetadataFiltersSchema);
+}

--- a/src/handlers/memory/metadataFilters.ts
+++ b/src/handlers/memory/metadataFilters.ts
@@ -30,7 +30,11 @@ const memoryRecordMetadataValueSchema = z.union([
   z.object({ stringValue: z.string() }).strict(),
   z.object({ stringListValue: z.array(z.string()) }).strict(),
   z.object({ numberValue: z.number() }).strict(),
-  z.object({ dateTimeValue: z.coerce.date() }).strict(),
+  z
+    .object({
+      dateTimeValue: z.iso.datetime({ offset: true }).transform((value) => new Date(value)),
+    })
+    .strict(),
 ]);
 
 const memoryMetadataFilterExpressionSchema = z

--- a/src/handlers/memory/record/get/index.tsx
+++ b/src/handlers/memory/record/get/index.tsx
@@ -1,4 +1,5 @@
 import z from "zod";
+import { InputValidationError } from "../../../../errors";
 import { createHandler, flag } from "../../../../router";
 import { JsonRendererKey } from "../../../../tui";
 import type { Core } from "../../../types";
@@ -9,10 +10,17 @@ export const createGetMemoryRecordHandler = (core: Core) =>
     name: "get",
     description: "get an AgentCore Memory record",
     flags: [
-      flag("memory", "the ID of the Memory", z.string()),
-      flag("record-id", "the ID of the Memory record", z.string()),
+      flag("memory", "the ID of the Memory", z.string().optional()),
+      flag("record-id", "the ID of the Memory record", z.string().optional()),
     ],
     handle: async (ctx, flags) => {
+      if (!flags.memory) {
+        throw new InputValidationError("required option '--memory <memory>' not specified");
+      }
+      if (!flags["record-id"]) {
+        throw new InputValidationError("required option '--record-id <record-id>' not specified");
+      }
+
       const response = await core.memory.getMemoryRecord(
         {
           memoryId: flags.memory,

--- a/src/handlers/memory/record/get/index.tsx
+++ b/src/handlers/memory/record/get/index.tsx
@@ -1,0 +1,26 @@
+import z from "zod";
+import { createHandler, flag } from "../../../../router";
+import { JsonRendererKey } from "../../../../tui";
+import type { Core } from "../../../types";
+import { coreOptsFromCtx } from "../../../utils";
+
+export const createGetMemoryRecordHandler = (core: Core) =>
+  createHandler({
+    name: "get",
+    description: "get an AgentCore Memory record",
+    flags: [
+      flag("memory", "the ID of the Memory", z.string()),
+      flag("record-id", "the ID of the Memory record", z.string()),
+    ],
+    handle: async (ctx, flags) => {
+      const response = await core.memory.getMemoryRecord(
+        {
+          memoryId: flags.memory,
+          memoryRecordId: flags["record-id"],
+        },
+        coreOptsFromCtx(ctx),
+      );
+
+      ctx.require(JsonRendererKey).renderJson(response);
+    },
+  });

--- a/src/handlers/memory/record/index.tsx
+++ b/src/handlers/memory/record/index.tsx
@@ -1,0 +1,10 @@
+import { Router } from "../../../router";
+import type { Core } from "../../types";
+import { createGetMemoryRecordHandler } from "./get";
+import { createListMemoryRecordsHandler } from "./list";
+
+export function createMemoryRecordHandler(core: Core): Router {
+  return new Router("record", "inspect AgentCore Memory records")
+    .handler(createGetMemoryRecordHandler(core))
+    .handler(createListMemoryRecordsHandler(core));
+}

--- a/src/handlers/memory/record/list/index.tsx
+++ b/src/handlers/memory/record/list/index.tsx
@@ -1,0 +1,50 @@
+import z from "zod";
+import type { MemoryMetadataFilterExpression } from "@aws-sdk/client-bedrock-agentcore";
+import { InputValidationError } from "../../../../errors";
+import { createHandler, flag } from "../../../../router";
+import { JsonRendererKey } from "../../../../tui";
+import type { Core } from "../../../types";
+import { coreOptsFromCtx, parseJsonFlag } from "../../../utils";
+
+export const createListMemoryRecordsHandler = (core: Core) =>
+  createHandler({
+    name: "list",
+    description: "list AgentCore Memory records",
+    flags: [
+      flag("memory", "the ID of the Memory", z.string()),
+      flag("namespace", "filter by namespace prefix", z.string().optional()),
+      flag("namespace-path", "filter by namespace hierarchy", z.string().optional()),
+      flag("strategy-id", "filter by Memory strategy ID", z.string().optional()),
+      flag("metadata-filters", "Memory record metadata filters as JSON", z.string().optional()),
+      flag("max-results", "maximum number of records to return", z.number().optional()),
+      flag("next-token", "pagination token returned by a previous request", z.string().optional()),
+    ],
+    handle: async (ctx, flags) => {
+      const hasNamespace = flags.namespace !== undefined;
+      const hasNamespacePath = flags["namespace-path"] !== undefined;
+      if (hasNamespace === hasNamespacePath) {
+        throw new InputValidationError(
+          "exactly one of '--namespace' or '--namespace-path' must be specified",
+        );
+      }
+
+      const metadataFilters = parseJsonFlag<MemoryMetadataFilterExpression[]>(
+        "metadata-filters",
+        flags["metadata-filters"],
+      );
+      const response = await core.memory.listMemoryRecords(
+        {
+          memoryId: flags.memory,
+          namespace: flags.namespace,
+          namespacePath: flags["namespace-path"],
+          memoryStrategyId: flags["strategy-id"],
+          metadataFilters,
+          maxResults: flags["max-results"],
+          nextToken: flags["next-token"],
+        },
+        coreOptsFromCtx(ctx),
+      );
+
+      ctx.require(JsonRendererKey).renderJson(response);
+    },
+  });

--- a/src/handlers/memory/record/list/index.tsx
+++ b/src/handlers/memory/record/list/index.tsx
@@ -1,17 +1,17 @@
 import z from "zod";
-import type { MemoryMetadataFilterExpression } from "@aws-sdk/client-bedrock-agentcore";
 import { InputValidationError } from "../../../../errors";
 import { createHandler, flag } from "../../../../router";
 import { JsonRendererKey } from "../../../../tui";
 import type { Core } from "../../../types";
-import { coreOptsFromCtx, parseJsonFlag } from "../../../utils";
+import { coreOptsFromCtx } from "../../../utils";
+import { parseMemoryMetadataFilters } from "../../metadataFilters";
 
 export const createListMemoryRecordsHandler = (core: Core) =>
   createHandler({
     name: "list",
     description: "list AgentCore Memory records",
     flags: [
-      flag("memory", "the ID of the Memory", z.string()),
+      flag("memory", "the ID of the Memory", z.string().optional()),
       flag("namespace", "filter by namespace prefix", z.string().optional()),
       flag("namespace-path", "filter by namespace hierarchy", z.string().optional()),
       flag("strategy-id", "filter by Memory strategy ID", z.string().optional()),
@@ -20,6 +20,10 @@ export const createListMemoryRecordsHandler = (core: Core) =>
       flag("next-token", "pagination token returned by a previous request", z.string().optional()),
     ],
     handle: async (ctx, flags) => {
+      if (!flags.memory) {
+        throw new InputValidationError("required option '--memory <memory>' not specified");
+      }
+
       const hasNamespace = flags.namespace !== undefined;
       const hasNamespacePath = flags["namespace-path"] !== undefined;
       if (hasNamespace === hasNamespacePath) {
@@ -28,10 +32,7 @@ export const createListMemoryRecordsHandler = (core: Core) =>
         );
       }
 
-      const metadataFilters = parseJsonFlag<MemoryMetadataFilterExpression[]>(
-        "metadata-filters",
-        flags["metadata-filters"],
-      );
+      const metadataFilters = parseMemoryMetadataFilters(flags["metadata-filters"]);
       const response = await core.memory.listMemoryRecords(
         {
           memoryId: flags.memory,

--- a/src/handlers/memory/types.tsx
+++ b/src/handlers/memory/types.tsx
@@ -3,6 +3,16 @@ import type {
   ListMemoriesOutput,
   MemoryView,
 } from "@aws-sdk/client-bedrock-agentcore-control";
+import type {
+  GetEventInput,
+  GetEventOutput,
+  GetMemoryRecordInput,
+  GetMemoryRecordOutput,
+  ListEventsInput,
+  ListEventsOutput,
+  ListMemoryRecordsInput,
+  ListMemoryRecordsOutput,
+} from "@aws-sdk/client-bedrock-agentcore";
 import type { CoreOptions } from "../../core/types";
 
 export interface CoreMemoryClient {
@@ -12,4 +22,18 @@ export interface CoreMemoryClient {
     maxResults: number | undefined,
     options: CoreOptions,
   ): Promise<ListMemoriesOutput>;
+
+  getMemoryRecord(
+    input: GetMemoryRecordInput,
+    options: CoreOptions,
+  ): Promise<GetMemoryRecordOutput>;
+
+  listMemoryRecords(
+    input: ListMemoryRecordsInput,
+    options: CoreOptions,
+  ): Promise<ListMemoryRecordsOutput>;
+
+  getEvent(input: GetEventInput, options: CoreOptions): Promise<GetEventOutput>;
+
+  listEvents(input: ListEventsInput, options: CoreOptions): Promise<ListEventsOutput>;
 }

--- a/src/handlers/utils.tsx
+++ b/src/handlers/utils.tsx
@@ -1,6 +1,8 @@
 import type { Context } from "../router";
+import type z from "zod";
 import type { CoreOptions } from "../core/types";
 import { InputValidationError } from "../errors";
+import { formatZodError } from "../router/schema";
 import { EndpointKey, RegionKey } from "./keys";
 
 // coreOptsFromCtx builds the standard CoreOptions handed to Core operations from
@@ -29,6 +31,24 @@ export function parseJsonFlag<T>(name: string, raw: string | undefined): T | und
       { cause: error },
     );
   }
+}
+
+export function parseJsonFlagWithSchema<T>(
+  name: string,
+  raw: string | undefined,
+  schema: z.ZodType<T>,
+): T | undefined {
+  const parsed = parseJsonFlag<unknown>(name, raw);
+  if (parsed === undefined) return undefined;
+
+  const result = schema.safeParse(parsed);
+  if (!result.success) {
+    throw new InputValidationError(
+      `Invalid value for option '--${name}': ${formatZodError(result.error)}`,
+      { cause: result.error },
+    );
+  }
+  return result.data;
 }
 
 // parseTags parses a tags flag that accepts two mutually exclusive forms:

--- a/src/testing/TestCoreClient.tsx
+++ b/src/testing/TestCoreClient.tsx
@@ -47,12 +47,20 @@ import type {
   UpdateHarnessResponse,
 } from "@aws-sdk/client-bedrock-agentcore-control";
 import type {
+  GetEventInput,
+  GetEventOutput,
+  GetMemoryRecordInput,
+  GetMemoryRecordOutput,
   InvokeAgentRuntimeCommandRequest,
   InvokeAgentRuntimeCommandResponse,
   InvokeAgentRuntimeCommandStreamOutput,
   InvokeHarnessRequest,
   InvokeHarnessResponse,
   InvokeHarnessStreamOutput,
+  ListEventsInput,
+  ListEventsOutput,
+  ListMemoryRecordsInput,
+  ListMemoryRecordsOutput,
 } from "@aws-sdk/client-bedrock-agentcore";
 import type { Core } from "../handlers/types";
 import type { CoreHarnessClient, CreateHarnessInput } from "../handlers/harness/types";
@@ -127,6 +135,12 @@ const DEFAULT_UPDATE_API_KEY_RESPONSE = {} as UpdateApiKeyCredentialProviderResp
 const DEFAULT_DELETE_API_KEY_RESPONSE = {} as DeleteApiKeyCredentialProviderResponse;
 const DEFAULT_GET_MEMORY_RESPONSE = {} as GetMemoryOutput;
 const DEFAULT_LIST_MEMORIES_RESPONSE: ListMemoriesOutput = { memories: [] };
+const DEFAULT_GET_EVENT_RESPONSE: GetEventOutput = { event: undefined };
+const DEFAULT_LIST_EVENTS_RESPONSE: ListEventsOutput = { events: [] };
+const DEFAULT_GET_MEMORY_RECORD_RESPONSE: GetMemoryRecordOutput = { memoryRecord: undefined };
+const DEFAULT_LIST_MEMORY_RECORDS_RESPONSE: ListMemoryRecordsOutput = {
+  memoryRecordSummaries: [],
+};
 const DEFAULT_GET_GATEWAY_RESPONSE = {} as GetGatewayResponse;
 const DEFAULT_LIST_GATEWAYS_RESPONSE: ListGatewaysResponse = { items: [] };
 const DEFAULT_GET_GATEWAY_TARGET_RESPONSE = {} as GetGatewayTargetResponse;
@@ -627,6 +641,10 @@ export class TestMemoryClient implements CoreMemoryClient {
 
   private getResponse: GetMemoryOutput = DEFAULT_GET_MEMORY_RESPONSE;
   private listResponses = new Map<string | undefined, ListMemoriesOutput>();
+  private getEventResponse: GetEventOutput = DEFAULT_GET_EVENT_RESPONSE;
+  private listEventResponses = new Map<string | undefined, ListEventsOutput>();
+  private getMemoryRecordResponse: GetMemoryRecordOutput = DEFAULT_GET_MEMORY_RECORD_RESPONSE;
+  private listMemoryRecordResponses = new Map<string | undefined, ListMemoryRecordsOutput>();
   private error?: Error;
 
   setGetResponse(response: GetMemoryOutput): this {
@@ -636,6 +654,26 @@ export class TestMemoryClient implements CoreMemoryClient {
 
   setListResponse(response: ListMemoriesOutput, forNextToken?: string): this {
     this.listResponses.set(forNextToken, response);
+    return this;
+  }
+
+  setGetEventResponse(response: GetEventOutput): this {
+    this.getEventResponse = response;
+    return this;
+  }
+
+  setListEventsResponse(response: ListEventsOutput, forNextToken?: string): this {
+    this.listEventResponses.set(forNextToken, response);
+    return this;
+  }
+
+  setGetMemoryRecordResponse(response: GetMemoryRecordOutput): this {
+    this.getMemoryRecordResponse = response;
+    return this;
+  }
+
+  setListMemoryRecordsResponse(response: ListMemoryRecordsOutput, forNextToken?: string): this {
+    this.listMemoryRecordResponses.set(forNextToken, response);
     return this;
   }
 
@@ -661,6 +699,44 @@ export class TestMemoryClient implements CoreMemoryClient {
       this.listResponses.get(nextToken) ??
       this.listResponses.get(undefined) ??
       DEFAULT_LIST_MEMORIES_RESPONSE
+    );
+  }
+
+  async getEvent(input: GetEventInput, options: CoreOptions): Promise<GetEventOutput> {
+    this.calls.push({ method: "getEvent", args: [input, options] });
+    if (this.error) throw this.error;
+    return this.getEventResponse;
+  }
+
+  async listEvents(input: ListEventsInput, options: CoreOptions): Promise<ListEventsOutput> {
+    this.calls.push({ method: "listEvents", args: [input, options] });
+    if (this.error) throw this.error;
+    return (
+      this.listEventResponses.get(input.nextToken) ??
+      this.listEventResponses.get(undefined) ??
+      DEFAULT_LIST_EVENTS_RESPONSE
+    );
+  }
+
+  async getMemoryRecord(
+    input: GetMemoryRecordInput,
+    options: CoreOptions,
+  ): Promise<GetMemoryRecordOutput> {
+    this.calls.push({ method: "getMemoryRecord", args: [input, options] });
+    if (this.error) throw this.error;
+    return this.getMemoryRecordResponse;
+  }
+
+  async listMemoryRecords(
+    input: ListMemoryRecordsInput,
+    options: CoreOptions,
+  ): Promise<ListMemoryRecordsOutput> {
+    this.calls.push({ method: "listMemoryRecords", args: [input, options] });
+    if (this.error) throw this.error;
+    return (
+      this.listMemoryRecordResponses.get(input.nextToken) ??
+      this.listMemoryRecordResponses.get(undefined) ??
+      DEFAULT_LIST_MEMORY_RECORDS_RESPONSE
     );
   }
 }


### PR DESCRIPTION
This PR adds `get` and `list` commands for memory events and records and tests for the same.
Core + handler implementation only, no-TUI so far.

bun run typecheck, format, lint and test passed (there was one un-related failure, not introduced by this commit. ran `bun test src/handlers/memory/memory.test.tsx` to confirm)
Smoke tested with my account.