### PR TITLE
fix(memory): adjust import to use new path

### DIFF
--- a/src/components/ui/data-table/columnWidths.test.ts
+++ b/src/components/ui/data-table/columnWidths.test.ts
@@ -6,13 +6,13 @@ import { harnessVersionColumns } from "../../HarnessVersionPicker";
 import { runtimeEndpointColumns } from "../../RuntimeEndpointPicker";
 import { runtimeColumns } from "../../RuntimePicker";
 import { runtimeVersionColumns } from "../../RuntimeVersionPicker";
-import { memoryColumns } from "../../../handlers/memory/list/screen";
 import {
   computeColumnWidths,
   FLEX_MIN_WIDTH,
   resolveBorderWidth,
   SELECTION_MARKER_WIDTH,
 } from "./columnWidths";
+import { memoryColumns } from "../../MemoryPicker";
 
 const widths = [40, 60, 80, 100, 120, 160, 200];
 const flexConfigs = [


### PR DESCRIPTION
### Problem 
Typecheck is failing on refactor branch

```
Run bun run typecheck
$ tsc --noEmit
src/components/ui/data-table/columnWidths.test.ts(9,10): error TS2305: Module '"../../../handlers/memory/list/screen"' has no exported member 'memoryColumns'.
src/components/ui/data-table/columnWidths.test.ts(79,33): error TS7006: Parameter 'column' implicitly has an 'any' type.
src/components/ui/data-table/columnWidths.test.ts(79,41): error TS7006: Parameter 'index' implicitly has an 'any' type.
src/components/ui/data-table/columnWidths.test.ts(109,44): error TS7006: Parameter 'column' implicitly has an 'any' type.
```

### Solution
adjust import path. 

### Testing 
`bun run typecheck`. 