### PR TITLE
fix(memory): expand record TUI columns

### DIFF
--- a/src/handlers/memory/record/list/screen.tsx
+++ b/src/handlers/memory/record/list/screen.tsx
@@ -34,14 +34,14 @@ interface MemoryRecordRow extends Record<string, unknown> {
 }
 
 const recordColumns = [
-  { key: "recordId", header: "id", width: 18, minWidth: 10 },
-  { key: "content", header: "content", flex: true },
-  { key: "strategyId", header: "strategy", width: 16, minWidth: 8 },
+  { key: "recordId", header: "id", flex: true },
+  { key: "content", header: "content", width: 70, minWidth: 20 },
+  { key: "strategyId", header: "strategy", width: 32, minWidth: 16 },
   {
     key: "createdAt",
     header: "created UTC",
     width: 16,
-    minWidth: 11,
+    minWidth: 16,
     render: formatTimestamp,
   },
 ] satisfies DataTableColumn<MemoryRecordRow>[];

--- a/src/handlers/memory/record/record.screen.test.tsx
+++ b/src/handlers/memory/record/record.screen.test.tsx
@@ -12,6 +12,7 @@ import {
   waitFor,
   waitForText,
 } from "../../../testing";
+import stringWidth from "string-width";
 
 afterEach(cleanupScreens);
 
@@ -190,6 +191,40 @@ describe("Memory record list flow", () => {
         { region: "us-east-1" },
       ],
     });
+  });
+
+  test("shows full record identifiers, content, strategy, and timestamps in a wide terminal", async () => {
+    const memoryRecordId = "mem-6ff41abc-6571-4e56-9c47-90e7581785f1";
+    const content = "User is interested in total-market ETFs with low expense ratios.";
+    const memoryStrategyId = "tui_testdata_semantic-FEeDurAJJ1";
+    const core = new TestCoreClient();
+    core.memory.setListMemoryRecordsResponse({
+      memoryRecordSummaries: [
+        recordSummary({
+          memoryRecordId,
+          content: { text: content },
+          memoryStrategyId,
+          createdAt: new Date("2026-08-04T20:44:00.000Z"),
+        }),
+      ],
+    });
+    const screen = renderScreen(
+      "/agentcore/memory/record/list/memory-1/namespace/%2Fcustomers%2Facme",
+      { core },
+    );
+
+    await waitForText(screen.lastFrame, "total-market ETFs");
+    await screen.resize(191, 24);
+
+    const row = screen
+      .lastFrame()!
+      .split("\n")
+      .find((line) => line.includes(memoryRecordId));
+    expect(row).toBeDefined();
+    expect(row!).toContain(content);
+    expect(row!).toContain(memoryStrategyId);
+    expect(row!).toContain("2026-08-04 20:44");
+    expect(stringWidth(row!)).toBeLessThanOrEqual(191);
   });
 
   test("paginates records and distinguishes later-page empty state", async () => {


### PR DESCRIPTION
Rebalances record-list columns so record IDs take remaining space while content, strategy IDs, and timestamps retain useful widths. Adds a wide-terminal regression test covering the reported record layout.