### PR TITLE
refactor(runtime): propagate invoke SDK errors

### DIFF
--- a/src/core/core.test.ts
+++ b/src/core/core.test.ts
@@ -579,67 +579,21 @@ test("invokeRuntime aborts an established IAM response stream", async () => {
   expect(result).toBe("AbortError");
 });
 
-test("IAM invoke failures preserve safe SDK diagnostics without arbitrary causes", async () => {
-  const { logger, logs } = captureLogs();
-  const core = coreWithDataSend(async () => {
-    throw Object.assign(new Error("failed with secret request content"), {
-      name: "AccessDeniedException",
-      $metadata: {
-        httpStatusCode: 403,
-        requestId: "request-123",
-      },
-    });
-  }, logger);
-
-  const caught = await core.runtime
-    .invokeRuntime(
-      {
-        runtimeId: "runtime-123",
-        accountId: "123456789012",
-        qualifier: "DEFAULT",
-        payload: new TextEncoder().encode("secret payload"),
-        contentType: "application/json",
-        applicationHeaders: [["X-Secret", "secret-header-value"]],
-      },
-      { region: "us-east-1" },
-    )
-    .catch((caught: Error) => caught);
-  const error = caught as Error;
-
-  expect(error.message).toBe(
-    "Runtime invocation failed (AccessDeniedException, HTTP 403, request ID request-123)",
-  );
-  expect(error.message).not.toContain("secret request content");
-  expectSafeDebugLog(
-    logs,
-    "Runtime invocation SDK request failed",
-    {
-      authMode: "IAM",
-      runtimeId: "runtime-123",
-      qualifier: "DEFAULT",
-      region: "us-east-1",
-      errorName: "AccessDeniedException",
-      httpStatusCode: 403,
-      requestId: "request-123",
+test("IAM invoke preserves modeled AWS service errors", async () => {
+  const failure = new ValidationException({
+    message: "Runtime session ID must contain at least 33 characters",
+    reason: "FieldValidationFailed",
+    $metadata: {
+      httpStatusCode: 400,
+      requestId: "request-456",
     },
-    ["secret request content", "secret payload", "secret-header-value"],
-  );
-});
-
-test("IAM invoke failures include messages from modeled AWS service errors", async () => {
+  });
   const core = coreWithDataSend(async () => {
-    throw new ValidationException({
-      message: "Runtime session ID must contain at least 33 characters",
-      reason: "FieldValidationFailed",
-      $metadata: {
-        httpStatusCode: 400,
-        requestId: "request-456",
-      },
-    });
+    throw failure;
   });
 
-  const caught = await core.runtime
-    .invokeRuntime(
+  await expect(
+    core.runtime.invokeRuntime(
       {
         runtimeId: "runtime-123",
         accountId: "123456789012",
@@ -648,14 +602,8 @@ test("IAM invoke failures include messages from modeled AWS service errors", asy
         contentType: "application/json",
       },
       { region: "us-east-1" },
-    )
-    .catch((caught: Error) => caught);
-  const error = caught as Error;
-
-  expect(error.message).toBe(
-    "Runtime invocation failed: Runtime session ID must contain at least 33 characters " +
-      "(ValidationException, HTTP 400, request ID request-456)",
-  );
+    ),
+  ).rejects.toBe(failure);
 });
 
 test("CUSTOM_JWT invoke uses the generated endpoint and exact fetch request", async () => {

--- a/src/core/runtime.tsx
+++ b/src/core/runtime.tsx
@@ -1,5 +1,4 @@
 import { randomUUID } from "node:crypto";
-import { ServiceException } from "@smithy/core/client";
 import {
   GetAgentRuntimeCommand,
   GetAgentRuntimeEndpointCommand,
@@ -38,17 +37,17 @@ export class RuntimeClient implements CoreRuntimeClient {
     signal?: AbortSignal,
   ): Promise<RuntimeInvokeResponse> {
     const { runtimeId, bearerToken } = request;
-    const logger = this.logger.child({
-      operation: "invokeRuntime",
-      authMode: bearerToken === undefined ? "IAM" : "CUSTOM_JWT",
-      runtimeId,
-      qualifier: request.qualifier,
-      region: options.region,
-    });
     if (bearerToken !== undefined) {
+      const logger = this.logger.child({
+        operation: "invokeRuntime",
+        authMode: "CUSTOM_JWT",
+        runtimeId,
+        qualifier: request.qualifier,
+        region: options.region,
+      });
       return this.invokeRuntimeWithCustomJwt(request, bearerToken, options, logger, signal);
     }
-    return this.invokeRuntimeWithIam(request, options, logger, signal);
+    return this.invokeRuntimeWithIam(request, options, signal);
   }
 
   private async invokeRuntimeWithCustomJwt(
@@ -147,7 +146,6 @@ export class RuntimeClient implements CoreRuntimeClient {
   private async invokeRuntimeWithIam(
     request: RuntimeInvokeRequest,
     options: CoreOptions,
-    logger: Logger,
     signal?: AbortSignal,
   ): Promise<RuntimeInvokeResponse> {
     const { runtimeId, applicationHeaders, bearerToken: _bearerToken, ...input } = request;
@@ -169,41 +167,7 @@ export class RuntimeClient implements CoreRuntimeClient {
       });
     } catch (error) {
       if (signal?.aborted) throw signal.reason ?? error;
-      const sdkError = error as {
-        name?: unknown;
-        $metadata?: { httpStatusCode?: unknown; requestId?: unknown };
-      };
-      const serviceMessage =
-        ServiceException.isInstance(error) && error.message.trim()
-          ? error.message.trim()
-          : undefined;
-      const diagnostics: string[] = [];
-      if (typeof sdkError?.name === "string" && sdkError.name !== "Error") {
-        diagnostics.push(sdkError.name);
-      }
-      if (typeof sdkError?.$metadata?.httpStatusCode === "number") {
-        diagnostics.push(`HTTP ${sdkError.$metadata.httpStatusCode}`);
-      }
-      if (typeof sdkError?.$metadata?.requestId === "string") {
-        diagnostics.push(`request ID ${sdkError.$metadata.requestId}`);
-      }
-      logger
-        .child({
-          ...(typeof sdkError?.name === "string" && { errorName: sdkError.name }),
-          ...(typeof sdkError?.$metadata?.httpStatusCode === "number" && {
-            httpStatusCode: sdkError.$metadata.httpStatusCode,
-          }),
-          ...(typeof sdkError?.$metadata?.requestId === "string" && {
-            requestId: sdkError.$metadata.requestId,
-          }),
-        })
-        .debug("Runtime invocation SDK request failed");
-      throw new Error(
-        `Runtime invocation failed${serviceMessage ? `: ${serviceMessage}` : ""}${
-          diagnostics.length ? ` (${diagnostics.join(", ")})` : ""
-        }`,
-        { cause: error },
-      );
+      throw error;
     }
 
     const body = (response.response as AsyncIterable<Uint8Array> | undefined) ?? emptyBody();

--- a/src/handlers/runtime/invoke/invoke.screen.test.tsx
+++ b/src/handlers/runtime/invoke/invoke.screen.test.tsx
@@ -500,13 +500,13 @@ describe("Runtime invoke JSON console", () => {
   test("formats modeled AWS service errors with their diagnostics", async () => {
     const core = new TestCoreClient();
     core.runtime.setGetResponse({ agentRuntimeArn: RUNTIME_ARN } as GetAgentRuntimeResponse);
-    const cause = new ValidationException({
+    const error = new ValidationException({
       message: "Runtime session ID must contain at least 33 characters",
       reason: "FieldValidationFailed",
       $metadata: { httpStatusCode: 400, requestId: "request-456" },
     });
     core.runtime.invokeRuntime = async () => {
-      throw new Error("flattened wrapper", { cause });
+      throw error;
     };
     const screen = renderScreen(CONSOLE_PATH, { core });
 
@@ -517,7 +517,6 @@ describe("Runtime invoke JSON console", () => {
     await waitForText(screen.lastFrame, "ValidationException · HTTP 400");
     expect(screen.lastFrame()).toContain("Runtime session ID must contain at least 33 characters");
     expect(screen.lastFrame()).toContain("Request ID: request-456");
-    expect(screen.lastFrame()).not.toContain("flattened wrapper");
   });
 
   test.each([


### PR DESCRIPTION
## Summary

- rethrow IAM `InvokeAgentRuntime` SDK failures without wrapping or rebuilding their diagnostics
- let the existing root error boundary classify headless failures
- preserve direct `ServiceException` metadata for structured TUI rendering
- remove Runtime-specific logger plumbing and speculative redaction tests

Follow-up to the error-boundary review comments on #1930.

## Testing

- `bun test src/core/core.test.ts src/handlers/runtime/invoke/invoke.screen.test.tsx src/handlers/runtime/invoke/invoke.test.tsx` (`85` pass)
- `bun run typecheck`
- `bun run lint:check`
- `bun run format:check`
- TUI Harness: headless invalid session surfaced the original AWS validation message
- TUI Harness: interactive invalid session retained structured type, HTTP status, message, and request ID
- `bun test src` reached `816` pass; the only two failures were unchanged `src/io/exec.test.ts` subprocess-output assertions that reproduce in this environment