### PR TITLE
fix: remove client token flags

### DIFF
--- a/src/core/eval.tsx
+++ b/src/core/eval.tsx
@@ -131,7 +131,6 @@ export class EvalClient implements CoreEvalClient {
         evaluatorId: id,
         evaluatorConfig,
         kmsKeyArn: update.kmsKeyArn,
-        clientToken: update.clientToken,
       }),
     );
   }
@@ -176,7 +175,6 @@ export class EvalClient implements CoreEvalClient {
         evaluatorId: id,
         evaluatorConfig,
         kmsKeyArn: update.kmsKeyArn,
-        clientToken: update.clientToken,
       }),
     );
   }

--- a/src/handlers/eval/evaluator/code-based/create/index.tsx
+++ b/src/handlers/eval/evaluator/code-based/create/index.tsx
@@ -27,7 +27,6 @@ export const createCodeBasedCreateHandler = (core: Core, io: AppIO) =>
         "tags to apply (JSON object of key/value strings; inline, file://<path>, or - for stdin)",
         z.string().optional(),
       ),
-      flag("client-token", "idempotency token", z.string().optional()),
     ],
     handle: async (ctx, flags) => {
       if (!flags["name"])
@@ -58,7 +57,6 @@ export const createCodeBasedCreateHandler = (core: Core, io: AppIO) =>
           },
           kmsKeyArn: flags["kms-key-arn"],
           tags,
-          clientToken: flags["client-token"],
         },
         coreOptsFromCtx(ctx),
       );

--- a/src/handlers/eval/evaluator/code-based/update/index.tsx
+++ b/src/handlers/eval/evaluator/code-based/update/index.tsx
@@ -18,7 +18,6 @@ export const createCodeBasedUpdateHandler = (core: Core) =>
         z.number().int().min(1).max(300).optional(),
       ),
       flag("kms-key-arn", "customer managed KMS key ARN for evaluator data", z.string().optional()),
-      flag("client-token", "idempotency token", z.string().optional()),
     ],
     handle: async (ctx, flags) => {
       if (!flags["id"]) throw new InputValidationError("required option '--id <id>' not specified");
@@ -29,7 +28,6 @@ export const createCodeBasedUpdateHandler = (core: Core) =>
           lambdaArn: flags["lambda-arn"],
           timeout: flags["timeout"],
           kmsKeyArn: flags["kms-key-arn"],
-          clientToken: flags["client-token"],
         },
         coreOptsFromCtx(ctx),
       );

--- a/src/handlers/eval/evaluator/llm-as-a-judge/create/index.tsx
+++ b/src/handlers/eval/evaluator/llm-as-a-judge/create/index.tsx
@@ -24,7 +24,6 @@ export const createLlmAsAJudgeCreateHandler = (core: Core, io: AppIO) =>
         "tags to apply (JSON object of key/value strings; inline, file://<path>, or - for stdin)",
         z.string().optional(),
       ),
-      flag("client-token", "idempotency token", z.string().optional()),
     ],
     handle: async (ctx, flags) => {
       if (!flags["name"])
@@ -65,7 +64,6 @@ export const createLlmAsAJudgeCreateHandler = (core: Core, io: AppIO) =>
           },
           kmsKeyArn: flags["kms-key-arn"],
           tags,
-          clientToken: flags["client-token"],
         },
         coreOptsFromCtx(ctx),
       );

--- a/src/handlers/eval/evaluator/llm-as-a-judge/update/index.tsx
+++ b/src/handlers/eval/evaluator/llm-as-a-judge/update/index.tsx
@@ -17,7 +17,6 @@ export const createLlmAsAJudgeUpdateHandler = (core: Core, io: AppIO) =>
       flag("model", "the Bedrock model id used to judge", z.string().optional()),
       ratingScaleFlag,
       flag("kms-key-arn", "customer managed KMS key ARN for evaluator data", z.string().optional()),
-      flag("client-token", "idempotency token", z.string().optional()),
     ],
     handle: async (ctx, flags) => {
       if (!flags["id"]) throw new InputValidationError("required option '--id <id>' not specified");
@@ -33,7 +32,6 @@ export const createLlmAsAJudgeUpdateHandler = (core: Core, io: AppIO) =>
           model: flags["model"],
           ratingScale,
           kmsKeyArn: flags["kms-key-arn"],
-          clientToken: flags["client-token"],
         },
         coreOptsFromCtx(ctx),
       );

--- a/src/handlers/eval/types.tsx
+++ b/src/handlers/eval/types.tsx
@@ -32,7 +32,6 @@ export type LlmAsAJudgeUpdate = {
   model?: string;
   ratingScale?: RatingScale;
   kmsKeyArn?: string;
-  clientToken?: string;
 };
 
 // CodeBasedUpdate carries the fields a caller may change on a code-based
@@ -42,7 +41,6 @@ export type CodeBasedUpdate = {
   lambdaArn?: string;
   timeout?: number;
   kmsKeyArn?: string;
-  clientToken?: string;
 };
 
 // CreateOnlineEvalInput mirrors CreateOnlineEvaluationConfigRequest but lets the

--- a/src/handlers/harness/create/index.tsx
+++ b/src/handlers/harness/create/index.tsx
@@ -88,7 +88,6 @@ export const createCreateHarnessHandler = (core: Core) =>
       flag("tags", "tags to apply (JSON object of key/value strings)", z.string().optional(), {
         help: parameterHelp.tags,
       }),
-      flag("client-token", "idempotency token", z.string().optional()),
     ],
     handle: async (ctx, flags) => {
       // Required at runtime but declared optional so that a bare
@@ -131,7 +130,6 @@ export const createCreateHarnessHandler = (core: Core) =>
           maxTokens: flags["max-tokens"],
           timeoutSeconds: flags["timeout-seconds"],
           tags: parseJsonFlag<Record<string, string>>("tags", flags["tags"]),
-          clientToken: flags["client-token"],
         },
         coreOptsFromCtx(ctx),
       );

--- a/src/handlers/harness/delete/index.tsx
+++ b/src/handlers/harness/delete/index.tsx
@@ -16,7 +16,6 @@ export const createDeleteHarnessHandler = (core: Core) =>
         "whether to also delete the managed memory (default true; pass false to keep it)",
         z.enum(["true", "false"]).optional(),
       ),
-      flag("client-token", "idempotency token", z.string().optional()),
     ],
     handle: async (ctx, flags) => {
       // Required at runtime but declared optional so that a bare
@@ -32,7 +31,6 @@ export const createDeleteHarnessHandler = (core: Core) =>
             flags["delete-managed-memory"] === undefined
               ? undefined
               : flags["delete-managed-memory"] === "true",
-          clientToken: flags["client-token"],
         },
         coreOptsFromCtx(ctx),
       );

--- a/src/handlers/harness/endpoint/create/index.tsx
+++ b/src/handlers/harness/endpoint/create/index.tsx
@@ -18,7 +18,6 @@ export const createCreateEndpointHandler = (core: Core) =>
         z.string().optional(),
       ),
       flag("tags", "tags to apply (JSON object of key/value strings)", z.string().optional()),
-      flag("client-token", "idempotency token", z.string().optional()),
     ],
     handle: async (ctx, flags) => {
       // Required at runtime but declared optional so that a bare
@@ -36,7 +35,6 @@ export const createCreateEndpointHandler = (core: Core) =>
           endpointName: flags["name"],
           targetVersion: flags["target-version"],
           tags: parseJsonFlag<Record<string, string>>("tags", flags["tags"]),
-          clientToken: flags["client-token"],
         },
         coreOptsFromCtx(ctx),
       );

--- a/src/handlers/harness/endpoint/delete/index.tsx
+++ b/src/handlers/harness/endpoint/delete/index.tsx
@@ -12,7 +12,6 @@ export const createDeleteEndpointHandler = (core: Core) =>
     flags: [
       flag("id", "the ID of the harness", z.string().max(48).optional()),
       flag("qualifier", "the endpoint name (qualifier)", z.string().optional()),
-      flag("client-token", "idempotency token", z.string().optional()),
     ],
     handle: async (ctx, flags) => {
       // Required at runtime but declared optional so that a bare
@@ -28,7 +27,6 @@ export const createDeleteEndpointHandler = (core: Core) =>
         {
           harnessId: flags["id"],
           endpointName: flags["qualifier"],
-          clientToken: flags["client-token"],
         },
         coreOptsFromCtx(ctx),
       );

--- a/src/handlers/harness/endpoint/update/index.tsx
+++ b/src/handlers/harness/endpoint/update/index.tsx
@@ -13,7 +13,6 @@ export const createUpdateEndpointHandler = (core: Core) =>
       flag("id", "the ID of the harness", z.string().max(48).optional()),
       flag("qualifier", "the endpoint name (qualifier)", z.string().optional()),
       flag("target-version", "the harness version the endpoint points to", z.string().optional()),
-      flag("client-token", "idempotency token", z.string().optional()),
     ],
     handle: async (ctx, flags) => {
       // Required at runtime but declared optional so that a bare
@@ -30,7 +29,6 @@ export const createUpdateEndpointHandler = (core: Core) =>
           harnessId: flags["id"],
           endpointName: flags["qualifier"],
           targetVersion: flags["target-version"],
-          clientToken: flags["client-token"],
         },
         coreOptsFromCtx(ctx),
       );

--- a/src/handlers/harness/update/index.tsx
+++ b/src/handlers/harness/update/index.tsx
@@ -105,7 +105,6 @@ export const createUpdateHarnessHandler = (core: Core) =>
       flag("max-iterations", "max agent loop iterations per invocation", z.number().optional()),
       flag("max-tokens", "max total output tokens per invocation", z.number().optional()),
       flag("timeout-seconds", "max duration in seconds per invocation", z.number().optional()),
-      flag("client-token", "idempotency token", z.string().optional()),
     ],
     handle: async (ctx, flags) => {
       // Required at runtime but declared optional so that a bare
@@ -156,7 +155,6 @@ export const createUpdateHarnessHandler = (core: Core) =>
           maxIterations: flags["max-iterations"],
           maxTokens: flags["max-tokens"],
           timeoutSeconds: flags["timeout-seconds"],
-          clientToken: flags["client-token"],
         },
         coreOptsFromCtx(ctx),
       );


### PR DESCRIPTION
## Summary

- remove `--client-token` from Harness create, update, delete, and endpoint write commands
- remove `--client-token` from evaluator create and update commands
- remove the now-unused evaluator client token request plumbing

## Testing

- `bun test src --coverage --coverage-reporter=lcov` (977 passed)
- `bun run typecheck`
- `bun run lint:check`
- `bun run format:check`
- `bun run build`
- `git diff --check`