### PR TITLE
feat(project): implement resolve() + container template on FsTreeNode

### DIFF
--- a/src/assets/templates/hello-world-python-container/Dockerfile
+++ b/src/assets/templates/hello-world-python-container/Dockerfile
@@ -1,0 +1,37 @@
+FROM public.ecr.aws/docker/library/python:3.12-slim-trixie
+
+RUN pip install --no-cache-dir uv
+
+ARG UV_DEFAULT_INDEX
+ARG UV_INDEX
+
+WORKDIR /app
+
+ENV UV_SYSTEM_PYTHON=1 \
+    UV_COMPILE_BYTECODE=1 \
+    UV_NO_PROGRESS=1 \
+    PYTHONUNBUFFERED=1 \
+    DOCKER_CONTAINER=1 \
+    UV_DEFAULT_INDEX=${UV_DEFAULT_INDEX} \
+    UV_INDEX=${UV_INDEX} \
+    PATH="/app/.venv/bin:$PATH"
+
+RUN useradd -m -u 1000 bedrock_agentcore
+
+# Install dependencies first so code changes don't invalidate the layer.
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-dev --no-install-project
+
+COPY --chown=bedrock_agentcore:bedrock_agentcore . .
+RUN uv sync --frozen --no-dev
+
+USER bedrock_agentcore
+
+# AgentCore Runtime service contract ports
+# https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-service-contract.html
+# 8080: HTTP Mode
+# 8000: MCP Mode
+# 9000: A2A Mode
+EXPOSE 8080 8000 9000
+
+CMD ["python", "-m", "main"]

--- a/src/assets/templates/hello-world-python-container/README.md
+++ b/src/assets/templates/hello-world-python-container/README.md
@@ -1,0 +1,27 @@
+# hello-world
+
+An AgentCore Runtime agent built with the [Strands](https://strandsagents.com)
+SDK. Scaffolded by `agentcore project create`.
+
+## Layout
+
+- `main.py` — the agent: a `BedrockAgentCoreApp` entrypoint that streams
+  responses from a Strands `Agent`.
+- `pyproject.toml` — dependencies, installed with [uv](https://docs.astral.sh/uv/).
+
+## Develop
+
+Run the agent locally from the project root:
+
+```bash
+agentcore project dev
+```
+
+Environment variables for local development go in `agentcore/.env.local`
+(gitignored).
+
+## Deploy
+
+```bash
+agentcore project deploy
+```

--- a/src/assets/templates/hello-world-python-container/dockerignore.template
+++ b/src/assets/templates/hello-world-python-container/dockerignore.template
@@ -1,0 +1,27 @@
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+dist/
+build/
+
+# IDE
+.vscode/
+.idea/
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Secrets and environment files
+.env
+.env.*
+
+# Version control
+.git/
+
+# AgentCore build artifacts
+.agentcore/artifacts/
+*.zip

--- a/src/assets/templates/hello-world-python-container/main.py
+++ b/src/assets/templates/hello-world-python-container/main.py
@@ -1,0 +1,17 @@
+from bedrock_agentcore.runtime import BedrockAgentCoreApp
+from strands import Agent
+
+app = BedrockAgentCoreApp()
+agent = Agent(system_prompt="You are a helpful assistant.")
+
+
+@app.entrypoint
+async def invoke(payload, context):
+    """Stream the agent's response to the caller's prompt."""
+    prompt = payload.get("prompt", "Hello!")
+    async for event in agent.stream_async(prompt):
+        yield event
+
+
+if __name__ == "__main__":
+    app.run()

--- a/src/assets/templates/hello-world-python-container/pyproject.toml
+++ b/src/assets/templates/hello-world-python-container/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "hello-world"
+version = "0.1.0"
+description = "AgentCore Runtime application using the Strands SDK"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "aws-opentelemetry-distro",
+    "bedrock-agentcore >= 1.9.1",
+    "botocore[crt] >= 1.35.0",
+    "strands-agents >= 1.15.0",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]

--- a/src/assets/templates/shared/env.local.template
+++ b/src/assets/templates/shared/env.local.template
@@ -1,0 +1,7 @@
+# Environment variables for local development.
+# `agentcore dev` loads this file into your agent's process. Values here
+# override anything the CLI injects. This file is gitignored — keep secrets
+# out of version control, but they are safe here.
+#
+# Example:
+# MY_API_KEY=...

--- a/src/assets/templates/shared/gitignore.template
+++ b/src/assets/templates/shared/gitignore.template
@@ -1,0 +1,17 @@
+# Local environment (loaded by `agentcore dev`; never commit secrets)
+.env.local
+.env*.local
+
+# Python
+__pycache__/
+*.py[cod]
+.venv/
+
+# Node
+node_modules/
+
+# AgentCore CLI state
+agentcore/.cli/
+
+# CDK
+agentcore/cdk/cdk.out/

--- a/src/core/project/__snapshots__/manager.test.ts.snap
+++ b/src/core/project/__snapshots__/manager.test.ts.snap
@@ -2,6 +2,8 @@
 
 exports[`FsProjectManager.create scaffolds the expected file tree into a fresh directory 1`] = `
 [
+  ".gitignore",
+  "agentcore/.env.local",
   "agentcore/agentcore.json",
   "agentcore/aws-targets.json",
   "agentcore/cdk/.gitignore",

--- a/src/core/project/fsTree.ts
+++ b/src/core/project/fsTree.ts
@@ -105,6 +105,6 @@ export class FsTreeNode {
  * Ignore templates are renamed to dotfiles because npm strips real dotfiles when publishing.
  */
 function renderName(filename: string): string {
-  const ignore = filename.match(/^(git|npm)ignore\.template$/);
+  const ignore = filename.match(/^(git|npm|docker)ignore\.template$/);
   return ignore ? `.${ignore[1]}ignore` : filename;
 }

--- a/src/core/project/manager.test.ts
+++ b/src/core/project/manager.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtemp, readdir, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
 import { join, relative } from "node:path";
 import { tmpdir } from "node:os";
-import { ProjectStateError } from "../../errors/errors";
+import { InputValidationError, ProjectStateError } from "../../errors/errors";
 import { FsProjectManager } from "./manager";
 import {
   PROJECT_TEMPLATES,
@@ -160,7 +160,9 @@ describe("FsProjectManager.create", () => {
       "Syncing Python dependencies with uv",
       "Initializing git repository",
     ]);
-    expect(project).toEqual({ name: "example" });
+    expect(project.name).toBe("example");
+    expect(project.rootPath).toContain("example");
+    expect(project.runtimes).toHaveLength(1);
   });
 
   test("a failed step propagates and leaves the scaffolded files in place", async () => {
@@ -195,5 +197,35 @@ describe("FsProjectManager.create", () => {
         template: PROJECT_TEMPLATES.HELLO_WORLD_PYTHON,
       }),
     ).rejects.toBeInstanceOf(ProjectStateError);
+  });
+});
+
+describe("FsProjectManager.resolve", () => {
+  test("round-trips a project it just created", async () => {
+    const root = await inTempDirectory();
+    const subject = manager().manager;
+    await runCreate(subject, { name: "example", template: PROJECT_TEMPLATES.HELLO_WORLD_PYTHON });
+
+    // Resolve from a nested path to prove the walk-up to the project root.
+    const resolved = await subject.resolve({ filePath: join(root, "example", "app") });
+
+    expect(resolved?.name).toBe("example");
+    expect(resolved?.rootPath).toBe(join(root, "example"));
+    expect(resolved?.runtimes).toHaveLength(1);
+  });
+
+  test("returns undefined when no project encloses the path", async () => {
+    const root = await inTempDirectory();
+    expect(await manager().manager.resolve({ filePath: root })).toBeUndefined();
+  });
+
+  test("throws InputValidationError on a malformed agentcore.json", async () => {
+    const root = await inTempDirectory();
+    await mkdir(join(root, "agentcore"), { recursive: true });
+    await writeFile(join(root, "agentcore", "agentcore.json"), "{ not valid json");
+
+    await expect(manager().manager.resolve({ filePath: root })).rejects.toBeInstanceOf(
+      InputValidationError,
+    );
   });
 });

--- a/src/core/project/manager.test.ts
+++ b/src/core/project/manager.test.ts
@@ -102,6 +102,23 @@ describe("FsProjectManager.create", () => {
     expect(await Bun.file(join(configDir, "aws-targets.json")).json()).toEqual([]);
   });
 
+  test("scaffolds the container template with a Dockerfile and .dockerignore", async () => {
+    const directory = await inTempDirectory();
+    await runCreate(manager().manager, {
+      name: "example",
+      template: PROJECT_TEMPLATES.HELLO_WORLD_PYTHON_CONTAINER,
+    });
+
+    const appDir = join(directory, "example", "app", "hello-world");
+    // dockerignore.template must render to .dockerignore (the fsTree regex fix).
+    expect(await Bun.file(join(appDir, ".dockerignore")).exists()).toBe(true);
+    expect(await Bun.file(join(appDir, "dockerignore.template")).exists()).toBe(false);
+    expect(await Bun.file(join(appDir, "Dockerfile")).exists()).toBe(true);
+
+    const spec = await Bun.file(join(directory, "example", "agentcore", "agentcore.json")).json();
+    expect(spec.runtimes[0]).toMatchObject({ build: "Container", dockerfile: "Dockerfile" });
+  });
+
   test("refuses to overwrite an existing project", async () => {
     await inTempDirectory();
     const input = { name: "example", template: PROJECT_TEMPLATES.HELLO_WORLD_PYTHON };

--- a/src/core/project/manager.tsx
+++ b/src/core/project/manager.tsx
@@ -8,17 +8,25 @@ import type {
   ProjectEvent,
 } from "../../handlers/project/types";
 import type { Logger } from "../../logging";
-import { requireTool, runProcess, type ProcessRunner } from "../../io";
+import {
+  FsReadWriteJson,
+  requireTool,
+  runProcess,
+  type ProcessRunner,
+  type ReadWriteJson,
+} from "../../io";
 import { defaultSource, type AssetSource } from "./source";
 import { createProjectTreeFromTemplate, TEMPLATES } from "./templates";
+import { ProjectSpecSchema } from "./schema";
 import { enclosingProjectRoot } from "./fsUtils";
-import { ProjectStateError } from "../../errors/errors";
+import { DeserializationError, InputValidationError, ProjectStateError } from "../../errors/errors";
 
 type ProjectManagerConfig = {
   logger: Logger;
   source?: AssetSource; // Bun executable or dist/assets depending on runtime
   runner?: ProcessRunner; // injectable so tests never spawn real processes
   checkTool?: typeof requireTool; // injectable so tests don't depend on the host's PATH
+  json?: ReadWriteJson; // injectable so tests read fixtures instead of disk
 };
 
 /**
@@ -29,16 +37,33 @@ export class FsProjectManager implements ProjectManager {
   private readonly source: AssetSource;
   private readonly runner: ProcessRunner;
   private readonly checkTool: typeof requireTool;
+  private readonly json: ReadWriteJson;
 
   constructor(config: ProjectManagerConfig) {
     this.logger = config.logger;
     this.source = config.source ?? defaultSource();
     this.runner = config.runner ?? runProcess;
     this.checkTool = config.checkTool ?? requireTool;
+    this.json = config.json ?? new FsReadWriteJson({ logger: config.logger });
   }
 
-  public resolve(_input: ResolveProjectInput): Promise<Project> {
-    throw new Error(`ProjectManager.resolve is not implemented yet`);
+  public async resolve(input: ResolveProjectInput): Promise<Project | undefined> {
+    const rootPath = enclosingProjectRoot(input.filePath);
+    if (!rootPath) return undefined;
+
+    const configPath = join(rootPath, "agentcore", "agentcore.json");
+    try {
+      const spec = await this.json.read(configPath, ProjectSpecSchema);
+      return { name: spec.name, rootPath, runtimes: spec.runtimes };
+    } catch (error) {
+      // A malformed agentcore.json is a user-correctable problem, not a crash.
+      if (error instanceof DeserializationError) {
+        throw new InputValidationError(`invalid project configuration at ${configPath}`, {
+          cause: error,
+        });
+      }
+      throw error;
+    }
   }
 
   public async *create(input: CreateProjectInput): AsyncGenerator<ProjectEvent> {
@@ -81,7 +106,12 @@ export class FsProjectManager implements ProjectManager {
       await this.run(["git", "init"], destination);
     }
 
-    return { name: input.name };
+    // Return the same shape resolve() would: a created project is a resolvable one.
+    return {
+      name: input.name,
+      rootPath: destination,
+      runtimes: TEMPLATES[input.template].spec.runtimes ?? [],
+    };
   }
 
   // Runs a command with its output streamed to the file logger.

--- a/src/core/project/templates.ts
+++ b/src/core/project/templates.ts
@@ -36,6 +36,21 @@ export const TEMPLATES: Record<ProjectTemplate, Template> = {
       ],
     },
   },
+  [PROJECT_TEMPLATES.HELLO_WORLD_PYTHON_CONTAINER]: {
+    appDir: "hello-world",
+    assetDir: "templates/hello-world-python-container",
+    spec: {
+      runtimes: [
+        {
+          name: "hello_world",
+          build: "Container",
+          entrypoint: "main.py",
+          codeLocation: "app/hello-world",
+          dockerfile: "Dockerfile",
+        },
+      ],
+    },
+  },
 };
 
 /** Serializes a value as pretty-printed JSON with a trailing newline. */
@@ -61,10 +76,12 @@ export async function createProjectTreeFromTemplate(
 ): Promise<FsTreeNode> {
   const { appDir, assetDir } = TEMPLATES[template];
   return FsTreeNode.createDirectory(".", [
+    FsTreeNode.createFile(".gitignore", () => src.read("templates/shared/gitignore.template")),
     FsTreeNode.createDirectory("agentcore", [
       await FsTreeNode.fromAssetSource(src, "cdk"),
       FsTreeNode.createFile("agentcore.json", async () => json(agentcoreSpec(name, template))),
       FsTreeNode.createFile("aws-targets.json", async () => json([])),
+      FsTreeNode.createFile(".env.local", () => src.read("templates/shared/env.local.template")),
     ]),
     FsTreeNode.createDirectory("app", [await FsTreeNode.fromAssetSource(src, assetDir, appDir)]),
   ]);

--- a/src/handlers/project/types.ts
+++ b/src/handlers/project/types.ts
@@ -6,6 +6,7 @@ export { ProjectNameSchema };
 /** Available project templates for scaffolding new AgentCore projects. */
 export const PROJECT_TEMPLATES = {
   HELLO_WORLD_PYTHON: "hello-world-python",
+  HELLO_WORLD_PYTHON_CONTAINER: "hello-world-python-container",
 } as const;
 
 export type ProjectTemplate = (typeof PROJECT_TEMPLATES)[keyof typeof PROJECT_TEMPLATES];

--- a/src/handlers/project/types.ts
+++ b/src/handlers/project/types.ts
@@ -1,4 +1,5 @@
 import { ProjectNameSchema } from "../../core/project/schema";
+import type { ProjectRuntime } from "../../core/project/schema";
 
 export { ProjectNameSchema };
 
@@ -33,6 +34,10 @@ export type ResolveProjectInput = {
 
 export type Project = {
   name: string;
+  /** Absolute path to the project root (the parent of agentcore/). */
+  rootPath: string;
+  /** The runtimes registered in agentcore.json. */
+  runtimes: ProjectRuntime[];
 };
 
 /**

--- a/src/middleware/withProject.test.ts
+++ b/src/middleware/withProject.test.ts
@@ -5,7 +5,7 @@ import { withProject } from "./withProject";
 import { FsProjectManager } from "../core/project";
 
 describe("withProject", () => {
-  test("throws not implemented", async () => {
+  test("throws when no project encloses the cwd", async () => {
     const projectManager = new FsProjectManager({ logger: createSilentLogger() });
 
     const app = new Router("app", "test");
@@ -18,6 +18,6 @@ describe("withProject", () => {
       }),
     );
 
-    await expect(app.route(["node", "app", "check"])).rejects.toThrow(/not implemented/);
+    await expect(app.route(["node", "app", "check"])).rejects.toThrow(/find project/);
   });
 });

--- a/src/middleware/withProject.test.ts
+++ b/src/middleware/withProject.test.ts
@@ -18,6 +18,6 @@ describe("withProject", () => {
       }),
     );
 
-    await expect(app.route(["node", "app", "check"])).rejects.toThrow(/find project/);
+    await expect(app.route(["node", "app", "check"])).rejects.toThrow(/no AgentCore project found/);
   });
 });

--- a/src/middleware/withProject.tsx
+++ b/src/middleware/withProject.tsx
@@ -1,4 +1,5 @@
 import type { Project, ProjectManager } from "../handlers/project/types";
+import { InputValidationError } from "../errors/errors";
 import { ProjectKey, type Middleware } from "../router";
 
 interface WithProjectConfig {
@@ -22,8 +23,9 @@ export function withProject(config: WithProjectConfig): Middleware {
     children: () => h.children(),
     handle: async (ctx, flags, args) => {
       const project = await config.projectManager.resolve({ filePath: config.cwd });
-      // TODO: swap this for a typed error.
-      if (!project) throw new Error(`Unable to find project at path ${config.cwd}`);
+      if (!project) {
+        throw new InputValidationError(`no AgentCore project found at ${config.cwd}`);
+      }
       await h.handle(ctx.withValue<Project>(ProjectKey, project), flags, args);
     },
   });


### PR DESCRIPTION
## Summary

- implement `ProjectManager.resolve()` by locating and validating the nearest `agentcore/agentcore.json`
- add the `hello-world-python-container` template and scaffold shared `.gitignore` and `agentcore/.env.local` files
- return typed validation errors when project configuration is invalid or no project contains the current directory

Supersedes #1880 after the project schema and `FsTreeNode` scaffolding landed separately.

## Testing

- `bun test` (972 pass)