### PR TITLE
feat: centralize support TUI command routing logic

### DIFF
--- a/src/components/RouterScreen.tsx
+++ b/src/components/RouterScreen.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState } from "react";
 import { Box, Text, useApp, useInput, useStdin } from "ink";
 import type { Command } from "commander";
 import { useNavigate } from "react-router";
-import { CommandKey } from "../router";
+import { CommandKey, isTuiCommandSupported } from "../router";
 import { Layout } from "./Layout";
 import { Divider } from "./ui/divider";
 import { TextInput } from "./ui/text-input";
@@ -44,18 +44,13 @@ export interface RouterScreenProps extends ScreenProps {
   // segment is the app root; the last is the command whose subcommands are the
   // menu options.
   path: string[];
-  // omit hides subcommands from the menu by name. The command tree still carries
-  // them (they remain usable from the CLI), but they are not offered here — used
-  // when the TUI intentionally does not route a command yet, so it can't fall
-  // through to the HelpScreen catch-all (which exits the app).
-  omit?: string[];
 }
 
 // RouterScreen renders the interactive command menu for a Router node: a filter
 // input at the top and the node's subcommands (read straight off the Commander
 // Command) as navigable options below. Selecting an option routes to that
 // subcommand's screen.
-export function RouterScreen({ ctx, path, omit }: RouterScreenProps) {
+export function RouterScreen({ ctx, path }: RouterScreenProps) {
   const navigate = useNavigate();
   const { isRawModeSupported } = useStdin();
   const { exit } = useApp();
@@ -64,9 +59,9 @@ export function RouterScreen({ ctx, path, omit }: RouterScreenProps) {
   const options: Option[] = useMemo(
     () =>
       command.commands
-        .filter((c) => !omit?.includes(c.name()))
+        .filter(isTuiCommandSupported)
         .map((c) => ({ name: c.name(), description: c.description() })),
-    [command, omit],
+    [command],
   );
 
   const [query, setQuery] = useState("");

--- a/src/handlers/eval/evaluator/evaluator.test.tsx
+++ b/src/handlers/eval/evaluator/evaluator.test.tsx
@@ -165,6 +165,19 @@ describe("eval command hierarchy", () => {
       );
     },
   );
+
+  test("runs normal validation for a bare CLI-only evaluator command", async () => {
+    await expect(run(["eval", "evaluator", "delete"])).rejects.toThrow(
+      "required option '--id <id>' not specified",
+    );
+  });
+
+  test("prints help for a bare CLI-only evaluator group", async () => {
+    const stdout = await run(["eval", "evaluator", "llm-as-a-judge"]);
+
+    expect(stdout).toContain("Usage: agentcore eval evaluator llm-as-a-judge");
+    expect(stdout).toContain("Commands:");
+  });
 });
 
 describe("evaluator CRUDL", () => {

--- a/src/handlers/eval/evaluator/index.tsx
+++ b/src/handlers/eval/evaluator/index.tsx
@@ -13,6 +13,7 @@ export function createEvaluatorHandler(core: Core, io: AppIO): Router {
   return new Router("evaluator", "manage AgentCore evaluators")
     .use(withTuiOnEmptyFlagsAndArgs(core, io))
     .default(renderTui(core, io))
+    .supportedTuiCommands("get", "list")
     .handler(createLlmAsAJudgeHandler(core, io))
     .handler(createCodeBasedHandler(core, io))
     .handler(createGetEvaluatorHandler(core))

--- a/src/handlers/eval/evaluator/screen.tsx
+++ b/src/handlers/eval/evaluator/screen.tsx
@@ -1,12 +1,6 @@
 import { RouterScreen } from "../../../components/RouterScreen";
 import type { ScreenProps } from "../../types";
 
-// The read-only TUI offers only get/list. The mutating subcommands
-// (llm-as-a-judge and code-based, which host create/update; and delete) stay
-// CLI-only for now, so they are omitted from the menu — an unrouted menu entry
-// would fall through to the HelpScreen catch-all and exit the app.
-const OMIT = ["llm-as-a-judge", "code-based", "delete"];
-
 export function EvaluatorScreen(props: ScreenProps) {
-  return <RouterScreen {...props} path={["agentcore", "eval", "evaluator"]} omit={OMIT} />;
+  return <RouterScreen {...props} path={["agentcore", "eval", "evaluator"]} />;
 }

--- a/src/handlers/eval/online-eval/index.tsx
+++ b/src/handlers/eval/online-eval/index.tsx
@@ -15,6 +15,7 @@ export function createOnlineEvalHandler(core: Core, io: AppIO): Router {
   return new Router("online-eval", "manage AgentCore online evaluation configs")
     .use(withTuiOnEmptyFlagsAndArgs(core, io))
     .default(renderTui(core, io))
+    .supportedTuiCommands("get", "list")
     .handler(createCreateOnlineEvalHandler(core, io))
     .handler(createGetOnlineEvalHandler(core))
     .handler(createListOnlineEvalHandler(core))

--- a/src/handlers/eval/online-eval/online-eval.test.tsx
+++ b/src/handlers/eval/online-eval/online-eval.test.tsx
@@ -111,6 +111,12 @@ describe("eval online-eval command hierarchy", () => {
       );
     },
   );
+
+  test("runs normal validation for a bare CLI-only command", async () => {
+    await expect(run(["eval", "online-eval", "create"])).rejects.toThrow(
+      "required option '--name <name>' not specified",
+    );
+  });
 });
 
 describe("online-eval CRUDL", () => {

--- a/src/handlers/eval/online-eval/screen.tsx
+++ b/src/handlers/eval/online-eval/screen.tsx
@@ -1,11 +1,6 @@
 import { RouterScreen } from "../../../components/RouterScreen";
 import type { ScreenProps } from "../../types";
 
-// The read-only TUI offers only get/list. The mutating subcommands stay CLI-only
-// for now, so they are omitted from the menu — an unrouted menu entry would fall
-// through to the HelpScreen catch-all and exit the app.
-const OMIT = ["create", "update", "pause", "resume", "delete"];
-
 export function OnlineEvalScreen(props: ScreenProps) {
-  return <RouterScreen {...props} path={["agentcore", "eval", "online-eval"]} omit={OMIT} />;
+  return <RouterScreen {...props} path={["agentcore", "eval", "online-eval"]} />;
 }

--- a/src/handlers/identity/api-key-credential-provider/index.tsx
+++ b/src/handlers/identity/api-key-credential-provider/index.tsx
@@ -11,6 +11,7 @@ import { createUpdateApiKeyCredentialProviderHandler } from "./update";
 export function createApiKeyCredentialProviderHandler(core: Core, io: AppIO): Router {
   return new Router("api-key-credential-provider", "manage API key credential providers")
     .default(renderTui(core, io))
+    .supportedTuiCommands("get", "list")
     .handler(createCreateApiKeyCredentialProviderHandler(core, io))
     .handler(createGetApiKeyCredentialProviderHandler(core))
     .handler(createListApiKeyCredentialProvidersHandler(core))

--- a/src/handlers/identity/api-key-credential-provider/screen.tsx
+++ b/src/handlers/identity/api-key-credential-provider/screen.tsx
@@ -1,14 +1,8 @@
 import { RouterScreen } from "../../../components/RouterScreen";
 import type { ScreenProps } from "../../types";
 
-const OMIT = ["create", "update", "delete"];
-
 export function ApiKeyCredentialProviderScreen(props: ScreenProps) {
   return (
-    <RouterScreen
-      {...props}
-      path={["agentcore", "identity", "api-key-credential-provider"]}
-      omit={OMIT}
-    />
+    <RouterScreen {...props} path={["agentcore", "identity", "api-key-credential-provider"]} />
   );
 }

--- a/src/handlers/identity/identity.test.tsx
+++ b/src/handlers/identity/identity.test.tsx
@@ -79,16 +79,22 @@ describe("api-key-credential-provider TUI dispatch", () => {
   test.each([
     ["identity", ["identity"]],
     ["api-key-credential-provider", ["identity", "api-key-credential-provider"]],
-    ["create", ["identity", "api-key-credential-provider", "create"]],
     ["get", ["identity", "api-key-credential-provider", "get"]],
     ["list", ["identity", "api-key-credential-provider", "list"]],
-    ["update", ["identity", "api-key-credential-provider", "update"]],
-    ["delete", ["identity", "api-key-credential-provider", "delete"]],
   ] as const)("opens the TUI for a bare `%s`", async (_label, args) => {
     await expect(run([...args])).rejects.toThrow(
       "interactive mode requires a TTY on stdin and stdout",
     );
   });
+
+  test.each(["create", "update", "delete"] as const)(
+    "runs normal validation for bare CLI-only `%s`",
+    async (command) => {
+      await expect(run(["identity", "api-key-credential-provider", command])).rejects.toThrow(
+        "required option '--name <name>' not specified",
+      );
+    },
+  );
 });
 
 describe("api-key-credential-provider CRUDL", () => {

--- a/src/handlers/identity/oauth2-credential-provider/index.tsx
+++ b/src/handlers/identity/oauth2-credential-provider/index.tsx
@@ -11,6 +11,7 @@ import { createUpdateOauth2CredentialProviderHandler } from "./update";
 export function createOauth2CredentialProviderHandler(core: Core, io: AppIO): Router {
   return new Router("oauth2-credential-provider", "manage OAuth2 credential providers")
     .default(renderTui(core, io))
+    .supportedTuiCommands("get", "list")
     .handler(createCreateOauth2CredentialProviderHandler(core, io))
     .handler(createGetOauth2CredentialProviderHandler(core))
     .handler(createListOauth2CredentialProvidersHandler(core))

--- a/src/handlers/identity/oauth2-credential-provider/oauth2.test.tsx
+++ b/src/handlers/identity/oauth2-credential-provider/oauth2.test.tsx
@@ -112,16 +112,22 @@ describe("oauth2-credential-provider command hierarchy", () => {
 describe("oauth2-credential-provider TUI dispatch", () => {
   test.each([
     ["oauth2-credential-provider", ["identity", "oauth2-credential-provider"]],
-    ["create", ["identity", "oauth2-credential-provider", "create"]],
     ["get", ["identity", "oauth2-credential-provider", "get"]],
     ["list", ["identity", "oauth2-credential-provider", "list"]],
-    ["update", ["identity", "oauth2-credential-provider", "update"]],
-    ["delete", ["identity", "oauth2-credential-provider", "delete"]],
   ] as const)("opens the TUI for a bare `%s`", async (_label, args) => {
     await expect(run([...args])).rejects.toThrow(
       "interactive mode requires a TTY on stdin and stdout",
     );
   });
+
+  test.each(["create", "update", "delete"] as const)(
+    "runs normal validation for bare CLI-only `%s`",
+    async (command) => {
+      await expect(run(["identity", "oauth2-credential-provider", command])).rejects.toThrow(
+        "required option '--name <name>' not specified",
+      );
+    },
+  );
 });
 
 describe("oauth2-credential-provider flag validation", () => {

--- a/src/handlers/identity/oauth2-credential-provider/screen.tsx
+++ b/src/handlers/identity/oauth2-credential-provider/screen.tsx
@@ -1,14 +1,6 @@
 import { RouterScreen } from "../../../components/RouterScreen";
 import type { ScreenProps } from "../../types";
 
-const OMIT = ["create", "update", "delete"];
-
 export function Oauth2CredentialProviderScreen(props: ScreenProps) {
-  return (
-    <RouterScreen
-      {...props}
-      path={["agentcore", "identity", "oauth2-credential-provider"]}
-      omit={OMIT}
-    />
-  );
+  return <RouterScreen {...props} path={["agentcore", "identity", "oauth2-credential-provider"]} />;
 }

--- a/src/middleware/withGlobalConfigAccessor.tsx
+++ b/src/middleware/withGlobalConfigAccessor.tsx
@@ -12,6 +12,7 @@ export function withGlobalConfigAccessor(accessor: GlobalConfigAccessor): Middle
     description: () => h.description(),
     flags: () => h.flags(),
     arguments: () => h.arguments(),
+    doesSupportTui: () => h.doesSupportTui(),
     children: () => h.children(),
     handle: async (ctx, flags, args) => {
       await h.handle(ctx.withValue(GlobalConfigAccessorKey, accessor), flags, args);

--- a/src/middleware/withJsonRenderer.tsx
+++ b/src/middleware/withJsonRenderer.tsx
@@ -18,6 +18,7 @@ export function withJsonRenderer(io: AppIO): Middleware {
     description: () => h.description(),
     flags: () => h.flags(),
     arguments: () => h.arguments(),
+    doesSupportTui: () => h.doesSupportTui(),
     children: () => h.children(),
     handle: async (ctx, flags, args) => {
       await h.handle(ctx.withValue(JsonRendererKey, renderer), flags, args);

--- a/src/middleware/withLogging.tsx
+++ b/src/middleware/withLogging.tsx
@@ -35,6 +35,7 @@ export function withLogging(config: WithLoggingConfig): Middleware {
     description: () => h.description(),
     flags: () => h.flags(),
     arguments: () => h.arguments(),
+    doesSupportTui: () => h.doesSupportTui(),
     children: () => h.children(),
     handle: async (ctx, flags, args) => {
       const commandPath = ctx.require(PathKey);

--- a/src/middleware/withProject.tsx
+++ b/src/middleware/withProject.tsx
@@ -19,6 +19,7 @@ export function withProject(config: WithProjectConfig): Middleware {
     description: () => h.description(),
     flags: () => h.flags(),
     arguments: () => h.arguments(),
+    doesSupportTui: () => h.doesSupportTui(),
     children: () => h.children(),
     handle: async (ctx, flags, args) => {
       const project = await config.projectManager.resolve({ filePath: config.cwd });

--- a/src/middleware/withRegion.tsx
+++ b/src/middleware/withRegion.tsx
@@ -61,6 +61,7 @@ export function withRegion(): Middleware {
     description: () => h.description(),
     flags: () => h.flags(),
     arguments: () => h.arguments(),
+    doesSupportTui: () => h.doesSupportTui(),
     children: () => h.children(),
     handle: async (ctx, flags, args) => {
       const region = await resolveRegion(ctx.value(RegionKey));

--- a/src/middleware/withTuiOnEmptyFlagsAndArgs.test.tsx
+++ b/src/middleware/withTuiOnEmptyFlagsAndArgs.test.tsx
@@ -8,7 +8,10 @@ import { TestCoreClient, testIO } from "../testing";
 // route runs a command tree whose leaf flags all carry defaults. The branch the
 // middleware takes is observable: the TUI attempt throws (testIO is not a TTY),
 // the headless path runs the leaf handler.
-function route(args: string[]): { ran: () => boolean; routed: Promise<void> } {
+function route(
+  args: string[],
+  supportedTuiCommands?: string[],
+): { ran: () => boolean; routed: Promise<void> } {
   let handled = false;
   const leaf = createHandler({
     name: "leaf",
@@ -26,6 +29,9 @@ function route(args: string[]): { ran: () => boolean; routed: Promise<void> } {
     .groupFlags(JsonKey)
     .use(withTuiOnEmptyFlagsAndArgs(new TestCoreClient(), testIO().io))
     .handler(leaf);
+  if (supportedTuiCommands) {
+    root.supportedTuiCommands(...supportedTuiCommands);
+  }
 
   return { ran: () => handled, routed: root.route(["node", "agentcore", "leaf", ...args]) };
 }
@@ -36,6 +42,13 @@ describe("withTuiOnEmptyFlagsAndArgs", () => {
 
     await expect(routed).rejects.toThrow("interactive mode requires a TTY on stdin and stdout");
     expect(ran()).toBe(false);
+  });
+
+  test("runs an unsupported bare command through its normal handler", async () => {
+    const { ran, routed } = route([], []);
+
+    await routed;
+    expect(ran()).toBe(true);
   });
 
   test.each([

--- a/src/middleware/withTuiOnEmptyFlagsAndArgs.tsx
+++ b/src/middleware/withTuiOnEmptyFlagsAndArgs.tsx
@@ -3,7 +3,7 @@ import { renderTui } from "../tui";
 import { JsonKey } from "../handlers/keys";
 import type { AppIO } from "../io";
 import type { Core } from "../handlers/types";
-import { CommandKey, isTuiCommandSupported, type Handler, type Middleware } from "../router";
+import { CommandKey, type Handler, type Middleware } from "../router";
 
 // countPassedValues counts how many entries of an object hold a defined value.
 const countPassedValues = (obj: object) =>
@@ -36,11 +36,12 @@ export function withTuiOnEmptyFlagsAndArgs(core: Core, io: AppIO): Middleware {
     description: () => h.description(),
     flags: () => h.flags(),
     arguments: () => h.arguments(),
+    doesSupportTui: () => h.doesSupportTui(),
     children: () => h.children(),
     handle: async (ctx, flags, args) => {
       const command = ctx.require(CommandKey);
       if (
-        isTuiCommandSupported(command) &&
+        h.doesSupportTui() &&
         !ctx.require(JsonKey) &&
         countPassedFlags(h, command) === 0 &&
         countPassedValues(args) === 0

--- a/src/middleware/withTuiOnEmptyFlagsAndArgs.tsx
+++ b/src/middleware/withTuiOnEmptyFlagsAndArgs.tsx
@@ -3,7 +3,7 @@ import { renderTui } from "../tui";
 import { JsonKey } from "../handlers/keys";
 import type { AppIO } from "../io";
 import type { Core } from "../handlers/types";
-import { CommandKey, type Handler, type Middleware } from "../router";
+import { CommandKey, isTuiCommandSupported, type Handler, type Middleware } from "../router";
 
 // countPassedValues counts how many entries of an object hold a defined value.
 const countPassedValues = (obj: object) =>
@@ -38,9 +38,11 @@ export function withTuiOnEmptyFlagsAndArgs(core: Core, io: AppIO): Middleware {
     arguments: () => h.arguments(),
     children: () => h.children(),
     handle: async (ctx, flags, args) => {
+      const command = ctx.require(CommandKey);
       if (
+        isTuiCommandSupported(command) &&
         !ctx.require(JsonKey) &&
-        countPassedFlags(h, ctx.require(CommandKey)) === 0 &&
+        countPassedFlags(h, command) === 0 &&
         countPassedValues(args) === 0
       ) {
         await boundRenderTui(ctx, flags, args);

--- a/src/router/handler.tsx
+++ b/src/router/handler.tsx
@@ -83,6 +83,8 @@ export interface Handler {
   description(): string;
   flags(): Flag[];
   arguments(): Argument[];
+  // Middleware must preserve this metadata when wrapping a handler.
+  doesSupportTui(): boolean;
   // At runtime `handle` receives the validated, coerced flags object. The precise
   // shape is supplied to authors via createHandler's generic; the interface keeps
   // it erased so middleware can forward it uniformly.
@@ -137,6 +139,10 @@ class BaseHandler implements Handler {
 
   arguments(): Argument[] {
     return this._arguments;
+  }
+
+  doesSupportTui(): boolean {
+    return true;
   }
 
   async handle(ctx: Context, flags: any, args: any): Promise<void> {

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -10,6 +10,7 @@ export {
   type DefaultHandle,
   type DefaultHandlerProvider,
   isDefaultHandlerProvider,
+  isTuiCommandSupported,
 } from "./router";
 export {
   type Handler,

--- a/src/router/router.test.ts
+++ b/src/router/router.test.ts
@@ -31,6 +31,7 @@ function record(log: string[], label: string): Middleware {
     description: () => h.description(),
     flags: () => h.flags(),
     arguments: () => h.arguments(),
+    doesSupportTui: () => h.doesSupportTui(),
     children: () => h.children(),
     handle: async (ctx: Context, flags: any, args: any) => {
       log.push(label);

--- a/src/router/router.test.ts
+++ b/src/router/router.test.ts
@@ -12,6 +12,7 @@ import {
   createHandler,
   flag,
   globalFlag,
+  isTuiCommandSupported,
   type Context,
   type Handler,
   type Middleware,
@@ -85,6 +86,40 @@ test("middleware applies only to the subtree where it is declared", async () => 
   await root.route(["node", "app", "top"]);
 
   expect(log).toEqual(["root", "top-handle"]);
+});
+
+// --- TUI command support ---------------------------------------------------
+
+test("all commands support the TUI when no allowlist is configured", () => {
+  const nested = new Router("nested").handler(leaf("deep", () => {}));
+  const root = new Router("app").handler(leaf("top", () => {})).handler(nested);
+
+  const command = compile(root, ValueContext.EmptyContext());
+  const top = command.commands.find((child) => child.name() === "top")!;
+  const nestedCommand = command.commands.find((child) => child.name() === "nested")!;
+  const deep = nestedCommand.commands.find((child) => child.name() === "deep")!;
+
+  expect(isTuiCommandSupported(command)).toBe(true);
+  expect(isTuiCommandSupported(top)).toBe(true);
+  expect(isTuiCommandSupported(nestedCommand)).toBe(true);
+  expect(isTuiCommandSupported(deep)).toBe(true);
+});
+
+test("a TUI allowlist supports named children and excludes other subtrees", () => {
+  const nested = new Router("nested").handler(leaf("deep", () => {}));
+  const root = new Router("app")
+    .supportedTuiCommands("top")
+    .handler(leaf("top", () => {}))
+    .handler(nested);
+
+  const command = compile(root, ValueContext.EmptyContext());
+  const top = command.commands.find((child) => child.name() === "top")!;
+  const nestedCommand = command.commands.find((child) => child.name() === "nested")!;
+  const deep = nestedCommand.commands.find((child) => child.name() === "deep")!;
+
+  expect(isTuiCommandSupported(top)).toBe(true);
+  expect(isTuiCommandSupported(nestedCommand)).toBe(false);
+  expect(isTuiCommandSupported(deep)).toBe(false);
 });
 
 // --- default handler (group invoked without a subcommand) ------------------

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -24,13 +24,36 @@ export const GlobalConfigAccessorKey: ContextKey<GlobalConfigAccessor> =
   contextKey<GlobalConfigAccessor>("globalConfigAccessor");
 export const ProjectKey = contextKey<Project>("project");
 
-// Allowlist of commands supported in TUI. Ensures read-only TUIs do not
-// render write commands, and ensures bare write commands do not launch TUI
-const supportedTuiCommandNames = new WeakMap<Handler, ReadonlySet<string>>();
-const compiledTuiSupport = new WeakMap<Command, boolean>();
+// RoutedCommand keeps the compiled handler and Commander command tree together.
+// TUI consumers can therefore read handler metadata without module-level state.
+class RoutedCommand extends Command {
+  constructor(readonly handler: Handler) {
+    super(handler.name());
+  }
+}
 
 export function isTuiCommandSupported(command: Command): boolean {
-  return compiledTuiSupport.get(command) ?? true;
+  return command instanceof RoutedCommand ? command.handler.doesSupportTui() : true;
+}
+
+interface TuiChildSupportProvider {
+  supportsTuiCommand(commandName: string): boolean;
+}
+
+function isTuiChildSupportProvider(h: Handler): h is Handler & TuiChildSupportProvider {
+  return typeof (h as Partial<TuiChildSupportProvider>).supportsTuiCommand === "function";
+}
+
+function withEffectiveTuiSupport(handler: Handler, supported: boolean): Handler {
+  return {
+    name: () => handler.name(),
+    description: () => handler.description(),
+    flags: () => handler.flags(),
+    arguments: () => handler.arguments(),
+    doesSupportTui: () => supported,
+    handle: (ctx, flags, args) => handler.handle(ctx, flags, args),
+    children: () => handler.children(),
+  };
 }
 
 // DefaultHandle runs when a group is selected without a subcommand (e.g.
@@ -129,8 +152,9 @@ export function compile(
   inheritedGlobals: GlobalFlag[] = [],
   tuiSupported = true,
 ): Command {
-  const c = new Command(node.name());
-  compiledTuiSupport.set(c, tuiSupported);
+  const effectiveTuiSupport = tuiSupported && node.doesSupportTui();
+  const compiledNode = withEffectiveTuiSupport(node, effectiveTuiSupport);
+  const c = new RoutedCommand(compiledNode);
   c.description(node.description());
 
   const ownFlags = node.flags();
@@ -167,10 +191,10 @@ export function compile(
     }
     // A group's own global flags become inherited flags for everything beneath it.
     const childGlobals = [...inheritedGlobals, ...globalFlagsOf(node)];
-    const tuiCommandNames = supportedTuiCommandNames.get(node);
     for (const child of children) {
       const childTuiSupported =
-        tuiSupported && (tuiCommandNames === undefined || tuiCommandNames.has(child.name()));
+        effectiveTuiSupport &&
+        (!isTuiChildSupportProvider(node) || node.supportsTuiCommand(child.name()));
       c.addCommand(compile(child, ctx, nextStack, childGlobals, childTuiSupported));
     }
     // A group may also carry a default handler that runs when it is invoked
@@ -179,11 +203,18 @@ export function compile(
     // has no own flags/arguments (globals-only).
     const fallback = isDefaultHandlerProvider(node) ? node.defaultHandler() : undefined;
     if (fallback) {
-      attachAction(c, fallback, ctx, nextStack, childGlobals, []);
+      attachAction(
+        c,
+        withEffectiveTuiSupport(fallback, effectiveTuiSupport && fallback.doesSupportTui()),
+        ctx,
+        nextStack,
+        childGlobals,
+        [],
+      );
     }
   } else {
     // Middleware wraps the node here; the wrapper's logic runs at leaf execution.
-    attachAction(c, node, ctx, nextStack, inheritedGlobals, ownFlags);
+    attachAction(c, compiledNode, ctx, nextStack, inheritedGlobals, ownFlags);
   }
 
   return c;
@@ -194,6 +225,7 @@ export class Router implements Handler, MiddlewareProvider, DefaultHandlerProvid
   private handlers: Handler[] = [];
   private globalFlags: GlobalFlag[] = [];
   private defaultHandle?: DefaultHandle;
+  private tuiCommandNames?: ReadonlySet<string>;
 
   constructor(
     private readonly cmdName: string,
@@ -221,8 +253,12 @@ export class Router implements Handler, MiddlewareProvider, DefaultHandlerProvid
   // TUI dispatch to the named children. Without this call, every child keeps the
   // existing TUI behavior.
   supportedTuiCommands(...commands: string[]): this {
-    supportedTuiCommandNames.set(this, new Set(commands));
+    this.tuiCommandNames = new Set(commands);
     return this;
+  }
+
+  supportsTuiCommand(commandName: string): boolean {
+    return this.tuiCommandNames?.has(commandName) ?? true;
   }
 
   // default registers a handler that runs when this group is selected without a
@@ -254,6 +290,10 @@ export class Router implements Handler, MiddlewareProvider, DefaultHandlerProvid
     return [];
   }
 
+  doesSupportTui(): boolean {
+    return true;
+  }
+
   // A group/branch never executes directly; it just hosts subcommands.
   async handle(_ctx: Context, _flags: any, _args: any): Promise<void> {}
 
@@ -278,6 +318,7 @@ export class Router implements Handler, MiddlewareProvider, DefaultHandlerProvid
       description: () => this.cmdDescription,
       flags: () => [],
       arguments: () => [],
+      doesSupportTui: () => true,
       handle: fn,
       children: () => [],
     };

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -24,6 +24,15 @@ export const GlobalConfigAccessorKey: ContextKey<GlobalConfigAccessor> =
   contextKey<GlobalConfigAccessor>("globalConfigAccessor");
 export const ProjectKey = contextKey<Project>("project");
 
+// Allowlist of commands supported in TUI. Ensures read-only TUIs do not
+// render write commands, and ensures bare write commands do not launch TUI
+const supportedTuiCommandNames = new WeakMap<Handler, ReadonlySet<string>>();
+const compiledTuiSupport = new WeakMap<Command, boolean>();
+
+export function isTuiCommandSupported(command: Command): boolean {
+  return compiledTuiSupport.get(command) ?? true;
+}
+
 // DefaultHandle runs when a group is selected without a subcommand (e.g.
 // `agentcore` or `agentcore harness`). It reads group-level/global flags from the
 // context; own flags/arguments are not supported, so it receives empty objects.
@@ -118,8 +127,10 @@ export function compile(
   ctx: Context,
   stack: Middleware[] = [],
   inheritedGlobals: GlobalFlag[] = [],
+  tuiSupported = true,
 ): Command {
   const c = new Command(node.name());
+  compiledTuiSupport.set(c, tuiSupported);
   c.description(node.description());
 
   const ownFlags = node.flags();
@@ -156,8 +167,11 @@ export function compile(
     }
     // A group's own global flags become inherited flags for everything beneath it.
     const childGlobals = [...inheritedGlobals, ...globalFlagsOf(node)];
+    const tuiCommandNames = supportedTuiCommandNames.get(node);
     for (const child of children) {
-      c.addCommand(compile(child, ctx, nextStack, childGlobals));
+      const childTuiSupported =
+        tuiSupported && (tuiCommandNames === undefined || tuiCommandNames.has(child.name()));
+      c.addCommand(compile(child, ctx, nextStack, childGlobals, childTuiSupported));
     }
     // A group may also carry a default handler that runs when it is invoked
     // without a subcommand. It executes with this group's own middleware and can
@@ -200,6 +214,14 @@ export class Router implements Handler, MiddlewareProvider, DefaultHandlerProvid
 
   groupFlags(...flags: GlobalFlag[]): this {
     this.globalFlags.push(...flags);
+    return this;
+  }
+
+  // supportedTuiCommands limits this router's interactive menu and bare-command
+  // TUI dispatch to the named children. Without this call, every child keeps the
+  // existing TUI behavior.
+  supportedTuiCommands(...commands: string[]): this {
+    supportedTuiCommandNames.set(this, new Set(commands));
     return this;
   }
 


### PR DESCRIPTION
## Problem
Some command groups have read-only TUIs while supporting both read and write operations through the CLI.

Previously, write commands were hidden directly in the `RouterScreen`. This filtering happens only after the TUI has already launched. Because `withTuiOnEmptyFlagsAndArgs` runs earlier, invoking an omitted write command without flags still launched Ink instead of reaching its normal CLI validation or help behavior.

## Solution

Add `Router.supportedTuiCommands()` as the source of truth for TUI menu visibility and bare-command dispatch. Also, migrated the read-only TUIs which were filtering commands to use this new structure. 

The allowlist is propagated through the Commander command tree and used by both:
- `withTuiOnEmptyFlagsAndArgs`, to determine whether a bare command should launch the TUI.
- `RouterScreen`, to determine which commands should appear in TUI menus.

Commands excluded from the TUI remain registered in Commander and fully available through the CLI. Additionally, any Router that omits .supportedTuiCommands() will include all its command keys. 

## Description
- Add `Router.supportedTuiCommands()`.
- Add `isTuiCommandSupported()` for consumers of compiled commands.
- Update `withTuiOnEmptyFlagsAndArgs` to delegate unsupported commands to their normal CLI handlers.
- Update `RouterScreen` to filter using router metadata.
- Remove the `RouterScreen` `omit` prop.
- Migrated read-only Eval and Identity TUIs to the new API.
- Add test coverage for menu filtering, nested propagation, backward compatibility, and bare CLI-only commands.


## Related Issue

<!-- Every PR must be associated with an issue. Link it below using #issue-number format. -->

Closes #

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Check all that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

`bun run test` (825 pass, 0 fail)

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [x] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
