### PR TITLE
feat(project): port complete project schema

### DIFF
--- a/src/core/project/index.tsx
+++ b/src/core/project/index.tsx
@@ -1,1 +1,3 @@
 export { FsProjectManager } from "./manager";
+export { ProjectNameSchema, ProjectSpecSchema } from "./schema";
+export type { ProjectRuntime, ProjectSpec } from "./schema";

--- a/src/core/project/schema.ts
+++ b/src/core/project/schema.ts
@@ -1,0 +1,6 @@
+export {
+  AgentCoreProjectSpecSchema as ProjectSpecSchema,
+  ProjectNameSchema,
+} from "./schema/project";
+export type { AgentCoreProjectSpec as ProjectSpec } from "./schema/project";
+export type { AgentEnvSpec as ProjectRuntime } from "./schema/runtime";

--- a/src/core/project/schema/ab-test.test.ts
+++ b/src/core/project/schema/ab-test.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+import { ABTestSchema } from "./ab-test";
+const configurationBundle = { bundleArn: "arn:bundle", bundleVersion: "1" };
+const base = {
+  name: "Experiment",
+  gatewayRef: "{{gateway:main}}",
+  variants: [
+    { name: "C", weight: 50, variantConfiguration: { configurationBundle } },
+    { name: "T1", weight: 50, variantConfiguration: { configurationBundle } },
+  ],
+  evaluationConfig: { onlineEvaluationConfigArn: "arn:evaluation" },
+};
+describe("ABTestSchema custom validation", () => {
+  it("requires one control and one treatment variant", () => {
+    const result = ABTestSchema.safeParse({
+      ...base,
+      variants: base.variants.map((variant) => ({ ...variant, name: "C" })),
+    });
+    expect(result.success).toBe(false);
+  });
+  it("requires variant weights to sum to 100", () => {
+    const result = ABTestSchema.safeParse({
+      ...base,
+      variants: [
+        { ...base.variants[0], weight: 60 },
+        { ...base.variants[1], weight: 60 },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+  it("binds variant configuration to the selected mode", () => {
+    const targetBased = ABTestSchema.safeParse({
+      ...base,
+      mode: "target-based",
+      variants: [
+        { name: "C", weight: 50, variantConfiguration: { target: { targetName: "control" } } },
+        { name: "T1", weight: 50, variantConfiguration: { target: { targetName: "treatment" } } },
+      ],
+    });
+    expect(targetBased.success).toBe(true);
+    expect(ABTestSchema.safeParse({ ...base, mode: "target-based" }).success).toBe(false);
+  });
+});

--- a/src/core/project/schema/ab-test.ts
+++ b/src/core/project/schema/ab-test.ts
@@ -1,0 +1,111 @@
+import { z } from "zod";
+export const ABTestNameSchema = z
+  .string()
+  .min(1, "Name is required")
+  .max(48)
+  .regex(
+    /^[a-zA-Z][a-zA-Z0-9_]{0,47}$/,
+    "Must begin with a letter and contain only alphanumeric characters and underscores (max 48 chars)",
+  );
+export const ABTestDescriptionSchema = z.string().min(1).max(200).optional();
+export const ABTestModeSchema = z
+  .enum(["config-bundle", "target-based"])
+  .optional()
+  .default("config-bundle");
+export type ABTestMode = z.infer<typeof ABTestModeSchema>;
+export const VariantNameSchema = z.enum(["C", "T1"]);
+export const VariantWeightSchema = z.number().int().min(1).max(100);
+export const ConfigurationBundleRefSchema = z.object({
+  bundleArn: z.string().min(1),
+  bundleVersion: z.string().min(1),
+});
+export type ConfigurationBundleRef = z.infer<typeof ConfigurationBundleRefSchema>;
+export const TargetRefSchema = z.object({
+  targetName: z.string().min(1).max(100),
+});
+export type TargetRef = z.infer<typeof TargetRefSchema>;
+const ConfigBundleVariantConfigSchema = z.object({
+  configurationBundle: ConfigurationBundleRefSchema,
+  target: z.never().optional(),
+});
+const TargetVariantConfigSchema = z.object({
+  configurationBundle: z.never().optional(),
+  target: TargetRefSchema,
+});
+export const VariantConfigurationSchema = z.union([
+  ConfigBundleVariantConfigSchema,
+  TargetVariantConfigSchema,
+]);
+export type VariantConfiguration = z.infer<typeof VariantConfigurationSchema>;
+export const ABTestVariantSchema = z.object({
+  name: VariantNameSchema,
+  weight: VariantWeightSchema,
+  variantConfiguration: VariantConfigurationSchema,
+});
+export type ABTestVariant = z.infer<typeof ABTestVariantSchema>;
+export const PerVariantOnlineEvaluationConfigSchema = z.object({
+  treatmentName: VariantNameSchema,
+  onlineEvaluationConfigArn: z.string().min(1),
+});
+export type PerVariantOnlineEvaluationConfig = z.infer<
+  typeof PerVariantOnlineEvaluationConfigSchema
+>;
+export const ABTestEvaluationConfigSchema = z.union([
+  z.object({ onlineEvaluationConfigArn: z.string().min(1) }),
+  z.object({
+    perVariantOnlineEvaluationConfig: z.array(PerVariantOnlineEvaluationConfigSchema).length(2),
+  }),
+]);
+export type ABTestEvaluationConfig = z.infer<typeof ABTestEvaluationConfigSchema>;
+export const GatewayFilterSchema = z.object({
+  targetPaths: z.array(z.string().min(1).max(500)).max(1),
+});
+export type GatewayFilter = z.infer<typeof GatewayFilterSchema>;
+export const TrafficRouteOnHeaderSchema = z.object({
+  headerName: z.string().min(1),
+});
+export const TrafficAllocationConfigSchema = z.object({
+  routeOnHeader: TrafficRouteOnHeaderSchema,
+});
+export type TrafficAllocationConfig = z.infer<typeof TrafficAllocationConfigSchema>;
+export const ABTestSchema = z
+  .object({
+    name: ABTestNameSchema,
+    description: ABTestDescriptionSchema,
+    mode: ABTestModeSchema,
+    gatewayRef: z.string().min(1),
+    roleArn: z.string().min(1).optional(),
+    variants: z.array(ABTestVariantSchema).length(2),
+    evaluationConfig: ABTestEvaluationConfigSchema,
+    gatewayFilter: GatewayFilterSchema.optional(),
+    enableOnCreate: z.boolean().optional(),
+    promoted: z.boolean().optional(),
+  })
+  .refine(
+    (data) => {
+      const names = data.variants.map((v) => v.name);
+      return names.includes("C") && names.includes("T1");
+    },
+    {
+      message: "Variants must include exactly one control (C) and one treatment (T1)",
+      path: ["variants"],
+    },
+  )
+  .refine((data) => data.variants.reduce((sum, v) => sum + v.weight, 0) === 100, {
+    message: "Variant weights must sum to 100",
+    path: ["variants"],
+  })
+  .refine(
+    (data) => {
+      if (data.mode === "target-based") {
+        return data.variants.every((v) => v.variantConfiguration.target != null);
+      }
+      return data.variants.every((v) => v.variantConfiguration.configurationBundle != null);
+    },
+    {
+      message:
+        "Target-based mode requires target on each variant; config-bundle mode requires configurationBundle",
+      path: ["variants"],
+    },
+  );
+export type ABTest = z.infer<typeof ABTestSchema>;

--- a/src/core/project/schema/auth.test.ts
+++ b/src/core/project/schema/auth.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "bun:test";
+import {
+  ClaimMatchValueSchema,
+  CustomClaimValidationSchema,
+  CustomJwtAuthorizerConfigSchema,
+  PrivateEndpointSchema,
+} from "./auth";
+const lattice = {
+  selfManagedLatticeResource: {
+    resourceConfigurationIdentifier: "rcfg-0123456789abcdef0",
+  },
+};
+const vpc = {
+  managedVpcResource: {
+    vpcIdentifier: "vpc-0123456789abcdef0",
+    subnetIds: ["subnet-0123456789abcdef0"],
+    endpointIpAddressType: "IPV4" as const,
+  },
+};
+describe("auth custom validation", () => {
+  it("requires exactly one claim match value representation", () => {
+    expect(ClaimMatchValueSchema.safeParse({ matchValueString: "admin" }).success).toBe(true);
+    expect(
+      ClaimMatchValueSchema.safeParse({
+        matchValueString: "admin",
+        matchValueStringList: ["admin"],
+      }).success,
+    ).toBe(false);
+    expect(ClaimMatchValueSchema.safeParse({}).success).toBe(false);
+  });
+  it("rejects reserved custom claim names", () => {
+    expect(
+      CustomClaimValidationSchema.safeParse({
+        inboundTokenClaimName: "client_id",
+        inboundTokenClaimValueType: "STRING",
+        authorizingClaimMatchValue: {
+          claimMatchOperator: "EQUALS",
+          claimMatchValue: { matchValueString: "user" },
+        },
+      }).success,
+    ).toBe(false);
+  });
+  it("requires exactly one private endpoint arm", () => {
+    expect(PrivateEndpointSchema.safeParse(lattice).success).toBe(true);
+    expect(PrivateEndpointSchema.safeParse(vpc).success).toBe(true);
+    expect(PrivateEndpointSchema.safeParse({ ...lattice, ...vpc }).success).toBe(false);
+    expect(PrivateEndpointSchema.safeParse({}).success).toBe(false);
+  });
+  it("requires override arms to match the base endpoint and domains to be unique", () => {
+    const base = {
+      discoveryUrl: "https://example.com/.well-known/openid-configuration",
+      allowedAudience: ["audience"],
+      privateEndpoint: lattice,
+    };
+    expect(
+      CustomJwtAuthorizerConfigSchema.safeParse({
+        ...base,
+        privateEndpointOverrides: [{ domain: "example.com", privateEndpoint: vpc }],
+      }).success,
+    ).toBe(false);
+    expect(
+      CustomJwtAuthorizerConfigSchema.safeParse({
+        ...base,
+        privateEndpointOverrides: [
+          { domain: "example.com", privateEndpoint: lattice },
+          { domain: "example.com", privateEndpoint: lattice },
+        ],
+      }).success,
+    ).toBe(false);
+  });
+  it("does not allow endpoint overrides without a base endpoint", () => {
+    const result = CustomJwtAuthorizerConfigSchema.safeParse({
+      discoveryUrl: "https://example.com/.well-known/openid-configuration",
+      allowedAudience: ["audience"],
+      privateEndpointOverrides: [{ domain: "example.com", privateEndpoint: lattice }],
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/core/project/schema/auth.ts
+++ b/src/core/project/schema/auth.ts
@@ -1,0 +1,213 @@
+import { SECURITY_GROUP_ID_PATTERN, SUBNET_ID_PATTERN, VPC_ID_PATTERN } from "./constants";
+import { TagsSchema } from "./tags";
+import { z } from "zod";
+export const GatewayAuthorizerTypeSchema = z.enum(["NONE", "AWS_IAM", "CUSTOM_JWT"]);
+export type GatewayAuthorizerType = z.infer<typeof GatewayAuthorizerTypeSchema>;
+export const RuntimeAuthorizerTypeSchema = z.enum(["AWS_IAM", "CUSTOM_JWT"]);
+export type RuntimeAuthorizerType = z.infer<typeof RuntimeAuthorizerTypeSchema>;
+const OIDC_WELL_KNOWN_SUFFIX = "/.well-known/openid-configuration";
+const OidcDiscoveryUrlSchema = z
+  .string()
+  .url("Must be a valid URL")
+  .refine((url) => url.startsWith("https://"), {
+    message: "OIDC discovery URL must use HTTPS",
+  })
+  .refine((url) => url.endsWith(OIDC_WELL_KNOWN_SUFFIX), {
+    message: `OIDC discovery URL must end with '${OIDC_WELL_KNOWN_SUFFIX}'`,
+  });
+const MATCH_VALUE_PATTERN = /^[A-Za-z0-9_.-]+$/;
+const ALLOWED_SCOPE_PATTERN = /^[\x21\x23-\x5B\x5D-\x7E]+$/;
+const CLAIM_NAME_PATTERN = /^[A-Za-z0-9_.:-]+$/;
+const RESERVED_CLAIM_NAMES = ["client_id"];
+export const ClaimMatchOperatorSchema = z.enum(["EQUALS", "CONTAINS", "CONTAINS_ANY"]);
+export type ClaimMatchOperator = z.infer<typeof ClaimMatchOperatorSchema>;
+export const ClaimMatchValueSchema = z
+  .object({
+    matchValueString: z
+      .string()
+      .min(1)
+      .max(255)
+      .regex(MATCH_VALUE_PATTERN, "Match value must match [A-Za-z0-9_.-]+")
+      .optional(),
+    matchValueStringList: z
+      .array(
+        z
+          .string()
+          .min(1)
+          .max(255)
+          .regex(MATCH_VALUE_PATTERN, "Each match value must match [A-Za-z0-9_.-]+"),
+      )
+      .min(1)
+      .max(255)
+      .optional(),
+  })
+  .refine(
+    (data) => data.matchValueString !== undefined || data.matchValueStringList !== undefined,
+    {
+      message: "Either matchValueString or matchValueStringList must be provided",
+    },
+  )
+  .refine(
+    (data) => !(data.matchValueString !== undefined && data.matchValueStringList !== undefined),
+    {
+      message: "Only one of matchValueString or matchValueStringList may be provided",
+    },
+  );
+export type ClaimMatchValue = z.infer<typeof ClaimMatchValueSchema>;
+export const InboundTokenClaimValueTypeSchema = z.enum(["STRING", "STRING_ARRAY"]);
+export type InboundTokenClaimValueType = z.infer<typeof InboundTokenClaimValueTypeSchema>;
+export const CustomClaimValidationSchema = z
+  .object({
+    inboundTokenClaimName: z
+      .string()
+      .min(1)
+      .max(255)
+      .regex(CLAIM_NAME_PATTERN, "Claim name must match [A-Za-z0-9_.-:]+")
+      .refine((name) => !RESERVED_CLAIM_NAMES.includes(name), {
+        message: `Claim name cannot be a reserved name (${RESERVED_CLAIM_NAMES.join(", ")})`,
+      }),
+    inboundTokenClaimValueType: InboundTokenClaimValueTypeSchema,
+    authorizingClaimMatchValue: z.object({
+      claimMatchOperator: ClaimMatchOperatorSchema,
+      claimMatchValue: ClaimMatchValueSchema,
+    }),
+  })
+  .strict();
+export type CustomClaimValidation = z.infer<typeof CustomClaimValidationSchema>;
+export const LATTICE_RESOURCE_CONFIG_PATTERN =
+  /^((rcfg-[0-9a-z]{17})|(arn:[a-z0-9-]+:vpc-lattice:[a-zA-Z0-9-]+:\d{12}:resourceconfiguration\/rcfg-[0-9a-z]{17}))$/;
+export const EndpointIpAddressTypeSchema = z.enum(["IPV4", "IPV6"]);
+export type EndpointIpAddressType = z.infer<typeof EndpointIpAddressTypeSchema>;
+export const SelfManagedLatticeResourceSchema = z
+  .object({
+    resourceConfigurationIdentifier: z
+      .string()
+      .min(20)
+      .max(2048)
+      .regex(
+        LATTICE_RESOURCE_CONFIG_PATTERN,
+        "Must be a VPC Lattice resource-config id (rcfg-...) or its ARN",
+      ),
+  })
+  .strict();
+export type SelfManagedLatticeResource = z.infer<typeof SelfManagedLatticeResourceSchema>;
+export const ManagedVpcResourceSchema = z
+  .object({
+    vpcIdentifier: z.string().regex(VPC_ID_PATTERN, "Must be a VPC id (vpc-...)"),
+    subnetIds: z
+      .array(z.string().regex(SUBNET_ID_PATTERN, "Must be a subnet id (subnet-...)"))
+      .min(1),
+    endpointIpAddressType: EndpointIpAddressTypeSchema,
+    securityGroupIds: z
+      .array(z.string().regex(SECURITY_GROUP_ID_PATTERN, "Must be a security group id (sg-...)"))
+      .max(5)
+      .optional(),
+    tags: TagsSchema.optional(),
+    routingDomain: z.string().min(3).max(255).optional(),
+  })
+  .strict();
+export type ManagedVpcResource = z.infer<typeof ManagedVpcResourceSchema>;
+export const PrivateEndpointSchema = z
+  .object({
+    selfManagedLatticeResource: SelfManagedLatticeResourceSchema.optional(),
+    managedVpcResource: ManagedVpcResourceSchema.optional(),
+  })
+  .strict()
+  .superRefine((data, ctx) => {
+    const count = [data.selfManagedLatticeResource, data.managedVpcResource].filter(
+      (v) => v !== undefined,
+    ).length;
+    if (count !== 1) {
+      ctx.addIssue({
+        code: "custom",
+        message:
+          "A private endpoint must set exactly one of selfManagedLatticeResource or managedVpcResource",
+      });
+    }
+  });
+export type PrivateEndpoint = z.infer<typeof PrivateEndpointSchema>;
+export const PrivateEndpointOverrideSchema = z
+  .object({
+    domain: z.string().min(1).max(253),
+    privateEndpoint: PrivateEndpointSchema,
+  })
+  .strict();
+export type PrivateEndpointOverride = z.infer<typeof PrivateEndpointOverrideSchema>;
+type PrivateEndpointArm = "selfManagedLatticeResource" | "managedVpcResource" | undefined;
+function privateEndpointArm(pe: PrivateEndpoint): PrivateEndpointArm {
+  if (pe.selfManagedLatticeResource) return "selfManagedLatticeResource";
+  if (pe.managedVpcResource) return "managedVpcResource";
+  return undefined;
+}
+export const CustomJwtAuthorizerConfigSchema = z
+  .object({
+    discoveryUrl: OidcDiscoveryUrlSchema,
+    allowedAudience: z.array(z.string().min(1)).optional(),
+    allowedClients: z.array(z.string().min(1)).optional(),
+    allowedScopes: z
+      .array(
+        z
+          .string()
+          .min(1)
+          .max(255)
+          .regex(ALLOWED_SCOPE_PATTERN, "Scope must be printable ASCII with no spaces or quotes"),
+      )
+      .optional(),
+    customClaims: z.array(CustomClaimValidationSchema).min(1).optional(),
+    privateEndpoint: PrivateEndpointSchema.optional(),
+    privateEndpointOverrides: z.array(PrivateEndpointOverrideSchema).max(5).optional(),
+  })
+  .strict()
+  .superRefine((data, ctx) => {
+    const hasAudience = data.allowedAudience && data.allowedAudience.length > 0;
+    const hasClients = data.allowedClients && data.allowedClients.length > 0;
+    const hasScopes = data.allowedScopes && data.allowedScopes.length > 0;
+    const hasClaims = data.customClaims && data.customClaims.length > 0;
+    if (!hasAudience && !hasClients && !hasScopes && !hasClaims) {
+      ctx.addIssue({
+        code: "custom",
+        message:
+          "At least one of allowedAudience, allowedClients, allowedScopes, or customClaims must be provided",
+      });
+    }
+    const overrides = data.privateEndpointOverrides ?? [];
+    if (overrides.length > 0) {
+      if (!data.privateEndpoint) {
+        ctx.addIssue({
+          code: "custom",
+          message: "privateEndpointOverrides can only be used when privateEndpoint is also set",
+          path: ["privateEndpointOverrides"],
+        });
+      } else {
+        const baseArm = privateEndpointArm(data.privateEndpoint);
+        overrides.forEach((o, i) => {
+          if (privateEndpointArm(o.privateEndpoint) !== baseArm) {
+            ctx.addIssue({
+              code: "custom",
+              message:
+                "privateEndpoint and privateEndpointOverrides must all be the same kind — either all selfManagedLatticeResource or all managedVpcResource",
+              path: ["privateEndpointOverrides", i, "privateEndpoint"],
+            });
+          }
+        });
+      }
+      const seen = new Set<string>();
+      overrides.forEach((o, i) => {
+        if (seen.has(o.domain)) {
+          ctx.addIssue({
+            code: "custom",
+            message: `Duplicate privateEndpointOverride domain: ${o.domain}`,
+            path: ["privateEndpointOverrides", i, "domain"],
+          });
+        }
+        seen.add(o.domain);
+      });
+    }
+  });
+export type CustomJwtAuthorizerConfig = z.infer<typeof CustomJwtAuthorizerConfigSchema>;
+export const AuthorizerConfigSchema = z.object({
+  customJwtAuthorizer: CustomJwtAuthorizerConfigSchema.optional(),
+});
+export type AuthorizerConfig = z.infer<typeof AuthorizerConfigSchema>;
+export const GatewayAuthorizerConfigSchema = AuthorizerConfigSchema;
+export type GatewayAuthorizerConfig = AuthorizerConfig;

--- a/src/core/project/schema/config-bundle.ts
+++ b/src/core/project/schema/config-bundle.ts
@@ -1,0 +1,27 @@
+import { KmsKeyArnSchema } from "./evaluator";
+import { z } from "zod";
+export const ConfigBundleNameSchema = z
+  .string()
+  .min(1, "Name is required")
+  .max(100)
+  .regex(
+    /^[a-zA-Z][a-zA-Z0-9_]{0,99}$/,
+    "Must begin with a letter and contain only alphanumeric characters and underscores (max 100 chars)",
+  );
+export const ConfigBundleDescriptionSchema = z.string().min(1).max(500).optional();
+export const ComponentConfigurationSchema = z.object({
+  configuration: z.record(z.string(), z.unknown()),
+});
+export type ComponentConfiguration = z.infer<typeof ComponentConfigurationSchema>;
+export const ComponentConfigurationMapSchema = z.record(z.string(), ComponentConfigurationSchema);
+export type ComponentConfigurationMap = z.infer<typeof ComponentConfigurationMapSchema>;
+export const ConfigBundleSchema = z.object({
+  name: ConfigBundleNameSchema,
+  type: z.literal("ConfigurationBundle").default("ConfigurationBundle"),
+  description: ConfigBundleDescriptionSchema,
+  components: ComponentConfigurationMapSchema,
+  branchName: z.string().max(128).optional(),
+  commitMessage: z.string().max(500).optional(),
+  kmsKeyArn: KmsKeyArnSchema.optional(),
+});
+export type ConfigBundle = z.infer<typeof ConfigBundleSchema>;

--- a/src/core/project/schema/connections.ts
+++ b/src/core/project/schema/connections.ts
@@ -1,0 +1,94 @@
+import { z } from "zod";
+export const GatewayGrantTypeSchema = z.enum([
+  "CLIENT_CREDENTIALS",
+  "AUTHORIZATION_CODE",
+  "TOKEN_EXCHANGE",
+]);
+export type GatewayGrantType = z.infer<typeof GatewayGrantTypeSchema>;
+export const GatewayOutboundAuthSchema = z.union([
+  z.object({ awsIam: z.object({}).strict() }).strict(),
+  z.object({ none: z.object({}).strict() }).strict(),
+  z
+    .object({
+      oauth: z
+        .object({
+          providerArn: z.string().min(1),
+          scopes: z.array(z.string().min(1)),
+          grantType: GatewayGrantTypeSchema.optional(),
+          customParameters: z.record(z.string(), z.string()).optional(),
+        })
+        .strict(),
+    })
+    .strict(),
+]);
+export type GatewayOutboundAuth = z.infer<typeof GatewayOutboundAuthSchema>;
+const MEMORY_ARN_PATTERN = /^arn:[^:]+:bedrock-agentcore:[a-z0-9-]+:\d{12}:memory\/.+$/;
+const GATEWAY_ARN_PATTERN = /^arn:[^:]+:bedrock-agentcore:[a-z0-9-]+:\d{12}:gateway\/.+$/;
+const RUNTIME_ARN_PATTERN = /^arn:[^:]+:bedrock-agentcore:[a-z0-9-]+:\d{12}:runtime\/.+$/;
+export const BROWSER_ARN_PATTERN =
+  /^arn:[^:]+:bedrock-agentcore:[a-z0-9-]+:(\d{12}|aws):browser(-custom)?\/.+$/;
+export const CODE_INTERPRETER_ARN_PATTERN =
+  /^arn:[^:]+:bedrock-agentcore:[a-z0-9-]+:(\d{12}|aws):code-interpreter(-custom)?\/.+$/;
+const MemoryTargetSchema = z
+  .object({
+    type: z.literal("memory"),
+    arn: z.string().regex(MEMORY_ARN_PATTERN, "Must be a valid bedrock-agentcore memory ARN"),
+    namespaces: z.array(z.string().min(1)).optional(),
+  })
+  .strict();
+const GatewayTargetSchema = z
+  .object({
+    type: z.literal("gateway"),
+    arn: z.string().regex(GATEWAY_ARN_PATTERN, "Must be a valid bedrock-agentcore gateway ARN"),
+    outboundAuth: GatewayOutboundAuthSchema.optional(),
+  })
+  .strict();
+const RuntimeTargetSchema = z
+  .object({
+    type: z.literal("runtime"),
+    arn: z.string().regex(RUNTIME_ARN_PATTERN, "Must be a valid bedrock-agentcore runtime ARN"),
+    exec: z.boolean().optional(),
+  })
+  .strict();
+const BrowserTargetSchema = z
+  .object({
+    type: z.literal("browser"),
+    arn: z
+      .string()
+      .regex(BROWSER_ARN_PATTERN, "Must be a valid bedrock-agentcore browser ARN")
+      .optional(),
+  })
+  .strict();
+const CodeInterpreterTargetSchema = z
+  .object({
+    type: z.literal("codeInterpreter"),
+    arn: z
+      .string()
+      .regex(CODE_INTERPRETER_ARN_PATTERN, "Must be a valid bedrock-agentcore code-interpreter ARN")
+      .optional(),
+  })
+  .strict();
+export const ConnectionTargetSchema = z.discriminatedUnion("type", [
+  MemoryTargetSchema,
+  GatewayTargetSchema,
+  RuntimeTargetSchema,
+  BrowserTargetSchema,
+  CodeInterpreterTargetSchema,
+]);
+export type ConnectionTarget = z.infer<typeof ConnectionTargetSchema>;
+export const ConnectionSchema = z
+  .object({
+    id: z
+      .string()
+      .regex(
+        /^[a-zA-Z][a-zA-Z0-9_-]{0,63}$/,
+        "Connection id must match [a-zA-Z][a-zA-Z0-9_-]{0,63}",
+      )
+      .optional(),
+    to: ConnectionTargetSchema,
+    access: z.enum(["read", "readwrite"]).optional(),
+    description: z.string().max(200).optional(),
+  })
+  .strict();
+export type Connection = z.infer<typeof ConnectionSchema>;
+export const ConnectionsSchema = z.array(ConnectionSchema);

--- a/src/core/project/schema/constants.ts
+++ b/src/core/project/schema/constants.ts
@@ -1,0 +1,85 @@
+import z from "zod";
+const RESERVED_PROJECT_NAMES: readonly string[] = [
+  "anthropic",
+  "autogen",
+  "autogenagentchat",
+  "autogenext",
+  "bedrock",
+  "bedrockagentcore",
+  "crewai",
+  "crewaitools",
+  "googleadk",
+  "googlegenerativeai",
+  "langchain",
+  "langchainanthropic",
+  "langchainaws",
+  "langchaingooglegenai",
+  "langchainmcpadapters",
+  "langchainopenai",
+  "langgraph",
+  "mcp",
+  "openai",
+  "openaiagents",
+  "strands",
+  "strandsagents",
+  "strandsagentstools",
+  "agui",
+  "aguistrands",
+  "aguilanggraph",
+  "aguiadk",
+  "aguiprotocol",
+  "vercelai",
+  "aisdk",
+  "httpx",
+  "pytest",
+  "pytestasyncio",
+  "pythondotenv",
+  "tiktoken",
+  "hatchling",
+  "setuptools",
+  "wheel",
+  "awsopentelemetrydistro",
+  "boto3",
+  "botocore",
+  "test",
+  "tests",
+  "src",
+  "lib",
+  "dist",
+  "build",
+  "env",
+  "venv",
+  "site",
+  "pip",
+  "uv",
+];
+export function isReservedProjectName(name: string): boolean {
+  return RESERVED_PROJECT_NAMES.includes(name.toLowerCase());
+}
+export const PythonRuntimeSchema = z.enum([
+  "PYTHON_3_10",
+  "PYTHON_3_11",
+  "PYTHON_3_12",
+  "PYTHON_3_13",
+  "PYTHON_3_14",
+]);
+export type PythonRuntime = z.infer<typeof PythonRuntimeSchema>;
+export const NodeRuntimeSchema = z.enum(["NODE_18", "NODE_20", "NODE_22"]);
+export type NodeRuntime = z.infer<typeof NodeRuntimeSchema>;
+export const RuntimeVersionSchema = z.union([PythonRuntimeSchema, NodeRuntimeSchema]);
+export type RuntimeVersion = z.infer<typeof RuntimeVersionSchema>;
+export const NetworkModeSchema = z.enum(["PUBLIC", "VPC"]);
+export type NetworkMode = z.infer<typeof NetworkModeSchema>;
+export const VPC_ID_PATTERN = /^vpc-(?:[0-9a-f]{8}|[0-9a-f]{17})$/;
+export const SUBNET_ID_PATTERN = /^subnet-(?:[0-9a-f]{8}|[0-9a-f]{17})$/;
+export const SECURITY_GROUP_ID_PATTERN = /^sg-(?:[0-9a-f]{8}|[0-9a-f]{17})$/;
+export const MAX_CONTAINER_BUILD_SECURITY_GROUPS = 5;
+export function isContainerBuild(spec: {
+  build?: string;
+  containerUri?: string;
+  dockerfile?: string;
+}): boolean {
+  return spec.build === "Container" || !!spec.containerUri || !!spec.dockerfile;
+}
+export const ProtocolModeSchema = z.enum(["HTTP", "MCP", "A2A", "AGUI"]);
+export type ProtocolMode = z.infer<typeof ProtocolModeSchema>;

--- a/src/core/project/schema/credential.ts
+++ b/src/core/project/schema/credential.ts
@@ -1,0 +1,43 @@
+import z from "zod";
+import { PaymentProviderSchema } from "./payment";
+export const CredentialNameSchema = z
+  .string()
+  .min(1, "Credential name is required")
+  .max(128, "Credential name must be 128 characters or less")
+  .regex(
+    /^[a-zA-Z0-9\-_]+$/,
+    "Must contain only alphanumeric characters, hyphens, and underscores (1-128 chars)",
+  );
+export const CredentialTypeSchema = z.enum([
+  "ApiKeyCredentialProvider",
+  "OAuthCredentialProvider",
+  "PaymentCredentialProvider",
+]);
+export type CredentialType = z.infer<typeof CredentialTypeSchema>;
+export const ApiKeyCredentialSchema = z.object({
+  authorizerType: z.literal("ApiKeyCredentialProvider"),
+  name: CredentialNameSchema,
+});
+export type ApiKeyCredential = z.infer<typeof ApiKeyCredentialSchema>;
+export const OAuthCredentialSchema = z.object({
+  authorizerType: z.literal("OAuthCredentialProvider"),
+  name: CredentialNameSchema,
+  discoveryUrl: z.string().url().optional(),
+  scopes: z.array(z.string()).optional(),
+  vendor: z.string().default("CustomOauth2"),
+  managed: z.boolean().optional(),
+  usage: z.enum(["inbound", "outbound"]).optional(),
+});
+export type OAuthCredential = z.infer<typeof OAuthCredentialSchema>;
+export const PaymentCredentialSchema = z.object({
+  authorizerType: z.literal("PaymentCredentialProvider"),
+  name: CredentialNameSchema,
+  provider: PaymentProviderSchema,
+});
+export type PaymentCredential = z.infer<typeof PaymentCredentialSchema>;
+export const CredentialSchema = z.discriminatedUnion("authorizerType", [
+  ApiKeyCredentialSchema,
+  OAuthCredentialSchema,
+  PaymentCredentialSchema,
+]);
+export type Credential = z.infer<typeof CredentialSchema>;

--- a/src/core/project/schema/dataset.ts
+++ b/src/core/project/schema/dataset.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+export const DatasetNameSchema = z
+  .string()
+  .min(1, "Dataset name is required")
+  .max(48)
+  .regex(
+    /^[a-zA-Z][a-zA-Z0-9_]{0,47}$/,
+    "Must begin with a letter and contain only alphanumeric characters and underscores (max 48 chars)",
+  );
+export const DatasetSchemaTypeSchema = z.enum([
+  "AGENTCORE_EVALUATION_PREDEFINED_V1",
+  "AGENTCORE_EVALUATION_SIMULATED_V1",
+]);
+export type DatasetSchemaType = z.infer<typeof DatasetSchemaTypeSchema>;
+export const DatasetManagedConfigSchema = z.object({
+  location: z.string().min(1),
+});
+export const DatasetConfigSchema = z.object({
+  managed: DatasetManagedConfigSchema,
+});
+export const DatasetSchema = z.object({
+  name: DatasetNameSchema,
+  schemaType: DatasetSchemaTypeSchema,
+  description: z.string().max(200).optional(),
+  config: DatasetConfigSchema,
+  kmsKeyArn: z
+    .string()
+    .regex(
+      /^arn:aws(-[a-z]+)*:kms:[a-zA-Z0-9-]*:[0-9]{12}:key\/[a-zA-Z0-9-]{36}$/,
+      "Must be a valid KMS key ARN",
+    )
+    .optional(),
+});
+export type Dataset = z.infer<typeof DatasetSchema>;

--- a/src/core/project/schema/evaluator.test.ts
+++ b/src/core/project/schema/evaluator.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "bun:test";
+import {
+  CodeBasedConfigSchema,
+  EvaluatorConfigSchema,
+  RatingScaleSchema,
+  isValidBedrockModelId,
+  isValidKmsKeyArn,
+} from "./evaluator";
+const numerical = [{ value: 1, label: "bad", definition: "Bad response" }];
+const categorical = [{ label: "pass", definition: "Passes" }];
+describe("evaluator custom validation", () => {
+  it("requires exactly one rating scale representation", () => {
+    expect(RatingScaleSchema.safeParse({ numerical }).success).toBe(true);
+    expect(RatingScaleSchema.safeParse({ numerical, categorical }).success).toBe(false);
+    expect(RatingScaleSchema.safeParse({}).success).toBe(false);
+  });
+  it("requires exactly one code-based implementation", () => {
+    const managed = { codeLocation: "./evaluator" };
+    const external = {
+      lambdaArn: "arn:aws:lambda:us-east-1:123456789012:function:evaluator",
+    };
+    expect(CodeBasedConfigSchema.safeParse({ managed }).success).toBe(true);
+    expect(CodeBasedConfigSchema.safeParse({ managed, external }).success).toBe(false);
+    expect(CodeBasedConfigSchema.safeParse({}).success).toBe(false);
+  });
+  it("requires exactly one evaluator configuration kind", () => {
+    const llmAsAJudge = { model: "model", instructions: "Judge", ratingScale: { numerical } };
+    const codeBased = { managed: { codeLocation: "./evaluator" } };
+    expect(EvaluatorConfigSchema.safeParse({ llmAsAJudge }).success).toBe(true);
+    expect(EvaluatorConfigSchema.safeParse({ llmAsAJudge, codeBased }).success).toBe(false);
+  });
+  it("validates model identifiers and KMS key ARNs through owned helpers", () => {
+    expect(isValidBedrockModelId("anthropic.claude-v2:1")).toBe(true);
+    expect(isValidBedrockModelId("not a model")).toBe(false);
+    expect(
+      isValidKmsKeyArn(
+        "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012",
+      ),
+    ).toBe(true);
+    expect(isValidKmsKeyArn("arn:aws:kms:us-east-1:123456789012:alias/example")).toBe(false);
+  });
+});

--- a/src/core/project/schema/evaluator.ts
+++ b/src/core/project/schema/evaluator.ts
@@ -1,0 +1,101 @@
+import { z } from "zod";
+import { TagsSchema } from "./tags";
+export const EvaluationLevelSchema = z.enum(["SESSION", "TRACE", "TOOL_CALL"]);
+export type EvaluationLevel = z.infer<typeof EvaluationLevelSchema>;
+export const EvaluatorNameSchema = z
+  .string()
+  .min(1, "Name is required")
+  .max(48)
+  .regex(
+    /^[a-zA-Z][a-zA-Z0-9_]{0,47}$/,
+    "Must begin with a letter and contain only alphanumeric characters and underscores (max 48 chars)",
+  );
+export const NumericalRatingSchema = z.object({
+  value: z.number().int(),
+  label: z.string().min(1),
+  definition: z.string().min(1),
+});
+export type NumericalRating = z.infer<typeof NumericalRatingSchema>;
+export const CategoricalRatingSchema = z.object({
+  label: z.string().min(1),
+  definition: z.string().min(1),
+});
+export type CategoricalRating = z.infer<typeof CategoricalRatingSchema>;
+export const RatingScaleSchema = z
+  .object({
+    numerical: z.array(NumericalRatingSchema).optional(),
+    categorical: z.array(CategoricalRatingSchema).optional(),
+  })
+  .refine(
+    (scale) => {
+      const hasNumerical = Boolean(scale.numerical);
+      const hasCategorical = Boolean(scale.categorical);
+      return hasNumerical !== hasCategorical;
+    },
+    { message: "Rating scale must have either numerical or categorical, not both" },
+  );
+export type RatingScale = z.infer<typeof RatingScaleSchema>;
+const BEDROCK_MODEL_ID_PATTERN = /^[a-z][a-z0-9-]*\.[a-zA-Z0-9._-]+(:[0-9]+)?$/;
+const BEDROCK_ARN_PATTERN =
+  /^arn:aws[a-z-]*:bedrock:[a-z0-9-]+:\d{12}:(inference-profile|foundation-model)\/.+$/;
+export function isValidBedrockModelId(value: string): boolean {
+  return BEDROCK_MODEL_ID_PATTERN.test(value) || BEDROCK_ARN_PATTERN.test(value);
+}
+export const BedrockModelIdSchema = z.string().min(1, "Model ID is required");
+export const LlmAsAJudgeConfigSchema = z.object({
+  model: BedrockModelIdSchema,
+  instructions: z.string().min(1, "Evaluation instructions are required"),
+  ratingScale: RatingScaleSchema,
+});
+export type LlmAsAJudgeConfig = z.infer<typeof LlmAsAJudgeConfigSchema>;
+export const ManagedCodeBasedConfigSchema = z.object({
+  codeLocation: z.string().min(1),
+  entrypoint: z.string().min(1).default("lambda_function.handler"),
+  timeoutSeconds: z.number().int().min(1).max(300).default(60),
+  additionalPolicies: z.array(z.string().min(1)).optional(),
+});
+export type ManagedCodeBasedConfig = z.infer<typeof ManagedCodeBasedConfigSchema>;
+const LAMBDA_ARN_PATTERN = /^arn:aws[a-z-]*:lambda:[a-z0-9-]+:\d{12}:function:.+$/;
+export const ExternalCodeBasedConfigSchema = z.object({
+  lambdaArn: z.string().min(1).regex(LAMBDA_ARN_PATTERN, "Must be a valid Lambda function ARN"),
+});
+export type ExternalCodeBasedConfig = z.infer<typeof ExternalCodeBasedConfigSchema>;
+export const CodeBasedConfigSchema = z
+  .object({
+    managed: ManagedCodeBasedConfigSchema.optional(),
+    external: ExternalCodeBasedConfigSchema.optional(),
+  })
+  .refine((config) => Boolean(config.managed) !== Boolean(config.external), {
+    message: "Code-based config must have either managed or external, not both",
+  });
+export type CodeBasedConfig = z.infer<typeof CodeBasedConfigSchema>;
+export const EvaluatorConfigSchema = z
+  .object({
+    llmAsAJudge: LlmAsAJudgeConfigSchema.optional(),
+    codeBased: CodeBasedConfigSchema.optional(),
+  })
+  .refine((config) => Boolean(config.llmAsAJudge) !== Boolean(config.codeBased), {
+    message: "Config must have either llmAsAJudge or codeBased, not both",
+  });
+export type EvaluatorConfig = z.infer<typeof EvaluatorConfigSchema>;
+export const KMS_KEY_ARN_PATTERN = /^arn:[^:]+:kms:[a-zA-Z0-9-]*:[0-9]{12}:key\/[a-zA-Z0-9-]{36}$/;
+export const KmsKeyArnSchema = z
+  .string()
+  .regex(
+    KMS_KEY_ARN_PATTERN,
+    "Must be a valid KMS key ARN (e.g. arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012)",
+  );
+export function isValidKmsKeyArn(value: string): boolean {
+  return KMS_KEY_ARN_PATTERN.test(value);
+}
+export const EvaluatorTypeSchema = z.literal("CustomEvaluator");
+export type EvaluatorType = z.infer<typeof EvaluatorTypeSchema>;
+export const EvaluatorSchema = z.object({
+  name: EvaluatorNameSchema,
+  level: EvaluationLevelSchema,
+  description: z.string().optional(),
+  config: EvaluatorConfigSchema,
+  kmsKeyArn: KmsKeyArnSchema.optional(),
+  tags: TagsSchema.optional(),
+});
+export type Evaluator = z.infer<typeof EvaluatorSchema>;

--- a/src/core/project/schema/gateway.test.ts
+++ b/src/core/project/schema/gateway.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "bun:test";
+import {
+  AgentCoreGatewaySchema,
+  AgentCoreGatewayTargetSchema,
+  ToolComputeConfigSchema,
+} from "./gateway";
+const toolDefinition = {
+  name: "tool",
+  description: "A tool",
+  inputSchema: { type: "object" as const },
+};
+const lambdaCompute = {
+  host: "Lambda" as const,
+  implementation: { language: "Python" as const, path: "tools", handler: "handler.main" },
+  pythonVersion: "PYTHON_3_12" as const,
+};
+describe("gateway custom validation", () => {
+  it("binds compute runtime versions to implementation languages", () => {
+    expect(
+      ToolComputeConfigSchema.safeParse({
+        host: "Lambda",
+        implementation: { language: "TypeScript", path: "tools", handler: "index.handler" },
+      }).success,
+    ).toBe(false);
+    expect(
+      ToolComputeConfigSchema.safeParse({
+        host: "Lambda",
+        implementation: { language: "Python", path: "tools", handler: "handler.main" },
+      }).success,
+    ).toBe(false);
+    expect(
+      ToolComputeConfigSchema.safeParse({
+        host: "AgentCoreRuntime",
+        implementation: { language: "TypeScript", path: "tools", handler: "index.handler" },
+      }).success,
+    ).toBe(false);
+  });
+  it.each([
+    ["apiGateway", {}],
+    ["openApiSchema", {}],
+    ["smithyModel", {}],
+    ["lambdaFunctionArn", {}],
+    ["mcpServer", {}],
+    ["httpRuntime", {}],
+    ["passthrough", {}],
+    ["lambda", { toolDefinitions: [toolDefinition] }],
+    ["lambda", { compute: lambdaCompute }],
+    ["connector", {}],
+  ])("enforces required configuration for %s targets", (targetType, extra) => {
+    const result = AgentCoreGatewayTargetSchema.safeParse({
+      name: "target",
+      targetType,
+      ...extra,
+    });
+    expect(result.success).toBe(false);
+  });
+  it.each([
+    [
+      "apiGateway",
+      {
+        apiGateway: {
+          restApiId: "api",
+          stage: "prod",
+          apiGatewayToolConfiguration: { toolFilters: [{ filterPath: "/*", methods: ["GET"] }] },
+        },
+        endpoint: "https://example.com",
+      },
+    ],
+    [
+      "openApiSchema",
+      {
+        schemaSource: { inline: { path: "openapi.json" } },
+        outboundAuth: { type: "OAUTH", credentialName: "oauth" },
+        compute: lambdaCompute,
+      },
+    ],
+    [
+      "lambdaFunctionArn",
+      {
+        lambdaFunctionArn: {
+          lambdaArn: "arn:aws:lambda:us-east-1:123456789012:function:tool",
+          toolSchemaFile: "tools.json",
+        },
+        outboundAuth: { type: "NONE" },
+      },
+    ],
+    ["httpRuntime", { httpRuntime: { runtime: "agent" }, endpoint: "https://example.com" }],
+    ["connector", { connectorId: "web-search", schemaSource: { inline: { path: "schema.json" } } }],
+  ])("rejects configuration that is not applicable to %s targets", (targetType, extra) => {
+    const result = AgentCoreGatewayTargetSchema.safeParse({
+      name: "target",
+      targetType,
+      ...extra,
+    });
+    expect(result.success).toBe(false);
+  });
+  it("centralizes outbound authentication rules by target type", () => {
+    const openApi = {
+      name: "openapi",
+      targetType: "openApiSchema",
+      schemaSource: { inline: { path: "openapi.json" } },
+    };
+    expect(AgentCoreGatewayTargetSchema.safeParse(openApi).success).toBe(false);
+    expect(
+      AgentCoreGatewayTargetSchema.safeParse({
+        ...openApi,
+        outboundAuth: { type: "OAUTH" },
+      }).success,
+    ).toBe(false);
+    expect(
+      AgentCoreGatewayTargetSchema.safeParse({
+        ...openApi,
+        outboundAuth: { type: "OAUTH", credentialName: "oauth" },
+      }).success,
+    ).toBe(true);
+    expect(
+      AgentCoreGatewayTargetSchema.safeParse({
+        name: "http",
+        targetType: "httpRuntime",
+        httpRuntime: { runtime: "agent" },
+        outboundAuth: { type: "API_KEY", credentialName: "key" },
+      }).success,
+    ).toBe(false);
+  });
+  it("limits passthrough-only authentication modes", () => {
+    expect(
+      AgentCoreGatewayTargetSchema.safeParse({
+        name: "mcp",
+        targetType: "mcpServer",
+        endpoint: "https://example.com/mcp",
+        outboundAuth: { type: "JWT_PASSTHROUGH" },
+      }).success,
+    ).toBe(false);
+    expect(
+      AgentCoreGatewayTargetSchema.safeParse({
+        name: "pass",
+        targetType: "passthrough",
+        passthrough: { endpoint: "https://example.com", protocolType: "CUSTOM" },
+        outboundAuth: { type: "GATEWAY_IAM_ROLE" },
+      }).success,
+    ).toBe(false);
+    expect(
+      AgentCoreGatewayTargetSchema.safeParse({
+        name: "pass",
+        targetType: "passthrough",
+        passthrough: { endpoint: "https://example.com", protocolType: "CUSTOM" },
+        outboundAuth: { type: "GATEWAY_IAM_ROLE", service: "execute-api" },
+      }).success,
+    ).toBe(true);
+  });
+  it("requires JWT configuration when a gateway selects CUSTOM_JWT", () => {
+    const gateway = { name: "gateway", targets: [] };
+    expect(
+      AgentCoreGatewaySchema.safeParse({ ...gateway, authorizerType: "CUSTOM_JWT" }).success,
+    ).toBe(false);
+    expect(
+      AgentCoreGatewaySchema.safeParse({
+        ...gateway,
+        authorizerType: "CUSTOM_JWT",
+        authorizerConfiguration: {
+          customJwtAuthorizer: {
+            discoveryUrl: "https://example.com/.well-known/openid-configuration",
+            allowedAudience: ["audience"],
+          },
+        },
+      }).success,
+    ).toBe(true);
+  });
+  it("allows HTTP targets only on protocolType None gateways", () => {
+    const target = {
+      name: "runtime",
+      targetType: "httpRuntime",
+      httpRuntime: { runtime: "agent" },
+    };
+    expect(AgentCoreGatewaySchema.safeParse({ name: "gateway", targets: [target] }).success).toBe(
+      false,
+    );
+    expect(
+      AgentCoreGatewaySchema.safeParse({
+        name: "gateway",
+        protocolType: "None",
+        targets: [target],
+      }).success,
+    ).toBe(true);
+  });
+});

--- a/src/core/project/schema/gateway.ts
+++ b/src/core/project/schema/gateway.ts
@@ -1,0 +1,786 @@
+import { NetworkModeSchema, NodeRuntimeSchema, PythonRuntimeSchema } from "./constants";
+import type { DirectoryPath, FilePath } from "./types";
+import { EnvVarNameSchema, GatewayNameSchema } from "./runtime";
+import { GatewayAuthorizerConfigSchema, GatewayAuthorizerTypeSchema } from "./auth";
+import { ToolDefinitionSchema } from "./mcp-defs";
+import { TagsSchema } from "./tags";
+import { z } from "zod";
+export const GatewayTargetTypeSchema = z.enum([
+  "lambda",
+  "mcpServer",
+  "openApiSchema",
+  "smithyModel",
+  "apiGateway",
+  "lambdaFunctionArn",
+  "httpRuntime",
+  "connector",
+  "passthrough",
+]);
+export type GatewayTargetType = z.infer<typeof GatewayTargetTypeSchema>;
+export const NON_MCP_TARGET_TYPES: readonly GatewayTargetType[] = [
+  "httpRuntime",
+  "passthrough",
+] as const;
+export const MCP_TARGET_TYPES: readonly GatewayTargetType[] = [
+  "lambda",
+  "mcpServer",
+  "openApiSchema",
+  "smithyModel",
+  "apiGateway",
+  "lambdaFunctionArn",
+] as const;
+export const CONNECTOR_ID = {
+  BEDROCK_KNOWLEDGE_BASES: "bedrock-knowledge-bases",
+  WEB_SEARCH: "web-search",
+} as const;
+export const CONNECTOR_ID_VALUES = [
+  CONNECTOR_ID.BEDROCK_KNOWLEDGE_BASES,
+  CONNECTOR_ID.WEB_SEARCH,
+] as const;
+export const ConnectorIdSchema = z.enum(CONNECTOR_ID_VALUES);
+export type ConnectorId = z.infer<typeof ConnectorIdSchema>;
+export const REAL_KB_ID_PATTERN = /^[A-Z0-9]{10}$/;
+export const OutboundAuthTypeSchema = z.enum([
+  "OAUTH",
+  "API_KEY",
+  "NONE",
+  "GATEWAY_IAM_ROLE",
+  "JWT_PASSTHROUGH",
+]);
+export type OutboundAuthType = z.infer<typeof OutboundAuthTypeSchema>;
+export const OutboundAuthSchema = z
+  .object({
+    type: OutboundAuthTypeSchema.default("NONE"),
+    credentialName: z.string().min(1).optional(),
+    scopes: z.array(z.string()).optional(),
+    service: z.string().min(1).max(64).optional(),
+    region: z.string().min(1).max(32).optional(),
+  })
+  .strict();
+export type OutboundAuth = z.infer<typeof OutboundAuthSchema>;
+export const TARGET_TYPE_AUTH_CONFIG: Record<
+  GatewayTargetType,
+  {
+    authRequired: boolean;
+    validAuthTypes: readonly OutboundAuthType[];
+    iamRoleFallback: boolean;
+  }
+> = {
+  openApiSchema: {
+    authRequired: true,
+    validAuthTypes: ["OAUTH", "API_KEY"],
+    iamRoleFallback: false,
+  },
+  smithyModel: { authRequired: false, validAuthTypes: [], iamRoleFallback: true },
+  apiGateway: { authRequired: false, validAuthTypes: ["API_KEY", "NONE"], iamRoleFallback: true },
+  mcpServer: { authRequired: false, validAuthTypes: ["OAUTH", "NONE"], iamRoleFallback: false },
+  lambda: { authRequired: false, validAuthTypes: ["OAUTH", "NONE"], iamRoleFallback: true },
+  lambdaFunctionArn: {
+    authRequired: false,
+    validAuthTypes: ["OAUTH", "NONE"],
+    iamRoleFallback: true,
+  },
+  httpRuntime: { authRequired: false, validAuthTypes: ["OAUTH", "NONE"], iamRoleFallback: true },
+  connector: { authRequired: false, validAuthTypes: [], iamRoleFallback: true },
+  passthrough: {
+    authRequired: true,
+    validAuthTypes: ["GATEWAY_IAM_ROLE", "OAUTH", "JWT_PASSTHROUGH"],
+    iamRoleFallback: false,
+  },
+};
+export const ApiGatewayHttpMethodSchema = z.enum([
+  "GET",
+  "POST",
+  "PUT",
+  "DELETE",
+  "PATCH",
+  "HEAD",
+  "OPTIONS",
+]);
+export type ApiGatewayHttpMethod = z.infer<typeof ApiGatewayHttpMethodSchema>;
+export const ApiGatewayToolFilterSchema = z
+  .object({
+    filterPath: z.string().min(1),
+    methods: z.array(ApiGatewayHttpMethodSchema).min(1),
+  })
+  .strict();
+export const ApiGatewayToolOverrideSchema = z
+  .object({
+    name: z.string().min(1),
+    path: z.string().min(1),
+    method: ApiGatewayHttpMethodSchema,
+    description: z.string().optional(),
+  })
+  .strict();
+export const ApiGatewayToolConfigurationSchema = z
+  .object({
+    toolFilters: z.array(ApiGatewayToolFilterSchema).min(1),
+    toolOverrides: z.array(ApiGatewayToolOverrideSchema).optional(),
+  })
+  .strict();
+export const ApiGatewayConfigSchema = z
+  .object({
+    restApiId: z.string().min(1),
+    stage: z.string().min(1),
+    apiGatewayToolConfiguration: ApiGatewayToolConfigurationSchema,
+  })
+  .strict();
+export type ApiGatewayConfig = z.infer<typeof ApiGatewayConfigSchema>;
+export const LambdaFunctionArnConfigSchema = z
+  .object({
+    lambdaArn: z.string().min(1).max(170),
+    toolSchemaFile: z.string().min(1),
+  })
+  .strict();
+export type LambdaFunctionArnConfig = z.infer<typeof LambdaFunctionArnConfigSchema>;
+export const McpImplLanguageSchema = z.enum(["TypeScript", "Python"]);
+export type McpImplementationLanguage = z.infer<typeof McpImplLanguageSchema>;
+export const ComputeHostSchema = z.enum(["Lambda", "AgentCoreRuntime"]);
+export type ComputeHost = z.infer<typeof ComputeHostSchema>;
+const DirectoryPathSchema = z.string().min(1) as unknown as z.ZodType<DirectoryPath>;
+export const ToolImplementationBindingSchema = z
+  .object({
+    language: z.enum(["TypeScript", "Python"]),
+    path: z.string().min(1),
+    handler: z.string().min(1),
+  })
+  .strict();
+export type ToolImplementationBinding = z.infer<typeof ToolImplementationBindingSchema>;
+export const IamPolicyDocumentSchema = z
+  .object({
+    Version: z.string(),
+    Statement: z.array(z.unknown()),
+  })
+  .passthrough();
+export type IamPolicyDocument = z.infer<typeof IamPolicyDocumentSchema>;
+const AgentRuntimeNameSchema = z
+  .string()
+  .min(1)
+  .max(48)
+  .regex(
+    /^[a-zA-Z][a-zA-Z0-9_]{0,47}$/,
+    "Must begin with a letter and contain only alphanumeric characters and underscores (max 48 chars)",
+  );
+const PythonEntrypointSchema = z
+  .string()
+  .min(1)
+  .regex(
+    /^[a-zA-Z0-9_][a-zA-Z0-9_/.-]*\.py(:[a-zA-Z_][a-zA-Z0-9_]*)?$/,
+    'Must be a Python file path with optional handler (e.g., "main.py:agent" or "src/handler.py:app")',
+  ) as unknown as z.ZodType<FilePath>;
+const InstrumentationSchema = z.object({
+  enableOtel: z.boolean().default(true),
+});
+const CodeZipRuntimeConfigSchema = z
+  .object({
+    artifact: z.literal("CodeZip"),
+    pythonVersion: PythonRuntimeSchema,
+    name: AgentRuntimeNameSchema,
+    entrypoint: PythonEntrypointSchema,
+    codeLocation: DirectoryPathSchema,
+    instrumentation: InstrumentationSchema.optional(),
+    networkMode: NetworkModeSchema.optional().default("PUBLIC"),
+    description: z.string().optional(),
+  })
+  .strict();
+export type CodeZipRuntimeConfig = z.infer<typeof CodeZipRuntimeConfigSchema>;
+export const RuntimeConfigSchema = CodeZipRuntimeConfigSchema;
+export type RuntimeConfig = z.infer<typeof RuntimeConfigSchema>;
+const LambdaComputeConfigSchema = z
+  .object({
+    host: z.literal("Lambda"),
+    implementation: ToolImplementationBindingSchema,
+    nodeVersion: NodeRuntimeSchema.optional(),
+    pythonVersion: PythonRuntimeSchema.optional(),
+    timeout: z.number().int().min(1).max(900).optional(),
+    memorySize: z.number().int().min(128).max(10240).optional(),
+    iamPolicy: IamPolicyDocumentSchema.optional(),
+  })
+  .strict()
+  .refine(
+    (data) => {
+      if (data.implementation.language === "TypeScript" && !data.nodeVersion) {
+        return false;
+      }
+      if (data.implementation.language === "Python" && !data.pythonVersion) {
+        return false;
+      }
+      return true;
+    },
+    {
+      message:
+        "TypeScript Lambda must specify nodeVersion, Python Lambda must specify pythonVersion",
+    },
+  );
+export type LambdaComputeConfig = z.infer<typeof LambdaComputeConfigSchema>;
+const AgentCoreRuntimeComputeConfigSchema = z
+  .object({
+    host: z.literal("AgentCoreRuntime"),
+    implementation: ToolImplementationBindingSchema,
+    runtime: RuntimeConfigSchema.optional(),
+    iamPolicy: IamPolicyDocumentSchema.optional(),
+  })
+  .strict()
+  .refine((data) => data.implementation.language === "Python", {
+    message: "AgentCore Runtime only supports Python",
+  });
+export type AgentCoreRuntimeComputeConfig = z.infer<typeof AgentCoreRuntimeComputeConfigSchema>;
+export const ToolComputeConfigSchema = z.discriminatedUnion("host", [
+  LambdaComputeConfigSchema,
+  AgentCoreRuntimeComputeConfigSchema,
+]);
+export type ToolComputeConfig = z.infer<typeof ToolComputeConfigSchema>;
+const SchemaS3SourceSchema = z
+  .object({
+    uri: z.string().min(1).startsWith("s3://"),
+    bucketOwnerAccountId: z.string().optional(),
+  })
+  .strict();
+const SchemaInlineSourceSchema = z
+  .object({
+    path: z.string().min(1),
+  })
+  .strict();
+export const SchemaSourceSchema = z.union([
+  z.object({ inline: SchemaInlineSourceSchema }).strict(),
+  z.object({ s3: SchemaS3SourceSchema }).strict(),
+]);
+export type SchemaSource = z.infer<typeof SchemaSourceSchema>;
+export const HttpRuntimeConfigSchema = z
+  .object({
+    runtime: z.string().min(1),
+    runtimeEndpoint: z.string().min(1).optional(),
+  })
+  .strict();
+export type HttpRuntimeConfig = z.infer<typeof HttpRuntimeConfigSchema>;
+export const StickinessConfigSchema = z
+  .object({
+    identifier: z.string().min(1).max(256),
+    timeout: z.number().int().min(1).max(86400).optional(),
+  })
+  .strict();
+export type StickinessConfig = z.infer<typeof StickinessConfigSchema>;
+export const PassthroughProtocolTypeSchema = z.enum(["MCP", "A2A", "INFERENCE", "CUSTOM"]);
+export type PassthroughProtocolType = z.infer<typeof PassthroughProtocolTypeSchema>;
+export const PassthroughConfigSchema = z
+  .object({
+    endpoint: z
+      .string()
+      .min(1)
+      .regex(/^https:\/\/[a-zA-Z0-9\-.]+(:[0-9]{1,5})?(\/.*)?$/, "Must be a valid HTTPS URL"),
+    protocolType: PassthroughProtocolTypeSchema.default("CUSTOM"),
+    stickinessConfiguration: StickinessConfigSchema.optional(),
+  })
+  .strict();
+export type PassthroughConfig = z.infer<typeof PassthroughConfigSchema>;
+export const AgentCoreGatewayTargetSchema = z
+  .object({
+    name: z.string().min(1),
+    targetType: GatewayTargetTypeSchema,
+    toolDefinitions: z.array(ToolDefinitionSchema).optional(),
+    compute: ToolComputeConfigSchema.optional(),
+    endpoint: z.string().url().optional(),
+    outboundAuth: OutboundAuthSchema.optional(),
+    apiGateway: ApiGatewayConfigSchema.optional(),
+    schemaSource: SchemaSourceSchema.optional(),
+    lambdaFunctionArn: LambdaFunctionArnConfigSchema.optional(),
+    httpRuntime: HttpRuntimeConfigSchema.optional(),
+    connectorId: ConnectorIdSchema.optional(),
+    configurations: z
+      .array(
+        z.object({
+          name: z.string(),
+          description: z.string().optional(),
+          parameterValues: z.record(z.string(), z.unknown()).optional(),
+          parameterOverrides: z
+            .array(
+              z.object({
+                path: z.string(),
+                description: z.string().optional(),
+                visible: z.boolean().optional(),
+              }),
+            )
+            .optional(),
+        }),
+      )
+      .optional(),
+    passthrough: PassthroughConfigSchema.optional(),
+  })
+  .strict()
+  .superRefine((data, ctx) => {
+    if (data.targetType === "apiGateway") {
+      if (!data.apiGateway) {
+        ctx.addIssue({
+          code: "custom",
+          message: "apiGateway config is required for apiGateway target type",
+          path: ["apiGateway"],
+        });
+      }
+      if (data.compute) {
+        ctx.addIssue({
+          code: "custom",
+          message: "compute is not applicable for apiGateway target type",
+          path: ["compute"],
+        });
+      }
+      if (data.endpoint) {
+        ctx.addIssue({
+          code: "custom",
+          message: "endpoint is not applicable for apiGateway target type",
+          path: ["endpoint"],
+        });
+      }
+      if (data.toolDefinitions && data.toolDefinitions.length > 0) {
+        ctx.addIssue({
+          code: "custom",
+          message:
+            "toolDefinitions is not applicable for apiGateway target type (tools are auto-discovered)",
+          path: ["toolDefinitions"],
+        });
+      }
+      if (data.lambdaFunctionArn) {
+        ctx.addIssue({
+          code: "custom",
+          message: "lambdaFunctionArn is not applicable for apiGateway target type",
+          path: ["lambdaFunctionArn"],
+        });
+      }
+    }
+    if (data.targetType === "openApiSchema" || data.targetType === "smithyModel") {
+      if (!data.schemaSource) {
+        ctx.addIssue({
+          code: "custom",
+          message: `${data.targetType} targets require a schemaSource.`,
+          path: ["schemaSource"],
+        });
+      }
+      if (data.compute) {
+        ctx.addIssue({
+          code: "custom",
+          message: `compute is not applicable for ${data.targetType} target type`,
+          path: ["compute"],
+        });
+      }
+      if (data.endpoint) {
+        ctx.addIssue({
+          code: "custom",
+          message: `endpoint is not applicable for ${data.targetType} target type`,
+          path: ["endpoint"],
+        });
+      }
+      if (data.toolDefinitions && data.toolDefinitions.length > 0) {
+        ctx.addIssue({
+          code: "custom",
+          message: `toolDefinitions is not applicable for ${data.targetType} target type`,
+          path: ["toolDefinitions"],
+        });
+      }
+      if (data.apiGateway) {
+        ctx.addIssue({
+          code: "custom",
+          message: `apiGateway config is not applicable for ${data.targetType} target type`,
+          path: ["apiGateway"],
+        });
+      }
+    }
+    if (data.targetType === "lambdaFunctionArn") {
+      if (!data.lambdaFunctionArn) {
+        ctx.addIssue({
+          code: "custom",
+          message: "lambdaFunctionArn config is required for lambdaFunctionArn target type",
+          path: ["lambdaFunctionArn"],
+        });
+      }
+      if (data.compute) {
+        ctx.addIssue({
+          code: "custom",
+          message: "compute is not applicable for lambdaFunctionArn target type",
+          path: ["compute"],
+        });
+      }
+      if (data.endpoint) {
+        ctx.addIssue({
+          code: "custom",
+          message: "endpoint is not applicable for lambdaFunctionArn target type",
+          path: ["endpoint"],
+        });
+      }
+      if (data.apiGateway) {
+        ctx.addIssue({
+          code: "custom",
+          message: "apiGateway is not applicable for lambdaFunctionArn target type",
+          path: ["apiGateway"],
+        });
+      }
+      if (data.outboundAuth) {
+        ctx.addIssue({
+          code: "custom",
+          message: "outboundAuth is not applicable for lambdaFunctionArn target type",
+          path: ["outboundAuth"],
+        });
+      }
+      if (data.toolDefinitions && data.toolDefinitions.length > 0) {
+        ctx.addIssue({
+          code: "custom",
+          message:
+            "toolDefinitions is not applicable for lambdaFunctionArn target type (tools are defined via toolSchemaFile)",
+          path: ["toolDefinitions"],
+        });
+      }
+    }
+    if (data.targetType === "mcpServer") {
+      if (!data.compute && !data.endpoint) {
+        ctx.addIssue({
+          code: "custom",
+          message: "MCP Server targets require either an endpoint URL or compute configuration.",
+        });
+      }
+      if (data.apiGateway) {
+        ctx.addIssue({
+          code: "custom",
+          message: "apiGateway is not applicable for mcpServer target type",
+          path: ["apiGateway"],
+        });
+      }
+      if (data.lambdaFunctionArn) {
+        ctx.addIssue({
+          code: "custom",
+          message: "lambdaFunctionArn is not applicable for mcpServer target type",
+          path: ["lambdaFunctionArn"],
+        });
+      }
+    }
+    if (data.targetType === "httpRuntime") {
+      if (!data.httpRuntime) {
+        ctx.addIssue({
+          code: "custom",
+          message:
+            "httpRuntime targets require an httpRuntime configuration (with a runtime reference).",
+          path: ["httpRuntime"],
+        });
+      }
+      if (data.endpoint) {
+        ctx.addIssue({
+          code: "custom",
+          message:
+            "httpRuntime targets should use httpRuntime.runtimeEndpoint instead of endpoint.",
+          path: ["endpoint"],
+        });
+      }
+      if (data.compute) {
+        ctx.addIssue({
+          code: "custom",
+          message: "compute is not applicable for httpRuntime target type",
+          path: ["compute"],
+        });
+      }
+      if (data.apiGateway) {
+        ctx.addIssue({
+          code: "custom",
+          message: "apiGateway is not applicable for httpRuntime target type",
+          path: ["apiGateway"],
+        });
+      }
+      if (data.lambdaFunctionArn) {
+        ctx.addIssue({
+          code: "custom",
+          message: "lambdaFunctionArn is not applicable for httpRuntime target type",
+          path: ["lambdaFunctionArn"],
+        });
+      }
+      if (data.toolDefinitions && data.toolDefinitions.length > 0) {
+        ctx.addIssue({
+          code: "custom",
+          message: "toolDefinitions is not applicable for httpRuntime target type",
+          path: ["toolDefinitions"],
+        });
+      }
+    }
+    if (data.targetType === "passthrough") {
+      if (!data.passthrough) {
+        ctx.addIssue({
+          code: "custom",
+          message: "passthrough targets require a passthrough configuration (with an endpoint).",
+          path: ["passthrough"],
+        });
+      }
+      if (data.endpoint) {
+        ctx.addIssue({
+          code: "custom",
+          message: "passthrough targets should use passthrough.endpoint instead of endpoint.",
+          path: ["endpoint"],
+        });
+      }
+      if (data.compute) {
+        ctx.addIssue({
+          code: "custom",
+          message: "compute is not applicable for passthrough target type",
+          path: ["compute"],
+        });
+      }
+      if (data.apiGateway) {
+        ctx.addIssue({
+          code: "custom",
+          message: "apiGateway is not applicable for passthrough target type",
+          path: ["apiGateway"],
+        });
+      }
+      if (data.lambdaFunctionArn) {
+        ctx.addIssue({
+          code: "custom",
+          message: "lambdaFunctionArn is not applicable for passthrough target type",
+          path: ["lambdaFunctionArn"],
+        });
+      }
+      if (data.httpRuntime) {
+        ctx.addIssue({
+          code: "custom",
+          message: "httpRuntime is not applicable for passthrough target type",
+          path: ["httpRuntime"],
+        });
+      }
+      if (data.toolDefinitions && data.toolDefinitions.length > 0) {
+        ctx.addIssue({
+          code: "custom",
+          message: "toolDefinitions is not applicable for passthrough target type",
+          path: ["toolDefinitions"],
+        });
+      }
+    }
+    if (data.targetType === "lambda" && !data.compute) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Lambda targets require compute configuration.",
+        path: ["compute"],
+      });
+    }
+    if (
+      data.targetType === "lambda" &&
+      (!data.toolDefinitions || data.toolDefinitions.length === 0)
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Lambda targets require at least one tool definition.",
+        path: ["toolDefinitions"],
+      });
+    }
+    if (data.targetType === "connector") {
+      if (!data.connectorId) {
+        ctx.addIssue({
+          code: "custom",
+          message: "connectorId is required for connector target type",
+          path: ["connectorId"],
+        });
+      }
+      if (data.compute) {
+        ctx.addIssue({
+          code: "custom",
+          message: "compute is not applicable for connector target type",
+          path: ["compute"],
+        });
+      }
+      if (data.endpoint) {
+        ctx.addIssue({
+          code: "custom",
+          message: "endpoint is not applicable for connector target type",
+          path: ["endpoint"],
+        });
+      }
+      if (data.toolDefinitions && data.toolDefinitions.length > 0) {
+        ctx.addIssue({
+          code: "custom",
+          message: "toolDefinitions is not applicable for connector target type",
+          path: ["toolDefinitions"],
+        });
+      }
+      if (data.apiGateway) {
+        ctx.addIssue({
+          code: "custom",
+          message: "apiGateway is not applicable for connector target type",
+          path: ["apiGateway"],
+        });
+      }
+      if (data.lambdaFunctionArn) {
+        ctx.addIssue({
+          code: "custom",
+          message: "lambdaFunctionArn is not applicable for connector target type",
+          path: ["lambdaFunctionArn"],
+        });
+      }
+      if (data.schemaSource) {
+        ctx.addIssue({
+          code: "custom",
+          message: "schemaSource is not applicable for connector target type",
+          path: ["schemaSource"],
+        });
+      }
+      if (data.httpRuntime) {
+        ctx.addIssue({
+          code: "custom",
+          message: "httpRuntime is not applicable for connector target type",
+          path: ["httpRuntime"],
+        });
+      }
+      if (data.passthrough) {
+        ctx.addIssue({
+          code: "custom",
+          message: "passthrough is not applicable for connector target type",
+          path: ["passthrough"],
+        });
+      }
+    }
+    if (data.targetType !== "connector") {
+      if (data.connectorId) {
+        ctx.addIssue({
+          code: "custom",
+          message: `connectorId only applies to connector target type`,
+          path: ["connectorId"],
+        });
+      }
+      if (data.configurations && data.configurations.length > 0) {
+        ctx.addIssue({
+          code: "custom",
+          message: `configurations only applies to connector target type`,
+          path: ["configurations"],
+        });
+      }
+    }
+    const authConfig = TARGET_TYPE_AUTH_CONFIG[data.targetType];
+    const authType = data.outboundAuth?.type ?? "NONE";
+    if (authConfig.authRequired && authType === "NONE") {
+      ctx.addIssue({
+        code: "custom",
+        message: `${data.targetType} targets require outbound auth (${authConfig.validAuthTypes.join(" or ")})`,
+        path: ["outboundAuth"],
+      });
+    }
+    if (authConfig.validAuthTypes.length === 0 && authType !== "NONE") {
+      ctx.addIssue({
+        code: "custom",
+        message: `${data.targetType} targets use IAM role auth; outboundAuth is not applicable`,
+        path: ["outboundAuth"],
+      });
+    }
+    if (
+      authConfig.validAuthTypes.length > 0 &&
+      authType !== "NONE" &&
+      !authConfig.validAuthTypes.includes(authType)
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message: `${data.targetType} targets do not support ${authType} outbound auth`,
+        path: ["outboundAuth"],
+      });
+    }
+    if (
+      data.outboundAuth &&
+      data.outboundAuth.type !== "NONE" &&
+      data.outboundAuth.type !== "GATEWAY_IAM_ROLE" &&
+      data.outboundAuth.type !== "JWT_PASSTHROUGH" &&
+      !data.outboundAuth.credentialName
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message: `${data.outboundAuth.type} outbound auth requires a credentialName.`,
+        path: ["outboundAuth", "credentialName"],
+      });
+    }
+    if (
+      data.targetType === "passthrough" &&
+      data.outboundAuth?.type === "GATEWAY_IAM_ROLE" &&
+      !data.outboundAuth.service
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message: "GATEWAY_IAM_ROLE outbound auth on passthrough targets requires a service name.",
+        path: ["outboundAuth", "service"],
+      });
+    }
+    if (data.outboundAuth?.type === "JWT_PASSTHROUGH" && data.targetType !== "passthrough") {
+      ctx.addIssue({
+        code: "custom",
+        message: "JWT_PASSTHROUGH outbound auth is only valid for passthrough targets.",
+        path: ["outboundAuth", "type"],
+      });
+    }
+  });
+export type AgentCoreGatewayTarget = z.infer<typeof AgentCoreGatewayTargetSchema>;
+export const GatewayExceptionLevelSchema = z.enum(["NONE", "DEBUG"]);
+export type GatewayExceptionLevel = z.infer<typeof GatewayExceptionLevelSchema>;
+export const PolicyEngineModeSchema = z.enum(["LOG_ONLY", "ENFORCE"]);
+export type PolicyEngineMode = z.infer<typeof PolicyEngineModeSchema>;
+export const GatewayPolicyEngineConfigurationSchema = z
+  .object({
+    policyEngineName: z.string().min(1),
+    mode: PolicyEngineModeSchema,
+  })
+  .strict();
+export type GatewayPolicyEngineConfiguration = z.infer<
+  typeof GatewayPolicyEngineConfigurationSchema
+>;
+export const GatewayProtocolTypeSchema = z.enum(["MCP", "None"]);
+export type GatewayProtocolType = z.infer<typeof GatewayProtocolTypeSchema>;
+export const AgentCoreGatewaySchema = z
+  .object({
+    name: GatewayNameSchema,
+    resourceName: GatewayNameSchema.optional(),
+    protocolType: GatewayProtocolTypeSchema.optional(),
+    description: z.string().optional(),
+    targets: z.array(AgentCoreGatewayTargetSchema),
+    authorizerType: GatewayAuthorizerTypeSchema.default("NONE"),
+    authorizerConfiguration: GatewayAuthorizerConfigSchema.optional(),
+    enableSemanticSearch: z.boolean().default(true),
+    exceptionLevel: GatewayExceptionLevelSchema.default("NONE"),
+    policyEngineConfiguration: GatewayPolicyEngineConfigurationSchema.optional(),
+    executionRoleArn: z
+      .string()
+      .regex(/^arn:[^:]+:iam::\d{12}:role\/.+/, "Must be a valid IAM role ARN")
+      .max(2048)
+      .optional(),
+    tags: TagsSchema.optional(),
+  })
+  .strict()
+  .refine(
+    (data) => {
+      if (data.authorizerType === "CUSTOM_JWT") {
+        return data.authorizerConfiguration?.customJwtAuthorizer !== undefined;
+      }
+      return true;
+    },
+    {
+      message: "customJwtAuthorizer configuration is required when authorizerType is CUSTOM_JWT",
+      path: ["authorizerConfiguration"],
+    },
+  )
+  .superRefine((gw, ctx) => {
+    for (const target of gw.targets) {
+      if (gw.protocolType !== "None" && NON_MCP_TARGET_TYPES.includes(target.targetType)) {
+        ctx.addIssue({
+          code: "custom",
+          message: `Target "${target.name}" is ${target.targetType} but gateway does not have protocolType: "None". Add --protocol-type None when creating the gateway.`,
+        });
+      }
+    }
+  });
+export type AgentCoreGateway = z.infer<typeof AgentCoreGatewaySchema>;
+export const McpRuntimeBindingSchema = z
+  .object({
+    runtimeName: z.string().min(1),
+    envVarName: EnvVarNameSchema,
+  })
+  .strict();
+export type McpRuntimeBinding = z.infer<typeof McpRuntimeBindingSchema>;
+export const AgentCoreMcpRuntimeToolSchema = z
+  .object({
+    name: z.string().min(1),
+    toolDefinition: ToolDefinitionSchema,
+    compute: AgentCoreRuntimeComputeConfigSchema,
+    bindings: z.array(McpRuntimeBindingSchema).optional(),
+  })
+  .strict();
+export type AgentCoreMcpRuntimeTool = z.infer<typeof AgentCoreMcpRuntimeToolSchema>;
+export interface AgentCoreMcpSpec {
+  agentCoreGateways: AgentCoreGateway[];
+  mcpRuntimeTools?: AgentCoreMcpRuntimeTool[];
+  unassignedTargets?: AgentCoreGatewayTarget[];
+}

--- a/src/core/project/schema/harness.test.ts
+++ b/src/core/project/schema/harness.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from "bun:test";
+import {
+  HarnessMemoryRefSchema,
+  HarnessModelSchema,
+  HarnessSpecSchema,
+  HarnessToolSchema,
+  HarnessTruncationConfigSchema,
+  HarnessMemoryRetrievalConfigSchema,
+  looksLikeLegacyPromptPath,
+  validateApiFormat,
+} from "./harness";
+const minimalHarness = {
+  name: "harness",
+  model: { provider: "bedrock" as const, modelId: "model" },
+};
+const networkConfig = {
+  subnets: ["subnet-0123456789abcdef0"],
+  securityGroups: ["sg-0123456789abcdef0"],
+};
+describe("harness custom validation", () => {
+  it("binds model-only fields to their providers", () => {
+    expect(HarnessModelSchema.safeParse({ provider: "open_ai", modelId: "gpt" }).success).toBe(
+      false,
+    );
+    expect(
+      HarnessModelSchema.safeParse({
+        provider: "gemini",
+        modelId: "gemini",
+        apiKeyArn: "arn:key",
+        topK: 40,
+      }).success,
+    ).toBe(true);
+    expect(
+      HarnessModelSchema.safeParse({ provider: "bedrock", modelId: "model", topK: 40 }).success,
+    ).toBe(false);
+    expect(
+      HarnessModelSchema.safeParse({
+        provider: "bedrock",
+        modelId: "model",
+        apiBase: "https://proxy.example.com",
+      }).success,
+    ).toBe(false);
+  });
+  it("validates provider-specific API formats through the shared helper", () => {
+    expect(validateApiFormat("responses", "open_ai")).toEqual({ valid: true });
+    expect(validateApiFormat("converse_stream", "open_ai").valid).toBe(false);
+    expect(validateApiFormat("responses", "gemini").valid).toBe(false);
+    expect(validateApiFormat("unknown", "bedrock").valid).toBe(false);
+  });
+  it("binds tool types to their configuration arms", () => {
+    expect(
+      HarnessToolSchema.safeParse({
+        type: "remote_mcp",
+        name: "mcp",
+        config: { remoteMcp: { url: "https://example.com/mcp" } },
+      }).success,
+    ).toBe(true);
+    expect(HarnessToolSchema.safeParse({ type: "remote_mcp", name: "mcp" }).success).toBe(false);
+    expect(
+      HarnessToolSchema.safeParse({
+        type: "remote_mcp",
+        name: "mcp",
+        config: { agentCoreBrowser: {} },
+      }).success,
+    ).toBe(false);
+  });
+  it("rejects the removed gateway credentialProviderName with migration guidance", () => {
+    const result = HarnessToolSchema.safeParse({
+      type: "agentcore_gateway",
+      name: "gateway",
+      config: {
+        agentCoreGateway: {
+          gatewayArn: "arn:gateway",
+          credentialProviderName: "legacy",
+        },
+      },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((issue) => issue.message.includes("no longer supported")),
+      ).toBe(true);
+    }
+  });
+  it("normalizes legacy memory references without inventing memory", () => {
+    expect(HarnessMemoryRefSchema.parse({ name: "memory" })).toEqual({
+      mode: "existing",
+      name: "memory",
+    });
+    expect(HarnessSpecSchema.parse(minimalHarness).memory).toBeUndefined();
+  });
+  it("validates existing-memory references and retrieval tuning", () => {
+    expect(HarnessMemoryRefSchema.safeParse({ mode: "existing" }).success).toBe(false);
+    expect(HarnessMemoryRetrievalConfigSchema.safeParse({}).success).toBe(false);
+    expect(
+      HarnessMemoryRefSchema.safeParse({
+        mode: "existing",
+        arn: "arn:memory",
+        retrievalConfig: { topK: 5 },
+      }).success,
+    ).toBe(false);
+    expect(
+      HarnessMemoryRefSchema.safeParse({
+        mode: "existing",
+        name: "memory",
+        retrievalConfig: { topK: 5 },
+      }).success,
+    ).toBe(true);
+  });
+  it("binds truncation configuration to its strategy", () => {
+    expect(
+      HarnessTruncationConfigSchema.safeParse({
+        strategy: "sliding_window",
+        config: { summarization: { summaryRatio: 0.5 } },
+      }).success,
+    ).toBe(false);
+    expect(
+      HarnessTruncationConfigSchema.safeParse({
+        strategy: "none",
+        config: { slidingWindow: { preserveRecentMessages: 5 } },
+      }).success,
+    ).toBe(false);
+  });
+  it("rejects legacy path-shaped and blank system prompts", () => {
+    expect(looksLikeLegacyPromptPath("./prompt.md")).toBe(true);
+    expect(looksLikeLegacyPromptPath("Use prompt.md when needed")).toBe(false);
+    expect(
+      HarnessSpecSchema.safeParse({ ...minimalHarness, systemPrompt: "./prompt.md" }).success,
+    ).toBe(false);
+    expect(HarnessSpecSchema.safeParse({ ...minimalHarness, systemPrompt: "   " }).success).toBe(
+      false,
+    );
+  });
+  it("rejects duplicate tools and excessive environment variables", () => {
+    expect(
+      HarnessSpecSchema.safeParse({
+        ...minimalHarness,
+        tools: [
+          { type: "agentcore_browser", name: "same" },
+          { type: "agentcore_code_interpreter", name: "same" },
+        ],
+      }).success,
+    ).toBe(false);
+    const environmentVariables = Object.fromEntries(
+      Array.from({ length: 51 }, (_, index) => [`KEY_${index}`, "value"]),
+    );
+    expect(HarnessSpecSchema.safeParse({ ...minimalHarness, environmentVariables }).success).toBe(
+      false,
+    );
+  });
+  it("enforces mutually exclusive build sources and VPC configuration coupling", () => {
+    expect(
+      HarnessSpecSchema.safeParse({
+        ...minimalHarness,
+        containerUri: "123456789012.dkr.ecr.us-east-1.amazonaws.com/repo:tag",
+        dockerfile: "Dockerfile",
+      }).success,
+    ).toBe(false);
+    expect(HarnessSpecSchema.safeParse({ ...minimalHarness, networkMode: "VPC" }).success).toBe(
+      false,
+    );
+    expect(HarnessSpecSchema.safeParse({ ...minimalHarness, networkConfig }).success).toBe(false);
+  });
+  it("requires VPC mode for external mounts and unique mount paths", () => {
+    const efsAccessPoints = [
+      {
+        accessPointArn:
+          "arn:aws:elasticfilesystem:us-east-1:123456789012:access-point/fsap-0123456789abcdef0",
+        mountPath: "/mnt/data",
+      },
+    ];
+    expect(HarnessSpecSchema.safeParse({ ...minimalHarness, efsAccessPoints }).success).toBe(false);
+    expect(
+      HarnessSpecSchema.safeParse({
+        ...minimalHarness,
+        networkMode: "VPC",
+        networkConfig,
+        sessionStoragePath: "/mnt/data/",
+        efsAccessPoints,
+      }).success,
+    ).toBe(false);
+  });
+  it("enforces inbound auth coupling", () => {
+    expect(
+      HarnessSpecSchema.safeParse({ ...minimalHarness, authorizerType: "CUSTOM_JWT" }).success,
+    ).toBe(false);
+    expect(
+      HarnessSpecSchema.safeParse({
+        ...minimalHarness,
+        authorizerType: "AWS_IAM",
+        authorizerConfiguration: {
+          customJwtAuthorizer: {
+            discoveryUrl: "https://example.com/.well-known/openid-configuration",
+          },
+        },
+      }).success,
+    ).toBe(false);
+  });
+  it("applies the CodeBuild security-group cap to every container build source", () => {
+    const securityGroups = Array.from(
+      { length: 6 },
+      (_, index) => `sg-${String(index + 1).padStart(17, "0")}`,
+    );
+    for (const source of [
+      { dockerfile: "Dockerfile" },
+      { containerUri: "123456789012.dkr.ecr.us-east-1.amazonaws.com/repo:tag" },
+    ]) {
+      expect(
+        HarnessSpecSchema.safeParse({
+          ...minimalHarness,
+          ...source,
+          networkMode: "VPC",
+          networkConfig: { ...networkConfig, securityGroups },
+        }).success,
+      ).toBe(false);
+    }
+  });
+});

--- a/src/core/project/schema/harness.ts
+++ b/src/core/project/schema/harness.ts
@@ -1,0 +1,567 @@
+import {
+  MAX_CONTAINER_BUILD_SECURITY_GROUPS,
+  NetworkModeSchema,
+  isContainerBuild,
+} from "./constants";
+import {
+  EfsAccessPointConfigSchema,
+  LifecycleConfigurationSchema,
+  NetworkConfigSchema,
+  S3FilesAccessPointConfigSchema,
+  SessionStorageSchema,
+} from "./runtime";
+import { AuthorizerConfigSchema, RuntimeAuthorizerTypeSchema } from "./auth";
+import { ConnectionSchema } from "./connections";
+import { uniqueBy } from "./zod-util";
+import { TagsSchema } from "./tags";
+import { z } from "zod";
+export const CONTAINER_URI_PATTERN =
+  /^(([0-9]{12})\.dkr\.ecr\.([a-z0-9-]+)\.amazonaws\.com(\.cn)?|public\.ecr\.aws)\/((?:[a-z0-9]+(?:[._-][a-z0-9]+)*\/)*[a-z0-9]+(?:[._-][a-z0-9]+)*)(?::([^:@]{1,300}))?(?:@(.+))?$/;
+export const MAX_CONTAINER_URI_LENGTH = 1024;
+export const MAX_ENV_VAR_VALUE_LENGTH = 5000;
+export const MAX_ENV_VARS = 50;
+export const MAX_ENV_VAR_KEY_LENGTH = 100;
+export const HarnessNameSchema = z
+  .string()
+  .min(1, "Harness name is required")
+  .max(40)
+  .regex(
+    /^[a-zA-Z][a-zA-Z0-9_]{0,39}$/,
+    "Must begin with a letter and contain only alphanumeric characters and underscores (max 40 chars)",
+  );
+export const HarnessModelProviderSchema = z.enum(["bedrock", "open_ai", "gemini", "lite_llm"]);
+export type HarnessModelProvider = z.infer<typeof HarnessModelProviderSchema>;
+export const MAX_LITE_LLM_API_BASE_LENGTH = 16383;
+export const BedrockApiFormatSchema = z.enum(["converse_stream", "responses", "chat_completions"]);
+export type BedrockApiFormat = z.infer<typeof BedrockApiFormatSchema>;
+export const OpenAiApiFormatSchema = z.enum(["responses", "chat_completions"]);
+export type OpenAiApiFormat = z.infer<typeof OpenAiApiFormatSchema>;
+export const HarnessApiFormatSchema = z.enum(["converse_stream", "responses", "chat_completions"]);
+export type HarnessApiFormat = z.infer<typeof HarnessApiFormatSchema>;
+export const HarnessModelSchema = z
+  .object({
+    provider: HarnessModelProviderSchema,
+    modelId: z.string().min(1, "Model ID is required"),
+    apiKeyArn: z.string().optional(),
+    apiFormat: HarnessApiFormatSchema.optional(),
+    temperature: z.number().min(0).max(2).optional(),
+    topP: z.number().min(0).max(1).optional(),
+    topK: z.number().int().min(0).max(500).optional(),
+    maxTokens: z.number().int().min(1).optional(),
+    apiBase: z.string().min(1).max(MAX_LITE_LLM_API_BASE_LENGTH).optional(),
+    additionalParams: z.record(z.string(), z.unknown()).optional(),
+  })
+  .superRefine((model, ctx) => {
+    if (model.topK !== undefined && model.provider !== "gemini") {
+      ctx.addIssue({
+        code: "custom",
+        message: 'topK is only supported for the "gemini" provider',
+        path: ["topK"],
+      });
+    }
+    if (model.apiFormat !== undefined) {
+      if (model.provider !== "bedrock" && model.provider !== "open_ai") {
+        ctx.addIssue({
+          code: "custom",
+          message: "--api-format is only supported for bedrock and open_ai providers",
+          path: ["apiFormat"],
+        });
+      } else if (model.provider === "open_ai" && model.apiFormat === "converse_stream") {
+        ctx.addIssue({
+          code: "custom",
+          message: `Invalid API format for open_ai: ${model.apiFormat}. Use ${OpenAiApiFormatSchema.options.join(", ")}`,
+          path: ["apiFormat"],
+        });
+      }
+    }
+    if (
+      model.apiKeyArn === undefined &&
+      (model.provider === "open_ai" || model.provider === "gemini")
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message: `apiKeyArn is required for the "${model.provider}" provider`,
+        path: ["apiKeyArn"],
+      });
+    }
+    if (model.apiBase !== undefined && model.provider !== "lite_llm") {
+      ctx.addIssue({
+        code: "custom",
+        message: 'apiBase is only supported for the "lite_llm" provider',
+        path: ["apiBase"],
+      });
+    }
+    if (model.additionalParams !== undefined && model.provider !== "lite_llm") {
+      ctx.addIssue({
+        code: "custom",
+        message: 'additionalParams is only supported for the "lite_llm" provider',
+        path: ["additionalParams"],
+      });
+    }
+  });
+export type HarnessModel = z.infer<typeof HarnessModelSchema>;
+export function validateApiFormat(
+  apiFormat: string,
+  provider: string,
+):
+  | {
+      valid: true;
+    }
+  | {
+      valid: false;
+      error: string;
+    } {
+  const allFormats = HarnessApiFormatSchema.options as readonly string[];
+  if (!allFormats.includes(apiFormat)) {
+    return {
+      valid: false,
+      error: `Invalid API format: ${apiFormat}. Use ${allFormats.join(", ")}`,
+    };
+  }
+  if (provider !== "bedrock" && provider !== "open_ai") {
+    return {
+      valid: false,
+      error: "--api-format is only supported for bedrock and open_ai providers",
+    };
+  }
+  const result = HarnessModelSchema.safeParse({ provider, modelId: "placeholder", apiFormat });
+  if (result.success) return { valid: true };
+  const apiFormatIssue = result.error.issues.find((i) => i.path.includes("apiFormat"));
+  if (apiFormatIssue) {
+    return {
+      valid: false,
+      error: `Invalid API format for ${provider}: ${apiFormat}. Use ${(provider === "open_ai" ? OpenAiApiFormatSchema : BedrockApiFormatSchema).options.join(", ")}`,
+    };
+  }
+  return { valid: true };
+}
+export const HarnessToolTypeSchema = z.enum([
+  "remote_mcp",
+  "agentcore_browser",
+  "agentcore_gateway",
+  "inline_function",
+  "agentcore_code_interpreter",
+]);
+export type HarnessToolType = z.infer<typeof HarnessToolTypeSchema>;
+export const HarnessToolNameSchema = z
+  .string()
+  .min(1)
+  .max(64)
+  .regex(
+    /^[a-zA-Z0-9_-]+$/,
+    "Tool name must contain only alphanumeric characters, hyphens, and underscores (1-64 chars)",
+  );
+export const RemoteMcpConfigSchema = z.object({
+  remoteMcp: z.object({
+    url: z.string().min(1),
+    headers: z.record(z.string(), z.string()).optional(),
+  }),
+});
+export const AgentCoreBrowserConfigSchema = z.object({
+  agentCoreBrowser: z.object({
+    browserArn: z.string().optional(),
+  }),
+});
+export const AgentCoreCodeInterpreterConfigSchema = z.object({
+  agentCoreCodeInterpreter: z.object({
+    codeInterpreterArn: z.string().optional(),
+  }),
+});
+export const GatewayOAuthGrantTypeSchema = z.enum(["CLIENT_CREDENTIALS", "USER_FEDERATION"]);
+export const HarnessGatewayOutboundAuthSchema = z.union([
+  z.object({ awsIam: z.object({}) }),
+  z.object({ none: z.object({}) }),
+  z.object({
+    oauth: z.object({
+      providerArn: z.string().min(1),
+      scopes: z.array(z.string().min(1)),
+      grantType: GatewayOAuthGrantTypeSchema.optional(),
+      customParameters: z.record(z.string(), z.string()).optional(),
+    }),
+  }),
+]);
+export type HarnessGatewayOutboundAuth = z.infer<typeof HarnessGatewayOutboundAuthSchema>;
+export const AgentCoreGatewayConfigSchema = z.object({
+  agentCoreGateway: z
+    .object({
+      gatewayArn: z.string().min(1),
+      outboundAuth: HarnessGatewayOutboundAuthSchema.optional(),
+    })
+    .passthrough()
+    .superRefine((data, ctx) => {
+      if ("credentialProviderName" in data) {
+        ctx.addIssue({
+          code: "custom",
+          message:
+            'credentialProviderName is no longer supported. Use outboundAuth instead. Example: outboundAuth: { awsIam: {} } or outboundAuth: { oauth: { providerArn: "...", scopes: [...] } }',
+          path: ["credentialProviderName"],
+        });
+      }
+    }),
+});
+export const InlineFunctionConfigSchema = z.object({
+  inlineFunction: z.object({
+    description: z.string().min(1),
+    inputSchema: z.record(z.string(), z.unknown()),
+  }),
+});
+export const HarnessToolConfigSchema = z.union([
+  RemoteMcpConfigSchema,
+  AgentCoreBrowserConfigSchema,
+  AgentCoreCodeInterpreterConfigSchema,
+  AgentCoreGatewayConfigSchema,
+  InlineFunctionConfigSchema,
+]);
+const TOOL_TYPE_TO_CONFIG_KEY: Record<HarnessToolType, string> = {
+  remote_mcp: "remoteMcp",
+  agentcore_browser: "agentCoreBrowser",
+  agentcore_gateway: "agentCoreGateway",
+  inline_function: "inlineFunction",
+  agentcore_code_interpreter: "agentCoreCodeInterpreter",
+};
+const TOOL_TYPES_REQUIRING_CONFIG = new Set<HarnessToolType>([
+  "remote_mcp",
+  "agentcore_gateway",
+  "inline_function",
+]);
+export const HarnessToolSchema = z
+  .object({
+    type: HarnessToolTypeSchema,
+    name: HarnessToolNameSchema,
+    config: HarnessToolConfigSchema.optional(),
+  })
+  .superRefine((tool, ctx) => {
+    const expectedKey = TOOL_TYPE_TO_CONFIG_KEY[tool.type];
+    if (!tool.config) {
+      if (TOOL_TYPES_REQUIRING_CONFIG.has(tool.type)) {
+        ctx.addIssue({
+          code: "custom",
+          message: `Tool type "${tool.type}" requires a "${expectedKey}" config`,
+          path: ["config"],
+        });
+      }
+      return;
+    }
+    const configKeys = Object.keys(tool.config);
+    if (configKeys.length !== 1 || configKeys[0] !== expectedKey) {
+      ctx.addIssue({
+        code: "custom",
+        message: `Tool type "${tool.type}" requires "${expectedKey}" config, got "${configKeys[0]}"`,
+        path: ["config"],
+      });
+    }
+  });
+export type HarnessTool = z.infer<typeof HarnessToolSchema>;
+export const HarnessMemoryRetrievalConfigSchema = z
+  .object({
+    topK: z.number().int().min(1).optional(),
+    relevanceScore: z.number().min(0).max(1).optional(),
+  })
+  .strict()
+  .refine((v) => v.topK !== undefined || v.relevanceScore !== undefined, {
+    message: "retrievalConfig must specify at least one of topK or relevanceScore",
+  });
+export type HarnessMemoryRetrievalConfig = z.infer<typeof HarnessMemoryRetrievalConfigSchema>;
+export const ManagedMemoryStrategySchema = z.enum([
+  "SEMANTIC",
+  "SUMMARIZATION",
+  "USER_PREFERENCE",
+  "EPISODIC",
+]);
+const ManagedMemoryRefSchema = z
+  .object({
+    mode: z.literal("managed"),
+    strategies: z.array(ManagedMemoryStrategySchema).min(1).max(4).optional(),
+    eventExpiryDuration: z.number().int().min(3).max(365).optional(),
+    encryptionKeyArn: z.string().min(1).optional(),
+  })
+  .strict();
+const ExistingMemoryRefSchema = z
+  .object({
+    mode: z.literal("existing"),
+    name: z.string().min(1).optional(),
+    arn: z.string().min(1).optional(),
+    actorId: z.string().optional(),
+    messagesCount: z.number().int().min(1).optional(),
+    retrievalConfig: HarnessMemoryRetrievalConfigSchema.optional(),
+  })
+  .strict()
+  .refine((m) => m.arn != null || m.name != null, {
+    message: "existing memory requires `arn` or `name`",
+    path: ["name"],
+  })
+  .superRefine((ref, ctx) => {
+    if (ref.arn && ref.retrievalConfig !== undefined) {
+      ctx.addIssue({
+        code: "custom",
+        message:
+          "retrievalConfig is not supported when memory is referenced by `arn` (per-namespace tuning is only resolvable for a by-name reference). Reference the memory by `name` only, or drop retrievalConfig.",
+        path: ["retrievalConfig"],
+      });
+    }
+  });
+const DisabledMemoryRefSchema = z.object({ mode: z.literal("disabled") }).strict();
+export const HarnessMemoryRefSchema = z.preprocess(
+  (val) => {
+    if (val == null || typeof val !== "object") return val;
+    const obj = val as Record<string, unknown>;
+    if ("mode" in obj) return obj;
+    return { mode: "existing", ...obj };
+  },
+  z.discriminatedUnion("mode", [
+    ManagedMemoryRefSchema,
+    ExistingMemoryRefSchema,
+    DisabledMemoryRefSchema,
+  ]),
+);
+export type HarnessMemoryRef = z.infer<typeof HarnessMemoryRefSchema>;
+export type ManagedMemoryStrategy = z.infer<typeof ManagedMemoryStrategySchema>;
+export const HarnessTruncationStrategySchema = z.enum(["sliding_window", "summarization", "none"]);
+export const SlidingWindowConfigSchema = z
+  .object({
+    slidingWindow: z.object({
+      messagesCount: z.number().int().min(1).optional(),
+    }),
+  })
+  .strict();
+export const SummarizationConfigSchema = z
+  .object({
+    summarization: z.object({
+      summaryRatio: z.number().min(0).max(1).optional(),
+      preserveRecentMessages: z.number().int().min(0).optional(),
+      summarizationSystemPrompt: z.string().optional(),
+    }),
+  })
+  .strict();
+export const HarnessTruncationConfigSchema = z
+  .object({
+    strategy: HarnessTruncationStrategySchema,
+    config: z.union([SlidingWindowConfigSchema, SummarizationConfigSchema]).optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (!data.config) return;
+    const configKey = "slidingWindow" in data.config ? "slidingWindow" : "summarization";
+    const expected: Record<typeof data.strategy, string | undefined> = {
+      sliding_window: "slidingWindow",
+      summarization: "summarization",
+      none: undefined,
+    };
+    if (expected[data.strategy] === undefined) {
+      ctx.addIssue({
+        code: "custom",
+        message: `Truncation strategy "${data.strategy}" does not take a config`,
+        path: ["config"],
+      });
+    } else if (expected[data.strategy] !== configKey) {
+      ctx.addIssue({
+        code: "custom",
+        message: `Truncation strategy "${data.strategy}" requires a "${expected[data.strategy]}" config, got "${configKey}"`,
+        path: ["config"],
+      });
+    }
+  });
+export type HarnessTruncationConfig = z.infer<typeof HarnessTruncationConfigSchema>;
+export const HarnessSkillGitAuthSchema = z.object({
+  credentialName: z.string().min(1),
+  username: z.string().optional(),
+});
+export type HarnessSkillGitAuth = z.infer<typeof HarnessSkillGitAuthSchema>;
+export const HarnessSkillS3SourceSchema = z
+  .object({
+    s3Uri: z
+      .string()
+      .min(5)
+      .regex(/^s3:\/\//, "Must be an S3 URI starting with s3://"),
+  })
+  .strict();
+export type HarnessSkillS3Source = z.infer<typeof HarnessSkillS3SourceSchema>;
+export const HarnessSkillGitSourceSchema = z
+  .object({
+    gitUrl: z
+      .string()
+      .min(8)
+      .regex(/^https:\/\//, "Must be an HTTPS git URL"),
+    path: z.string().min(1).optional(),
+    auth: HarnessSkillGitAuthSchema.optional(),
+  })
+  .strict();
+export type HarnessSkillGitSource = z.infer<typeof HarnessSkillGitSourceSchema>;
+export const HarnessSkillPathSourceSchema = z
+  .object({
+    path: z.string().min(1),
+  })
+  .strict();
+export type HarnessSkillPathSource = z.infer<typeof HarnessSkillPathSourceSchema>;
+export const HarnessSkillAwsSkillsSourceSchema = z
+  .object({
+    awsSkills: z
+      .object({
+        paths: z.array(z.string().min(1).max(4096)).optional(),
+      })
+      .strict(),
+  })
+  .strict();
+export type HarnessSkillAwsSkillsSource = z.infer<typeof HarnessSkillAwsSkillsSourceSchema>;
+export const HarnessSkillSchema = z.union([
+  z
+    .string()
+    .min(1)
+    .transform((path) => ({ path })),
+  HarnessSkillS3SourceSchema,
+  HarnessSkillGitSourceSchema,
+  HarnessSkillPathSourceSchema,
+  HarnessSkillAwsSkillsSourceSchema,
+]);
+export type HarnessSkillInput = z.input<typeof HarnessSkillSchema>;
+export type HarnessSkill = z.output<typeof HarnessSkillSchema>;
+export const AllowedToolSchema = z
+  .string()
+  .min(1)
+  .max(64)
+  .regex(/^(\*|@?[^/]+(\/[^/]+)?)$/, 'Must be "*" or a tool name pattern (max 64 chars)');
+export function looksLikeLegacyPromptPath(value: string): boolean {
+  const v = value.trim();
+  if (!/^\S+$/.test(v)) return false;
+  return /^\.\.?\//.test(v) || /\.(md|txt)$/i.test(v);
+}
+export const HarnessSpecSchema = z
+  .object({
+    name: HarnessNameSchema,
+    model: HarnessModelSchema,
+    systemPrompt: z
+      .string()
+      .refine((val) => val.trim().length > 0, {
+        message: "systemPrompt must not be empty or whitespace-only",
+      })
+      .refine((val) => !looksLikeLegacyPromptPath(val), {
+        message:
+          "systemPrompt looks like a file path. It is now always literal text — put file-backed prompts in a `system-prompt.md` in the harness directory (auto-discovered), or inline the prompt text here.",
+      })
+      .optional(),
+    tools: z
+      .array(HarnessToolSchema)
+      .default([])
+      .superRefine(
+        uniqueBy(
+          (tool) => tool.name,
+          (name) => `Duplicate tool name: ${name}`,
+        ),
+      ),
+    skills: z.array(HarnessSkillSchema).default([]),
+    allowedTools: z.array(AllowedToolSchema).optional(),
+    memory: HarnessMemoryRefSchema.optional(),
+    maxIterations: z.number().int().min(1).optional(),
+    maxTokens: z.number().int().min(1).optional(),
+    timeoutSeconds: z.number().int().min(1).optional(),
+    truncation: HarnessTruncationConfigSchema.optional(),
+    containerUri: z
+      .string()
+      .min(1)
+      .max(MAX_CONTAINER_URI_LENGTH)
+      .regex(
+        CONTAINER_URI_PATTERN,
+        "containerUri must be an ECR image URI (12-digit private ECR or public.ecr.aws)",
+      )
+      .optional(),
+    dockerfile: z.string().min(1).optional(),
+    executionRoleArn: z.string().optional(),
+    networkMode: NetworkModeSchema.optional(),
+    networkConfig: NetworkConfigSchema.optional(),
+    lifecycleConfig: LifecycleConfigurationSchema.optional(),
+    sessionStoragePath: SessionStorageSchema.shape.mountPath.optional(),
+    efsAccessPoints: z.array(EfsAccessPointConfigSchema).max(2).optional(),
+    s3AccessPoints: z.array(S3FilesAccessPointConfigSchema).max(2).optional(),
+    environmentVariables: z
+      .record(
+        z.string().min(1).max(MAX_ENV_VAR_KEY_LENGTH),
+        z.string().max(MAX_ENV_VAR_VALUE_LENGTH),
+      )
+      .refine((rec) => Object.keys(rec).length <= MAX_ENV_VARS, {
+        message: `A maximum of ${MAX_ENV_VARS} environment variables is allowed`,
+      })
+      .optional(),
+    authorizerType: RuntimeAuthorizerTypeSchema.optional(),
+    authorizerConfiguration: AuthorizerConfigSchema.optional(),
+    connections: z.array(ConnectionSchema).optional(),
+    tags: TagsSchema.optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.containerUri !== undefined && data.dockerfile !== undefined) {
+      ctx.addIssue({
+        code: "custom",
+        message: "containerUri and dockerfile are mutually exclusive",
+        path: ["containerUri"],
+      });
+    }
+    if (data.networkMode === "VPC" && !data.networkConfig) {
+      ctx.addIssue({
+        code: "custom",
+        message: "networkConfig is required when networkMode is VPC",
+        path: ["networkConfig"],
+      });
+    }
+    if (data.networkMode !== "VPC" && data.networkConfig) {
+      ctx.addIssue({
+        code: "custom",
+        message: "networkConfig is only allowed when networkMode is VPC",
+        path: ["networkConfig"],
+      });
+    }
+    if (
+      data.networkMode === "VPC" &&
+      isContainerBuild(data) &&
+      data.networkConfig &&
+      data.networkConfig.securityGroups.length > MAX_CONTAINER_BUILD_SECURITY_GROUPS
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message: `Container builds in VPC mode allow at most ${MAX_CONTAINER_BUILD_SECURITY_GROUPS} security groups (CodeBuild limit)`,
+        path: ["networkConfig", "securityGroups"],
+      });
+    }
+    if (
+      (data.efsAccessPoints?.length || data.s3AccessPoints?.length) &&
+      data.networkMode !== "VPC"
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message: "efsAccessPoints and s3AccessPoints require networkMode: VPC",
+        path: ["efsAccessPoints"],
+      });
+    }
+    const mountPaths: string[] = [];
+    if (data.sessionStoragePath) mountPaths.push(data.sessionStoragePath.replace(/\/$/, ""));
+    for (const ap of data.efsAccessPoints ?? []) mountPaths.push(ap.mountPath.replace(/\/$/, ""));
+    for (const ap of data.s3AccessPoints ?? []) mountPaths.push(ap.mountPath.replace(/\/$/, ""));
+    if (new Set(mountPaths).size !== mountPaths.length) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Filesystem mount paths must be unique",
+        path: ["efsAccessPoints"],
+      });
+    }
+    if (
+      data.authorizerType === "CUSTOM_JWT" &&
+      !data.authorizerConfiguration?.customJwtAuthorizer
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message:
+          "authorizerConfiguration with customJwtAuthorizer is required when authorizerType is CUSTOM_JWT",
+        path: ["authorizerConfiguration"],
+      });
+    }
+    if (data.authorizerType !== "CUSTOM_JWT" && data.authorizerConfiguration) {
+      ctx.addIssue({
+        code: "custom",
+        message: "authorizerConfiguration is only allowed when authorizerType is CUSTOM_JWT",
+        path: ["authorizerConfiguration"],
+      });
+    }
+  });
+export type HarnessSpec = z.infer<typeof HarnessSpecSchema>;
+export const HarnessRegistryEntrySchema = z.object({
+  name: HarnessNameSchema,
+  path: z.string().min(1, "Path to harness config directory is required"),
+});
+export type HarnessRegistryEntry = z.infer<typeof HarnessRegistryEntrySchema>;

--- a/src/core/project/schema/knowledge-base.test.ts
+++ b/src/core/project/schema/knowledge-base.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "bun:test";
+import { KnowledgeBaseSchema, S3DataSourceSchema } from "./knowledge-base";
+describe("knowledge base custom validation", () => {
+  it("validates the bucket portion of S3 URIs", () => {
+    expect(
+      S3DataSourceSchema.safeParse({ type: "S3", uri: "s3://valid-bucket/docs" }).success,
+    ).toBe(true);
+    for (const uri of ["https://bucket/docs", "s3://BadBucket/docs", "s3://bad..bucket/docs"]) {
+      expect(S3DataSourceSchema.safeParse({ type: "S3", uri }).success).toBe(false);
+    }
+  });
+  it("rejects duplicate data source locations across connector variants", () => {
+    const result = KnowledgeBaseSchema.safeParse({
+      name: "docs",
+      dataSources: [
+        { type: "WEB", connectorConfigFile: "connectors/web.json" },
+        { type: "CONFLUENCE", connectorConfigFile: "connectors/web.json" },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/core/project/schema/knowledge-base.ts
+++ b/src/core/project/schema/knowledge-base.ts
@@ -1,0 +1,68 @@
+import { uniqueBy } from "./zod-util";
+import { z } from "zod";
+export const KnowledgeBaseNameSchema = z
+  .string()
+  .min(1, "Name is required")
+  .max(48)
+  .regex(
+    /^[a-zA-Z][a-zA-Z0-9_-]{0,47}$/,
+    "Must begin with a letter and contain only alphanumeric characters, dashes, and underscores (max 48 chars)",
+  );
+const S3_BUCKET_NAME =
+  /^(?!xn--)(?!sthree-)[a-z0-9](?!.*\.\.)[a-z0-9.-]{1,61}[a-z0-9](?<!-s3alias)$/;
+export const S3DataSourceSchema = z
+  .object({
+    type: z.literal("S3"),
+    uri: z
+      .string()
+      .min(1)
+      .refine(
+        (s) => {
+          const m = /^s3:\/\/([^/]+)(?:\/.*)?$/.exec(s);
+          return !!m && S3_BUCKET_NAME.test(m[1]!);
+        },
+        { message: "Must be a valid s3:// URI with an AWS-compliant bucket name" },
+      ),
+  })
+  .strict();
+export type S3DataSource = z.infer<typeof S3DataSourceSchema>;
+export const ConnectorDataSourceTypeSchema = z.enum([
+  "WEB",
+  "CONFLUENCE",
+  "SHAREPOINT",
+  "ONEDRIVE",
+  "GOOGLEDRIVE",
+]);
+export type ConnectorDataSourceType = z.infer<typeof ConnectorDataSourceTypeSchema>;
+export const ConnectorFileDataSourceSchema = z
+  .object({
+    type: ConnectorDataSourceTypeSchema,
+    connectorConfigFile: z.string().min(1, "connectorConfigFile path is required"),
+  })
+  .strict();
+export type ConnectorFileDataSource = z.infer<typeof ConnectorFileDataSourceSchema>;
+export const DataSourceSchema = z.discriminatedUnion("type", [
+  S3DataSourceSchema,
+  ConnectorFileDataSourceSchema,
+]);
+export type DataSource = z.infer<typeof DataSourceSchema>;
+export const KnowledgeBaseTypeSchema = z.literal("AgentCoreKnowledgeBase");
+export type KnowledgeBaseType = z.infer<typeof KnowledgeBaseTypeSchema>;
+export const KnowledgeBaseSchema = z
+  .object({
+    type: KnowledgeBaseTypeSchema.default("AgentCoreKnowledgeBase"),
+    name: KnowledgeBaseNameSchema,
+    description: z.string().max(2048).optional(),
+    dataSources: z
+      .array(DataSourceSchema)
+      .min(1, "At least one data source is required")
+      .superRefine(
+        uniqueBy(
+          (ds) => (ds.type === "S3" ? ds.uri : ds.connectorConfigFile),
+          (key) => `Duplicate data source: ${key}`,
+        ),
+      ),
+    gateway: z.string().min(1).optional(),
+  })
+  .strict();
+export type KnowledgeBase = z.infer<typeof KnowledgeBaseSchema>;

--- a/src/core/project/schema/mcp-defs.ts
+++ b/src/core/project/schema/mcp-defs.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+export const SchemaPrimitiveTypeSchema = z.enum([
+  "string",
+  "number",
+  "object",
+  "array",
+  "boolean",
+  "integer",
+]);
+export type SchemaPrimitiveType = z.infer<typeof SchemaPrimitiveTypeSchema>;
+export interface SchemaDefinition {
+  type: SchemaPrimitiveType;
+  description?: string;
+  items?: SchemaDefinition;
+  properties?: Record<string, SchemaDefinition>;
+  required?: string[];
+}
+export const SchemaDefinitionSchema: z.ZodType<SchemaDefinition> = z.object({
+  type: SchemaPrimitiveTypeSchema,
+  description: z.string().optional(),
+  items: z.lazy(() => SchemaDefinitionSchema).optional(),
+  properties: z.lazy(() => z.record(z.string(), SchemaDefinitionSchema)).optional(),
+  required: z.array(z.string()).optional(),
+});
+export const ToolNameSchema = z
+  .string()
+  .min(1, "Tool name is required")
+  .max(128, "Tool name must be at most 128 characters")
+  .regex(
+    /^[a-zA-Z][a-zA-Z0-9-]*$/,
+    "Tool name must start with a letter and contain only alphanumeric characters or hyphens",
+  );
+export const ToolDefinitionSchema = z
+  .object({
+    name: z.string().min(1).max(128),
+    description: z.string().min(1),
+    inputSchema: SchemaDefinitionSchema,
+    outputSchema: SchemaDefinitionSchema.optional(),
+  })
+  .strict();
+export type ToolDefinition = z.infer<typeof ToolDefinitionSchema>;
+export const AgentCoreCliMcpDefsSchema = z.object({
+  tools: z.record(z.string(), ToolDefinitionSchema),
+});
+export type AgentCoreCliMcpDefs = z.infer<typeof AgentCoreCliMcpDefsSchema>;

--- a/src/core/project/schema/memory.test.ts
+++ b/src/core/project/schema/memory.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "bun:test";
+import { MemorySchema, MemoryStrategySchema } from "./memory";
+describe("memory custom validation", () => {
+  it("keeps deprecated and current namespace fields mutually exclusive", () => {
+    const result = MemoryStrategySchema.safeParse({
+      type: "SEMANTIC",
+      namespaces: ["/legacy"],
+      namespaceTemplates: ["/current"],
+    });
+    expect(result.success).toBe(false);
+  });
+  it("requires valid episodic reflection namespace relationships", () => {
+    expect(
+      MemoryStrategySchema.safeParse({
+        type: "EPISODIC",
+        namespaceTemplates: ["/episodes/{actorId}/{sessionId}"],
+      }).success,
+    ).toBe(false);
+    expect(
+      MemoryStrategySchema.safeParse({
+        type: "SEMANTIC",
+        reflectionNamespaceTemplates: ["/users/{actorId}"],
+      }).success,
+    ).toBe(false);
+    expect(
+      MemoryStrategySchema.safeParse({
+        type: "EPISODIC",
+        namespaceTemplates: ["/episodes/{actorId}/{sessionId}"],
+        reflectionNamespaceTemplates: ["/unrelated"],
+      }).success,
+    ).toBe(false);
+    expect(
+      MemoryStrategySchema.safeParse({
+        type: "EPISODIC",
+        namespaceTemplates: ["/episodes/{actorId}/{sessionId}"],
+        reflectionNamespaceTemplates: ["/episodes/{actorId}"],
+      }).success,
+    ).toBe(true);
+  });
+  it("rejects duplicate strategy types and indexed keys", () => {
+    expect(
+      MemorySchema.safeParse({
+        name: "memory",
+        eventExpiryDuration: 30,
+        strategies: [{ type: "SEMANTIC" }, { type: "SEMANTIC" }],
+      }).success,
+    ).toBe(false);
+    expect(
+      MemorySchema.safeParse({
+        name: "memory",
+        eventExpiryDuration: 30,
+        strategies: [{ type: "SEMANTIC" }],
+        indexedKeys: [
+          { key: "orderId", type: "STRING" },
+          { key: "orderId", type: "STRING" },
+        ],
+      }).success,
+    ).toBe(false);
+  });
+  it("requires a long-term strategy when indexed keys are configured", () => {
+    const result = MemorySchema.safeParse({
+      name: "memory",
+      eventExpiryDuration: 30,
+      indexedKeys: [{ key: "orderId", type: "STRING" }],
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/core/project/schema/memory.ts
+++ b/src/core/project/schema/memory.ts
@@ -1,0 +1,182 @@
+import { z } from "zod";
+import { TagsSchema } from "./tags";
+import { uniqueBy } from "./zod-util";
+export const MemoryStrategyTypeSchema = z.enum([
+  "SEMANTIC",
+  "SUMMARIZATION",
+  "USER_PREFERENCE",
+  "EPISODIC",
+]);
+export type MemoryStrategyType = z.infer<typeof MemoryStrategyTypeSchema>;
+export const DEFAULT_STRATEGY_NAMESPACE_TEMPLATES: Partial<Record<MemoryStrategyType, string[]>> = {
+  SEMANTIC: ["/users/{actorId}/facts"],
+  USER_PREFERENCE: ["/users/{actorId}/preferences"],
+  SUMMARIZATION: ["/summaries/{actorId}/{sessionId}"],
+  EPISODIC: ["/episodes/{actorId}/{sessionId}"],
+};
+export const DEFAULT_STRATEGY_NAMESPACES = DEFAULT_STRATEGY_NAMESPACE_TEMPLATES;
+export const DEFAULT_EPISODIC_REFLECTION_NAMESPACE_TEMPLATES: string[] = ["/episodes/{actorId}"];
+export const DEFAULT_EPISODIC_REFLECTION_NAMESPACES =
+  DEFAULT_EPISODIC_REFLECTION_NAMESPACE_TEMPLATES;
+export const MemoryStrategyNameSchema = z
+  .string()
+  .min(1)
+  .max(48)
+  .regex(
+    /^[a-zA-Z][a-zA-Z0-9_]{0,47}$/,
+    "Must begin with a letter and contain only alphanumeric characters and underscores (max 48 chars)",
+  );
+export const MemoryStrategySchema = z
+  .object({
+    type: MemoryStrategyTypeSchema,
+    name: MemoryStrategyNameSchema.optional(),
+    description: z.string().optional(),
+    namespaceTemplates: z.array(z.string()).optional(),
+    namespaces: z.array(z.string()).optional(),
+    reflectionNamespaceTemplates: z.array(z.string()).optional(),
+    reflectionNamespaces: z.array(z.string()).optional(),
+  })
+  .refine(
+    (strategy) =>
+      !((strategy.namespaces?.length ?? 0) > 0 && (strategy.namespaceTemplates?.length ?? 0) > 0),
+    {
+      message:
+        "'namespaces' and 'namespaceTemplates' are mutually exclusive. Prefer 'namespaceTemplates' ('namespaces' is deprecated).",
+      path: ["namespaceTemplates"],
+    },
+  )
+  .refine(
+    (strategy) =>
+      !(
+        (strategy.reflectionNamespaces?.length ?? 0) > 0 &&
+        (strategy.reflectionNamespaceTemplates?.length ?? 0) > 0
+      ),
+    {
+      message:
+        "'reflectionNamespaces' and 'reflectionNamespaceTemplates' are mutually exclusive. Prefer 'reflectionNamespaceTemplates' ('reflectionNamespaces' is deprecated).",
+      path: ["reflectionNamespaceTemplates"],
+    },
+  )
+  .refine(
+    (strategy) =>
+      strategy.type === "EPISODIC" ||
+      (strategy.reflectionNamespaceTemplates === undefined &&
+        strategy.reflectionNamespaces === undefined),
+    {
+      message: "'reflectionNamespaceTemplates' is only allowed on EPISODIC strategies",
+      path: ["reflectionNamespaceTemplates"],
+    },
+  )
+  .refine(
+    (strategy) => {
+      if (strategy.type !== "EPISODIC") return true;
+      const reflection = strategy.reflectionNamespaceTemplates ?? strategy.reflectionNamespaces;
+      return reflection !== undefined && reflection.length > 0;
+    },
+    {
+      message: "EPISODIC strategy requires reflectionNamespaceTemplates",
+      path: ["reflectionNamespaceTemplates"],
+    },
+  )
+  .refine(
+    (strategy) => {
+      if (strategy.type !== "EPISODIC") return true;
+      const reflection = strategy.reflectionNamespaceTemplates ?? strategy.reflectionNamespaces;
+      const templates = strategy.namespaceTemplates ?? strategy.namespaces;
+      if (!reflection || !templates) return true;
+      return reflection.every((ref) => templates.some((ns) => ns.startsWith(ref)));
+    },
+    {
+      message:
+        "Each reflectionNamespaceTemplate must be a prefix of at least one namespaceTemplate",
+      path: ["reflectionNamespaceTemplates"],
+    },
+  );
+export type MemoryStrategy = z.infer<typeof MemoryStrategySchema>;
+export const MemoryTypeSchema = z.literal("AgentCoreMemory");
+export type MemoryType = z.infer<typeof MemoryTypeSchema>;
+export const MemoryNameSchema = z
+  .string()
+  .min(1, "Name is required")
+  .max(48)
+  .regex(
+    /^[a-zA-Z][a-zA-Z0-9_]{0,47}$/,
+    "Must begin with a letter and contain only alphanumeric characters and underscores (max 48 chars)",
+  );
+export const StreamContentLevelSchema = z.enum(["FULL_CONTENT", "METADATA_ONLY"]);
+export type StreamContentLevel = z.infer<typeof StreamContentLevelSchema>;
+export const StreamDeliveryResourcesSchema = z.object({
+  resources: z
+    .array(
+      z.object({
+        kinesis: z.object({
+          dataStreamArn: z.string().min(1),
+          contentConfigurations: z
+            .array(
+              z.object({
+                type: z.literal("MEMORY_RECORDS"),
+                level: StreamContentLevelSchema,
+              }),
+            )
+            .min(1),
+        }),
+      }),
+    )
+    .min(1),
+});
+export type StreamDeliveryResources = z.infer<typeof StreamDeliveryResourcesSchema>;
+export const IndexedKeyTypeSchema = z.enum(["STRING", "STRINGLIST", "NUMBER"]);
+export type IndexedKeyType = z.infer<typeof IndexedKeyTypeSchema>;
+export const INDEXED_KEY_NAME_PATTERN = /^[a-zA-Z0-9\s._:/=+@-]+$/;
+export const INDEXED_KEY_NAME_PATTERN_MESSAGE =
+  "Must contain only alphanumeric characters, whitespace, or the symbols . _ : / = + @ -";
+export const MAX_INDEXED_KEY_NAME_LENGTH = 128;
+export const MAX_INDEXED_KEYS = 10;
+export const IndexedKeySchema = z.object({
+  key: z
+    .string()
+    .min(1)
+    .max(MAX_INDEXED_KEY_NAME_LENGTH)
+    .regex(INDEXED_KEY_NAME_PATTERN, INDEXED_KEY_NAME_PATTERN_MESSAGE)
+    .refine((value) => value.trim().length > 0, "Key cannot be only whitespace"),
+  type: IndexedKeyTypeSchema,
+});
+export type IndexedKey = z.infer<typeof IndexedKeySchema>;
+export const MemorySchema = z
+  .object({
+    name: MemoryNameSchema,
+    eventExpiryDuration: z.number().int().min(3).max(365),
+    strategies: z
+      .array(MemoryStrategySchema)
+      .default([])
+      .superRefine(
+        uniqueBy(
+          (strategy) => strategy.type,
+          (type) => `Duplicate memory strategy type: ${type}`,
+        ),
+      ),
+    indexedKeys: z
+      .array(IndexedKeySchema)
+      .max(MAX_INDEXED_KEYS)
+      .superRefine(
+        uniqueBy(
+          (entry) => entry.key,
+          (key) => `Duplicate indexed key: ${key}`,
+        ),
+      )
+      .optional(),
+    tags: TagsSchema.optional(),
+    encryptionKeyArn: z.string().optional(),
+    executionRoleArn: z.string().optional(),
+    streamDeliveryResources: StreamDeliveryResourcesSchema.optional(),
+  })
+  .superRefine((memory, ctx) => {
+    if (memory.indexedKeys && memory.indexedKeys.length > 0 && memory.strategies.length === 0) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["indexedKeys"],
+        message: "indexedKeys requires at least one memory strategy (long-term memory)",
+      });
+    }
+  });
+export type Memory = z.infer<typeof MemorySchema>;

--- a/src/core/project/schema/online-eval-config.test.ts
+++ b/src/core/project/schema/online-eval-config.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "bun:test";
+import { OnlineEvalConfigSchema } from "./online-eval-config";
+const base = {
+  name: "quality",
+  samplingRate: 10,
+  evaluators: ["Builtin.Helpfulness"],
+};
+describe("online evaluation custom validation", () => {
+  it("requires exactly one data source", () => {
+    expect(OnlineEvalConfigSchema.safeParse(base).success).toBe(false);
+    expect(OnlineEvalConfigSchema.safeParse({ ...base, agent: "agent" }).success).toBe(true);
+    expect(
+      OnlineEvalConfigSchema.safeParse({
+        ...base,
+        agent: "agent",
+        logGroupNames: ["/aws/app"],
+      }).success,
+    ).toBe(false);
+  });
+  it("binds endpoint and service filters to their corresponding data sources", () => {
+    expect(
+      OnlineEvalConfigSchema.safeParse({
+        ...base,
+        logGroupNames: ["/aws/app"],
+        endpoint: "prod",
+      }).success,
+    ).toBe(false);
+    expect(
+      OnlineEvalConfigSchema.safeParse({ ...base, agent: "agent", serviceNames: ["service"] })
+        .success,
+    ).toBe(false);
+  });
+  it("requires exactly one analysis mode and binds clustering to insights", () => {
+    const source = { ...base, agent: "agent" };
+    expect(
+      OnlineEvalConfigSchema.safeParse({ ...source, evaluators: [], insights: [] }).success,
+    ).toBe(false);
+    expect(OnlineEvalConfigSchema.safeParse({ ...source, insights: ["Latency"] }).success).toBe(
+      false,
+    );
+    expect(
+      OnlineEvalConfigSchema.safeParse({
+        ...source,
+        evaluators: undefined,
+        clusteringConfig: { frequencies: ["DAILY"] },
+      }).success,
+    ).toBe(false);
+    expect(
+      OnlineEvalConfigSchema.safeParse({
+        ...source,
+        evaluators: undefined,
+        insights: ["Latency"],
+        clusteringConfig: { frequencies: ["DAILY"] },
+      }).success,
+    ).toBe(true);
+  });
+});

--- a/src/core/project/schema/online-eval-config.ts
+++ b/src/core/project/schema/online-eval-config.ts
@@ -1,0 +1,63 @@
+import { TagsSchema } from "./tags";
+import { z } from "zod";
+export const OnlineEvalConfigNameSchema = z
+  .string()
+  .min(1, "Name is required")
+  .max(48)
+  .regex(
+    /^[a-zA-Z][a-zA-Z0-9_]{0,47}$/,
+    "Must begin with a letter and contain only alphanumeric characters and underscores (max 48 chars)",
+  );
+export const ClusteringConfigSchema = z.object({
+  frequencies: z
+    .array(z.enum(["DAILY", "WEEKLY", "MONTHLY"]))
+    .min(1)
+    .max(3),
+});
+export type ClusteringConfig = z.infer<typeof ClusteringConfigSchema>;
+export const OnlineEvalConfigSchema = z
+  .object({
+    name: OnlineEvalConfigNameSchema,
+    agent: z.string().min(1, "Agent name is required").optional(),
+    endpoint: z.string().min(1).optional(),
+    logGroupNames: z.array(z.string().min(1)).min(1).max(5).optional(),
+    serviceNames: z.array(z.string().min(1)).min(1).optional(),
+    evaluators: z.array(z.string().min(1)).optional(),
+    insights: z.array(z.string().min(1)).optional(),
+    clusteringConfig: ClusteringConfigSchema.optional(),
+    samplingRate: z.number().min(0.01).max(100),
+    description: z.string().max(200).optional(),
+    enableOnCreate: z.boolean().optional(),
+    tags: TagsSchema.optional(),
+  })
+  .refine((data) => data.agent ?? data.logGroupNames, {
+    message: 'Either "agent" or "logGroupNames" must be provided',
+  })
+  .refine((data) => !(data.agent && data.logGroupNames), {
+    message: '"agent" and "logGroupNames" are mutually exclusive',
+  })
+  .refine((data) => !data.endpoint || data.agent, {
+    message: '"endpoint" requires "agent"',
+  })
+  .refine((data) => !data.serviceNames || data.logGroupNames, {
+    message: '"serviceNames" requires "logGroupNames"',
+  })
+  .refine(
+    (data) => {
+      const hasEvaluators = data.evaluators != null && data.evaluators.length > 0;
+      const hasInsights = data.insights != null && data.insights.length > 0;
+      return hasEvaluators || hasInsights;
+    },
+    { message: "At least one of evaluators or insights must be provided" },
+  )
+  .refine(
+    (data) =>
+      !(data.evaluators && data.evaluators.length > 0 && data.insights && data.insights.length > 0),
+    {
+      message: "Cannot have both evaluators and insights (preview constraint)",
+    },
+  )
+  .refine((data) => !data.clusteringConfig || (data.insights && data.insights.length > 0), {
+    message: "clusteringConfig requires insights to be set",
+  });
+export type OnlineEvalConfig = z.infer<typeof OnlineEvalConfigSchema>;

--- a/src/core/project/schema/payment.test.ts
+++ b/src/core/project/schema/payment.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "bun:test";
+import { PaymentManagerSchema } from "./payment";
+describe("payment manager custom validation", () => {
+  it("requires JWT authorizer configuration only for CUSTOM_JWT", () => {
+    expect(
+      PaymentManagerSchema.safeParse({
+        name: "payments",
+        authorizerType: "CUSTOM_JWT",
+      }).success,
+    ).toBe(false);
+    expect(
+      PaymentManagerSchema.safeParse({
+        name: "payments",
+        authorizerType: "CUSTOM_JWT",
+        authorizerConfiguration: {
+          customJWTAuthorizer: {
+            discoveryUrl: "https://example.com/.well-known/openid-configuration",
+          },
+        },
+      }).success,
+    ).toBe(true);
+  });
+});

--- a/src/core/project/schema/payment.ts
+++ b/src/core/project/schema/payment.ts
@@ -1,0 +1,64 @@
+import { z } from "zod";
+export const PaymentProviderSchema = z.enum(["CoinbaseCDP", "StripePrivy"]);
+export type PaymentProvider = z.infer<typeof PaymentProviderSchema>;
+export const DEFAULT_AUTO_PAYMENT = true;
+export const DEFAULT_SPEND_LIMIT = "10.00";
+export const PaymentManagerNameSchema = z
+  .string()
+  .min(1, "Payment manager name is required")
+  .max(48)
+  .regex(
+    /^[a-zA-Z][a-zA-Z0-9]{0,47}$/,
+    "Must begin with a letter and contain only alphanumeric characters (max 48 chars)",
+  );
+export const PaymentConnectorNameSchema = z
+  .string()
+  .min(1, "Payment connector name is required")
+  .max(48)
+  .regex(
+    /^[a-zA-Z][a-zA-Z0-9_]{0,47}$/,
+    "Must begin with a letter and contain only alphanumeric characters and underscores (max 48 chars)",
+  );
+export const PaymentConnectorSchema = z.object({
+  name: PaymentConnectorNameSchema,
+  provider: PaymentProviderSchema.default("CoinbaseCDP"),
+  credentialName: z.string().min(1),
+});
+export type PaymentConnector = z.infer<typeof PaymentConnectorSchema>;
+export const PaymentManagerSchema = z
+  .object({
+    name: PaymentManagerNameSchema,
+    authorizerType: z.enum(["AWS_IAM", "CUSTOM_JWT"]).default("AWS_IAM"),
+    authorizerConfiguration: z
+      .object({
+        customJWTAuthorizer: z.object({
+          discoveryUrl: z.string().url(),
+          allowedClients: z.array(z.string()).optional(),
+          allowedAudience: z.array(z.string()).optional(),
+          allowedScopes: z.array(z.string()).optional(),
+        }),
+      })
+      .optional(),
+    connectors: z.array(PaymentConnectorSchema).default([]),
+    description: z.string().optional(),
+    autoPayment: z.boolean().default(DEFAULT_AUTO_PAYMENT),
+    defaultSpendLimit: z.string().default(DEFAULT_SPEND_LIMIT),
+    paymentToolAllowlist: z.array(z.string()).optional(),
+    networkPreferences: z.array(z.string()).optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (
+      data.authorizerType === "CUSTOM_JWT" &&
+      !data.authorizerConfiguration?.customJWTAuthorizer
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message:
+          "authorizerConfiguration with customJWTAuthorizer is required when authorizerType is CUSTOM_JWT",
+        path: ["authorizerConfiguration"],
+      });
+    }
+  });
+export type PaymentManager = z.infer<typeof PaymentManagerSchema>;
+export const PaymentAuthorizerTypeSchema = z.enum(["AWS_IAM", "CUSTOM_JWT"]);
+export type PaymentAuthorizerType = z.infer<typeof PaymentAuthorizerTypeSchema>;

--- a/src/core/project/schema/policy.ts
+++ b/src/core/project/schema/policy.ts
@@ -1,0 +1,51 @@
+import { uniqueBy } from "./zod-util";
+import { TagsSchema } from "./tags";
+import { z } from "zod";
+export const PolicyEngineNameSchema = z
+  .string()
+  .min(1, "Policy engine name is required")
+  .max(48, "Policy engine name must be 48 characters or less")
+  .regex(
+    /^[A-Za-z][A-Za-z0-9_]{0,47}$/,
+    "Must begin with a letter and contain only alphanumeric characters and underscores (max 48 chars)",
+  );
+export const PolicyNameSchema = z
+  .string()
+  .min(1, "Policy name is required")
+  .max(48, "Policy name must be 48 characters or less")
+  .regex(
+    /^[A-Za-z][A-Za-z0-9_]{0,47}$/,
+    "Must begin with a letter and contain only alphanumeric characters and underscores (max 48 chars)",
+  );
+export const ValidationModeSchema = z.enum(["FAIL_ON_ANY_FINDINGS", "IGNORE_ALL_FINDINGS"]);
+export type ValidationMode = z.infer<typeof ValidationModeSchema>;
+export const AuthorizationPhaseSchema = z.enum(["INITIATE", "RETURN_OUTPUT"]).default("INITIATE");
+export type AuthorizationPhase = z.infer<typeof AuthorizationPhaseSchema>;
+export const EnforcementModeSchema = z.enum(["ACTIVE", "LOG_ONLY"]).default("ACTIVE");
+export type EnforcementMode = z.infer<typeof EnforcementModeSchema>;
+export const PolicySchema = z.object({
+  name: PolicyNameSchema,
+  description: z.string().min(1).max(4096).optional(),
+  statement: z.string().min(1, "Cedar policy statement is required"),
+  sourceFile: z.string().optional(),
+  validationMode: ValidationModeSchema.default("FAIL_ON_ANY_FINDINGS"),
+  enforcementMode: EnforcementModeSchema.default("ACTIVE"),
+  authorizationPhase: AuthorizationPhaseSchema.optional(),
+});
+export type Policy = z.infer<typeof PolicySchema>;
+export const PolicyEngineSchema = z.object({
+  name: PolicyEngineNameSchema,
+  description: z.string().min(1).max(4096).optional(),
+  encryptionKeyArn: z.string().optional(),
+  tags: TagsSchema.optional(),
+  policies: z
+    .array(PolicySchema)
+    .default([])
+    .superRefine(
+      uniqueBy(
+        (policy) => policy.name,
+        (name) => `Duplicate policy name: ${name}`,
+      ),
+    ),
+});
+export type PolicyEngine = z.infer<typeof PolicyEngineSchema>;

--- a/src/core/project/schema/project.test.ts
+++ b/src/core/project/schema/project.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from "bun:test";
+import { AgentCoreProjectSpecSchema, ProjectNameSchema } from "./project";
+
+const minimalProject = { name: "project", version: 1 };
+
+const runtime = {
+  name: "agent",
+  build: "CodeZip" as const,
+  entrypoint: "main.py",
+  codeLocation: "./agent",
+  endpoints: { LIVE: { version: 1 } },
+};
+
+describe("project custom validation", () => {
+  it("rejects reserved project names case-insensitively", () => {
+    expect(ProjectNameSchema.safeParse("OpenAI").success).toBe(false);
+    expect(ProjectNameSchema.safeParse("myproject").success).toBe(true);
+  });
+
+  it("rejects duplicate resource identities", () => {
+    const result = AgentCoreProjectSpecSchema.safeParse({
+      ...minimalProject,
+      runtimes: [runtime, runtime],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((issue) => issue.message.includes("Duplicate agent"))).toBe(
+        true,
+      );
+    }
+  });
+
+  it("validates online evaluation agent and evaluator references", () => {
+    const result = AgentCoreProjectSpecSchema.safeParse({
+      ...minimalProject,
+      onlineEvalConfigs: [
+        {
+          name: "quality",
+          agent: "missing-agent",
+          evaluators: ["missing-evaluator"],
+          samplingRate: 10,
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((issue) => issue.message.includes("unknown agent"))).toBe(
+        true,
+      );
+      expect(result.error.issues.some((issue) => issue.message.includes("unknown evaluator"))).toBe(
+        true,
+      );
+    }
+  });
+
+  it("allows built-in and ARN evaluator references", () => {
+    const result = AgentCoreProjectSpecSchema.safeParse({
+      ...minimalProject,
+      runtimes: [runtime],
+      onlineEvalConfigs: [
+        {
+          name: "quality",
+          agent: "agent",
+          evaluators: [
+            "Builtin.Helpfulness",
+            "arn:aws:bedrock-agentcore:us-east-1:123:evaluator/e",
+          ],
+          samplingRate: 10,
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("validates HTTP runtime and endpoint references", () => {
+    const gateway = {
+      name: "gateway",
+      protocolType: "None" as const,
+      targets: [
+        {
+          name: "runtime",
+          targetType: "httpRuntime" as const,
+          httpRuntime: { runtime: "agent", runtimeEndpoint: "MISSING" },
+        },
+      ],
+    };
+    expect(
+      AgentCoreProjectSpecSchema.safeParse({
+        ...minimalProject,
+        runtimes: [runtime],
+        agentCoreGateways: [gateway],
+      }).success,
+    ).toBe(false);
+    expect(
+      AgentCoreProjectSpecSchema.safeParse({
+        ...minimalProject,
+        runtimes: [runtime],
+        agentCoreGateways: [
+          {
+            ...gateway,
+            targets: [
+              {
+                ...gateway.targets[0],
+                httpRuntime: { runtime: "agent", runtimeEndpoint: "LIVE" },
+              },
+            ],
+          },
+        ],
+      }).success,
+    ).toBe(true);
+  });
+
+  it("validates target-based AB test gateway and target references", () => {
+    const abTest = {
+      name: "experiment",
+      mode: "target-based" as const,
+      gatewayRef: "{{gateway:gateway}}",
+      variants: [
+        {
+          name: "C" as const,
+          weight: 50,
+          variantConfiguration: { target: { targetName: "control" } },
+        },
+        {
+          name: "T1" as const,
+          weight: 50,
+          variantConfiguration: { target: { targetName: "missing" } },
+        },
+      ],
+      evaluationConfig: { onlineEvaluationConfigArn: "arn:evaluation" },
+    };
+    const result = AgentCoreProjectSpecSchema.safeParse({
+      ...minimalProject,
+      agentCoreGateways: [
+        {
+          name: "gateway",
+          targets: [{ name: "control", targetType: "connector", connectorId: "web-search" }],
+        },
+      ],
+      abTests: [abTest],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((issue) => issue.message.includes('target "missing"'))).toBe(
+        true,
+      );
+    }
+  });
+
+  it("distinguishes project knowledge-base names from external IDs", () => {
+    const target = {
+      name: "knowledge",
+      targetType: "connector" as const,
+      connectorId: "bedrock-knowledge-bases" as const,
+      configurations: [
+        {
+          name: "Retrieve",
+          parameterValues: { knowledgeBaseId: "missing-name" },
+        },
+      ],
+    };
+    expect(
+      AgentCoreProjectSpecSchema.safeParse({
+        ...minimalProject,
+        agentCoreGateways: [{ name: "gateway", targets: [target] }],
+      }).success,
+    ).toBe(false);
+    expect(
+      AgentCoreProjectSpecSchema.safeParse({
+        ...minimalProject,
+        agentCoreGateways: [
+          {
+            name: "gateway",
+            targets: [
+              {
+                ...target,
+                configurations: [
+                  { name: "Retrieve", parameterValues: { knowledgeBaseId: "ABCDEFGHIJ" } },
+                ],
+              },
+            ],
+          },
+        ],
+      }).success,
+    ).toBe(true);
+  });
+
+  it("validates payment connector credential references and types", () => {
+    const payment = {
+      name: "payments",
+      connectors: [
+        {
+          name: "stripe",
+          provider: "StripePrivy" as const,
+          credentialName: "credential",
+        },
+      ],
+    };
+    expect(
+      AgentCoreProjectSpecSchema.safeParse({ ...minimalProject, payments: [payment] }).success,
+    ).toBe(false);
+    expect(
+      AgentCoreProjectSpecSchema.safeParse({
+        ...minimalProject,
+        credentials: [{ authorizerType: "ApiKeyCredentialProvider", name: "credential" }],
+        payments: [payment],
+      }).success,
+    ).toBe(false);
+    expect(
+      AgentCoreProjectSpecSchema.safeParse({
+        ...minimalProject,
+        credentials: [
+          {
+            authorizerType: "PaymentCredentialProvider",
+            name: "credential",
+            provider: "StripePrivy",
+          },
+        ],
+        payments: [payment],
+      }).success,
+    ).toBe(true);
+  });
+});

--- a/src/core/project/schema/project.ts
+++ b/src/core/project/schema/project.ts
@@ -1,0 +1,262 @@
+import { isReservedProjectName } from "./constants";
+import { AgentEnvSpecSchema } from "./runtime";
+import {
+  AgentCoreGatewaySchema,
+  AgentCoreGatewayTargetSchema,
+  AgentCoreMcpRuntimeToolSchema,
+  REAL_KB_ID_PATTERN,
+} from "./gateway";
+import { ABTestSchema } from "./ab-test";
+import { ConfigBundleSchema } from "./config-bundle";
+import { CredentialSchema } from "./credential";
+import { DatasetSchema } from "./dataset";
+import { EvaluatorSchema } from "./evaluator";
+import { HarnessRegistryEntrySchema } from "./harness";
+import { KnowledgeBaseSchema } from "./knowledge-base";
+import { MemorySchema } from "./memory";
+import { OnlineEvalConfigSchema } from "./online-eval-config";
+import { PaymentManagerSchema } from "./payment";
+import { PolicyEngineSchema } from "./policy";
+import { TagsSchema } from "./tags";
+import { uniqueBy } from "./zod-util";
+import { z } from "zod";
+export const ManagedBySchema = z.enum(["CDK"]).default("CDK");
+export type ManagedBy = z.infer<typeof ManagedBySchema>;
+export const ProjectNameSchema = z
+  .string()
+  .min(1, "Project name is required")
+  .max(23, "Project name must be 23 characters or less")
+  .regex(
+    /^[A-Za-z][A-Za-z0-9]{0,22}$/,
+    "Project name must start with a letter and contain only alphanumeric characters",
+  )
+  .refine((name) => !isReservedProjectName(name), {
+    message:
+      "This name conflicts with a reserved package dependency. Please choose a different name.",
+  });
+const BUILTIN_EVALUATOR_PREFIX = "Builtin.";
+const ARN_PREFIX = "arn:";
+const uniqueNames = (resource: string) =>
+  uniqueBy<{ name: string }>(
+    ({ name }) => name,
+    (name) => `Duplicate ${resource} name: ${name}`,
+  );
+export const AgentCoreProjectSpecSchema = z
+  .object({
+    $schema: z.string().optional(),
+    name: ProjectNameSchema,
+    version: z.number().int().min(1),
+    managedBy: ManagedBySchema,
+    tags: TagsSchema.optional(),
+    runtimes: z.array(AgentEnvSpecSchema).default([]).superRefine(uniqueNames("agent")),
+    memories: z.array(MemorySchema).default([]).superRefine(uniqueNames("memory")),
+    knowledgeBases: z
+      .array(KnowledgeBaseSchema)
+      .default([])
+      .superRefine(uniqueNames("knowledge base")),
+    credentials: z.array(CredentialSchema).default([]).superRefine(uniqueNames("credential")),
+    evaluators: z.array(EvaluatorSchema).default([]).superRefine(uniqueNames("evaluator")),
+    onlineEvalConfigs: z
+      .array(OnlineEvalConfigSchema)
+      .default([])
+      .superRefine(uniqueNames("online eval config")),
+    agentCoreGateways: z
+      .array(AgentCoreGatewaySchema)
+      .default([])
+      .superRefine(uniqueNames("gateway")),
+    mcpRuntimeTools: z
+      .array(AgentCoreMcpRuntimeToolSchema)
+      .optional()
+      .superRefine(uniqueNames("MCP runtime tool")),
+    unassignedTargets: z
+      .array(AgentCoreGatewayTargetSchema)
+      .optional()
+      .superRefine(uniqueNames("unassigned target")),
+    policyEngines: z
+      .array(PolicyEngineSchema)
+      .default([])
+      .superRefine(uniqueNames("policy engine")),
+    configBundles: z
+      .array(ConfigBundleSchema)
+      .default([])
+      .superRefine(uniqueNames("config bundle")),
+    abTests: z.array(ABTestSchema).default([]).superRefine(uniqueNames("AB test")),
+    harnesses: z.array(HarnessRegistryEntrySchema).default([]).superRefine(uniqueNames("harness")),
+    datasets: z.array(DatasetSchema).optional().superRefine(uniqueNames("dataset")),
+    httpGateways: z
+      .array(z.unknown())
+      .max(
+        0,
+        '"httpGateways" is deprecated. Migrate to agentCoreGateways with protocolType: "None", or use "agentcore import gateway".',
+      )
+      .optional(),
+    payments: z.array(PaymentManagerSchema).optional().superRefine(uniqueNames("payment manager")),
+  })
+  .strict()
+  .superRefine((spec, ctx) => {
+    const agentNames = new Set(spec.runtimes.map((a) => a.name));
+    const evaluatorNames = new Set(spec.evaluators.map((e) => e.name));
+    for (const config of spec.onlineEvalConfigs) {
+      if (config.agent && !agentNames.has(config.agent)) {
+        ctx.addIssue({
+          code: "custom",
+          message: `Online eval config "${config.name}" references unknown agent "${config.agent}"`,
+        });
+      }
+      for (const evalName of config.evaluators ?? []) {
+        if (evalName.startsWith(BUILTIN_EVALUATOR_PREFIX) || evalName.startsWith(ARN_PREFIX))
+          continue;
+        if (!evaluatorNames.has(evalName)) {
+          ctx.addIssue({
+            code: "custom",
+            message: `Online eval config "${config.name}" references unknown evaluator "${evalName}"`,
+          });
+        }
+      }
+    }
+    for (const gw of spec.agentCoreGateways ?? []) {
+      for (const target of gw.targets) {
+        if (target.targetType === "httpRuntime") {
+          if (target.httpRuntime?.runtime) {
+            const runtimeExists = spec.runtimes.some((r) => r.name === target.httpRuntime!.runtime);
+            if (!runtimeExists) {
+              ctx.addIssue({
+                code: "custom",
+                message: `Gateway "${gw.name}" target "${target.name}" references unknown runtime "${target.httpRuntime.runtime}". Check spec.runtimes.`,
+              });
+            } else if (
+              target.httpRuntime.runtimeEndpoint &&
+              target.httpRuntime.runtimeEndpoint !== "DEFAULT"
+            ) {
+              const runtime = spec.runtimes.find((r) => r.name === target.httpRuntime!.runtime);
+              if (runtime && !runtime.endpoints?.[target.httpRuntime.runtimeEndpoint]) {
+                ctx.addIssue({
+                  code: "custom",
+                  message: `Gateway "${gw.name}" target "${target.name}" references endpoint "${target.httpRuntime.runtimeEndpoint}" which does not exist on runtime "${target.httpRuntime.runtime}".`,
+                });
+              }
+            }
+          }
+        }
+      }
+    }
+    for (const test of spec.abTests ?? []) {
+      const gwField = test.gatewayRef;
+      if (gwField && typeof gwField === "string") {
+        const match = /^\{\{gateway:(.+)\}\}$/.exec(gwField);
+        if (match) {
+          const gwName = match[1];
+          const gwExists = (spec.agentCoreGateways ?? []).some((gw) => gw.name === gwName);
+          if (!gwExists) {
+            ctx.addIssue({
+              code: "custom",
+              message: `AB test "${test.name}" references gateway "${gwName}" which does not exist in agentCoreGateways`,
+            });
+          }
+          if (test.mode === "target-based") {
+            const gw = (spec.agentCoreGateways ?? []).find((g) => g.name === gwName);
+            if (gw) {
+              const gwTargetNames = new Set((gw.targets ?? []).map((t) => t.name));
+              for (const variant of test.variants) {
+                const targetName = variant.variantConfiguration.target?.targetName;
+                if (targetName && !gwTargetNames.has(targetName)) {
+                  ctx.addIssue({
+                    code: "custom",
+                    message: `AB test "${test.name}" variant "${variant.name}" references target "${targetName}" which does not exist in gateway "${gwName}" targets`,
+                  });
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    const knowledgeBaseNames = new Set((spec.knowledgeBases ?? []).map((kb) => kb.name));
+    const validateKbReference = (
+      target: {
+        name: string;
+      },
+      value: string,
+      fieldLabel: string,
+    ): void => {
+      const looksLikeRealId = REAL_KB_ID_PATTERN.test(value);
+      if (looksLikeRealId) {
+        if (knowledgeBaseNames.has(value)) {
+          ctx.addIssue({
+            code: "custom",
+            message: `Connector target "${target.name}" ${fieldLabel} "${value}" looks like a literal KB ID but also matches a knowledgeBases[] entry. Rename the knowledge base or reference it by its project name instead.`,
+          });
+        }
+      } else {
+        if (!knowledgeBaseNames.has(value)) {
+          ctx.addIssue({
+            code: "custom",
+            message: `Connector target "${target.name}" ${fieldLabel} "${value}" does not match any knowledgeBases[] entry. To wire an external KB that this project does not own, use its 10-character KB ID.`,
+          });
+        }
+      }
+    };
+    for (const gateway of spec.agentCoreGateways ?? []) {
+      for (const target of gateway.targets ?? []) {
+        if (target.targetType !== "connector") continue;
+        if (target.connectorId !== "bedrock-knowledge-bases") {
+          continue;
+        }
+        for (const cfg of target.configurations ?? []) {
+          const pv = cfg.parameterValues;
+          if (
+            cfg.name === "Retrieve" &&
+            pv?.knowledgeBaseId &&
+            typeof pv.knowledgeBaseId === "string"
+          ) {
+            validateKbReference(
+              target,
+              pv.knowledgeBaseId,
+              "configurations[].parameterValues.knowledgeBaseId",
+            );
+          }
+          if (cfg.name === "AgenticRetrieveStream") {
+            const rawRetrievers = pv?.retrievers;
+            if (!Array.isArray(rawRetrievers)) continue;
+            for (const r of rawRetrievers) {
+              if (!r || typeof r !== "object") continue;
+              const kbId = (
+                r as {
+                  configuration?: {
+                    knowledgeBase?: {
+                      knowledgeBaseId?: string;
+                    };
+                  };
+                }
+              ).configuration?.knowledgeBase?.knowledgeBaseId;
+              if (kbId)
+                validateKbReference(
+                  target,
+                  kbId,
+                  "configurations[].parameterValues.retrievers[].knowledgeBaseId",
+                );
+            }
+          }
+        }
+      }
+    }
+    for (const [paymentIndex, payment] of (spec.payments ?? []).entries()) {
+      for (const [connectorIndex, connector] of payment.connectors.entries()) {
+        const credential = spec.credentials.find((c) => c.name === connector.credentialName);
+        if (!credential) {
+          ctx.addIssue({
+            code: "custom",
+            message: `Payment connector "${connector.name}" in manager "${payment.name}" references credential "${connector.credentialName}" which does not exist in credentials[]`,
+            path: ["payments", paymentIndex, "connectors", connectorIndex, "credentialName"],
+          });
+        } else if (credential.authorizerType !== "PaymentCredentialProvider") {
+          ctx.addIssue({
+            code: "custom",
+            message: `Payment connector "${connector.name}" in manager "${payment.name}" references credential "${connector.credentialName}" which is a ${credential.authorizerType}, not a PaymentCredentialProvider`,
+            path: ["payments", paymentIndex, "connectors", connectorIndex, "credentialName"],
+          });
+        }
+      }
+    }
+  });
+export type AgentCoreProjectSpec = z.infer<typeof AgentCoreProjectSpecSchema>;

--- a/src/core/project/schema/runtime.test.ts
+++ b/src/core/project/schema/runtime.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "bun:test";
+import {
+  AgentEnvSpecSchema,
+  LifecycleConfigurationSchema,
+  checkAllowlistHeader,
+  isReservedBuildArgKey,
+  isValidDockerfilePath,
+} from "./runtime";
+const codeZipAgent = {
+  name: "agent",
+  build: "CodeZip" as const,
+  entrypoint: "main.py",
+  codeLocation: "./agent",
+};
+const containerAgent = {
+  name: "agent",
+  build: "Container" as const,
+  entrypoint: "main.py",
+  codeLocation: "./agent",
+};
+const networkConfig = {
+  subnets: ["subnet-0123456789abcdef0"],
+  securityGroups: ["sg-0123456789abcdef0"],
+};
+describe("runtime custom validation", () => {
+  it("validates Dockerfile paths through the shared guard", () => {
+    expect(isValidDockerfilePath(".docker/Dockerfile")).toBe(true);
+    for (const path of ["../Dockerfile", "/Dockerfile", "docker/", "a//Dockerfile", "a;rm"]) {
+      expect(isValidDockerfilePath(path)).toBe(false);
+    }
+  });
+  it("identifies build-environment-reserved argument names", () => {
+    for (const key of ["IMAGE_URI", "PATH", "AWS_REGION", "CODEBUILD_ID"]) {
+      expect(isReservedBuildArgKey(key)).toBe(true);
+    }
+    expect(isReservedBuildArgKey("USER")).toBe(false);
+  });
+  it("validates runtime header allowlist names and reserved prefixes", () => {
+    expect(checkAllowlistHeader("X-Custom")).toBeNull();
+    expect(checkAllowlistHeader("bad header")).not.toBeNull();
+    expect(checkAllowlistHeader("x-amz-security-token")).not.toBeNull();
+    expect(checkAllowlistHeader("x-amzn-trace-id")).not.toBeNull();
+    expect(checkAllowlistHeader("X-Amzn-Bedrock-AgentCore-Runtime-Custom-Tenant")).toBeNull();
+  });
+  it("requires lifecycle idle timeout not to exceed maximum lifetime", () => {
+    expect(
+      LifecycleConfigurationSchema.safeParse({
+        idleRuntimeSessionTimeout: 1000,
+        maxLifetime: 500,
+      }).success,
+    ).toBe(false);
+  });
+  it("couples VPC mode and network configuration", () => {
+    expect(AgentEnvSpecSchema.safeParse({ ...codeZipAgent, networkMode: "VPC" }).success).toBe(
+      false,
+    );
+    expect(AgentEnvSpecSchema.safeParse({ ...codeZipAgent, networkConfig }).success).toBe(false);
+  });
+  it("couples CUSTOM_JWT and authorizer configuration", () => {
+    expect(
+      AgentEnvSpecSchema.safeParse({ ...codeZipAgent, authorizerType: "CUSTOM_JWT" }).success,
+    ).toBe(false);
+    expect(
+      AgentEnvSpecSchema.safeParse({
+        ...codeZipAgent,
+        authorizerType: "AWS_IAM",
+        authorizerConfiguration: {
+          customJwtAuthorizer: {
+            discoveryUrl: "https://example.com/.well-known/openid-configuration",
+          },
+        },
+      }).success,
+    ).toBe(false);
+  });
+  it("restricts container-only fields to container builds", () => {
+    for (const field of [
+      { dockerfile: "Dockerfile" },
+      { buildContextPath: "." },
+      { customDockerBuildArgs: { KEY: "value" } },
+    ]) {
+      expect(AgentEnvSpecSchema.safeParse({ ...codeZipAgent, ...field }).success).toBe(false);
+      expect(AgentEnvSpecSchema.safeParse({ ...containerAgent, ...field }).success).toBe(true);
+    }
+  });
+  it("rejects reserved build args and control characters", () => {
+    expect(
+      AgentEnvSpecSchema.safeParse({
+        ...containerAgent,
+        customDockerBuildArgs: { IMAGE_URI: "value" },
+      }).success,
+    ).toBe(false);
+    expect(
+      AgentEnvSpecSchema.safeParse({
+        ...containerAgent,
+        customDockerBuildArgs: { SAFE: "line1\nline2" },
+      }).success,
+    ).toBe(false);
+  });
+  it("enforces filesystem counts, VPC dependency, and unique mount paths", () => {
+    const efsAccessPoint = {
+      efsAccessPoint: {
+        accessPointArn:
+          "arn:aws:elasticfilesystem:us-east-1:123456789012:access-point/fsap-0123456789abcdef0",
+        mountPath: "/mnt/data",
+      },
+    };
+    expect(
+      AgentEnvSpecSchema.safeParse({
+        ...codeZipAgent,
+        filesystemConfigurations: [efsAccessPoint],
+      }).success,
+    ).toBe(false);
+    expect(
+      AgentEnvSpecSchema.safeParse({
+        ...codeZipAgent,
+        networkMode: "VPC",
+        networkConfig,
+        filesystemConfigurations: [{ sessionStorage: { mountPath: "/mnt/data/" } }, efsAccessPoint],
+      }).success,
+    ).toBe(false);
+    expect(
+      AgentEnvSpecSchema.safeParse({
+        ...codeZipAgent,
+        filesystemConfigurations: Array.from({ length: 6 }, (_, index) => ({
+          sessionStorage: { mountPath: `/mnt/data${index}` },
+        })),
+      }).success,
+    ).toBe(false);
+  });
+  it("applies the CodeBuild security-group cap only to container builds", () => {
+    const securityGroups = Array.from(
+      { length: 6 },
+      (_, index) => `sg-${String(index + 1).padStart(17, "0")}`,
+    );
+    const vpc = {
+      networkMode: "VPC" as const,
+      networkConfig: { ...networkConfig, securityGroups },
+    };
+    expect(AgentEnvSpecSchema.safeParse({ ...containerAgent, ...vpc }).success).toBe(false);
+    expect(AgentEnvSpecSchema.safeParse({ ...codeZipAgent, ...vpc }).success).toBe(true);
+  });
+});

--- a/src/core/project/schema/runtime.ts
+++ b/src/core/project/schema/runtime.ts
@@ -1,0 +1,388 @@
+import {
+  MAX_CONTAINER_BUILD_SECURITY_GROUPS,
+  NetworkModeSchema,
+  ProtocolModeSchema,
+  RuntimeVersionSchema as RuntimeVersionSchemaFromConstants,
+  SECURITY_GROUP_ID_PATTERN,
+  SUBNET_ID_PATTERN,
+  VPC_ID_PATTERN,
+  isContainerBuild,
+} from "./constants";
+import type { DirectoryPath, FilePath } from "./types";
+import { AuthorizerConfigSchema, RuntimeAuthorizerTypeSchema } from "./auth";
+import { ConnectionSchema } from "./connections";
+import { TagsSchema } from "./tags";
+import { z } from "zod";
+export const AgentNameSchema = z
+  .string()
+  .min(1, "Name is required")
+  .max(48)
+  .regex(
+    /^[a-zA-Z][a-zA-Z0-9_]{0,47}$/,
+    "Must begin with a letter and contain only alphanumeric characters and underscores (max 48 chars)",
+  );
+export const EnvVarNameSchema = z
+  .string()
+  .min(1)
+  .max(255)
+  .regex(
+    /^[A-Za-z_][A-Za-z0-9_]*$/,
+    "Must start with a letter or underscore, contain only letters, digits, and underscores",
+  );
+export const GatewayNameSchema = z
+  .string()
+  .min(1)
+  .max(100)
+  .regex(
+    /^[0-9a-zA-Z](?:[0-9a-zA-Z-]*[0-9a-zA-Z])?$/,
+    "Gateway name must be alphanumeric with optional hyphens (max 100 chars)",
+  );
+export const AccessSchema = z.enum(["read", "readwrite"]);
+export type Access = z.infer<typeof AccessSchema>;
+export const AgentTypeSchema = z.literal("AgentCoreRuntime");
+export type AgentType = z.infer<typeof AgentTypeSchema>;
+export const BuildTypeSchema = z.enum(["CodeZip", "Container"]);
+export type BuildType = z.infer<typeof BuildTypeSchema>;
+export const EntrypointSchema = z
+  .string()
+  .min(1)
+  .regex(
+    /^[a-zA-Z0-9_][a-zA-Z0-9_/.-]*\.(py|ts|js)(:[a-zA-Z_][a-zA-Z0-9_]*)?$/,
+    'Must be a Python (.py) or TypeScript (.ts/.js) file path with optional handler (e.g., "main.py:handler" or "index.ts")',
+  ) as unknown as z.ZodType<FilePath>;
+const DirectoryPathSchema = z.string().min(1) as unknown as z.ZodType<DirectoryPath>;
+const DOCKERFILE_PATH_ALLOWED_CHARS = /^[A-Za-z0-9._/-]+$/;
+export function isValidDockerfilePath(p: string): boolean {
+  if (!DOCKERFILE_PATH_ALLOWED_CHARS.test(p)) return false;
+  if (p.startsWith("/")) return false;
+  return !p.split("/").some((segment) => segment === "" || segment === "..");
+}
+const DockerfilePathSchema = z
+  .string()
+  .min(1)
+  .max(255)
+  .refine(
+    isValidDockerfilePath,
+    'Must be a relative path within the build context: a filename or forward-slash subpath using only letters, digits, dot, dash, underscore, and slash; no leading slash, no ".." traversal, and no empty segments (no trailing or double slash)',
+  );
+export const RESERVED_BUILD_ARG_KEYS = [
+  "ECR_REGISTRY",
+  "IMAGE_URI",
+  "DOCKERFILE_PATH",
+  "BUILD_ARG_FLAGS",
+  "PATH",
+  "HOME",
+  "IFS",
+  "LD_PRELOAD",
+  "LD_LIBRARY_PATH",
+  "DOCKER_HOST",
+  "DOCKER_CONFIG",
+  "DOCKER_TLS_VERIFY",
+  "DOCKER_CERT_PATH",
+];
+export function isReservedBuildArgKey(key: string): boolean {
+  return (
+    RESERVED_BUILD_ARG_KEYS.includes(key) || key.startsWith("CODEBUILD_") || key.startsWith("AWS_")
+  );
+}
+const BuildArgValueSchema = z
+  .string()
+  .max(4096, "Build arg values must be at most 4096 characters")
+  .refine(
+    (v) => ![...v].some((ch) => ch.charCodeAt(0) < 0x20 || ch.charCodeAt(0) === 0x7f),
+    "Build arg values must not contain control characters (including newlines)",
+  );
+export const EnvVarSchema = z.object({
+  name: EnvVarNameSchema,
+  value: z.string(),
+});
+export type EnvVar = z.infer<typeof EnvVarSchema>;
+export const InstrumentationSchema = z.object({
+  enableOtel: z.boolean().default(true),
+});
+export type Instrumentation = z.infer<typeof InstrumentationSchema>;
+export const NetworkConfigSchema = z.object({
+  subnets: z
+    .array(z.string().regex(SUBNET_ID_PATTERN, "Must be a subnet id (subnet-...)"))
+    .min(1)
+    .max(16),
+  securityGroups: z
+    .array(z.string().regex(SECURITY_GROUP_ID_PATTERN, "Must be a security group id (sg-...)"))
+    .min(1)
+    .max(16),
+  vpcId: z.string().regex(VPC_ID_PATTERN, "Must be a VPC id (vpc-...)").optional(),
+});
+export type NetworkConfig = z.infer<typeof NetworkConfigSchema>;
+export const HEADER_ALLOWLIST_PREFIX = "X-Amzn-Bedrock-AgentCore-Runtime-Custom-";
+export const HEADER_NAME_PATTERN = /^[A-Za-z0-9\-_]+$/;
+export const MAX_HEADER_ALLOWLIST_SIZE = 20;
+export function checkAllowlistHeader(val: string): string | null {
+  if (!HEADER_NAME_PATTERN.test(val)) {
+    return `Header name "${val}" must contain only alphanumeric characters, hyphens, and underscores.`;
+  }
+  const lower = val.toLowerCase();
+  if (lower.startsWith("x-amz-")) {
+    return `Header "${val}" is not allowed. Headers starting with "x-amz-" are reserved for AWS request signing.`;
+  }
+  if (
+    lower.startsWith("x-amzn-") &&
+    !lower.startsWith("x-amzn-bedrock-agentcore-runtime-custom-")
+  ) {
+    return `Header "${val}" is not allowed. Headers starting with "x-amzn-" are reserved, except for "X-Amzn-Bedrock-AgentCore-Runtime-Custom-*".`;
+  }
+  return null;
+}
+export const RequestHeaderAllowlistSchema = z
+  .array(
+    z.string().superRefine((val, ctx) => {
+      const error = checkAllowlistHeader(val);
+      if (error) {
+        ctx.addIssue({ code: "custom", message: error });
+      }
+    }),
+  )
+  .max(MAX_HEADER_ALLOWLIST_SIZE, `Maximum ${MAX_HEADER_ALLOWLIST_SIZE} headers allowed`);
+export const SessionStorageSchema = z.object({
+  mountPath: z
+    .string()
+    .min(6)
+    .max(200)
+    .regex(
+      /^\/mnt\/[a-zA-Z0-9._-]+\/?$/,
+      "Must be a path under /mnt with exactly one subdirectory (e.g. /mnt/data)",
+    ),
+});
+export type SessionStorage = z.infer<typeof SessionStorageSchema>;
+export const EFS_ACCESS_POINT_ARN_PATTERN =
+  /^arn:aws[-a-z]*:elasticfilesystem:[a-z][a-z0-9-]*:[0-9]{12}:access-point\/fsap-[0-9a-f]{8,40}$/;
+export const S3_FILES_ACCESS_POINT_ARN_PATTERN =
+  /^arn:aws[-a-z]*:s3files:[a-z][a-z0-9-]*:[0-9]{12}:file-system\/fs-[0-9a-f]{17,40}\/access-point\/fsap-[0-9a-f]{17,40}$/;
+export const EfsAccessPointConfigSchema = z.object({
+  accessPointArn: z
+    .string()
+    .regex(
+      EFS_ACCESS_POINT_ARN_PATTERN,
+      "Must be an EFS access point ARN (arn:aws[-a-z]*:elasticfilesystem:{region}:{account}:access-point/fsap-{id})",
+    ),
+  mountPath: z
+    .string()
+    .min(6)
+    .max(200)
+    .regex(
+      /^\/mnt\/[a-zA-Z0-9._-]+\/?$/,
+      "Must be a path under /mnt with exactly one subdirectory (e.g. /mnt/tools)",
+    ),
+});
+export type EfsAccessPointConfig = z.infer<typeof EfsAccessPointConfigSchema>;
+export const S3FilesAccessPointConfigSchema = z.object({
+  accessPointArn: z
+    .string()
+    .regex(
+      S3_FILES_ACCESS_POINT_ARN_PATTERN,
+      "Must be an S3 Files access point ARN (arn:aws[-a-z]*:s3files:{region}:{account}:file-system/fs-{id}/access-point/fsap-{id})",
+    ),
+  mountPath: z
+    .string()
+    .min(6)
+    .max(200)
+    .regex(
+      /^\/mnt\/[a-zA-Z0-9._-]+\/?$/,
+      "Must be a path under /mnt with exactly one subdirectory (e.g. /mnt/datasets)",
+    ),
+});
+export type S3FilesAccessPointConfig = z.infer<typeof S3FilesAccessPointConfigSchema>;
+export const MAX_EFS_MOUNTS = 2;
+export const MAX_S3_MOUNTS = 2;
+export const FilesystemConfigurationSchema = z.union([
+  z.strictObject({ sessionStorage: SessionStorageSchema }),
+  z.strictObject({ efsAccessPoint: EfsAccessPointConfigSchema }),
+  z.strictObject({ s3FilesAccessPoint: S3FilesAccessPointConfigSchema }),
+]);
+export type FilesystemConfiguration = z.infer<typeof FilesystemConfigurationSchema>;
+export const LIFECYCLE_TIMEOUT_MIN = 60;
+export const LIFECYCLE_TIMEOUT_MAX = 28800;
+export const LifecycleConfigurationSchema = z
+  .object({
+    idleRuntimeSessionTimeout: z
+      .number()
+      .int()
+      .min(LIFECYCLE_TIMEOUT_MIN)
+      .max(LIFECYCLE_TIMEOUT_MAX)
+      .optional(),
+    maxLifetime: z.number().int().min(LIFECYCLE_TIMEOUT_MIN).max(LIFECYCLE_TIMEOUT_MAX).optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.idleRuntimeSessionTimeout !== undefined && data.maxLifetime !== undefined) {
+      if (data.idleRuntimeSessionTimeout > data.maxLifetime) {
+        ctx.addIssue({
+          code: "custom",
+          message: "idleRuntimeSessionTimeout must be <= maxLifetime",
+          path: ["idleRuntimeSessionTimeout"],
+        });
+      }
+    }
+  });
+export type LifecycleConfiguration = z.infer<typeof LifecycleConfigurationSchema>;
+export const RuntimeEndpointNameSchema = z
+  .string()
+  .min(1, "Endpoint name is required")
+  .max(48)
+  .regex(
+    /^[a-zA-Z][a-zA-Z0-9_]{0,47}$/,
+    "Must begin with a letter and contain only alphanumeric characters and underscores (max 48 chars)",
+  );
+export const RuntimeEndpointSchema = z.object({
+  version: z.number().int().min(1),
+  description: z.string().max(200).optional(),
+});
+export type RuntimeEndpoint = z.infer<typeof RuntimeEndpointSchema>;
+export const AgentEnvSpecSchema = z
+  .object({
+    name: AgentNameSchema,
+    description: z.string().max(200).optional(),
+    build: BuildTypeSchema,
+    entrypoint: EntrypointSchema,
+    codeLocation: DirectoryPathSchema,
+    dockerfile: DockerfilePathSchema.optional(),
+    buildContextPath: DirectoryPathSchema.optional(),
+    customDockerBuildArgs: z.record(EnvVarNameSchema, BuildArgValueSchema).optional(),
+    runtimeVersion: RuntimeVersionSchemaFromConstants.optional(),
+    envVars: z.array(EnvVarSchema).optional(),
+    networkMode: NetworkModeSchema.optional(),
+    networkConfig: NetworkConfigSchema.optional(),
+    instrumentation: InstrumentationSchema.optional(),
+    protocol: ProtocolModeSchema.optional(),
+    requestHeaderAllowlist: RequestHeaderAllowlistSchema.optional(),
+    executionRoleArn: z.string().optional(),
+    additionalPolicies: z.array(z.string().min(1)).optional(),
+    authorizerType: RuntimeAuthorizerTypeSchema.optional(),
+    authorizerConfiguration: AuthorizerConfigSchema.optional(),
+    tags: TagsSchema.optional(),
+    lifecycleConfiguration: LifecycleConfigurationSchema.optional(),
+    filesystemConfigurations: z.array(FilesystemConfigurationSchema).optional(),
+    endpoints: z.record(RuntimeEndpointNameSchema, RuntimeEndpointSchema).optional(),
+    connections: z.array(ConnectionSchema).optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.networkMode === "VPC" && !data.networkConfig) {
+      ctx.addIssue({
+        code: "custom",
+        message: "networkConfig is required when networkMode is VPC",
+        path: ["networkConfig"],
+      });
+    }
+    if (data.networkMode !== "VPC" && data.networkConfig) {
+      ctx.addIssue({
+        code: "custom",
+        message: "networkConfig is only allowed when networkMode is VPC",
+        path: ["networkConfig"],
+      });
+    }
+    if (
+      data.networkMode === "VPC" &&
+      isContainerBuild(data) &&
+      data.networkConfig &&
+      data.networkConfig.securityGroups.length > MAX_CONTAINER_BUILD_SECURITY_GROUPS
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message: `Container builds in VPC mode allow at most ${MAX_CONTAINER_BUILD_SECURITY_GROUPS} security groups (CodeBuild limit)`,
+        path: ["networkConfig", "securityGroups"],
+      });
+    }
+    if (
+      data.authorizerType === "CUSTOM_JWT" &&
+      !data.authorizerConfiguration?.customJwtAuthorizer
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message:
+          "authorizerConfiguration with customJwtAuthorizer is required when authorizerType is CUSTOM_JWT",
+        path: ["authorizerConfiguration"],
+      });
+    }
+    if (data.authorizerType !== "CUSTOM_JWT" && data.authorizerConfiguration) {
+      ctx.addIssue({
+        code: "custom",
+        message: "authorizerConfiguration is only allowed when authorizerType is CUSTOM_JWT",
+        path: ["authorizerConfiguration"],
+      });
+    }
+    for (const field of ["dockerfile", "buildContextPath", "customDockerBuildArgs"] as const) {
+      if (data.build !== "Container" && data[field]) {
+        ctx.addIssue({
+          code: "custom",
+          message: `${field} is only allowed for Container builds`,
+          path: [field],
+        });
+      }
+    }
+    for (const key of Object.keys(data.customDockerBuildArgs ?? {})) {
+      if (isReservedBuildArgKey(key)) {
+        ctx.addIssue({
+          code: "custom",
+          message: `customDockerBuildArgs key "${key}" is reserved by the build environment (must not be ${RESERVED_BUILD_ARG_KEYS.join(", ")}, or start with CODEBUILD_ or AWS_)`,
+          path: ["customDockerBuildArgs", key],
+        });
+      }
+    }
+    const fcs = data.filesystemConfigurations ?? [];
+    if (fcs.length > 0) {
+      const efsCount = fcs.filter((fc) => "efsAccessPoint" in fc).length;
+      const s3Count = fcs.filter((fc) => "s3FilesAccessPoint" in fc).length;
+      const ssCount = fcs.filter((fc) => "sessionStorage" in fc).length;
+      if (fcs.length > 5) {
+        ctx.addIssue({
+          code: "custom",
+          message: "Maximum 5 filesystem configurations allowed",
+          path: ["filesystemConfigurations"],
+        });
+      }
+      if (efsCount > MAX_EFS_MOUNTS) {
+        ctx.addIssue({
+          code: "custom",
+          message: `Maximum ${MAX_EFS_MOUNTS} efsAccessPoint configurations allowed`,
+          path: ["filesystemConfigurations"],
+        });
+      }
+      if (s3Count > MAX_S3_MOUNTS) {
+        ctx.addIssue({
+          code: "custom",
+          message: `Maximum ${MAX_S3_MOUNTS} s3FilesAccessPoint configurations allowed`,
+          path: ["filesystemConfigurations"],
+        });
+      }
+      if (ssCount > 1) {
+        ctx.addIssue({
+          code: "custom",
+          message: "Maximum 1 sessionStorage configuration allowed",
+          path: ["filesystemConfigurations"],
+        });
+      }
+      const hasByo = efsCount > 0 || s3Count > 0;
+      if (hasByo && data.networkMode !== "VPC") {
+        ctx.addIssue({
+          code: "custom",
+          message:
+            "efsAccessPoint and s3FilesAccessPoint filesystem mounts require networkMode: VPC",
+          path: ["filesystemConfigurations"],
+        });
+      }
+      const mountPaths = fcs.map((fc) =>
+        ("sessionStorage" in fc
+          ? fc.sessionStorage.mountPath
+          : "efsAccessPoint" in fc
+            ? fc.efsAccessPoint.mountPath
+            : fc.s3FilesAccessPoint.mountPath
+        ).replace(/\/$/, ""),
+      );
+      if (new Set(mountPaths).size !== mountPaths.length) {
+        ctx.addIssue({
+          code: "custom",
+          message: "Filesystem mount paths must be unique",
+          path: ["filesystemConfigurations"],
+        });
+      }
+    }
+  });
+export type AgentEnvSpec = z.infer<typeof AgentEnvSpecSchema>;

--- a/src/core/project/schema/tags.test.ts
+++ b/src/core/project/schema/tags.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "bun:test";
+import { TagKeySchema, TagsSchema } from "./tags";
+describe("tag custom validation", () => {
+  it("rejects whitespace-only and reserved keys", () => {
+    expect(TagKeySchema.safeParse("   ").success).toBe(false);
+    expect(TagKeySchema.safeParse("aws:owned").success).toBe(false);
+  });
+  it("enforces the AWS resource tag count", () => {
+    const tags = Object.fromEntries(Array.from({ length: 51 }, (_, index) => [`key${index}`, "v"]));
+    expect(TagsSchema.safeParse(tags).success).toBe(false);
+  });
+});

--- a/src/core/project/schema/tags.ts
+++ b/src/core/project/schema/tags.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+const TAG_CHAR_PATTERN = /^[\p{L}\p{N}\s_.:/=+\-@]*$/u;
+export const TagKeySchema = z
+  .string()
+  .min(1, "Tag key is required")
+  .max(128, "Tag key must be 128 characters or less")
+  .regex(TAG_CHAR_PATTERN, "Tag key contains invalid characters")
+  .refine(
+    (key) => key.trim().length > 0,
+    "Tag key must contain at least one non-whitespace character",
+  )
+  .refine((key) => !key.startsWith("aws:"), 'Tag keys starting with "aws:" are reserved');
+export const TagValueSchema = z
+  .string()
+  .max(256, "Tag value must be 256 characters or less")
+  .regex(TAG_CHAR_PATTERN, "Tag value contains invalid characters");
+export const TagsSchema = z
+  .record(TagKeySchema, TagValueSchema)
+  .refine((tags) => Object.keys(tags).length <= 50, "Maximum 50 tags per resource");
+export type Tags = z.infer<typeof TagsSchema>;

--- a/src/core/project/schema/types.ts
+++ b/src/core/project/schema/types.ts
@@ -1,0 +1,6 @@
+export type FilePath = string & {
+  readonly __brand: "FilePath";
+};
+export type DirectoryPath = string & {
+  readonly __brand: "DirectoryPath";
+};

--- a/src/core/project/schema/zod-util.test.ts
+++ b/src/core/project/schema/zod-util.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "bun:test";
+import { z } from "zod";
+import { uniqueBy } from "./zod-util";
+describe("uniqueBy", () => {
+  const uniqueNames = uniqueBy<{ name: string }>(
+    (item) => item.name,
+    (name) => `Duplicate: ${name}`,
+  );
+
+  it("reports each duplicate at its array index without flagging the first occurrence", () => {
+    const schema = z.array(z.object({ name: z.string() })).superRefine(uniqueNames);
+    const result = schema.safeParse([{ name: "same" }, { name: "same" }, { name: "same" }]);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.map((issue) => issue.path)).toEqual([[1], [2]]);
+    }
+  });
+
+  it("ignores an absent optional array", () => {
+    const schema = z
+      .array(z.object({ name: z.string() }))
+      .optional()
+      .superRefine(uniqueNames);
+
+    expect(schema.safeParse(undefined).success).toBe(true);
+  });
+});

--- a/src/core/project/schema/zod-util.ts
+++ b/src/core/project/schema/zod-util.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+export function uniqueBy<T>(
+  keyFn: (item: T) => string,
+  errorMessage: (key: string) => string,
+): (items: T[] | null | undefined, ctx: z.RefinementCtx) => void {
+  return (items, ctx) => {
+    if (!items) return;
+    const seen = new Set<string>();
+    for (const [idx, item] of items.entries()) {
+      const key = keyFn(item);
+      if (seen.has(key)) {
+        ctx.addIssue({ code: "custom", message: errorMessage(key), path: [idx] });
+      }
+      seen.add(key);
+    }
+  };
+}

--- a/src/handlers/project/types.ts
+++ b/src/handlers/project/types.ts
@@ -1,4 +1,6 @@
-import z from "zod";
+import { ProjectNameSchema } from "../../core/project/schema";
+
+export { ProjectNameSchema };
 
 /** Available project templates for scaffolding new AgentCore projects. */
 export const PROJECT_TEMPLATES = {
@@ -6,82 +8,6 @@ export const PROJECT_TEMPLATES = {
 } as const;
 
 export type ProjectTemplate = (typeof PROJECT_TEMPLATES)[keyof typeof PROJECT_TEMPLATES];
-
-// A generated project's Python package is named after the
-// project, so a name that collides with a dependency breaks imports.
-const RESERVED_PROJECT_NAMES: readonly string[] = [
-  // Core SDK packages
-  "anthropic",
-  "autogen",
-  "autogenagentchat",
-  "autogenext",
-  "bedrock",
-  "bedrockagentcore",
-  "crewai",
-  "crewaitools",
-  "googleadk",
-  "googlegenerativeai",
-  "langchain",
-  "langchainanthropic",
-  "langchainaws",
-  "langchaingooglegenai",
-  "langchainmcpadapters",
-  "langchainopenai",
-  "langgraph",
-  "mcp",
-  "openai",
-  "openaiagents",
-  "strands",
-  "strandsagents",
-  "strandsagentstools",
-  // AG-UI adapter packages
-  "agui",
-  "aguistrands",
-  "aguilanggraph",
-  "aguiadk",
-  "aguiprotocol",
-  "vercelai",
-  "aisdk",
-  // Common utilities
-  "httpx",
-  "pytest",
-  "pytestasyncio",
-  "pythondotenv",
-  "tiktoken",
-  // Build tools
-  "hatchling",
-  "setuptools",
-  "wheel",
-  // AWS packages
-  "awsopentelemetrydistro",
-  "boto3",
-  "botocore",
-  // Common Python stdlib/package names that could cause issues
-  "test",
-  "tests",
-  "src",
-  "lib",
-  "dist",
-  "build",
-  "env",
-  "venv",
-  "site",
-  "pip",
-  "uv",
-];
-
-// Mirrors ProjectNameSchema in @aws/agentcore-cdk
-export const ProjectNameSchema = z
-  .string()
-  .min(1, "project name is required")
-  .max(23, "project name must be 23 characters or less")
-  .regex(
-    /^[A-Za-z][A-Za-z0-9]{0,22}$/,
-    "project name must start with a letter and contain only letters and digits",
-  )
-  .refine((name) => !RESERVED_PROJECT_NAMES.includes(name.toLowerCase()), {
-    message: "this name conflicts with a Python package dependency; choose a different name",
-  });
 
 export type CreateProjectInput = {
   /** The name of the project; also the directory it is scaffolded into. */


### PR DESCRIPTION
## Summary

- Port the complete v1 project schema from the existing CLI into resource-owned Zod modules.
- Expose the schema through `src/core/project/schema.ts` and derive project handler types from it.
- Preserve custom cross-resource validation while sharing repeated rules such as unique resource names.
- Add focused tests only for owned custom validation and helper behavior.

## Validation

- `bun test` (965 pass)
- `bun test src/core/project/schema` (77 pass)
- `bun run typecheck`
- `bun run lint:check`
- `bun run format:check`
- `bun run build`