### PR TITLE
feat: add Memory record TUI

### DIFF
--- a/src/components/FormTextInput.tsx
+++ b/src/components/FormTextInput.tsx
@@ -11,6 +11,7 @@ export interface FormTextInputProps {
   errorText: string;
   value: string;
   onChange: (value: string) => void;
+  onSubmit?: (value: string) => void;
   pattern?: RegExp;
   // focused controls whether the input captures keystrokes; when several
   // FormTextInputs are on screen, exactly one should be focused.
@@ -24,6 +25,7 @@ export function FormTextInput({
   errorText,
   value,
   onChange,
+  onSubmit,
   pattern,
   focused = true,
 }: FormTextInputProps) {
@@ -34,7 +36,13 @@ export function FormTextInput({
         <Text color={theme.colors.muted}>{helpText}</Text>
       </Box>
       <Box borderStyle="round" borderColor={focused ? theme.colors.focus : theme.colors.border}>
-        <TextInput value={value} onChange={onChange} placeholder={placeholder} focus={focused} />
+        <TextInput
+          value={value}
+          onChange={onChange}
+          onSubmit={onSubmit}
+          placeholder={placeholder}
+          focus={focused}
+        />
       </Box>
       {value !== "" && pattern && !pattern.test(value) && (
         <Text color={theme.colors.error}>{errorText}</Text>

--- a/src/components/Root.tsx
+++ b/src/components/Root.tsx
@@ -51,6 +51,9 @@ import { BatchEvaluationGetJsonScreen } from "../handlers/eval/batch-evaluation/
 import { MemoryEventScreen } from "../handlers/memory/event/screen.tsx";
 import { MemoryEventGetScreen } from "../handlers/memory/event/get/screen.tsx";
 import { MemoryEventListScreen } from "../handlers/memory/event/list/screen.tsx";
+import { MemoryRecordScreen } from "../handlers/memory/record/screen.tsx";
+import { MemoryRecordGetScreen } from "../handlers/memory/record/get/screen.tsx";
+import { MemoryRecordListScreen } from "../handlers/memory/record/list/screen.tsx";
 import { IdentityScreen } from "../handlers/identity/screen.tsx";
 import { ApiKeyCredentialProviderScreen } from "../handlers/identity/api-key-credential-provider/screen.tsx";
 import { ApiKeyCredentialProviderListScreen } from "../handlers/identity/api-key-credential-provider/list/screen.tsx";
@@ -407,6 +410,30 @@ export function Root({ path, ctx, core, queryClient }: RootProps) {
           <Route
             path="agentcore/memory/event/list/:memoryId/:actorId/:sessionId"
             element={<MemoryEventListScreen ctx={ctx} core={core} />}
+          />
+          <Route
+            path="agentcore/memory/record"
+            element={<MemoryRecordScreen ctx={ctx} core={core} />}
+          />
+          <Route
+            path="agentcore/memory/record/get"
+            element={<Navigate to="/agentcore/memory/record/list" replace />}
+          />
+          <Route
+            path="agentcore/memory/record/get/:memoryId/:recordId"
+            element={<MemoryRecordGetScreen ctx={ctx} core={core} />}
+          />
+          <Route
+            path="agentcore/memory/record/list"
+            element={<MemoryRecordListScreen ctx={ctx} core={core} />}
+          />
+          <Route
+            path="agentcore/memory/record/list/:memoryId"
+            element={<MemoryRecordListScreen ctx={ctx} core={core} />}
+          />
+          <Route
+            path="agentcore/memory/record/list/:memoryId/:scopeKind/:scope"
+            element={<MemoryRecordListScreen ctx={ctx} core={core} />}
           />
           <Route path="agentcore/identity" element={<IdentityScreen ctx={ctx} core={core} />} />
           <Route

--- a/src/handlers/memory/event/event.screen.test.tsx
+++ b/src/handlers/memory/event/event.screen.test.tsx
@@ -100,6 +100,13 @@ describe("Memory event list flow", () => {
         { region: "us-east-1" },
       ],
     });
+
+    await screen.press("escape");
+    await waitForText(screen.lastFrame, "choose a session to list");
+    await screen.press("escape");
+    await waitForText(screen.lastFrame, "choose an actor to list");
+    await screen.press("escape");
+    await waitForText(screen.lastFrame, "choose a Memory to list");
   });
 
   test("calls listEvents with the exact route scope and Core options", async () => {

--- a/src/handlers/memory/event/list/screen.tsx
+++ b/src/handlers/memory/event/list/screen.tsx
@@ -99,7 +99,7 @@ function ActorPicker({ ctx, core, memoryId }: ActorPickerProps) {
           `/agentcore/memory/event/list/${encodeURIComponent(memoryId)}/${encodeURIComponent(actorId)}`,
         )
       }
-      onBack={() => navigate("/agentcore/memory/event/list")}
+      onBack={() => navigate(-1)}
       loadingMessage={`Loading actors for Memory ${memoryId}...`}
       errorMessage={(error) => `Error loading actors for Memory ${memoryId}: ${error.message}`}
       emptyMessage={`No actors found for Memory ${memoryId}.`}
@@ -140,7 +140,7 @@ function SessionPicker({ ctx, core, memoryId, actorId }: SessionPickerProps) {
           `/agentcore/memory/event/list/${encodeURIComponent(memoryId)}/${encodeURIComponent(actorId)}/${encodeURIComponent(sessionId)}`,
         )
       }
-      onBack={() => navigate(`/agentcore/memory/event/list/${encodeURIComponent(memoryId)}`)}
+      onBack={() => navigate(-1)}
       loadingMessage={`Loading sessions for actor ${actorId}...`}
       errorMessage={(error) => `Error loading sessions for actor ${actorId}: ${error.message}`}
       emptyMessage={`No sessions found for actor ${actorId}.`}
@@ -187,11 +187,7 @@ function EventPicker({ ctx, core, memoryId, actorId, sessionId }: EventPickerPro
           `/agentcore/memory/event/get/${encodeURIComponent(memoryId)}/${encodeURIComponent(actorId)}/${encodeURIComponent(sessionId)}/${encodeURIComponent(eventId)}`,
         )
       }
-      onBack={() =>
-        navigate(
-          `/agentcore/memory/event/list/${encodeURIComponent(memoryId)}/${encodeURIComponent(actorId)}`,
-        )
-      }
+      onBack={() => navigate(-1)}
       loadingMessage={`Loading events for session ${sessionId}...`}
       errorMessage={(error) => `Error loading events for session ${sessionId}: ${error.message}`}
       emptyMessage={`No events found for session ${sessionId}.`}

--- a/src/handlers/memory/get/screen.tsx
+++ b/src/handlers/memory/get/screen.tsx
@@ -5,6 +5,24 @@ import { ResourceDetailScreen } from "../../../components/ResourceDetailScreen";
 import type { ScreenProps } from "../../types";
 import { coreOptsFromCtx } from "../../utils";
 
+const ACTIONS = [
+  {
+    name: "detail",
+    description: "show the full JSON definition",
+    to: (id: string) => `/agentcore/memory/get/${encodeURIComponent(id)}/json`,
+  },
+  {
+    name: "events",
+    description: "list this Memory's events",
+    to: (id: string) => `/agentcore/memory/event/list/${encodeURIComponent(id)}`,
+  },
+  {
+    name: "records",
+    description: "list this Memory's records",
+    to: (id: string) => `/agentcore/memory/record/list/${encodeURIComponent(id)}`,
+  },
+] as const;
+
 function useMemoryDetail({ ctx, core }: ScreenProps, memoryId: string | undefined) {
   const opts = coreOptsFromCtx(ctx);
   return useQuery({
@@ -37,14 +55,11 @@ export function MemoryGetScreen(props: ScreenProps) {
       }}
       actions={
         memoryId && memory
-          ? [
-              {
-                name: "detail",
-                description: "show the full JSON definition",
-                onSelect: () =>
-                  navigate(`/agentcore/memory/get/${encodeURIComponent(memoryId)}/json`),
-              },
-            ]
+          ? ACTIONS.map((action) => ({
+              name: action.name,
+              description: action.description,
+              onSelect: () => navigate(action.to(memoryId)),
+            }))
           : []
       }
       loadingLabel="Loading Memory…"

--- a/src/handlers/memory/index.tsx
+++ b/src/handlers/memory/index.tsx
@@ -15,5 +15,5 @@ export function createMemoryHandler(core: Core, io: AppIO): Router {
     .handler(createGetMemoryHandler(core))
     .handler(createListMemoriesHandler(core))
     .handler(createMemoryEventHandler(core, io))
-    .handler(createMemoryRecordHandler(core));
+    .handler(createMemoryRecordHandler(core, io));
 }

--- a/src/handlers/memory/memory.screen.test.tsx
+++ b/src/handlers/memory/memory.screen.test.tsx
@@ -235,12 +235,15 @@ describe("Memory detail", () => {
     expect(frame).toContain('"strategies"');
   });
 
-  test("opens the event flow scoped to this Memory and returns to its detail", async () => {
+  test("unwinds the event flow from an empty actor picker through Memory detail to the list", async () => {
     const core = new TestCoreClient();
+    core.memory.setListResponse({ memories: [memorySummary()] });
     core.memory.setGetResponse(getMemoryOutput());
     core.memory.setListActorsResponse({ actorSummaries: [] });
-    const screen = renderScreen("/agentcore/memory/get/memory-1", { core });
+    const screen = renderScreen("/agentcore/memory/list", { core });
 
+    await waitForText(screen.lastFrame, "memory-1");
+    await screen.press("return");
     await waitForText(screen.lastFrame, "list this Memory's events");
     await screen.press("down");
     await screen.press("return");
@@ -253,13 +256,19 @@ describe("Memory detail", () => {
 
     await screen.press("escape");
     await waitForText(screen.lastFrame, "list this Memory's events");
+    await screen.press("escape");
+    await waitForText(screen.lastFrame, "updated UTC");
+    expect(screen.lastFrame()).not.toContain("list this Memory's events");
   });
 
-  test("opens the record flow scoped to this Memory and returns to its detail", async () => {
+  test("unwinds the record flow through Memory detail to the list", async () => {
     const core = new TestCoreClient();
+    core.memory.setListResponse({ memories: [memorySummary()] });
     core.memory.setGetResponse(getMemoryOutput());
-    const screen = renderScreen("/agentcore/memory/get/memory-1", { core });
+    const screen = renderScreen("/agentcore/memory/list", { core });
 
+    await waitForText(screen.lastFrame, "memory-1");
+    await screen.press("return");
     await waitForText(screen.lastFrame, "list this Memory's records");
     await screen.press("down");
     await screen.press("down");
@@ -268,6 +277,9 @@ describe("Memory detail", () => {
 
     await screen.press("escape");
     await waitForText(screen.lastFrame, "list this Memory's records");
+    await screen.press("escape");
+    await waitForText(screen.lastFrame, "updated UTC");
+    expect(screen.lastFrame()).not.toContain("list this Memory's records");
   });
 
   test("retries a failed detail query", async () => {

--- a/src/handlers/memory/memory.screen.test.tsx
+++ b/src/handlers/memory/memory.screen.test.tsx
@@ -66,6 +66,17 @@ function coreWithMemories(memories: MemorySummary[]): TestCoreClient {
 }
 
 describe("Memory picker", () => {
+  test("shows event and record commands in the Memory TUI menu", async () => {
+    const screen = renderScreen("/agentcore/memory");
+
+    await waitForText(screen.lastFrame, "manage AgentCore Memories");
+    const frame = screen.lastFrame()!;
+    expect(frame).toContain("get");
+    expect(frame).toContain("list");
+    expect(frame).toContain("event");
+    expect(frame).toContain("record");
+  });
+
   test("renders Memory identity, status, and update time", async () => {
     const core = coreWithMemories([
       memorySummary({
@@ -222,6 +233,41 @@ describe("Memory detail", () => {
     const frame = screen.lastFrame()!;
     expect(frame).toContain('"memoryExecutionRoleArn"');
     expect(frame).toContain('"strategies"');
+  });
+
+  test("opens the event flow scoped to this Memory and returns to its detail", async () => {
+    const core = new TestCoreClient();
+    core.memory.setGetResponse(getMemoryOutput());
+    core.memory.setListActorsResponse({ actorSummaries: [] });
+    const screen = renderScreen("/agentcore/memory/get/memory-1", { core });
+
+    await waitForText(screen.lastFrame, "list this Memory's events");
+    await screen.press("down");
+    await screen.press("return");
+    await waitForText(screen.lastFrame, "choose an actor to list sessions for");
+
+    await waitFor(() => core.memory.calls.some((call) => call.method === "listActors"));
+    expect(core.memory.calls.find((call) => call.method === "listActors")?.args[0]).toMatchObject({
+      memoryId: "memory-1",
+    });
+
+    await screen.press("escape");
+    await waitForText(screen.lastFrame, "list this Memory's events");
+  });
+
+  test("opens the record flow scoped to this Memory and returns to its detail", async () => {
+    const core = new TestCoreClient();
+    core.memory.setGetResponse(getMemoryOutput());
+    const screen = renderScreen("/agentcore/memory/get/memory-1", { core });
+
+    await waitForText(screen.lastFrame, "list this Memory's records");
+    await screen.press("down");
+    await screen.press("down");
+    await screen.press("return");
+    await waitForText(screen.lastFrame, "choose the namespace scope for the record list");
+
+    await screen.press("escape");
+    await waitForText(screen.lastFrame, "list this Memory's records");
   });
 
   test("retries a failed detail query", async () => {

--- a/src/handlers/memory/memory.test.tsx
+++ b/src/handlers/memory/memory.test.tsx
@@ -140,6 +140,8 @@ describe("memory TUI dispatch", () => {
     ["list", ["memory", "list"]],
     ["event get", ["memory", "event", "get"]],
     ["event list", ["memory", "event", "list"]],
+    ["record get", ["memory", "record", "get"]],
+    ["record list", ["memory", "record", "list"]],
   ] as const)("opens the TUI for a bare Memory %s leaf", async (_label, args) => {
     const { core, route } = testMemoryCommand();
 

--- a/src/handlers/memory/record/get/screen.tsx
+++ b/src/handlers/memory/record/get/screen.tsx
@@ -1,0 +1,33 @@
+import { useQuery } from "@tanstack/react-query";
+import { useParams } from "react-router";
+import { JsonDetail } from "../../../../components/JsonDetail";
+import type { ScreenProps } from "../../../types";
+import { coreOptsFromCtx } from "../../../utils";
+
+export function MemoryRecordGetScreen({ ctx, core }: ScreenProps) {
+  const opts = coreOptsFromCtx(ctx);
+  const { memoryId, recordId } = useParams();
+  const detail = useQuery({
+    queryKey: ["memory-record", opts.region, memoryId, recordId],
+    queryFn: () =>
+      core.memory.getMemoryRecord(
+        {
+          memoryId: memoryId!,
+          memoryRecordId: recordId!,
+        },
+        opts,
+      ),
+    enabled: memoryId !== undefined && recordId !== undefined,
+  });
+
+  return (
+    <JsonDetail
+      breadcrumb={["agentcore", "memory", "record", "get", memoryId ?? "", recordId ?? ""]}
+      isPending={detail.isPending}
+      error={detail.isError ? (detail.error as Error) : null}
+      data={detail.data?.memoryRecord}
+      loadingLabel={`Loading Memory record ${recordId ?? ""}...`}
+      onRetry={() => void detail.refetch()}
+    />
+  );
+}

--- a/src/handlers/memory/record/index.tsx
+++ b/src/handlers/memory/record/index.tsx
@@ -1,10 +1,13 @@
 import { Router } from "../../../router";
+import { renderTui } from "../../../tui";
+import type { AppIO } from "../../../io";
 import type { Core } from "../../types";
 import { createGetMemoryRecordHandler } from "./get";
 import { createListMemoryRecordsHandler } from "./list";
 
-export function createMemoryRecordHandler(core: Core): Router {
+export function createMemoryRecordHandler(core: Core, io: AppIO): Router {
   return new Router("record", "inspect AgentCore Memory records")
+    .default(renderTui(core, io))
     .handler(createGetMemoryRecordHandler(core))
     .handler(createListMemoryRecordsHandler(core));
 }

--- a/src/handlers/memory/record/list/screen.tsx
+++ b/src/handlers/memory/record/list/screen.tsx
@@ -1,0 +1,205 @@
+import type { MemoryContent, MemoryRecordSummary } from "@aws-sdk/client-bedrock-agentcore";
+import { Box, Text, useInput } from "ink";
+import { useState } from "react";
+import { useNavigate, useParams } from "react-router";
+import { FormRadioGroup, type FormRadioOption } from "../../../../components/FormRadioGroup";
+import { FormTextInput } from "../../../../components/FormTextInput";
+import { Layout } from "../../../../components/Layout";
+import { MemoryPicker } from "../../../../components/MemoryPicker";
+import { PaginatedTablePicker } from "../../../../components/PaginatedTablePicker";
+import { formatTimestamp } from "../../../../components/formatTimestamp";
+import { darkTheme } from "../../../../components/ui/_core";
+import type { DataTableColumn } from "../../../../components/ui/data-table";
+import type { ScreenProps } from "../../../types";
+import { coreOptsFromCtx } from "../../../utils";
+
+type RecordScopeKind = "namespace" | "namespace-path";
+
+const scopeOptions = [
+  {
+    label: "namespace",
+    description: "match records whose namespace starts with this prefix",
+  },
+  {
+    label: "namespace path",
+    description: "match records under the same namespace hierarchy",
+  },
+] satisfies FormRadioOption[];
+
+interface MemoryRecordRow extends Record<string, unknown> {
+  recordId: string;
+  content: string;
+  strategyId: string;
+  createdAt: string;
+}
+
+const recordColumns = [
+  { key: "recordId", header: "id", width: 18, minWidth: 10 },
+  { key: "content", header: "content", flex: true },
+  { key: "strategyId", header: "strategy", width: 16, minWidth: 8 },
+  {
+    key: "createdAt",
+    header: "created UTC",
+    width: 16,
+    minWidth: 11,
+    render: formatTimestamp,
+  },
+] satisfies DataTableColumn<MemoryRecordRow>[];
+
+function contentText(content: MemoryContent | undefined): string {
+  if (content?.text) return content.text.replace(/\s+/g, " ");
+  return "-";
+}
+
+function toRow(record: MemoryRecordSummary): MemoryRecordRow {
+  return {
+    recordId: record.memoryRecordId ?? "",
+    content: contentText(record.content),
+    strategyId: record.memoryStrategyId ?? "-",
+    createdAt: record.createdAt?.toISOString() ?? "-",
+  };
+}
+
+interface MemoryRecordScopeScreenProps {
+  memoryId: string;
+}
+
+function MemoryRecordScopeScreen({ memoryId }: MemoryRecordScopeScreenProps) {
+  const navigate = useNavigate();
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [scope, setScope] = useState("");
+  const [submitted, setSubmitted] = useState(false);
+
+  const submit = (value: string) => {
+    if (value.trim() === "") {
+      setSubmitted(true);
+      return;
+    }
+
+    const kind: RecordScopeKind = selectedIndex === 0 ? "namespace" : "namespace-path";
+    navigate(
+      `/agentcore/memory/record/list/${encodeURIComponent(memoryId)}/${kind}/${encodeURIComponent(value)}`,
+    );
+  };
+
+  useInput((_input, key) => {
+    if (key.escape) {
+      navigate("/agentcore/memory/record/list");
+      return;
+    }
+    if (key.upArrow) {
+      setSelectedIndex(0);
+      return;
+    }
+    if (key.downArrow) {
+      setSelectedIndex(1);
+    }
+  });
+
+  return (
+    <Layout
+      breadcrumb={["agentcore", "memory", "record", "list", memoryId]}
+      description="choose the namespace scope for the record list"
+      keyHints={[
+        { key: "up/down", label: "scope type" },
+        { key: "enter", label: "list records" },
+        { key: "esc", label: "back" },
+        { key: "ctl+c", label: "quit" },
+      ]}
+    >
+      <Box flexDirection="column" gap={1} paddingX={1}>
+        <FormRadioGroup
+          name="scope type"
+          helpText="Choose how the service should match record namespaces."
+          options={scopeOptions}
+          selectedIndex={selectedIndex}
+        />
+        <FormTextInput
+          name={selectedIndex === 0 ? "namespace" : "namespace path"}
+          helpText="Enter the namespace value used to scope this request."
+          placeholder="/strategies/strategy-id/actors/actor-id"
+          errorText="A namespace value is required."
+          value={scope}
+          onChange={(value) => {
+            setScope(value);
+            setSubmitted(false);
+          }}
+          onSubmit={submit}
+        />
+        {submitted && scope.trim() === "" ? (
+          <Text color={darkTheme.colors.error}>A namespace value is required.</Text>
+        ) : null}
+      </Box>
+    </Layout>
+  );
+}
+
+interface MemoryRecordPickerProps extends ScreenProps {
+  memoryId: string;
+  scopeKind: RecordScopeKind;
+  scope: string;
+}
+
+function MemoryRecordPicker({ ctx, core, memoryId, scopeKind, scope }: MemoryRecordPickerProps) {
+  const opts = coreOptsFromCtx(ctx);
+  const navigate = useNavigate();
+
+  return (
+    <PaginatedTablePicker
+      breadcrumb={["agentcore", "memory", "record", "list", memoryId]}
+      description={`${scopeKind}: ${scope}`}
+      queryKey={["memory-records", opts.region, memoryId, scopeKind, scope]}
+      loadPage={async (token, pageSize) => {
+        const response = await core.memory.listMemoryRecords(
+          {
+            memoryId,
+            namespace: scopeKind === "namespace" ? scope : undefined,
+            namespacePath: scopeKind === "namespace-path" ? scope : undefined,
+            maxResults: pageSize,
+            nextToken: token,
+          },
+          opts,
+        );
+        return {
+          items: response.memoryRecordSummaries ?? [],
+          nextToken: response.nextToken,
+        };
+      }}
+      toRow={toRow}
+      columns={recordColumns}
+      getValue={(row) => row.recordId}
+      onSelect={(recordId) =>
+        navigate(
+          `/agentcore/memory/record/get/${encodeURIComponent(memoryId)}/${encodeURIComponent(recordId)}`,
+        )
+      }
+      onBack={() => navigate(`/agentcore/memory/record/list/${encodeURIComponent(memoryId)}`)}
+      loadingMessage={`Loading Memory records for ${memoryId}...`}
+      errorMessage={(error) => `Error loading Memory records for ${memoryId}: ${error.message}`}
+      emptyMessage={`No Memory records found for ${scopeKind} ${scope}.`}
+      emptyPageMessage={`No Memory records on this page for ${scopeKind} ${scope}.`}
+    />
+  );
+}
+
+export function MemoryRecordListScreen(props: ScreenProps) {
+  const navigate = useNavigate();
+  const { memoryId, scopeKind, scope } = useParams();
+
+  if (!memoryId) {
+    return (
+      <MemoryPicker
+        {...props}
+        breadcrumb={["agentcore", "memory", "record", "list"]}
+        description="choose a Memory to list records for"
+        onSelect={(id) => navigate(`/agentcore/memory/record/list/${encodeURIComponent(id)}`)}
+      />
+    );
+  }
+
+  if (scope === undefined || (scopeKind !== "namespace" && scopeKind !== "namespace-path")) {
+    return <MemoryRecordScopeScreen memoryId={memoryId} />;
+  }
+
+  return <MemoryRecordPicker {...props} memoryId={memoryId} scopeKind={scopeKind} scope={scope} />;
+}

--- a/src/handlers/memory/record/list/screen.tsx
+++ b/src/handlers/memory/record/list/screen.tsx
@@ -34,14 +34,14 @@ interface MemoryRecordRow extends Record<string, unknown> {
 }
 
 const recordColumns = [
-  { key: "recordId", header: "id", width: 18, minWidth: 10 },
-  { key: "content", header: "content", flex: true },
-  { key: "strategyId", header: "strategy", width: 16, minWidth: 8 },
+  { key: "recordId", header: "id", flex: true },
+  { key: "content", header: "content", width: 70, minWidth: 20 },
+  { key: "strategyId", header: "strategy", width: 32, minWidth: 16 },
   {
     key: "createdAt",
     header: "created UTC",
     width: 16,
-    minWidth: 11,
+    minWidth: 16,
     render: formatTimestamp,
   },
 ] satisfies DataTableColumn<MemoryRecordRow>[];

--- a/src/handlers/memory/record/list/screen.tsx
+++ b/src/handlers/memory/record/list/screen.tsx
@@ -84,7 +84,7 @@ function MemoryRecordScopeScreen({ memoryId }: MemoryRecordScopeScreenProps) {
 
   useInput((_input, key) => {
     if (key.escape) {
-      navigate("/agentcore/memory/record/list");
+      navigate(-1);
       return;
     }
     if (key.upArrow) {
@@ -173,7 +173,7 @@ function MemoryRecordPicker({ ctx, core, memoryId, scopeKind, scope }: MemoryRec
           `/agentcore/memory/record/get/${encodeURIComponent(memoryId)}/${encodeURIComponent(recordId)}`,
         )
       }
-      onBack={() => navigate(`/agentcore/memory/record/list/${encodeURIComponent(memoryId)}`)}
+      onBack={() => navigate(-1)}
       loadingMessage={`Loading Memory records for ${memoryId}...`}
       errorMessage={(error) => `Error loading Memory records for ${memoryId}: ${error.message}`}
       emptyMessage={`No Memory records found for ${scopeKind} ${scope}.`}

--- a/src/handlers/memory/record/record.screen.test.tsx
+++ b/src/handlers/memory/record/record.screen.test.tsx
@@ -44,6 +44,13 @@ function recordSummary(overrides: Partial<MemoryRecordSummary> = {}): MemoryReco
 }
 
 describe("Memory record list flow", () => {
+  test("renders the record command menu", async () => {
+    const screen = renderScreen("/agentcore/memory/record");
+
+    await waitForText(screen.lastFrame, "inspect AgentCore Memory records");
+    expect(screen.lastFrame()).toContain("list");
+  });
+
   test("uses the Memory picker before asking for a namespace scope", async () => {
     const memoryId = "memory/blue one";
     const core = new TestCoreClient();
@@ -61,6 +68,36 @@ describe("Memory record list flow", () => {
     expect(frame).toContain("namespace path");
     expect(frame).toContain("namespace");
     expect(core.memory.calls.some((call) => call.method === "listMemoryRecords")).toBe(false);
+  });
+
+  test("returns from scope selection to the Memory picker", async () => {
+    const screen = renderScreen("/agentcore/memory/record/list/memory-1");
+
+    await waitForText(screen.lastFrame, "scope type");
+    await screen.press("escape");
+    await waitForText(screen.lastFrame, "choose a Memory to list records for");
+  });
+
+  test("uses namespace scope again after moving the selector up", async () => {
+    const core = new TestCoreClient();
+    core.memory.setListMemoryRecordsResponse({
+      memoryRecordSummaries: [recordSummary()],
+    });
+    const screen = renderScreen("/agentcore/memory/record/list/memory-1", { core });
+
+    await waitForText(screen.lastFrame, "scope type");
+    await screen.press("down");
+    await screen.press("up");
+    await screen.write("/customers/acme");
+    await screen.press("return");
+    await waitFor(() => core.memory.calls.some((call) => call.method === "listMemoryRecords"));
+
+    expect(
+      core.memory.calls.find((call) => call.method === "listMemoryRecords")?.args[0],
+    ).toMatchObject({
+      namespace: "/customers/acme",
+      namespacePath: undefined,
+    });
   });
 
   test("submits a namespace prefix and calls listMemoryRecords with exact options", async () => {
@@ -97,6 +134,25 @@ describe("Memory record list flow", () => {
         ],
       },
     ]);
+  });
+
+  test("renders a placeholder when a record summary has no text content", async () => {
+    const core = new TestCoreClient();
+    core.memory.setListMemoryRecordsResponse({
+      memoryRecordSummaries: [
+        recordSummary({
+          memoryRecordId: "no-text",
+          content: { text: "" },
+        }),
+      ],
+    });
+    const screen = renderScreen(
+      "/agentcore/memory/record/list/memory-1/namespace/%2Fcustomers%2Facme",
+      { core },
+    );
+
+    await waitForText(screen.lastFrame, "no-text");
+    expect(screen.lastFrame()).toContain("-");
   });
 
   test("maps namespace-path scope to namespacePath", async () => {

--- a/src/handlers/memory/record/record.screen.test.tsx
+++ b/src/handlers/memory/record/record.screen.test.tsx
@@ -12,6 +12,7 @@ import {
   waitFor,
   waitForText,
 } from "../../../testing";
+import stringWidth from "string-width";
 
 afterEach(cleanupScreens);
 
@@ -222,6 +223,40 @@ describe("Memory record list flow", () => {
         { region: "us-east-1" },
       ],
     });
+  });
+
+  test("shows full record identifiers, content, strategy, and timestamps in a wide terminal", async () => {
+    const memoryRecordId = "mem-6ff41abc-6571-4e56-9c47-90e7581785f1";
+    const content = "User is interested in total-market ETFs with low expense ratios.";
+    const memoryStrategyId = "tui_testdata_semantic-FEeDurAJJ1";
+    const core = new TestCoreClient();
+    core.memory.setListMemoryRecordsResponse({
+      memoryRecordSummaries: [
+        recordSummary({
+          memoryRecordId,
+          content: { text: content },
+          memoryStrategyId,
+          createdAt: new Date("2026-08-04T20:44:00.000Z"),
+        }),
+      ],
+    });
+    const screen = renderScreen(
+      "/agentcore/memory/record/list/memory-1/namespace/%2Fcustomers%2Facme",
+      { core },
+    );
+
+    await waitForText(screen.lastFrame, "total-market ETFs");
+    await screen.resize(191, 24);
+
+    const row = screen
+      .lastFrame()!
+      .split("\n")
+      .find((line) => line.includes(memoryRecordId));
+    expect(row).toBeDefined();
+    expect(row!).toContain(content);
+    expect(row!).toContain(memoryStrategyId);
+    expect(row!).toContain("2026-08-04 20:44");
+    expect(stringWidth(row!)).toBeLessThanOrEqual(191);
   });
 
   test("paginates records and distinguishes later-page empty state", async () => {

--- a/src/handlers/memory/record/record.screen.test.tsx
+++ b/src/handlers/memory/record/record.screen.test.tsx
@@ -1,0 +1,217 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type {
+  GetMemoryRecordOutput,
+  MemoryRecord,
+  MemoryRecordSummary,
+} from "@aws-sdk/client-bedrock-agentcore";
+import type { MemorySummary } from "@aws-sdk/client-bedrock-agentcore-control";
+import {
+  cleanupScreens,
+  renderScreen,
+  TestCoreClient,
+  waitFor,
+  waitForText,
+} from "../../../testing";
+
+afterEach(cleanupScreens);
+
+const memoryEndpointUrl = "https://memory.test";
+
+function memorySummary(overrides: Partial<MemorySummary> = {}): MemorySummary {
+  return {
+    arn: "arn:aws:bedrock-agentcore:us-east-1:123456789012:memory/memory-1",
+    id: "memory-1",
+    status: "ACTIVE",
+    createdAt: new Date("2026-07-19T01:02:03.000Z"),
+    updatedAt: new Date("2026-07-20T12:34:56.000Z"),
+    ...overrides,
+  };
+}
+
+function record(overrides: Partial<MemoryRecord> = {}): MemoryRecord {
+  return {
+    memoryRecordId: "record-1",
+    content: { text: "Customer prefers email notifications." },
+    memoryStrategyId: "strategy-1",
+    namespaces: ["/customers/acme"],
+    createdAt: new Date("2026-08-03T12:34:56.000Z"),
+    ...overrides,
+  };
+}
+
+function recordSummary(overrides: Partial<MemoryRecordSummary> = {}): MemoryRecordSummary {
+  return record(overrides);
+}
+
+describe("Memory record list flow", () => {
+  test("uses the Memory picker before asking for a namespace scope", async () => {
+    const memoryId = "memory/blue one";
+    const core = new TestCoreClient();
+    core.memory.setListResponse({
+      memories: [memorySummary({ id: memoryId })],
+    });
+    const screen = renderScreen("/agentcore/memory/record/list", { core });
+
+    await waitForText(screen.lastFrame, memoryId);
+    await screen.press("return");
+    await waitForText(screen.lastFrame, `agentcore → memory → record → list → ${memoryId}`);
+
+    const frame = screen.lastFrame()!;
+    expect(frame).toContain("scope type");
+    expect(frame).toContain("namespace path");
+    expect(frame).toContain("namespace");
+    expect(core.memory.calls.some((call) => call.method === "listMemoryRecords")).toBe(false);
+  });
+
+  test("submits a namespace prefix and calls listMemoryRecords with exact options", async () => {
+    const core = new TestCoreClient();
+    core.memory.setListMemoryRecordsResponse({
+      memoryRecordSummaries: [recordSummary()],
+    });
+    const screen = renderScreen("/agentcore/memory/record/list/memory-1", {
+      core,
+      endpointUrl: memoryEndpointUrl,
+    });
+
+    await waitForText(screen.lastFrame, "scope type");
+    await screen.write("/customers/acme");
+    await screen.press("return");
+    await waitForText(screen.lastFrame, "Customer prefers email notifications.");
+    await waitFor(() => core.memory.calls.some((call) => call.method === "listMemoryRecords"));
+
+    expect(core.memory.calls.filter((call) => call.method === "listMemoryRecords")).toEqual([
+      {
+        method: "listMemoryRecords",
+        args: [
+          {
+            memoryId: "memory-1",
+            namespace: "/customers/acme",
+            namespacePath: undefined,
+            maxResults: expect.any(Number),
+            nextToken: undefined,
+          },
+          {
+            region: "us-east-1",
+            endpointUrl: memoryEndpointUrl,
+          },
+        ],
+      },
+    ]);
+  });
+
+  test("maps namespace-path scope to namespacePath", async () => {
+    const core = new TestCoreClient();
+    core.memory.setListMemoryRecordsResponse({
+      memoryRecordSummaries: [recordSummary()],
+    });
+    const screen = renderScreen("/agentcore/memory/record/list/memory-1", { core });
+
+    await waitForText(screen.lastFrame, "scope type");
+    await screen.press("down");
+    await screen.write("/customers/acme/*");
+    await screen.press("return");
+    await waitFor(() => core.memory.calls.some((call) => call.method === "listMemoryRecords"));
+
+    expect(core.memory.calls.find((call) => call.method === "listMemoryRecords")).toEqual({
+      method: "listMemoryRecords",
+      args: [
+        {
+          memoryId: "memory-1",
+          namespace: undefined,
+          namespacePath: "/customers/acme/*",
+          maxResults: expect.any(Number),
+          nextToken: undefined,
+        },
+        { region: "us-east-1" },
+      ],
+    });
+  });
+
+  test("renders record columns and opens the selected record JSON", async () => {
+    const response: GetMemoryRecordOutput = {
+      memoryRecord: record({ metadata: { tenant: { stringValue: "acme" } } }),
+    };
+    const core = new TestCoreClient();
+    core.memory.setListMemoryRecordsResponse({
+      memoryRecordSummaries: [
+        recordSummary({
+          memoryRecordId: "record blue",
+          memoryStrategyId: "summary-strategy",
+        }),
+      ],
+    });
+    core.memory.setGetMemoryRecordResponse(response);
+    const screen = renderScreen(
+      "/agentcore/memory/record/list/memory-1/namespace/%2Fcustomers%2Facme",
+      { core },
+    );
+
+    await waitForText(screen.lastFrame, "record blue");
+    const frame = screen.lastFrame()!;
+    expect(frame).toContain("content");
+    expect(frame).toContain("strategy");
+    expect(frame).toContain("created UTC");
+    expect(frame).toContain("summary-strategy");
+    expect(frame).toContain("2026-08-03 12:34");
+
+    await screen.press("return");
+    await waitForText(screen.lastFrame, '"tenant"');
+    expect(core.memory.calls.find((call) => call.method === "getMemoryRecord")).toEqual({
+      method: "getMemoryRecord",
+      args: [
+        {
+          memoryId: "memory-1",
+          memoryRecordId: "record blue",
+        },
+        { region: "us-east-1" },
+      ],
+    });
+  });
+
+  test("paginates records and distinguishes later-page empty state", async () => {
+    const core = new TestCoreClient();
+    core.memory.setListMemoryRecordsResponse({
+      memoryRecordSummaries: [recordSummary({ memoryRecordId: "page-one" })],
+      nextToken: "page-2",
+    });
+    core.memory.setListMemoryRecordsResponse({ memoryRecordSummaries: [] }, "page-2");
+    const screen = renderScreen("/agentcore/memory/record/list/memory-1/namespace/%2Fcustomers", {
+      core,
+    });
+
+    await waitForText(screen.lastFrame, "page 1 · more →");
+    await screen.write("l");
+    await waitForText(screen.lastFrame, "No Memory records on this page for namespace /customers.");
+  });
+
+  test("shows the scoped empty state and retries list failures", async () => {
+    const empty = renderScreen("/agentcore/memory/record/list/memory-1/namespace/%2Fcustomers");
+    await waitForText(empty.lastFrame, "No Memory records found for namespace /customers.");
+    empty.unmount();
+
+    const core = new TestCoreClient();
+    core.memory.setError(new Error("records unavailable"));
+    const failed = renderScreen("/agentcore/memory/record/list/memory-1/namespace/%2Fcustomers", {
+      core,
+    });
+
+    await waitForText(failed.lastFrame, "records unavailable");
+    expect(failed.lastFrame()).toContain("[r] retry");
+
+    core.memory.setError(undefined);
+    core.memory.setListMemoryRecordsResponse({
+      memoryRecordSummaries: [recordSummary()],
+    });
+    await failed.write("r");
+    await waitForText(failed.lastFrame, "Customer prefers email notifications.");
+  });
+
+  test("requires a non-empty namespace value", async () => {
+    const screen = renderScreen("/agentcore/memory/record/list/memory-1");
+
+    await waitForText(screen.lastFrame, "scope type");
+    await screen.press("return");
+    await waitForText(screen.lastFrame, "A namespace value is required.");
+    expect(screen.core.memory.calls).toEqual([]);
+  });
+});

--- a/src/handlers/memory/record/record.screen.test.tsx
+++ b/src/handlers/memory/record/record.screen.test.tsx
@@ -71,9 +71,25 @@ describe("Memory record list flow", () => {
     expect(core.memory.calls.some((call) => call.method === "listMemoryRecords")).toBe(false);
   });
 
-  test("returns from scope selection to the Memory picker", async () => {
-    const screen = renderScreen("/agentcore/memory/record/list/memory-1");
+  test("unwinds the record table through its scope and Memory pickers", async () => {
+    const memoryId = "memory/blue one";
+    const core = new TestCoreClient();
+    core.memory.setListResponse({
+      memories: [memorySummary({ id: memoryId })],
+    });
+    core.memory.setListMemoryRecordsResponse({
+      memoryRecordSummaries: [recordSummary()],
+    });
+    const screen = renderScreen("/agentcore/memory/record/list", { core });
 
+    await waitForText(screen.lastFrame, memoryId);
+    await screen.press("return");
+    await waitForText(screen.lastFrame, "scope type");
+    await screen.write("/customers/acme");
+    await screen.press("return");
+    await waitForText(screen.lastFrame, "Customer prefers email notifications.");
+
+    await screen.press("escape");
     await waitForText(screen.lastFrame, "scope type");
     await screen.press("escape");
     await waitForText(screen.lastFrame, "choose a Memory to list records for");

--- a/src/handlers/memory/record/screen.tsx
+++ b/src/handlers/memory/record/screen.tsx
@@ -1,0 +1,6 @@
+import { RouterScreen } from "../../../components/RouterScreen";
+import type { ScreenProps } from "../../types";
+
+export function MemoryRecordScreen(props: ScreenProps) {
+  return <RouterScreen {...props} path={["agentcore", "memory", "record"]} />;
+}


### PR DESCRIPTION
This PR adds TUI implementation to the memory record list and get commands implemented in PR https://github.com/aws/agentcore-cli/pull/1895

PR #1906 adds the event TUI. Stacks on top of the both of them.

The flow:
Adds Memory selection followed by namespace scope entry. Supports namespace and namespace-path.

It lists records with content, strategy, and creation timeand opens up selected event as an entire JSON. Pagination, filtering, retries, empty states, and back navigation is implemented.

I tested this myself + using the TUI harness skill.

Typcheck, lint, build and test passes

Additional TUI entry points:
- Events and records are available from the top-level Memory menu and beside detail in a selected Memory's action list.
- Record-list columns preserve IDs, content, strategy IDs, and timestamps at wide terminal widths.