### PR TITLE
feat: add Memory event TUI

### DIFF
--- a/src/components/MemoryPicker.tsx
+++ b/src/components/MemoryPicker.tsx
@@ -1,0 +1,68 @@
+import type { MemorySummary } from "@aws-sdk/client-bedrock-agentcore-control";
+import { useNavigate } from "react-router";
+import type { ScreenProps } from "../handlers/types";
+import { coreOptsFromCtx } from "../handlers/utils";
+import { formatTimestamp } from "./formatTimestamp";
+import { PaginatedTablePicker } from "./PaginatedTablePicker";
+import type { DataTableColumn } from "./ui/data-table";
+
+interface MemoryRow extends Record<string, unknown> {
+  memoryId: string;
+  status: string;
+  updatedAt: string;
+}
+
+export const memoryColumns = [
+  { key: "memoryId", header: "id", flex: true },
+  { key: "status", header: "status", width: 13 },
+  {
+    key: "updatedAt",
+    header: "updated UTC",
+    width: 16,
+    render: formatTimestamp,
+  },
+] satisfies DataTableColumn<MemoryRow>[];
+
+function toRow(memory: MemorySummary): MemoryRow {
+  return {
+    memoryId: memory.id ?? "",
+    status: memory.status ?? "-",
+    updatedAt: memory.updatedAt?.toISOString() ?? "-",
+  };
+}
+
+export interface MemoryPickerProps extends ScreenProps {
+  breadcrumb: string[];
+  description?: string;
+  onSelect: (memoryId: string) => void;
+}
+
+export function MemoryPicker({ ctx, core, breadcrumb, description, onSelect }: MemoryPickerProps) {
+  const opts = coreOptsFromCtx(ctx);
+  const navigate = useNavigate();
+  const goBack = () => navigate("/" + breadcrumb.slice(0, -1).join("/"));
+
+  return (
+    <PaginatedTablePicker
+      breadcrumb={breadcrumb}
+      description={description}
+      queryKey={["memories", opts.region]}
+      loadPage={async (token, pageSize) => {
+        const response = await core.memory.listMemories(token, pageSize, opts);
+        return {
+          items: response.memories ?? [],
+          nextToken: response.nextToken,
+        };
+      }}
+      toRow={toRow}
+      columns={memoryColumns}
+      getValue={(row) => row.memoryId}
+      onSelect={onSelect}
+      onBack={goBack}
+      loadingMessage="Loading Memories..."
+      errorMessage={(error) => `Error: ${error.message}`}
+      emptyMessage="No Memories found in this Region."
+      emptyPageMessage="No Memories on this page."
+    />
+  );
+}

--- a/src/components/Root.tsx
+++ b/src/components/Root.tsx
@@ -32,6 +32,9 @@ import { MemoryScreen } from "../handlers/memory/screen.tsx";
 import { MemoryGetJsonScreen, MemoryGetScreen } from "../handlers/memory/get/screen.tsx";
 import { MemoryListScreen } from "../handlers/memory/list/screen.tsx";
 import { RuntimeInvokeScreen } from "../handlers/runtime/invoke/screen.tsx";
+import { MemoryEventScreen } from "../handlers/memory/event/screen.tsx";
+import { MemoryEventGetScreen } from "../handlers/memory/event/get/screen.tsx";
+import { MemoryEventListScreen } from "../handlers/memory/event/list/screen.tsx";
 import { RootScreen, HelpScreen } from "../handlers/screen.tsx";
 import type { Context } from "../router";
 
@@ -287,6 +290,34 @@ export function Root({ path, ctx, core, queryClient }: RootProps) {
           <Route
             path="agentcore/runtime/invoke/:runtimeId/:qualifier"
             element={<RuntimeInvokeScreen ctx={ctx} core={core} />}
+          />
+          <Route
+            path="agentcore/memory/event"
+            element={<MemoryEventScreen ctx={ctx} core={core} />}
+          />
+          <Route
+            path="agentcore/memory/event/get"
+            element={<Navigate to="/agentcore/memory/event/list" replace />}
+          />
+          <Route
+            path="agentcore/memory/event/get/:memoryId/:actorId/:sessionId/:eventId"
+            element={<MemoryEventGetScreen ctx={ctx} core={core} />}
+          />
+          <Route
+            path="agentcore/memory/event/list"
+            element={<MemoryEventListScreen ctx={ctx} core={core} />}
+          />
+          <Route
+            path="agentcore/memory/event/list/:memoryId"
+            element={<MemoryEventListScreen ctx={ctx} core={core} />}
+          />
+          <Route
+            path="agentcore/memory/event/list/:memoryId/:actorId"
+            element={<MemoryEventListScreen ctx={ctx} core={core} />}
+          />
+          <Route
+            path="agentcore/memory/event/list/:memoryId/:actorId/:sessionId"
+            element={<MemoryEventListScreen ctx={ctx} core={core} />}
           />
           <Route path="*" element={<HelpScreen ctx={ctx} core={core} />} />
         </Routes>

--- a/src/core/core.test.ts
+++ b/src/core/core.test.ts
@@ -10,8 +10,10 @@ import {
   InvokeAgentRuntimeCommand,
   InvokeAgentRuntimeCommandCommand,
   InvokeHarnessCommand,
+  ListActorsCommand,
   ListEventsCommand,
   ListMemoryRecordsCommand,
+  ListSessionsCommand,
   type BedrockAgentCoreClient,
 } from "@aws-sdk/client-bedrock-agentcore";
 import type { RuntimeInvokeRequest } from "../handlers/runtime/types";
@@ -242,6 +244,49 @@ test("listEvents sends a ListEventsCommand on the data client", async () => {
   expect(sent).toHaveLength(1);
   expect(sent[0]).toBeInstanceOf(ListEventsCommand);
   expect((sent[0] as ListEventsCommand).input).toEqual(input);
+});
+
+test("listActors sends a ListActorsCommand on the data client", async () => {
+  const sent: unknown[] = [];
+  const response = { actorSummaries: [], nextToken: "next" };
+  const core = coreWithDataSend(async (command) => {
+    sent.push(command);
+    return response;
+  });
+  const input = {
+    memoryId: "memory-123",
+    maxResults: 25,
+    nextToken: "current",
+  };
+
+  const result = await core.memory.listActors(input, { region: "us-east-1" });
+
+  expect(result).toBe(response);
+  expect(sent).toHaveLength(1);
+  expect(sent[0]).toBeInstanceOf(ListActorsCommand);
+  expect((sent[0] as ListActorsCommand).input).toEqual(input);
+});
+
+test("listSessions sends a ListSessionsCommand on the data client", async () => {
+  const sent: unknown[] = [];
+  const response = { sessionSummaries: [], nextToken: "next" };
+  const core = coreWithDataSend(async (command) => {
+    sent.push(command);
+    return response;
+  });
+  const input = {
+    memoryId: "memory-123",
+    actorId: "actor-123",
+    maxResults: 25,
+    nextToken: "current",
+  };
+
+  const result = await core.memory.listSessions(input, { region: "us-east-1" });
+
+  expect(result).toBe(response);
+  expect(sent).toHaveLength(1);
+  expect(sent[0]).toBeInstanceOf(ListSessionsCommand);
+  expect((sent[0] as ListSessionsCommand).input).toEqual(input);
 });
 
 test("getMemoryRecord sends a GetMemoryRecordCommand on the data client", async () => {

--- a/src/core/memory.tsx
+++ b/src/core/memory.tsx
@@ -1,16 +1,22 @@
 import {
   GetEventCommand,
   GetMemoryRecordCommand,
+  ListActorsCommand,
   ListEventsCommand,
   ListMemoryRecordsCommand,
+  ListSessionsCommand,
   type GetEventInput,
   type GetEventOutput,
   type GetMemoryRecordInput,
   type GetMemoryRecordOutput,
+  type ListActorsInput,
+  type ListActorsOutput,
   type ListEventsInput,
   type ListEventsOutput,
   type ListMemoryRecordsInput,
   type ListMemoryRecordsOutput,
+  type ListSessionsInput,
+  type ListSessionsOutput,
 } from "@aws-sdk/client-bedrock-agentcore";
 import {
   GetMemoryCommand,
@@ -44,6 +50,14 @@ export class MemoryClient implements CoreMemoryClient {
 
   async getEvent(input: GetEventInput, options: CoreOptions): Promise<GetEventOutput> {
     return this.clients.data(toClientConfig(options)).send(new GetEventCommand(input));
+  }
+
+  async listActors(input: ListActorsInput, options: CoreOptions): Promise<ListActorsOutput> {
+    return this.clients.data(toClientConfig(options)).send(new ListActorsCommand(input));
+  }
+
+  async listSessions(input: ListSessionsInput, options: CoreOptions): Promise<ListSessionsOutput> {
+    return this.clients.data(toClientConfig(options)).send(new ListSessionsCommand(input));
   }
 
   async listEvents(input: ListEventsInput, options: CoreOptions): Promise<ListEventsOutput> {

--- a/src/handlers/memory/event/event.screen.test.tsx
+++ b/src/handlers/memory/event/event.screen.test.tsx
@@ -1,0 +1,208 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type { ActorSummary, Event, SessionSummary } from "@aws-sdk/client-bedrock-agentcore";
+import type { MemorySummary } from "@aws-sdk/client-bedrock-agentcore-control";
+import {
+  cleanupScreens,
+  renderScreen,
+  TestCoreClient,
+  waitFor,
+  waitForText,
+} from "../../../testing";
+
+afterEach(cleanupScreens);
+
+const memoryEndpointUrl = "https://memory.test";
+
+function memorySummary(overrides: Partial<MemorySummary> = {}): MemorySummary {
+  return {
+    arn: "arn:aws:bedrock-agentcore:us-east-1:123456789012:memory/memory-1",
+    id: "memory-1",
+    status: "ACTIVE",
+    createdAt: new Date("2026-07-19T01:02:03.000Z"),
+    updatedAt: new Date("2026-07-20T12:34:56.000Z"),
+    ...overrides,
+  };
+}
+
+function actor(overrides: Partial<ActorSummary> = {}): ActorSummary {
+  return {
+    actorId: "actor-1",
+    ...overrides,
+  };
+}
+
+function session(overrides: Partial<SessionSummary> = {}): SessionSummary {
+  return {
+    sessionId: "session-1",
+    actorId: "actor-1",
+    createdAt: new Date("2026-08-02T10:20:30.000Z"),
+    ...overrides,
+  };
+}
+
+function event(overrides: Partial<Event> = {}): Event {
+  return {
+    memoryId: "memory-1",
+    actorId: "actor-1",
+    sessionId: "session-1",
+    eventId: "event-1",
+    eventTimestamp: new Date("2026-08-03T12:34:56.000Z"),
+    payload: [],
+    branch: { name: "main" },
+    ...overrides,
+  };
+}
+
+describe("Memory event list flow", () => {
+  test("walks through Memory, actor, and session pickers before listing events", async () => {
+    const memoryId = "memory/blue one";
+    const actorId = "actor/blue one";
+    const sessionId = "session/blue one";
+    const core = new TestCoreClient();
+    core.memory.setListResponse({ memories: [memorySummary({ id: memoryId })] });
+    core.memory.setListActorsResponse({ actorSummaries: [actor({ actorId })] });
+    core.memory.setListSessionsResponse({
+      sessionSummaries: [session({ actorId, sessionId })],
+    });
+    core.memory.setListEventsResponse({
+      events: [event({ memoryId, actorId, sessionId })],
+    });
+    const screen = renderScreen("/agentcore/memory/event/list", { core });
+
+    await waitForText(screen.lastFrame, memoryId);
+    await screen.press("return");
+    await waitForText(screen.lastFrame, actorId);
+    await screen.press("return");
+    await waitForText(screen.lastFrame, sessionId);
+    await screen.press("return");
+    await waitForText(screen.lastFrame, "event-1");
+
+    expect(core.memory.calls.find((call) => call.method === "listActors")).toEqual({
+      method: "listActors",
+      args: [
+        {
+          memoryId,
+          maxResults: expect.any(Number),
+          nextToken: undefined,
+        },
+        { region: "us-east-1" },
+      ],
+    });
+    expect(core.memory.calls.find((call) => call.method === "listSessions")).toEqual({
+      method: "listSessions",
+      args: [
+        {
+          memoryId,
+          actorId,
+          maxResults: expect.any(Number),
+          nextToken: undefined,
+        },
+        { region: "us-east-1" },
+      ],
+    });
+  });
+
+  test("calls listEvents with the exact route scope and Core options", async () => {
+    const core = new TestCoreClient();
+    core.memory.setListEventsResponse({ events: [event()] });
+    renderScreen("/agentcore/memory/event/list/memory-1/actor-1/session-1", {
+      core,
+      endpointUrl: memoryEndpointUrl,
+    });
+
+    await waitFor(() => core.memory.calls.some((call) => call.method === "listEvents"));
+    expect(core.memory.calls.filter((call) => call.method === "listEvents")).toEqual([
+      {
+        method: "listEvents",
+        args: [
+          {
+            memoryId: "memory-1",
+            actorId: "actor-1",
+            sessionId: "session-1",
+            maxResults: expect.any(Number),
+            nextToken: undefined,
+          },
+          {
+            region: "us-east-1",
+            endpointUrl: memoryEndpointUrl,
+          },
+        ],
+      },
+    ]);
+  });
+
+  test("renders Event columns and opens the selected Event JSON", async () => {
+    const core = new TestCoreClient();
+    core.memory.setListEventsResponse({
+      events: [event({ eventId: "event blue", metadata: { tenant: { stringValue: "acme" } } })],
+    });
+    core.memory.setGetEventResponse({
+      event: event({
+        eventId: "event blue",
+        metadata: { tenant: { stringValue: "acme" } },
+      }),
+    });
+    const screen = renderScreen("/agentcore/memory/event/list/memory-1/actor-1/session-1", {
+      core,
+    });
+
+    await waitForText(screen.lastFrame, "event blue");
+    const frame = screen.lastFrame()!;
+    expect(frame).toContain("event id");
+    expect(frame).toContain("branch");
+    expect(frame).toContain("occurred UTC");
+    expect(frame).toContain("main");
+    expect(frame).toContain("2026-08-03 12:34");
+
+    await screen.press("return");
+    await waitForText(screen.lastFrame, '"tenant"');
+    expect(core.memory.calls.find((call) => call.method === "getEvent")).toEqual({
+      method: "getEvent",
+      args: [
+        {
+          memoryId: "memory-1",
+          actorId: "actor-1",
+          sessionId: "session-1",
+          eventId: "event blue",
+        },
+        { region: "us-east-1" },
+      ],
+    });
+  });
+
+  test("paginates events and distinguishes a later-page empty state", async () => {
+    const core = new TestCoreClient();
+    core.memory.setListEventsResponse({
+      events: [event({ eventId: "page-one" })],
+      nextToken: "page-2",
+    });
+    core.memory.setListEventsResponse({ events: [] }, "page-2");
+    const screen = renderScreen("/agentcore/memory/event/list/memory-1/actor-1/session-1", {
+      core,
+    });
+
+    await waitForText(screen.lastFrame, "page 1 · more →");
+    await screen.write("l");
+    await waitForText(screen.lastFrame, "No events on this page for session session-1.");
+  });
+
+  test("shows scoped empty and retry states", async () => {
+    const empty = renderScreen("/agentcore/memory/event/list/memory-1/actor-1/session-1");
+    await waitForText(empty.lastFrame, "No events found for session session-1.");
+    empty.unmount();
+
+    const core = new TestCoreClient();
+    core.memory.setError(new Error("events unavailable"));
+    const failed = renderScreen("/agentcore/memory/event/list/memory-1/actor-1/session-1", {
+      core,
+    });
+
+    await waitForText(failed.lastFrame, "events unavailable");
+    expect(failed.lastFrame()).toContain("[r] retry");
+
+    core.memory.setError(undefined);
+    core.memory.setListEventsResponse({ events: [event()] });
+    await failed.write("r");
+    await waitForText(failed.lastFrame, "event-1");
+  });
+});

--- a/src/handlers/memory/event/get/screen.tsx
+++ b/src/handlers/memory/event/get/screen.tsx
@@ -1,0 +1,48 @@
+import { useQuery } from "@tanstack/react-query";
+import { useParams } from "react-router";
+import { JsonDetail } from "../../../../components/JsonDetail";
+import type { ScreenProps } from "../../../types";
+import { coreOptsFromCtx } from "../../../utils";
+
+export function MemoryEventGetScreen({ ctx, core }: ScreenProps) {
+  const opts = coreOptsFromCtx(ctx);
+  const { memoryId, actorId, sessionId, eventId } = useParams();
+  const detail = useQuery({
+    queryKey: ["memory-event", opts.region, memoryId, actorId, sessionId, eventId],
+    queryFn: () =>
+      core.memory.getEvent(
+        {
+          memoryId: memoryId!,
+          actorId: actorId!,
+          sessionId: sessionId!,
+          eventId: eventId!,
+        },
+        opts,
+      ),
+    enabled:
+      memoryId !== undefined &&
+      actorId !== undefined &&
+      sessionId !== undefined &&
+      eventId !== undefined,
+  });
+
+  return (
+    <JsonDetail
+      breadcrumb={[
+        "agentcore",
+        "memory",
+        "event",
+        "get",
+        memoryId ?? "",
+        actorId ?? "",
+        sessionId ?? "",
+        eventId ?? "",
+      ]}
+      isPending={detail.isPending}
+      error={detail.isError ? (detail.error as Error) : null}
+      data={detail.data?.event}
+      loadingLabel={`Loading Memory event ${eventId ?? ""}...`}
+      onRetry={() => void detail.refetch()}
+    />
+  );
+}

--- a/src/handlers/memory/event/index.tsx
+++ b/src/handlers/memory/event/index.tsx
@@ -1,10 +1,13 @@
 import { Router } from "../../../router";
+import { renderTui } from "../../../tui";
+import type { AppIO } from "../../../io";
 import type { Core } from "../../types";
 import { createGetMemoryEventHandler } from "./get";
 import { createListMemoryEventsHandler } from "./list";
 
-export function createMemoryEventHandler(core: Core): Router {
+export function createMemoryEventHandler(core: Core, io: AppIO): Router {
   return new Router("event", "inspect AgentCore Memory events")
+    .default(renderTui(core, io))
     .handler(createGetMemoryEventHandler(core))
     .handler(createListMemoryEventsHandler(core));
 }

--- a/src/handlers/memory/event/list/screen.tsx
+++ b/src/handlers/memory/event/list/screen.tsx
@@ -1,0 +1,227 @@
+import type { ActorSummary, Event, SessionSummary } from "@aws-sdk/client-bedrock-agentcore";
+import { useNavigate, useParams } from "react-router";
+import { MemoryPicker } from "../../../../components/MemoryPicker";
+import { PaginatedTablePicker } from "../../../../components/PaginatedTablePicker";
+import { formatTimestamp } from "../../../../components/formatTimestamp";
+import type { DataTableColumn } from "../../../../components/ui/data-table";
+import type { ScreenProps } from "../../../types";
+import { coreOptsFromCtx } from "../../../utils";
+
+interface ActorRow extends Record<string, unknown> {
+  actorId: string;
+}
+
+const actorColumns = [
+  { key: "actorId", header: "actor id", flex: true },
+] satisfies DataTableColumn<ActorRow>[];
+
+function toActorRow(actor: ActorSummary): ActorRow {
+  return { actorId: actor.actorId ?? "" };
+}
+
+interface SessionRow extends Record<string, unknown> {
+  sessionId: string;
+  createdAt: string;
+}
+
+const sessionColumns = [
+  { key: "sessionId", header: "session id", flex: true },
+  {
+    key: "createdAt",
+    header: "created UTC",
+    width: 16,
+    minWidth: 11,
+    render: formatTimestamp,
+  },
+] satisfies DataTableColumn<SessionRow>[];
+
+function toSessionRow(session: SessionSummary): SessionRow {
+  return {
+    sessionId: session.sessionId ?? "",
+    createdAt: session.createdAt?.toISOString() ?? "-",
+  };
+}
+
+interface EventRow extends Record<string, unknown> {
+  eventId: string;
+  branch: string;
+  occurredAt: string;
+}
+
+const eventColumns = [
+  { key: "eventId", header: "event id", flex: true },
+  { key: "branch", header: "branch", width: 18, minWidth: 8 },
+  {
+    key: "occurredAt",
+    header: "occurred UTC",
+    width: 16,
+    minWidth: 11,
+    render: formatTimestamp,
+  },
+] satisfies DataTableColumn<EventRow>[];
+
+function toEventRow(event: Event): EventRow {
+  return {
+    eventId: event.eventId ?? "",
+    branch: event.branch?.name ?? "-",
+    occurredAt: event.eventTimestamp?.toISOString() ?? "-",
+  };
+}
+
+interface ActorPickerProps extends ScreenProps {
+  memoryId: string;
+}
+
+function ActorPicker({ ctx, core, memoryId }: ActorPickerProps) {
+  const opts = coreOptsFromCtx(ctx);
+  const navigate = useNavigate();
+
+  return (
+    <PaginatedTablePicker
+      breadcrumb={["agentcore", "memory", "event", "list", memoryId]}
+      description="choose an actor to list sessions for"
+      queryKey={["memory-actors", opts.region, memoryId]}
+      loadPage={async (token, pageSize) => {
+        const response = await core.memory.listActors(
+          { memoryId, maxResults: pageSize, nextToken: token },
+          opts,
+        );
+        return {
+          items: response.actorSummaries ?? [],
+          nextToken: response.nextToken,
+        };
+      }}
+      toRow={toActorRow}
+      columns={actorColumns}
+      getValue={(row) => row.actorId}
+      onSelect={(actorId) =>
+        navigate(
+          `/agentcore/memory/event/list/${encodeURIComponent(memoryId)}/${encodeURIComponent(actorId)}`,
+        )
+      }
+      onBack={() => navigate("/agentcore/memory/event/list")}
+      loadingMessage={`Loading actors for Memory ${memoryId}...`}
+      errorMessage={(error) => `Error loading actors for Memory ${memoryId}: ${error.message}`}
+      emptyMessage={`No actors found for Memory ${memoryId}.`}
+      emptyPageMessage={`No actors on this page for Memory ${memoryId}.`}
+    />
+  );
+}
+
+interface SessionPickerProps extends ScreenProps {
+  memoryId: string;
+  actorId: string;
+}
+
+function SessionPicker({ ctx, core, memoryId, actorId }: SessionPickerProps) {
+  const opts = coreOptsFromCtx(ctx);
+  const navigate = useNavigate();
+
+  return (
+    <PaginatedTablePicker
+      breadcrumb={["agentcore", "memory", "event", "list", memoryId, actorId]}
+      description="choose a session to list events for"
+      queryKey={["memory-sessions", opts.region, memoryId, actorId]}
+      loadPage={async (token, pageSize) => {
+        const response = await core.memory.listSessions(
+          { memoryId, actorId, maxResults: pageSize, nextToken: token },
+          opts,
+        );
+        return {
+          items: response.sessionSummaries ?? [],
+          nextToken: response.nextToken,
+        };
+      }}
+      toRow={toSessionRow}
+      columns={sessionColumns}
+      getValue={(row) => row.sessionId}
+      onSelect={(sessionId) =>
+        navigate(
+          `/agentcore/memory/event/list/${encodeURIComponent(memoryId)}/${encodeURIComponent(actorId)}/${encodeURIComponent(sessionId)}`,
+        )
+      }
+      onBack={() => navigate(`/agentcore/memory/event/list/${encodeURIComponent(memoryId)}`)}
+      loadingMessage={`Loading sessions for actor ${actorId}...`}
+      errorMessage={(error) => `Error loading sessions for actor ${actorId}: ${error.message}`}
+      emptyMessage={`No sessions found for actor ${actorId}.`}
+      emptyPageMessage={`No sessions on this page for actor ${actorId}.`}
+    />
+  );
+}
+
+interface EventPickerProps extends ScreenProps {
+  memoryId: string;
+  actorId: string;
+  sessionId: string;
+}
+
+function EventPicker({ ctx, core, memoryId, actorId, sessionId }: EventPickerProps) {
+  const opts = coreOptsFromCtx(ctx);
+  const navigate = useNavigate();
+
+  return (
+    <PaginatedTablePicker
+      breadcrumb={["agentcore", "memory", "event", "list", memoryId, actorId, sessionId]}
+      queryKey={["memory-events", opts.region, memoryId, actorId, sessionId]}
+      loadPage={async (token, pageSize) => {
+        const response = await core.memory.listEvents(
+          {
+            memoryId,
+            actorId,
+            sessionId,
+            maxResults: pageSize,
+            nextToken: token,
+          },
+          opts,
+        );
+        return {
+          items: response.events ?? [],
+          nextToken: response.nextToken,
+        };
+      }}
+      toRow={toEventRow}
+      columns={eventColumns}
+      getValue={(row) => row.eventId}
+      onSelect={(eventId) =>
+        navigate(
+          `/agentcore/memory/event/get/${encodeURIComponent(memoryId)}/${encodeURIComponent(actorId)}/${encodeURIComponent(sessionId)}/${encodeURIComponent(eventId)}`,
+        )
+      }
+      onBack={() =>
+        navigate(
+          `/agentcore/memory/event/list/${encodeURIComponent(memoryId)}/${encodeURIComponent(actorId)}`,
+        )
+      }
+      loadingMessage={`Loading events for session ${sessionId}...`}
+      errorMessage={(error) => `Error loading events for session ${sessionId}: ${error.message}`}
+      emptyMessage={`No events found for session ${sessionId}.`}
+      emptyPageMessage={`No events on this page for session ${sessionId}.`}
+    />
+  );
+}
+
+export function MemoryEventListScreen(props: ScreenProps) {
+  const navigate = useNavigate();
+  const { memoryId, actorId, sessionId } = useParams();
+
+  if (!memoryId) {
+    return (
+      <MemoryPicker
+        {...props}
+        breadcrumb={["agentcore", "memory", "event", "list"]}
+        description="choose a Memory to list events for"
+        onSelect={(id) => navigate(`/agentcore/memory/event/list/${encodeURIComponent(id)}`)}
+      />
+    );
+  }
+
+  if (!actorId) {
+    return <ActorPicker {...props} memoryId={memoryId} />;
+  }
+
+  if (!sessionId) {
+    return <SessionPicker {...props} memoryId={memoryId} actorId={actorId} />;
+  }
+
+  return <EventPicker {...props} memoryId={memoryId} actorId={actorId} sessionId={sessionId} />;
+}

--- a/src/handlers/memory/event/screen.tsx
+++ b/src/handlers/memory/event/screen.tsx
@@ -1,0 +1,6 @@
+import { RouterScreen } from "../../../components/RouterScreen";
+import type { ScreenProps } from "../../types";
+
+export function MemoryEventScreen(props: ScreenProps) {
+  return <RouterScreen {...props} path={["agentcore", "memory", "event"]} />;
+}

--- a/src/handlers/memory/index.tsx
+++ b/src/handlers/memory/index.tsx
@@ -14,6 +14,6 @@ export function createMemoryHandler(core: Core, io: AppIO): Router {
     .default(renderTui(core, io))
     .handler(createGetMemoryHandler(core))
     .handler(createListMemoriesHandler(core))
-    .handler(createMemoryEventHandler(core))
+    .handler(createMemoryEventHandler(core, io))
     .handler(createMemoryRecordHandler(core));
 }

--- a/src/handlers/memory/list/screen.tsx
+++ b/src/handlers/memory/list/screen.tsx
@@ -1,60 +1,15 @@
-import type { MemorySummary } from "@aws-sdk/client-bedrock-agentcore-control";
 import { useNavigate } from "react-router";
-import { formatTimestamp } from "../../../components/formatTimestamp";
-import { PaginatedTablePicker } from "../../../components/PaginatedTablePicker";
-import type { DataTableColumn } from "../../../components/ui/data-table";
+import { MemoryPicker } from "../../../components/MemoryPicker";
 import type { ScreenProps } from "../../types";
-import { coreOptsFromCtx } from "../../utils";
 
-interface MemoryRow extends Record<string, unknown> {
-  memoryId: string;
-  status: string;
-  updatedAt: string;
-}
-
-export const memoryColumns = [
-  { key: "memoryId", header: "id", flex: true },
-  { key: "status", header: "status", width: 13 },
-  {
-    key: "updatedAt",
-    header: "updated UTC",
-    width: 16,
-    render: formatTimestamp,
-  },
-] satisfies DataTableColumn<MemoryRow>[];
-
-function toRow(memory: MemorySummary): MemoryRow {
-  return {
-    memoryId: memory.id ?? "",
-    status: memory.status ?? "-",
-    updatedAt: memory.updatedAt?.toISOString() ?? "-",
-  };
-}
-
-export function MemoryListScreen({ ctx, core }: ScreenProps) {
-  const opts = coreOptsFromCtx(ctx);
+export function MemoryListScreen(props: ScreenProps) {
   const navigate = useNavigate();
 
   return (
-    <PaginatedTablePicker
+    <MemoryPicker
+      {...props}
       breadcrumb={["agentcore", "memory", "list"]}
-      queryKey={["memories", opts.region]}
-      loadPage={async (token, pageSize) => {
-        const response = await core.memory.listMemories(token, pageSize, opts);
-        return {
-          items: response.memories ?? [],
-          nextToken: response.nextToken,
-        };
-      }}
-      toRow={toRow}
-      columns={memoryColumns}
-      getValue={(row) => row.memoryId}
       onSelect={(memoryId) => navigate(`/agentcore/memory/get/${encodeURIComponent(memoryId)}`)}
-      onBack={() => navigate("/agentcore/memory")}
-      loadingMessage="Loading Memories…"
-      errorMessage={(error) => `Error: ${error.message}`}
-      emptyMessage="No Memories found in this Region."
-      emptyPageMessage="No Memories on this page."
     />
   );
 }

--- a/src/handlers/memory/memory.test.tsx
+++ b/src/handlers/memory/memory.test.tsx
@@ -136,6 +136,8 @@ describe("memory TUI dispatch", () => {
   test.each([
     ["get", ["memory", "get"]],
     ["list", ["memory", "list"]],
+    ["event get", ["memory", "event", "get"]],
+    ["event list", ["memory", "event", "list"]],
   ] as const)("opens the TUI for a bare Memory %s leaf", async (_label, args) => {
     const { core, route } = testMemoryCommand();
 

--- a/src/handlers/memory/types.tsx
+++ b/src/handlers/memory/types.tsx
@@ -8,10 +8,14 @@ import type {
   GetEventOutput,
   GetMemoryRecordInput,
   GetMemoryRecordOutput,
+  ListActorsInput,
+  ListActorsOutput,
   ListEventsInput,
   ListEventsOutput,
   ListMemoryRecordsInput,
   ListMemoryRecordsOutput,
+  ListSessionsInput,
+  ListSessionsOutput,
 } from "@aws-sdk/client-bedrock-agentcore";
 import type { CoreOptions } from "../../core/types";
 
@@ -34,6 +38,10 @@ export interface CoreMemoryClient {
   ): Promise<ListMemoryRecordsOutput>;
 
   getEvent(input: GetEventInput, options: CoreOptions): Promise<GetEventOutput>;
+
+  listActors(input: ListActorsInput, options: CoreOptions): Promise<ListActorsOutput>;
+
+  listSessions(input: ListSessionsInput, options: CoreOptions): Promise<ListSessionsOutput>;
 
   listEvents(input: ListEventsInput, options: CoreOptions): Promise<ListEventsOutput>;
 }

--- a/src/testing/TestCoreClient.tsx
+++ b/src/testing/TestCoreClient.tsx
@@ -57,10 +57,14 @@ import type {
   InvokeHarnessRequest,
   InvokeHarnessResponse,
   InvokeHarnessStreamOutput,
+  ListActorsInput,
+  ListActorsOutput,
   ListEventsInput,
   ListEventsOutput,
   ListMemoryRecordsInput,
   ListMemoryRecordsOutput,
+  ListSessionsInput,
+  ListSessionsOutput,
 } from "@aws-sdk/client-bedrock-agentcore";
 import type { Core } from "../handlers/types";
 import type { CoreHarnessClient, CreateHarnessInput } from "../handlers/harness/types";
@@ -136,6 +140,8 @@ const DEFAULT_DELETE_API_KEY_RESPONSE = {} as DeleteApiKeyCredentialProviderResp
 const DEFAULT_GET_MEMORY_RESPONSE = {} as GetMemoryOutput;
 const DEFAULT_LIST_MEMORIES_RESPONSE: ListMemoriesOutput = { memories: [] };
 const DEFAULT_GET_EVENT_RESPONSE: GetEventOutput = { event: undefined };
+const DEFAULT_LIST_ACTORS_RESPONSE: ListActorsOutput = { actorSummaries: [] };
+const DEFAULT_LIST_SESSIONS_RESPONSE: ListSessionsOutput = { sessionSummaries: [] };
 const DEFAULT_LIST_EVENTS_RESPONSE: ListEventsOutput = { events: [] };
 const DEFAULT_GET_MEMORY_RECORD_RESPONSE: GetMemoryRecordOutput = { memoryRecord: undefined };
 const DEFAULT_LIST_MEMORY_RECORDS_RESPONSE: ListMemoryRecordsOutput = {
@@ -642,6 +648,8 @@ export class TestMemoryClient implements CoreMemoryClient {
   private getResponse: GetMemoryOutput = DEFAULT_GET_MEMORY_RESPONSE;
   private listResponses = new Map<string | undefined, ListMemoriesOutput>();
   private getEventResponse: GetEventOutput = DEFAULT_GET_EVENT_RESPONSE;
+  private listActorResponses = new Map<string | undefined, ListActorsOutput>();
+  private listSessionResponses = new Map<string | undefined, ListSessionsOutput>();
   private listEventResponses = new Map<string | undefined, ListEventsOutput>();
   private getMemoryRecordResponse: GetMemoryRecordOutput = DEFAULT_GET_MEMORY_RECORD_RESPONSE;
   private listMemoryRecordResponses = new Map<string | undefined, ListMemoryRecordsOutput>();
@@ -659,6 +667,16 @@ export class TestMemoryClient implements CoreMemoryClient {
 
   setGetEventResponse(response: GetEventOutput): this {
     this.getEventResponse = response;
+    return this;
+  }
+
+  setListActorsResponse(response: ListActorsOutput, forNextToken?: string): this {
+    this.listActorResponses.set(forNextToken, response);
+    return this;
+  }
+
+  setListSessionsResponse(response: ListSessionsOutput, forNextToken?: string): this {
+    this.listSessionResponses.set(forNextToken, response);
     return this;
   }
 
@@ -706,6 +724,26 @@ export class TestMemoryClient implements CoreMemoryClient {
     this.calls.push({ method: "getEvent", args: [input, options] });
     if (this.error) throw this.error;
     return this.getEventResponse;
+  }
+
+  async listActors(input: ListActorsInput, options: CoreOptions): Promise<ListActorsOutput> {
+    this.calls.push({ method: "listActors", args: [input, options] });
+    if (this.error) throw this.error;
+    return (
+      this.listActorResponses.get(input.nextToken) ??
+      this.listActorResponses.get(undefined) ??
+      DEFAULT_LIST_ACTORS_RESPONSE
+    );
+  }
+
+  async listSessions(input: ListSessionsInput, options: CoreOptions): Promise<ListSessionsOutput> {
+    this.calls.push({ method: "listSessions", args: [input, options] });
+    if (this.error) throw this.error;
+    return (
+      this.listSessionResponses.get(input.nextToken) ??
+      this.listSessionResponses.get(undefined) ??
+      DEFAULT_LIST_SESSIONS_RESPONSE
+    );
   }
 
   async listEvents(input: ListEventsInput, options: CoreOptions): Promise<ListEventsOutput> {


### PR DESCRIPTION
This PR adds TUI implementation to the memory event list and get commands implemented in PR #1895 

The flow: 
Memory -> Actor -> Session -> Event selection 

It lists events with branch and occurrence time and opens up selected event as an entire JSON.  Pagination, filtering, retries, empty states, and back navigation is implemented.

I had to add internal read-only Actor and Session listing APIs, which we could as future work make into their own commands.

I tested myself + using the TUI harness skill.

Typcheck, lint, build and test passes