### PR TITLE
fix(runtime): polish invoke TUI errors and sessions

### DIFF
--- a/src/core/core.test.ts
+++ b/src/core/core.test.ts
@@ -14,6 +14,7 @@ import {
   ListEventsCommand,
   ListMemoryRecordsCommand,
   ListSessionsCommand,
+  ValidationException,
   type BedrockAgentCoreClient,
 } from "@aws-sdk/client-bedrock-agentcore";
 import type { RuntimeInvokeRequest } from "../handlers/runtime/types";
@@ -622,6 +623,38 @@ test("IAM invoke failures preserve safe SDK diagnostics without arbitrary causes
       requestId: "request-123",
     },
     ["secret request content", "secret payload", "secret-header-value"],
+  );
+});
+
+test("IAM invoke failures include messages from modeled AWS service errors", async () => {
+  const core = coreWithDataSend(async () => {
+    throw new ValidationException({
+      message: "Runtime session ID must contain at least 33 characters",
+      reason: "FieldValidationFailed",
+      $metadata: {
+        httpStatusCode: 400,
+        requestId: "request-456",
+      },
+    });
+  });
+
+  const caught = await core.runtime
+    .invokeRuntime(
+      {
+        runtimeId: "runtime-123",
+        accountId: "123456789012",
+        qualifier: "DEFAULT",
+        payload: new TextEncoder().encode("{}"),
+        contentType: "application/json",
+      },
+      { region: "us-east-1" },
+    )
+    .catch((caught: Error) => caught);
+  const error = caught as Error;
+
+  expect(error.message).toBe(
+    "Runtime invocation failed: Runtime session ID must contain at least 33 characters " +
+      "(ValidationException, HTTP 400, request ID request-456)",
   );
 });
 

--- a/src/core/runtime.tsx
+++ b/src/core/runtime.tsx
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { ServiceException } from "@smithy/core/client";
 import {
   GetAgentRuntimeCommand,
   GetAgentRuntimeEndpointCommand,
@@ -172,6 +173,10 @@ export class RuntimeClient implements CoreRuntimeClient {
         name?: unknown;
         $metadata?: { httpStatusCode?: unknown; requestId?: unknown };
       };
+      const serviceMessage =
+        ServiceException.isInstance(error) && error.message.trim()
+          ? error.message.trim()
+          : undefined;
       const diagnostics: string[] = [];
       if (typeof sdkError?.name === "string" && sdkError.name !== "Error") {
         diagnostics.push(sdkError.name);
@@ -194,7 +199,10 @@ export class RuntimeClient implements CoreRuntimeClient {
         })
         .debug("Runtime invocation SDK request failed");
       throw new Error(
-        `Runtime invocation failed${diagnostics.length ? ` (${diagnostics.join(", ")})` : ""}`,
+        `Runtime invocation failed${serviceMessage ? `: ${serviceMessage}` : ""}${
+          diagnostics.length ? ` (${diagnostics.join(", ")})` : ""
+        }`,
+        { cause: error },
       );
     }
 

--- a/src/handlers/runtime/invoke/RuntimePayloadInput.tsx
+++ b/src/handlers/runtime/invoke/RuntimePayloadInput.tsx
@@ -66,12 +66,9 @@ export function RuntimePayloadInput({
 
   if (value === "") {
     return (
-      <Box flexDirection="column">
-        <Text color={theme.colors.muted}>JSON payload</Text>
-        <Box>
-          <Cursor character={PLACEHOLDER[0]!} />
-          <Text color={theme.colors.muted}>{PLACEHOLDER.slice(1)}</Text>
-        </Box>
+      <Box>
+        <Cursor character={PLACEHOLDER[0]!} />
+        <Text color={theme.colors.muted}>{PLACEHOLDER.slice(1)}</Text>
       </Box>
     );
   }
@@ -86,7 +83,6 @@ export function RuntimePayloadInput({
 
   return (
     <Box flexDirection="column">
-      <Text color={theme.colors.muted}>JSON payload</Text>
       {visible.map((line, index) => {
         const lineIndex = start + index;
         const prefix = index === 0 && start > 0 ? "… " : "";

--- a/src/handlers/runtime/invoke/invoke.screen.test.tsx
+++ b/src/handlers/runtime/invoke/invoke.screen.test.tsx
@@ -19,6 +19,7 @@ const RUNTIME_ID = "runtime-123";
 const QUALIFIER = "prod";
 const RUNTIME_ARN = `arn:aws:bedrock-agentcore:${REGION}:123456789012:runtime/${RUNTIME_ID}`;
 const CONSOLE_PATH = `/agentcore/runtime/invoke/${RUNTIME_ID}/${QUALIFIER}`;
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 
 afterEach(cleanupScreens);
 
@@ -61,6 +62,10 @@ function invokeRequests(core: TestCoreClient): RuntimeInvokeRequest[] {
   return core.runtime.calls
     .filter((call) => call.method === "invokeRuntime")
     .map((call) => call.args[0] as RuntimeInvokeRequest);
+}
+
+function displayedSessionId(frame: string | undefined): string | undefined {
+  return frame?.match(/Ready · Session ID: ([^ ·\n]+)/)?.[1];
 }
 
 describe("Runtime invoke routing", () => {
@@ -164,12 +169,26 @@ describe("Runtime invoke routing", () => {
       screen.lastFrame,
       `agentcore → runtime → invoke → ${RUNTIME_ID} → ${nextQualifier}`,
     );
-    expect(screen.lastFrame()).toContain("Ready · Session ID: Not set");
+    const nextSessionId = displayedSessionId(screen.lastFrame());
+    expect(nextSessionId).toMatch(UUID_PATTERN);
+    expect(nextSessionId).not.toBe("cli-selected-session");
 
     await screen.write("{}");
     await screen.press("return");
     await waitFor(() => invokeRequests(core).length === 1);
-    expect(invokeRequests(core)[0]!.runtimeSessionId).toBeUndefined();
+    expect(invokeRequests(core)[0]!.runtimeSessionId).toBe(nextSessionId);
+  });
+
+  test("shows the full Runtime lookup error", async () => {
+    const core = new TestCoreClient();
+    core.runtime.getRuntime = async () => {
+      throw Object.assign(new Error("not authorized for this Runtime"), {
+        name: "AccessDeniedException",
+      });
+    };
+    const screen = renderScreen(CONSOLE_PATH, { core });
+
+    await waitForText(screen.lastFrame, "AccessDeniedException: not authorized for this Runtime");
   });
 
   test("unmount cancels the Runtime detail lookup", async () => {
@@ -200,7 +219,10 @@ describe("Runtime invoke JSON console", () => {
       });
     const screen = renderScreen(CONSOLE_PATH, { core });
 
-    await waitForText(screen.lastFrame, "JSON payload");
+    await waitForText(screen.lastFrame, "Enter JSON payload");
+    expect(screen.lastFrame()!.split("\n")).not.toContain("JSON payload");
+    const sessionId = displayedSessionId(screen.lastFrame());
+    expect(sessionId).toMatch(UUID_PATTERN);
     await screen.write('{"prompt":"hello"}');
     await screen.press("return");
     await waitFor(() => invokeRequests(core).length === 1);
@@ -209,6 +231,7 @@ describe("Runtime invoke JSON console", () => {
       runtimeId: RUNTIME_ID,
       qualifier: QUALIFIER,
       contentType: "application/json",
+      runtimeSessionId: sessionId,
     });
     expect(new TextDecoder().decode(invokeRequests(core)[0]!.payload)).toBe('{"prompt":"hello"}');
     await waitForText(screen.lastFrame, "complete · 2 bytes");
@@ -296,11 +319,8 @@ describe("Runtime invoke JSON console", () => {
     for (let index = 0; index < 3; index++) await screen.write("\x1b[13;2u");
 
     const expandedLines = screen.lastFrame()!.split("\n");
-    const labelLine = expandedLines.findIndex((line) => line.includes("JSON payload"));
-    const lowerDivider = expandedLines.findIndex(
-      (line, index) => index > labelLine && /^─+$/.test(line),
-    );
-    expect(lowerDivider - labelLine).toBe(5);
+    const dividerLines = expandedLines.flatMap((line, index) => (/^─+$/.test(line) ? [index] : []));
+    expect(dividerLines.at(-2)! - dividerLines.at(-3)!).toBe(5);
     expect(expandedLines.findIndex((line) => line.includes("Ready · Session ID"))).toBe(
       initialStatusLine,
     );
@@ -320,13 +340,13 @@ describe("Runtime invoke JSON console", () => {
 
     await waitForText(screen.lastFrame, "Ready");
     await screen.resize(80, 24);
-    expect(screen.lastFrame()).toContain("Ready · Session ID: Not set");
+    expect(displayedSessionId(screen.lastFrame())).toMatch(UUID_PATTERN);
     expect(screen.lastFrame()).toContain(
       "[enter] send  [⇧↵] newline  [ctl+t] target  [↑↓] scroll  [esc] back",
     );
 
     await screen.resize(60, 24);
-    expect(screen.lastFrame()).toContain("Ready · Session ID: Not set");
+    expect(displayedSessionId(screen.lastFrame())).toMatch(UUID_PATTERN);
     expect(screen.lastFrame()).toContain("[enter] send  [⇧↵] newline  [↑↓] scroll  [esc] back");
   });
 
@@ -439,7 +459,7 @@ describe("Runtime invoke JSON console", () => {
     const core = new TestCoreClient();
     core.runtime.setGetResponse({ agentRuntimeArn: RUNTIME_ARN } as GetAgentRuntimeResponse);
     core.runtime.invokeRuntime = async () => {
-      throw new Error("connection failed");
+      throw Object.assign(new Error("connection failed"), { name: "NetworkError" });
     };
     const screen = renderScreen(CONSOLE_PATH, { core });
 
@@ -447,7 +467,7 @@ describe("Runtime invoke JSON console", () => {
     await screen.write("{}");
     await screen.press("return");
 
-    await waitForText(screen.lastFrame, "connection failed");
+    await waitForText(screen.lastFrame, "NetworkError: connection failed");
     expect(screen.lastFrame()).toContain("failed · 0 bytes");
   });
 
@@ -460,7 +480,7 @@ describe("Runtime invoke JSON console", () => {
         contentType: "text/plain",
         body: (async function* () {
           yield Buffer.from("partial");
-          throw new Error("stream failed");
+          throw Object.assign(new Error("stream failed"), { name: "StreamReadError" });
         })(),
       });
     const screen = renderScreen(CONSOLE_PATH, { core });
@@ -469,7 +489,7 @@ describe("Runtime invoke JSON console", () => {
     await screen.write("{}");
     await screen.press("return");
 
-    await waitForText(screen.lastFrame, "response stream failed");
+    await waitForText(screen.lastFrame, "StreamReadError: stream failed");
     expect(screen.lastFrame()).toContain("partial");
     expect(screen.lastFrame()).toContain("failed · 7 bytes");
   });
@@ -641,7 +661,9 @@ describe("Runtime invoke JSON console", () => {
       `agentcore → runtime → invoke → ${RUNTIME_ID} → ${nextQualifier}`,
     );
     expect(screen.lastFrame()).not.toContain("old response");
-    expect(screen.lastFrame()).toContain("Ready · Session ID: Not set");
+    const nextSessionId = displayedSessionId(screen.lastFrame());
+    expect(nextSessionId).toMatch(UUID_PATTERN);
+    expect(nextSessionId).not.toBe("returned-runtime");
     expect(screen.lastFrame()).toContain("MCP session ID: Not set");
 
     core.runtime.setInvokeResponse({
@@ -652,7 +674,7 @@ describe("Runtime invoke JSON console", () => {
     await screen.write('{"turn":2}');
     await screen.press("return");
     await waitFor(() => invokeRequests(core).length === 2);
-    expect(invokeRequests(core)[1]!.runtimeSessionId).toBeUndefined();
+    expect(invokeRequests(core)[1]!.runtimeSessionId).toBe(nextSessionId);
     expect(invokeRequests(core)[1]!.mcpSessionId).toBeUndefined();
     expect(invokeRequests(core)[1]!.mcpProtocolVersion).toBeUndefined();
     expect(invokeRequests(core)[1]).toMatchObject({
@@ -812,6 +834,8 @@ describe("Runtime invoke JSON console", () => {
 
     try {
       await waitForText(screen.lastFrame, "Ready");
+      const initialSessionId = displayedSessionId(screen.lastFrame());
+      expect(initialSessionId).toMatch(UUID_PATTERN);
       await screen.write("{}");
       await screen.press("return");
       await waitForText(screen.lastFrame, "data: partial");
@@ -821,7 +845,7 @@ describe("Runtime invoke JSON console", () => {
       stop.reject(Object.assign(new Error("The operation was aborted"), { name: "AbortError" }));
       await waitForText(screen.lastFrame, "interrupted · 14 bytes");
       expect(screen.lastFrame()).toContain("data: partial");
-      expect(screen.lastFrame()).toContain("Ready · Session ID: Not set");
+      expect(screen.lastFrame()).toContain(`Ready · Session ID: ${initialSessionId}`);
       expect(
         screen
           .lastFrame()!

--- a/src/handlers/runtime/invoke/invoke.screen.test.tsx
+++ b/src/handlers/runtime/invoke/invoke.screen.test.tsx
@@ -425,6 +425,29 @@ describe("Runtime invoke JSON console", () => {
     expect(screen.lastFrame()).toContain("Session ID: returned-runtime");
   });
 
+  test("removes trailing response newlines before settled metadata", async () => {
+    const core = new TestCoreClient();
+    core.runtime
+      .setGetResponse({ agentRuntimeArn: RUNTIME_ARN } as GetAgentRuntimeResponse)
+      .setInvokeResponse({
+        statusCode: 200,
+        contentType: "text/event-stream",
+        runtimeSessionId: "returned-runtime",
+        body: responseBody(Buffer.from("data: one\n\ndata: two\n\n")),
+      });
+    const screen = renderScreen(CONSOLE_PATH, { core });
+
+    await waitForText(screen.lastFrame, "Ready");
+    await screen.write("{}");
+    await screen.press("return");
+    await waitForText(screen.lastFrame, "complete · 22 bytes");
+
+    const lines = screen.lastFrame()!.split("\n");
+    const lastEvent = lines.findIndex((line) => line.includes("data: two"));
+    const metadata = lines.findIndex((line) => line.includes("Session ID: returned-runtime"));
+    expect(metadata).toBe(lastEvent + 1);
+  });
+
   test.each([
     [
       "invalid UTF-8 text",

--- a/src/handlers/runtime/invoke/invoke.screen.test.tsx
+++ b/src/handlers/runtime/invoke/invoke.screen.test.tsx
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { ValidationException } from "@aws-sdk/client-bedrock-agentcore";
 import type {
   AgentRuntime,
   AgentRuntimeEndpoint,
@@ -188,7 +189,8 @@ describe("Runtime invoke routing", () => {
     };
     const screen = renderScreen(CONSOLE_PATH, { core });
 
-    await waitForText(screen.lastFrame, "AccessDeniedException: not authorized for this Runtime");
+    await waitForText(screen.lastFrame, "AccessDeniedException");
+    await waitForText(screen.lastFrame, "not authorized for this Runtime");
   });
 
   test("unmount cancels the Runtime detail lookup", async () => {
@@ -467,8 +469,32 @@ describe("Runtime invoke JSON console", () => {
     await screen.write("{}");
     await screen.press("return");
 
-    await waitForText(screen.lastFrame, "NetworkError: connection failed");
+    await waitForText(screen.lastFrame, "NetworkError");
+    await waitForText(screen.lastFrame, "connection failed");
     expect(screen.lastFrame()).toContain("failed · 0 bytes");
+  });
+
+  test("formats modeled AWS service errors with their diagnostics", async () => {
+    const core = new TestCoreClient();
+    core.runtime.setGetResponse({ agentRuntimeArn: RUNTIME_ARN } as GetAgentRuntimeResponse);
+    const cause = new ValidationException({
+      message: "Runtime session ID must contain at least 33 characters",
+      reason: "FieldValidationFailed",
+      $metadata: { httpStatusCode: 400, requestId: "request-456" },
+    });
+    core.runtime.invokeRuntime = async () => {
+      throw new Error("flattened wrapper", { cause });
+    };
+    const screen = renderScreen(CONSOLE_PATH, { core });
+
+    await waitForText(screen.lastFrame, "Ready");
+    await screen.write("{}");
+    await screen.press("return");
+
+    await waitForText(screen.lastFrame, "ValidationException · HTTP 400");
+    expect(screen.lastFrame()).toContain("Runtime session ID must contain at least 33 characters");
+    expect(screen.lastFrame()).toContain("Request ID: request-456");
+    expect(screen.lastFrame()).not.toContain("flattened wrapper");
   });
 
   test("shows failures that occur while reading a response", async () => {
@@ -489,7 +515,8 @@ describe("Runtime invoke JSON console", () => {
     await screen.write("{}");
     await screen.press("return");
 
-    await waitForText(screen.lastFrame, "StreamReadError: stream failed");
+    await waitForText(screen.lastFrame, "StreamReadError");
+    await waitForText(screen.lastFrame, "stream failed");
     expect(screen.lastFrame()).toContain("partial");
     expect(screen.lastFrame()).toContain("failed · 7 bytes");
   });

--- a/src/handlers/runtime/invoke/invoke.screen.test.tsx
+++ b/src/handlers/runtime/invoke/invoke.screen.test.tsx
@@ -498,22 +498,13 @@ describe("Runtime invoke JSON console", () => {
   });
 
   test.each([
-    ["string", () => "string failure", "string failure"],
-    ["object", () => ({ code: "OBJECT_FAILURE" }), '{"code":"OBJECT_FAILURE"}'],
-    [
-      "circular object",
-      () => {
-        const failure: { self?: unknown } = {};
-        failure.self = failure;
-        return failure;
-      },
-      "[object Object]",
-    ],
+    ["string", "string failure", "string failure"],
+    ["object", { code: "OBJECT_FAILURE" }, "[object Object]"],
   ])("surfaces a thrown %s", async (_case, failure, expected) => {
     const core = new TestCoreClient();
     core.runtime.setGetResponse({ agentRuntimeArn: RUNTIME_ARN } as GetAgentRuntimeResponse);
     core.runtime.invokeRuntime = async () => {
-      throw failure();
+      throw failure;
     };
     const screen = renderScreen(CONSOLE_PATH, { core });
 

--- a/src/handlers/runtime/invoke/invoke.screen.test.tsx
+++ b/src/handlers/runtime/invoke/invoke.screen.test.tsx
@@ -497,6 +497,34 @@ describe("Runtime invoke JSON console", () => {
     expect(screen.lastFrame()).not.toContain("flattened wrapper");
   });
 
+  test.each([
+    ["string", () => "string failure", "string failure"],
+    ["object", () => ({ code: "OBJECT_FAILURE" }), '{"code":"OBJECT_FAILURE"}'],
+    [
+      "circular object",
+      () => {
+        const failure: { self?: unknown } = {};
+        failure.self = failure;
+        return failure;
+      },
+      "[object Object]",
+    ],
+  ])("surfaces a thrown %s", async (_case, failure, expected) => {
+    const core = new TestCoreClient();
+    core.runtime.setGetResponse({ agentRuntimeArn: RUNTIME_ARN } as GetAgentRuntimeResponse);
+    core.runtime.invokeRuntime = async () => {
+      throw failure();
+    };
+    const screen = renderScreen(CONSOLE_PATH, { core });
+
+    await waitForText(screen.lastFrame, "Ready");
+    await screen.write("{}");
+    await screen.press("return");
+
+    await waitForText(screen.lastFrame, expected);
+    expect(screen.lastFrame()).toContain("failed · 0 bytes");
+  });
+
   test("shows failures that occur while reading a response", async () => {
     const core = new TestCoreClient();
     core.runtime

--- a/src/handlers/runtime/invoke/screen.tsx
+++ b/src/handlers/runtime/invoke/screen.tsx
@@ -399,7 +399,10 @@ function RuntimeInvokeConsole({
                     <Text>{exchange.payload}</Text>
                     <Text bold>{exchange.heading ?? "Response"}</Text>
                     <Text>
-                      {prettyJson && exchange.pretty ? exchange.pretty : exchange.response}
+                      {(prettyJson && exchange.pretty
+                        ? exchange.pretty
+                        : exchange.response
+                      ).replace(/[\r\n]+$/, "")}
                     </Text>
                     {exchange.state !== "connecting" && exchange.state !== "streaming" ? (
                       <>

--- a/src/handlers/runtime/invoke/screen.tsx
+++ b/src/handlers/runtime/invoke/screen.tsx
@@ -26,12 +26,12 @@ type ExchangeState = "connecting" | "streaming" | "complete" | "interrupted" | "
 
 type TargetPickerState = { stage: "runtime" } | { stage: "endpoint"; runtimeId: string };
 
-interface ErrorDetails {
+type ErrorDetails = {
   name: string;
   message?: string;
   statusCode?: number;
   requestId?: string;
-}
+};
 
 interface Exchange {
   payload: string;
@@ -63,28 +63,16 @@ const metadata = (response: RuntimeInvokeResponse) =>
     .join(" · ");
 
 function errorDetails(error: unknown): ErrorDetails {
-  const serviceError = ServiceException.isInstance(error)
-    ? error
-    : error instanceof Error && ServiceException.isInstance(error.cause)
-      ? error.cause
-      : undefined;
-  if (serviceError) {
-    return {
-      name: serviceError.name,
-      message: serviceError.message || undefined,
-      statusCode: serviceError.$metadata.httpStatusCode,
-      requestId: serviceError.$metadata.requestId,
-    };
-  }
-  if (error instanceof Error) {
-    return { name: error.name, message: error.message || undefined };
-  }
-  if (typeof error === "string") return { name: "Error", message: error };
-  try {
-    return { name: "Error", message: JSON.stringify(error) ?? String(error) };
-  } catch {
-    return { name: "Error", message: String(error) };
-  }
+  const reported = error instanceof Error ? error : new Error(String(error));
+  const display = ServiceException.isInstance(reported.cause) ? reported.cause : reported;
+  return {
+    name: display.name,
+    message: display.message || undefined,
+    ...(ServiceException.isInstance(display) && {
+      statusCode: display.$metadata.httpStatusCode,
+      requestId: display.$metadata.requestId,
+    }),
+  };
 }
 
 function ErrorBlock({ details }: { details: ErrorDetails }) {

--- a/src/handlers/runtime/invoke/screen.tsx
+++ b/src/handlers/runtime/invoke/screen.tsx
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { ServiceException } from "@smithy/core/client";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Box, Text, useInput, useWindowSize } from "ink";
 import { useQuery } from "@tanstack/react-query";
@@ -25,9 +26,17 @@ type ExchangeState = "connecting" | "streaming" | "complete" | "interrupted" | "
 
 type TargetPickerState = { stage: "runtime" } | { stage: "endpoint"; runtimeId: string };
 
+interface ErrorDetails {
+  name: string;
+  message?: string;
+  statusCode?: number;
+  requestId?: string;
+}
+
 interface Exchange {
   payload: string;
   response: string;
+  error?: ErrorDetails;
   pretty?: string;
   note?: string;
   heading?: string;
@@ -53,16 +62,42 @@ const metadata = (response: RuntimeInvokeResponse) =>
     .map((entry) => entry.join(" "))
     .join(" · ");
 
-function describeError(error: unknown): string {
+function errorDetails(error: unknown): ErrorDetails {
+  const serviceError = ServiceException.isInstance(error)
+    ? error
+    : error instanceof Error && ServiceException.isInstance(error.cause)
+      ? error.cause
+      : undefined;
+  if (serviceError) {
+    return {
+      name: serviceError.name,
+      message: serviceError.message || undefined,
+      statusCode: serviceError.$metadata.httpStatusCode,
+      requestId: serviceError.$metadata.requestId,
+    };
+  }
   if (error instanceof Error) {
-    return error.message ? `${error.name}: ${error.message}` : error.name;
+    return { name: error.name, message: error.message || undefined };
   }
-  if (typeof error === "string") return error;
+  if (typeof error === "string") return { name: "Error", message: error };
   try {
-    return JSON.stringify(error) ?? String(error);
+    return { name: "Error", message: JSON.stringify(error) ?? String(error) };
   } catch {
-    return String(error);
+    return { name: "Error", message: String(error) };
   }
+}
+
+function ErrorBlock({ details }: { details: ErrorDetails }) {
+  return (
+    <Box flexDirection="column">
+      <Text color="red">
+        {details.name}
+        {details.statusCode ? ` · HTTP ${details.statusCode}` : ""}
+      </Text>
+      {details.message ? <Text>{details.message}</Text> : null}
+      {details.requestId ? <Text color="gray">Request ID: {details.requestId}</Text> : null}
+    </Box>
+  );
 }
 
 export function RuntimeInvokeScreen(props: ScreenProps) {
@@ -238,7 +273,7 @@ function RuntimeInvokeConsole({
       if (controller.signal.aborted || (error as Error)?.name === "AbortError") {
         updateExchange({ note: "interrupted", state: "interrupted" });
       } else {
-        updateExchange({ note: describeError(error), state: "failed" });
+        updateExchange({ error: errorDetails(error), state: "failed" });
       }
     } finally {
       abortRef.current = null;
@@ -365,7 +400,7 @@ function RuntimeInvokeConsole({
         {detail.isPending ? (
           <Spinner label="Loading Runtime…" />
         ) : detail.isError ? (
-          <Text color="red">{describeError(detail.error)}</Text>
+          <ErrorBlock details={errorDetails(detail.error)} />
         ) : (
           <Box flexDirection="column">
             <Box height={transcriptHeight} flexDirection="column">
@@ -381,6 +416,7 @@ function RuntimeInvokeConsole({
                     {exchange.state !== "connecting" && exchange.state !== "streaming" ? (
                       <>
                         {exchange.metadata ? <Text color="gray">{exchange.metadata}</Text> : null}
+                        {exchange.error ? <ErrorBlock details={exchange.error} /> : null}
                         {exchange.note ? <Text color="yellow">{exchange.note}</Text> : null}
                         <Text color={exchange.state === "failed" ? "red" : "gray"}>
                           {exchange.state} · {exchange.byteCount} bytes

--- a/src/handlers/runtime/invoke/screen.tsx
+++ b/src/handlers/runtime/invoke/screen.tsx
@@ -1,10 +1,10 @@
+import { randomUUID } from "node:crypto";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Box, Text, useInput, useWindowSize } from "ink";
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate, useParams } from "react-router";
 import { ScrollView, type ScrollViewRef } from "ink-scroll-view";
 import cliTruncate from "cli-truncate";
-import { InputValidationError } from "../../../errors";
 import type { ScreenProps } from "../../types";
 import { coreOptsFromCtx } from "../../utils";
 import { Layout } from "../../../components/Layout";
@@ -52,6 +52,18 @@ const metadata = (response: RuntimeInvokeResponse) =>
     .filter((entry) => entry[1])
     .map((entry) => entry.join(" "))
     .join(" · ");
+
+function describeError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message ? `${error.name}: ${error.message}` : error.name;
+  }
+  if (typeof error === "string") return error;
+  try {
+    return JSON.stringify(error) ?? String(error);
+  } catch {
+    return String(error);
+  }
+}
 
 export function RuntimeInvokeScreen(props: ScreenProps) {
   const { runtimeId, qualifier } = useParams();
@@ -118,7 +130,9 @@ function RuntimeInvokeConsole({
   const [payload, setPayload] = useState("");
   const [inputError, setInputError] = useState<string>();
   const [requestContext, setRequestContext] = useState(initialContext);
-  const [runtimeSessionId, setRuntimeSessionId] = useState(initialContext?.runtimeSessionId);
+  const [runtimeSessionId, setRuntimeSessionId] = useState(
+    () => initialContext?.runtimeSessionId ?? randomUUID(),
+  );
   const [mcpSessionId, setMcpSessionId] = useState<string>();
   const [mcpProtocolVersion, setMcpProtocolVersion] = useState<string>();
   const [history, setHistory] = useState<Exchange[]>([]);
@@ -158,7 +172,6 @@ function RuntimeInvokeConsole({
     setPrettyJson(false);
     const controller = new AbortController();
     abortRef.current = controller;
-    let responseStarted = false;
 
     try {
       const request = normalizeRuntimeInvokeRequest(detail.data, {
@@ -173,7 +186,6 @@ function RuntimeInvokeConsole({
         ...(mcp && { mcpSessionId, mcpProtocolVersion }),
       });
       const response = await core.runtime.invokeRuntime(request, opts, controller.signal);
-      responseStarted = true;
       updateExchange({
         heading: `Response · ${response.statusCode} · ${response.contentType || "-"}`,
         metadata: metadata(response),
@@ -225,12 +237,8 @@ function RuntimeInvokeConsole({
     } catch (error) {
       if (controller.signal.aborted || (error as Error)?.name === "AbortError") {
         updateExchange({ note: "interrupted", state: "interrupted" });
-      } else if (error instanceof InputValidationError) {
-        updateExchange({ response: `Error: ${error.message}`, state: "failed" });
-      } else if (!responseStarted && error instanceof Error) {
-        updateExchange({ note: error.message, state: "failed" });
       } else {
-        updateExchange({ note: "response stream failed", state: "failed" });
+        updateExchange({ note: describeError(error), state: "failed" });
       }
     } finally {
       abortRef.current = null;
@@ -240,7 +248,7 @@ function RuntimeInvokeConsole({
   const liveState = history.at(-1)?.state;
   const busy = liveState === "connecting" || liveState === "streaming";
   const inputRows = Math.min(4, Math.max(1, payload.split("\n").length));
-  const transcriptHeight = Math.max(1, rows - 8 - inputRows);
+  const transcriptHeight = Math.max(1, rows - 7 - inputRows);
   const canPrettyJson = history.some((exchange) => exchange.pretty !== undefined);
   const requestContextSummary = [
     requestContext?.runtimeUserId ? "user" : undefined,
@@ -311,7 +319,7 @@ function RuntimeInvokeConsole({
           if (nextRuntimeId !== target.runtimeId || selected !== target.qualifier) {
             const runtimeChanged = nextRuntimeId !== target.runtimeId;
             setTarget({ runtimeId: nextRuntimeId, qualifier: selected });
-            setRuntimeSessionId(undefined);
+            setRuntimeSessionId(randomUUID());
             setMcpSessionId(undefined);
             setMcpProtocolVersion(undefined);
             if (runtimeChanged) setRequestContext(undefined);
@@ -357,7 +365,7 @@ function RuntimeInvokeConsole({
         {detail.isPending ? (
           <Spinner label="Loading Runtime…" />
         ) : detail.isError ? (
-          <Text color="red">Error: {(detail.error as Error).message}</Text>
+          <Text color="red">{describeError(detail.error)}</Text>
         ) : (
           <Box flexDirection="column">
             <Box height={transcriptHeight} flexDirection="column">

--- a/src/handlers/runtime/invoke/screen.tsx
+++ b/src/handlers/runtime/invoke/screen.tsx
@@ -33,7 +33,7 @@ type ErrorDetails = {
   requestId?: string;
 };
 
-interface Exchange {
+type Exchange = {
   payload: string;
   response: string;
   error?: ErrorDetails;
@@ -43,7 +43,7 @@ interface Exchange {
   metadata?: string;
   byteCount: number;
   state: ExchangeState;
-}
+};
 
 const invokePath = (...parts: string[]) =>
   ["/agentcore/runtime/invoke", ...parts.map(encodeURIComponent)].join("/");


### PR DESCRIPTION
## Summary

- surface available error names and messages for every non-abort Runtime lookup, invocation, and response-stream failure
- render modeled AWS service failures as a structured type, HTTP status, message, and request ID while preserving redaction for arbitrary transport causes
- generate and display a Runtime session ID before the first TUI send, while honoring `--session-id`
- remove the redundant `JSON payload` heading and trailing response whitespace before settled metadata

## Testing

- `bun test src/core/core.test.ts src/handlers/runtime/invoke/invoke.screen.test.tsx` (`60` pass)
- `bun run typecheck`
- `bun run lint:check`
- `bun run format:check`
- TUI Harness: successful live invocation without `--session-id`; generated ID persisted in request and response
- TUI Harness: intentionally short session ID rendered the AWS `ValidationException` type, HTTP status, complete message, and request ID on separate lines
- TUI Harness: final SSE event now renders directly above session metadata while preserving spacing between events
- `bun test src`: the only failures were two unchanged `src/io/exec.test.ts` subprocess-output assertions that reproduce when run alone in this environment