### PR TITLE
fix(add): correct gateway-target --help outbound auth per target type

### DIFF
--- a/src/cli/primitives/GatewayTargetPrimitive.ts
+++ b/src/cli/primitives/GatewayTargetPrimitive.ts
@@ -313,7 +313,10 @@ export class GatewayTargetPrimitive extends BasePrimitive<AddGatewayTargetOption
       .option('--endpoint <endpoint>', 'Server endpoint URL (for mcp-server type) [non-interactive]')
       .option('--language <lang>', 'Language of target code: Python, TypeScript, Other [non-interactive]')
       .option('--host <host>', 'Where to run the target: Lambda or AgentCoreRuntime [non-interactive]')
-      .option('--outbound-auth <type>', 'Outbound auth type: oauth, api-key, or none [non-interactive]')
+      .option(
+        '--outbound-auth <type>',
+        'Outbound auth type; valid values depend on --type (see "Auth" below) [non-interactive]'
+      )
       .option('--credential-name <name>', 'Existing credential name for outbound auth [non-interactive]')
       .option(
         '--oauth-client-id <id>',
@@ -415,9 +418,14 @@ Target types and their options:
     --stickiness-identifier <expr> Session routing expression (optional)
     --stickiness-timeout <seconds> Sticky session timeout in seconds (optional)
 
-  Auth (mcp-server, open-api-schema, smithy-model, lambda-function-arn, passthrough):
-    --outbound-auth <type>         oauth, api-key, or none
-    --credential-name <name>       Existing credential name
+  Auth (--outbound-auth <type>, --credential-name <name>) — valid types per target:
+    mcp-server                     oauth or none
+    lambda-function-arn            oauth or none
+    http-runtime                   oauth or none
+    open-api-schema                oauth or api-key (required)
+    api-gateway                    api-key or none
+    smithy-model                   none (uses gateway IAM role)
+    passthrough                    gateway-iam-role, oauth, or jwt-passthrough
 `
       )
       .action(async (rawOptions: Record<string, string | string[] | boolean | undefined>) => {

--- a/src/cli/primitives/__tests__/GatewayTargetPrimitive.test.ts
+++ b/src/cli/primitives/__tests__/GatewayTargetPrimitive.test.ts
@@ -1,5 +1,6 @@
 import type { AgentCoreProjectSpec } from '../../../schema';
 import { GatewayTargetPrimitive } from '../GatewayTargetPrimitive';
+import { Command } from '@commander-js/extra-typings';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const defaultProject: AgentCoreProjectSpec = {
@@ -381,5 +382,32 @@ describe('GatewayTargetPrimitive — createWebSearchGatewayTarget', () => {
         gateway: 'does-not-exist',
       })
     ).rejects.toThrow(/not found/);
+  });
+});
+
+// Regression guard for V2304968218: --help must not advertise api-key outbound
+// auth for target types the validator rejects (mcp-server, passthrough). The
+// help text is hand-written; this keeps it in step with TARGET_TYPE_AUTH_CONFIG.
+describe('GatewayTargetPrimitive — add gateway-target --help outbound auth', () => {
+  function renderHelp(): string {
+    const add = new Command('add');
+    const remove = new Command('remove');
+    new GatewayTargetPrimitive().registerCommands(add, remove);
+    const target = add.commands.find(c => c.name() === 'gateway-target');
+    if (!target) throw new Error('gateway-target command not registered');
+    // addHelpText('after', ...) is emitted by outputHelp(), not helpInformation().
+    let out = '';
+    target.configureOutput({ writeOut: (s: string) => (out += s) });
+    target.outputHelp();
+    return out;
+  }
+
+  it('does not offer api-key for mcp-server or passthrough', () => {
+    const help = renderHelp();
+    expect(help).toMatch(/mcp-server\s+oauth or none/);
+    expect(help).toMatch(/passthrough\s+gateway-iam-role, oauth, or jwt-passthrough/);
+    // api-key stays only where the validator accepts it.
+    expect(help).toMatch(/open-api-schema\s+oauth or api-key/);
+    expect(help).toMatch(/api-gateway\s+api-key or none/);
   });
 });


### PR DESCRIPTION
Fixes #1914

## Problem

`agentcore add gateway-target --help` advertised `oauth, api-key, or none` for `mcp-server`, `open-api-schema`, `smithy-model`, `lambda-function-arn` and `passthrough` collectively. But the validator (driven by `TARGET_TYPE_AUTH_CONFIG` in `src/schema/schemas/mcp.ts`) only accepts `api-key` for `open-api-schema` and `api-gateway`. So `agentcore validate` rejected `api-key` on `mcp-server` and `passthrough` even though `--help` said it was allowed — an unsupported design looked supported right up until deploy time.

## Change

- Replace the single lumped Auth line in `--help` with a per-target-type breakdown that mirrors `TARGET_TYPE_AUTH_CONFIG`.
- Reword the `--outbound-auth` flag blurb to point at that section (valid values depend on `--type`).
- Add a regression test asserting `--help` no longer offers `api-key` for `mcp-server`/`passthrough`, and still does for `open-api-schema`/`api-gateway`.

### Help output — before
```
  Auth (mcp-server, open-api-schema, smithy-model, lambda-function-arn, passthrough):
    --outbound-auth <type>         oauth, api-key, or none
    --credential-name <name>       Existing credential name
```

### Help output — after
```
  Auth (--outbound-auth <type>, --credential-name <name>) — valid types per target:
    mcp-server                     oauth or none
    lambda-function-arn            oauth or none
    http-runtime                   oauth or none
    open-api-schema                oauth or api-key (required)
    api-gateway                    api-key or none
    smithy-model                   none (uses gateway IAM role)
    passthrough                    gateway-iam-role, oauth, or jwt-passthrough
```

## Testing

- `npx vitest run src/cli/primitives/__tests__/GatewayTargetPrimitive.test.ts` — 15 passed (incl. new guard).
- `npm run typecheck` — clean.
- `eslint` on touched files — clean.

Docs-only help text; no runtime behavior change.