### PR TITLE
ci: add Slack PR review notification caller (refactor branch)

### DIFF
--- a/.github/workflows/slack-pr-review-notification.yml
+++ b/.github/workflows/slack-pr-review-notification.yml
@@ -1,0 +1,21 @@
+# Caller: posts PR-review activity to the "PR Summary" Slack workflow with @-mentions.
+# Copy this file verbatim into each of the 6 repos' .github/workflows/ — it is
+# repo-agnostic (the reusable auto-detects github.repository). Pin @<SHA> to the
+# devtools main commit that added reusable-slack-pr-review-notification.yml.
+name: Slack PR Review Notification
+
+on:
+  pull_request:
+    types: [review_requested, synchronize]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+  pull-requests: read
+  id-token: write
+
+jobs:
+  call:
+    uses: aws/agentcore-devx-devtools/.github/workflows/reusable-slack-pr-review-notification.yml@69340dffeeddd712ab360fb5f3dd03877068b928
+    secrets: inherit

--- a/.github/workflows/slack-pr-review-notification.yml
+++ b/.github/workflows/slack-pr-review-notification.yml
@@ -17,5 +17,5 @@ permissions:
 
 jobs:
   call:
-    uses: aws/agentcore-devx-devtools/.github/workflows/reusable-slack-pr-review-notification.yml@69340dffeeddd712ab360fb5f3dd03877068b928
+    uses: aws/agentcore-devx-devtools/.github/workflows/reusable-slack-pr-review-notification.yml@626595f508220b53805c86c1b54d089420add4d3
     secrets: inherit


### PR DESCRIPTION
Adds the caller workflow that pings PR reviewers in Slack (#agentcore-sdk-cli-prs) via the shared reusable `reusable-slack-pr-review-notification` (pinned `@69340df`).

## Behavior
| event | pings |
|---|---|
| review requested | the requested reviewer |
| review submitted | the PR author (approved / changes / commented) |
| new revision (synchronize) | prior reviewers + commenters + pending requested reviewers |

Mentions render as real Slack pills (Person-type vars, IDs resolved from the `SLACK_PR_REVIEW_USER_MAP` secret). Verified end-to-end against the live Slack workflow.

## Depends on
- devtools PR aws/agentcore-devx-devtools#1 (the reusable) — **merge that first**, then re-pin this to the squash SHA.
- Secrets `SLACK_PR_REVIEW_WEBHOOK_URL` + `SLACK_PR_REVIEW_USER_MAP` (created) and reader-role grants (done for all 6 repos).

> Companion to the main PR — same caller on the `refactor` base so PRs targeting `refactor` also fire.