### PR TITLE
fix(dev): forward custom headers from web UI proxy to local agent

### DIFF
--- a/src/cli/operations/dev/web-ui/handlers/invocations.ts
+++ b/src/cli/operations/dev/web-ui/handlers/invocations.ts
@@ -12,6 +12,21 @@ import { type IncomingMessage, type ServerResponse, request as httpRequest } fro
 let a2aRequestId = 1;
 
 /**
+ * Forward allowlisted custom headers from the incoming request.
+ * Currently forwards all `x-amzn-bedrock-agentcore-runtime-custom-*` headers
+ * which are the documented custom header prefix for AgentCore Runtime.
+ */
+function forwardCustomHeaders(req: IncomingMessage, headers: Record<string, string>): void {
+  if (req.headers) {
+    for (const [key, value] of Object.entries(req.headers)) {
+      if (key.startsWith('x-amzn-bedrock-agentcore-runtime-custom-') && typeof value === 'string') {
+        headers[key] = value;
+      }
+    }
+  }
+}
+
+/**
  * POST /invocations — proxy to the selected agent.
  * Body must include agentName to route to the correct running agent.
  * When ?target=deployed is set, invokes the deployed runtime via the AWS SDK.
@@ -84,7 +99,7 @@ export async function handleInvocations(
 
   // AGUI agents need RunAgentInput body; SSE response is passed through raw
   if (agentProtocol === 'AGUI') {
-    return handleAguiInvocation(ctx, res, body, agentPort, sessionId, userId, origin);
+    return handleAguiInvocation(ctx, req, res, body, agentPort, sessionId, userId, origin);
   }
 
   return new Promise<void>((resolve, reject) => {
@@ -96,6 +111,8 @@ export async function handleInvocations(
     if (userId) {
       headers['x-amzn-bedrock-agentcore-runtime-user-id'] = userId;
     }
+    // Forward custom headers from the incoming request
+    forwardCustomHeaders(req, headers);
 
     const proxyReq = httpRequest(
       {
@@ -277,6 +294,7 @@ async function handleA2AInvocation(
  */
 async function handleAguiInvocation(
   ctx: RouteContext,
+  req: IncomingMessage,
   res: ServerResponse,
   rawBody: string,
   agentPort: number,
@@ -314,6 +332,8 @@ async function handleAguiInvocation(
     if (userId) {
       headers['x-amzn-bedrock-agentcore-runtime-user-id'] = userId;
     }
+    // Forward custom headers from the incoming request
+    forwardCustomHeaders(req, headers);
 
     const proxyReq = httpRequest(
       {


### PR DESCRIPTION
## Description

The Agent Inspector web UI proxy (`handleInvocations` in `src/cli/operations/dev/web-ui/handlers/invocations.ts`) constructs new headers when proxying to the local Python/TS agent but never reads or forwards `req.headers` from the incoming request. This causes all `x-amzn-bedrock-agentcore-runtime-custom-*` headers to be silently dropped.

The direct CLI invoke path already does this correctly via `...customHeaders` spread — this patch brings the web UI proxy path to parity.

**Changes:**
- Adds a shared `forwardCustomHeaders()` helper that forwards all `x-amzn-bedrock-agentcore-runtime-custom-*` headers from the incoming request to the proxied request.
- Applies it to both `handleInvocations` (HTTP agents) and `handleAguiInvocation` (AGUI agents).
- Passes `req` (IncomingMessage) to `handleAguiInvocation` so it has access to the incoming headers.

**Reproduction:**
1. `agentcore create --name Test --framework Strands --model-provider Bedrock --protocol HTTP`
2. `agentcore dev` (launches Inspector on 8081, agent on 8082)
3. `curl -X POST http://localhost:8081/invocations -H 'X-Agentcore-Local: true' -H 'X-Amzn-Bedrock-AgentCore-Runtime-Custom-MyHeader: test-value' -H 'Content-Type: application/json' -d '{"prompt":"Hello"}'`
4. Before fix: custom header is NOT received by the Python agent
5. After fix: custom header IS received

Tested on CLI v0.25.0, Node.js 23.11.0, macOS ARM64.

## Related Issue

N/A —No existing GitHub issue found for this bug.

## Documentation PR

N/A — no documentation changes required.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

**Additional manual testing:**
- Ran `agentcore dev` with a Strands Python agent (Inspector on 8081, agent on 8082)
- Sent curl requests with `X-Amzn-Bedrock-AgentCore-Runtime-Custom-*` headers through the Inspector proxy (port 8081)
- Verified custom headers arrive in the Python agent's `context.request_headers` after the fix
- Verified direct calls to the Python agent port (8082) continue to work as before
- `npm run test:unit` blocked by local `@rolldown/binding-darwin-arm64` native dependency issue (npm bug #4828), unrelated to this change

## Checklist

- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.