### PR TITLE
feat: define build manifest contract

### DIFF
--- a/src/core/project/buildManifest.test.ts
+++ b/src/core/project/buildManifest.test.ts
@@ -98,6 +98,19 @@ describe("BuildManifestSchema", () => {
     expect(BuildManifestSchema.safeParse(extra).success).toBe(false);
   });
 
+  test("rejects a manifest with no deployment targets", () => {
+    const input = manifest({
+      targets: [],
+      artifact: {
+        kind: "cdk-cloud-assembly",
+        path: "agentcore/cdk/cdk.out",
+        stacksByTarget: {},
+      },
+    });
+
+    expect(BuildManifestSchema.safeParse(input).success).toBe(false);
+  });
+
   test("rejects duplicate target names", () => {
     const input = manifest({
       targets: [

--- a/src/core/project/buildManifest.test.ts
+++ b/src/core/project/buildManifest.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from "bun:test";
+import {
+  BUILD_MANIFEST_PATH,
+  BUILD_MANIFEST_VERSION,
+  BuildManifestSchema,
+  BuildResultSchema,
+  type BuildManifest,
+} from "./buildManifest";
+
+function manifest(overrides: Partial<BuildManifest> = {}): BuildManifest {
+  return {
+    manifestVersion: BUILD_MANIFEST_VERSION,
+    projectName: "MyAgent",
+    cliVersion: "1.0.0",
+    inputFingerprint: "a".repeat(64),
+    builtAt: "2026-08-06T12:34:56.000Z",
+    targets: [
+      {
+        name: "development",
+        account: "123456789012",
+        region: "us-east-1",
+      },
+    ],
+    artifact: {
+      kind: "cdk-cloud-assembly",
+      path: "agentcore/cdk/cdk.out",
+      stacksByTarget: {
+        development: "MyAgent-development",
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe("BuildResultSchema", () => {
+  test("returns the manifest and its canonical path", () => {
+    const builtManifest = manifest();
+    const result = BuildResultSchema.parse({
+      manifestPath: BUILD_MANIFEST_PATH,
+      manifest: builtManifest,
+    });
+
+    expect(result.manifestPath).toBe(BUILD_MANIFEST_PATH);
+    expect(result.manifest).toEqual(builtManifest);
+  });
+
+  test("rejects a non-canonical manifest path", () => {
+    expect(
+      BuildResultSchema.safeParse({
+        manifestPath: "manifest.json",
+        manifest: manifest(),
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("BuildManifestSchema", () => {
+  test("accepts a CDK artifact and records the canonical manifest path", () => {
+    const parsed = BuildManifestSchema.parse(manifest());
+
+    expect(parsed.artifact).toEqual({
+      kind: "cdk-cloud-assembly",
+      path: "agentcore/cdk/cdk.out",
+      stacksByTarget: {
+        development: "MyAgent-development",
+      },
+    });
+    expect(BUILD_MANIFEST_PATH).toBe("agentcore/.build/manifest.json");
+  });
+
+  test("requires every deployment target to have exactly one synthesized stack", () => {
+    const missing = manifest({
+      targets: [
+        {
+          name: "development",
+          account: "123456789012",
+          region: "us-east-1",
+        },
+        {
+          name: "production",
+          account: "210987654321",
+          region: "us-west-2",
+        },
+      ],
+    });
+    const extra = manifest({
+      artifact: {
+        kind: "cdk-cloud-assembly",
+        path: "agentcore/cdk/cdk.out",
+        stacksByTarget: {
+          development: "MyAgent-development",
+          unused: "MyAgent-unused",
+        },
+      },
+    });
+
+    expect(BuildManifestSchema.safeParse(missing).success).toBe(false);
+    expect(BuildManifestSchema.safeParse(extra).success).toBe(false);
+  });
+
+  test("rejects duplicate target names", () => {
+    const input = manifest({
+      targets: [
+        {
+          name: "development",
+          account: "123456789012",
+          region: "us-east-1",
+        },
+        {
+          name: "development",
+          account: "210987654321",
+          region: "us-west-2",
+        },
+      ],
+    });
+
+    expect(BuildManifestSchema.safeParse(input).success).toBe(false);
+  });
+
+  test.each([
+    "/tmp/cdk.out",
+    "../cdk.out",
+    "agentcore\\cdk\\cdk.out",
+    "C:\\cdk.out",
+    "agentcore//cdk.out",
+  ])("rejects an artifact path outside the project: %s", (path) => {
+    const input = manifest({
+      artifact: {
+        kind: "cdk-cloud-assembly",
+        path,
+        stacksByTarget: {
+          development: "MyAgent-development",
+        },
+      },
+    });
+
+    expect(BuildManifestSchema.safeParse(input).success).toBe(false);
+  });
+
+  test("rejects unknown artifact kinds", () => {
+    const input = {
+      ...manifest(),
+      artifact: {
+        kind: "terraform-plan",
+        path: "agentcore/terraform/plan.json",
+      },
+    };
+
+    expect(BuildManifestSchema.safeParse(input).success).toBe(false);
+  });
+});

--- a/src/core/project/buildManifest.ts
+++ b/src/core/project/buildManifest.ts
@@ -1,0 +1,120 @@
+import z from "zod";
+
+/** Relative to the project root; build writes this file and deploy reads it. */
+export const BUILD_MANIFEST_PATH = "agentcore/.build/manifest.json";
+
+export const BUILD_MANIFEST_VERSION = 1;
+
+export const DeploymentTargetSchema = z
+  .object({
+    name: z
+      .string()
+      .min(1)
+      .max(64)
+      .regex(
+        /^[a-zA-Z][a-zA-Z0-9-]*$/,
+        "must start with a letter and contain only letters, numbers, and hyphens",
+      ),
+    description: z.string().max(256).optional(),
+    account: z.string().regex(/^[0-9]{12}$/, "must be a 12-digit AWS account ID"),
+    region: z.string().min(1),
+  })
+  .strict();
+
+export type DeploymentTarget = z.infer<typeof DeploymentTargetSchema>;
+
+const ProjectRelativePathSchema = z
+  .string()
+  .min(1)
+  .refine(
+    (path) =>
+      !path.startsWith("/") &&
+      !path.startsWith("\\") &&
+      !/^[a-zA-Z]:[\\/]/.test(path) &&
+      !path.includes("\\") &&
+      path.split("/").every((segment) => segment !== "" && segment !== "." && segment !== ".."),
+    "must be a non-empty path relative to the project root",
+  );
+
+const CdkCloudAssemblyArtifactSchema = z
+  .object({
+    kind: z.literal("cdk-cloud-assembly"),
+    path: ProjectRelativePathSchema,
+    stacksByTarget: z.record(z.string().min(1), z.string().min(1)),
+  })
+  .strict();
+
+/**
+ * The artifact is the deploy dispatch point. Add a new discriminated variant
+ * before implementing another deployment mechanism.
+ */
+export const BuildArtifactSchema = z.discriminatedUnion("kind", [CdkCloudAssemblyArtifactSchema]);
+
+export type BuildArtifact = z.infer<typeof BuildArtifactSchema>;
+
+/**
+ * Persisted handofffrom build to deploy
+ *
+ * Deploy requires a new build when the manifest is missing, unreadable, not valid, has unsupported manifestVerison,
+ * or if its inputFinderprint differs from current project inputs. Otherwise, deploy would use the
+ * typed artifact to select its backend
+ */
+export const BuildManifestSchema = z
+  .object({
+    manifestVersion: z.literal(BUILD_MANIFEST_VERSION),
+    projectName: z.string().min(1),
+    cliVersion: z.string().min(1),
+    inputFingerprint: z.string().regex(/^[a-f0-9]{64}$/),
+    builtAt: z.iso.datetime(),
+    targets: z.array(DeploymentTargetSchema),
+    artifact: BuildArtifactSchema,
+  })
+  .strict()
+  .superRefine((manifest, ctx) => {
+    const targetNames = new Set<string>();
+
+    for (const [index, target] of manifest.targets.entries()) {
+      if (targetNames.has(target.name)) {
+        ctx.addIssue({
+          code: "custom",
+          message: `duplicate deployment target name: ${target.name}`,
+          path: ["targets", index, "name"],
+        });
+      }
+      targetNames.add(target.name);
+    }
+
+    if (manifest.artifact.kind !== "cdk-cloud-assembly") return;
+
+    const stackTargets = new Set(Object.keys(manifest.artifact.stacksByTarget));
+    for (const targetName of targetNames) {
+      if (!stackTargets.has(targetName)) {
+        ctx.addIssue({
+          code: "custom",
+          message: `missing stack for deployment target: ${targetName}`,
+          path: ["artifact", "stacksByTarget"],
+        });
+      }
+    }
+    for (const targetName of stackTargets) {
+      if (!targetNames.has(targetName)) {
+        ctx.addIssue({
+          code: "custom",
+          message: `stack is configured for an unknown deployment target: ${targetName}`,
+          path: ["artifact", "stacksByTarget", targetName],
+        });
+      }
+    }
+  });
+
+export type BuildManifest = z.infer<typeof BuildManifestSchema>;
+
+/** The JSON response emitted by `agentcore project build`. */
+export const BuildResultSchema = z
+  .object({
+    manifestPath: z.literal(BUILD_MANIFEST_PATH),
+    manifest: BuildManifestSchema,
+  })
+  .strict();
+
+export type BuildResult = z.infer<typeof BuildResultSchema>;

--- a/src/core/project/buildManifest.ts
+++ b/src/core/project/buildManifest.ts
@@ -55,18 +55,19 @@ export type BuildArtifact = z.infer<typeof BuildArtifactSchema>;
 /**
  * Persisted handoff from build to deploy
  *
- * Deploy requires a new build when the manifest is missing, unreadable, not valid, has unsupported manifestVerison,
- * or if its inputFinderprint differs from current project inputs. Otherwise, deploy would use the
- * typed artifact to select its backend
+ * Deploy requires a new build when the manifest is missing, unreadable, invalid, has an unsupported
+ * manifest version, or its input fingerprint differs from the current project inputs. Otherwise,
+ * deploy uses the typed artifact to select its backend.
  */
 export const BuildManifestSchema = z
   .object({
     manifestVersion: z.literal(BUILD_MANIFEST_VERSION),
     projectName: z.string().min(1),
     cliVersion: z.string().min(1),
+    /** Deploy recomputes this hash to reject artifacts built from stale project inputs. */
     inputFingerprint: z.string().regex(/^[a-f0-9]{64}$/),
     builtAt: z.iso.datetime(),
-    targets: z.array(DeploymentTargetSchema),
+    targets: z.array(DeploymentTargetSchema).min(1, "must include at least one deployment target"),
     artifact: BuildArtifactSchema,
   })
   .strict()

--- a/src/core/project/buildManifest.ts
+++ b/src/core/project/buildManifest.ts
@@ -53,7 +53,7 @@ export const BuildArtifactSchema = z.discriminatedUnion("kind", [CdkCloudAssembl
 export type BuildArtifact = z.infer<typeof BuildArtifactSchema>;
 
 /**
- * Persisted handofffrom build to deploy
+ * Persisted handoff from build to deploy
  *
  * Deploy requires a new build when the manifest is missing, unreadable, not valid, has unsupported manifestVerison,
  * or if its inputFinderprint differs from current project inputs. Otherwise, deploy would use the

--- a/src/core/project/index.tsx
+++ b/src/core/project/index.tsx
@@ -1,1 +1,13 @@
+export {
+  BUILD_MANIFEST_PATH,
+  BUILD_MANIFEST_VERSION,
+  BuildArtifactSchema,
+  BuildManifestSchema,
+  BuildResultSchema,
+  DeploymentTargetSchema,
+  type BuildArtifact,
+  type BuildManifest,
+  type BuildResult,
+  type DeploymentTarget,
+} from "./buildManifest";
 export { FsProjectManager } from "./manager";


### PR DESCRIPTION
This PR defines the versioned manifest contract to be shared between `build` and `deploy` commands.
It includes no command implementation yet.

You can look into the first draft PR I posted: https://github.com/aws/agentcore-cli/pull/1925

design considerations I took: 

- build writes its manifest to this path `agentcore/.build/manifest.json`
- The manifest records its format version, project name, CLI version, input fingerprint, build time, deployment targets, and artifact
- Artifacts are a discriminated union. CDK is the first supported one. Terraform and no-IaC modes can add their own typed variants later
- CDK manifests require exactly one synthesized stack for every recorded deployment target. Unit tests added for this.
- The CLI build response is a wrapper containing both `manifestPath` and the persisted `manifest`.
- Deploy will rebuild when the manifest is missing, invalid, unsupported, or has a stale input fingerprint.

ran typecheck, lint, format and test successfully.