### PR TITLE
fix(deps): patch fast-uri and brace-expansion to clear audit gate

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@aws/agentcore",
-  "version": "0.24.2",
+  "version": "0.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aws/agentcore",
-      "version": "0.24.2",
+      "version": "0.25.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6899,9 +6899,9 @@
       }
     },
     "node_modules/ajv/node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -7697,9 +7697,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"


### PR DESCRIPTION
## Summary

Unblocks the `security` job in **Quality and Safety Checks**, which has been failing on `main`.

`npm run security:audit` (`npm audit --audit-level=high --omit=dev`) reports two high-severity findings in the production tree:

| Package | On main | Fix | Advisory |
|---|---|---|---|
| `fast-uri` (via `ajv`) | 3.1.4 | **3.1.5** | [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) — host confusion via backslash authority introducer, range `3.0.0 - 3.1.4` |
| `brace-expansion` | 5.0.8 | **5.0.9** | [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) — DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation, range `4.0.0 - 5.0.8` |

Both are transitive and already in range for their parents, so this is shrinkwrap-only — no `package.json` edit, no major bump.

## Notes for review

**Pinned deliberately, not `npm audit fix`.** A blanket `npm audit fix` also bumped `@aws-sdk/core` 3.977.1→3.977.5, `@smithy/core` 3.30.0→3.31.1 (a minor), and `@smithy/signature-v4` 5.6.10→5.6.12 — none covered by an advisory. Those are left for a deliberate SDK bump.

**The root version line is a drift correction, not a version bump.** `package.json` is already `0.25.0` but the shrinkwrap root recorded `0.24.2`, so a previous version bump landed without regenerating the shrinkwrap. Any `npm install --package-lock-only` rewrites it, so it rides along here unavoidably.

**Remaining moderate findings are out of scope.** `fast-xml-parser` and the `@opentelemetry/*` tree are moderate, below the `--audit-level=high` threshold, so they do not gate. Clearing them requires an `@aws-sdk` bump — separate PR.

## Testing

Against current `main` (`1afa008`):

```
$ npm audit --audit-level=high --omit=dev
found 0 vulnerabilities   # exit 0

$ npm ci --ignore-scripts   # exit 0, integrity verified against registry tarballs
$ cat node_modules/ajv/node_modules/fast-uri/package.json | jq -r .version
3.1.5
$ cat node_modules/brace-expansion/package.json | jq -r .version
5.0.9
```

`resolved` and `integrity` are preserved for both packages, verified against the published tarballs.