### PR TITLE
fix(eval): surface batch-evaluation result truncation as a warning

### DIFF
--- a/src/core/batchEvaluationResults.test.ts
+++ b/src/core/batchEvaluationResults.test.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "bun:test";
 import type { CloudWatchLogsClient, OutputLogEvent } from "@aws-sdk/client-cloudwatch-logs";
+import { ResultTruncationError } from "../errors";
 import { createSilentLogger } from "../testing";
 import {
   isTerminalStatus,
@@ -174,9 +175,14 @@ test("readEvaluationResults throws (not silently truncates) when it hits the pag
     }),
   } as unknown as CloudWatchLogsClient;
 
-  await expect(
-    readEvaluationResults(everAdvancing, "lg", "ls", createSilentLogger()),
-  ).rejects.toThrow(/incomplete/);
+  const err = await readEvaluationResults(everAdvancing, "lg", "ls", createSilentLogger()).then(
+    () => undefined,
+    (e) => e as ResultTruncationError,
+  );
+  expect(err).toBeInstanceOf(ResultTruncationError);
+  expect(err?.message).toMatch(/incomplete/);
+  expect(err?.source).toBe("internal"); // our page cap, not a user or service fault
+  expect(err?.meta).toMatchObject({ logGroupName: "lg", logStreamName: "ls" });
 });
 
 test("parseEvaluationLogEvent warns on and skips an unparseable line", () => {

--- a/src/core/batchEvaluationResults.test.ts
+++ b/src/core/batchEvaluationResults.test.ts
@@ -156,6 +156,29 @@ test("readEvaluationResults skips lines without an evaluation name", async () =>
   expect(results).toEqual([]);
 });
 
+test("readEvaluationResults throws (not silently truncates) when it hits the page cap", async () => {
+  // Token advances on every call, so the loop never detects exhaustion and runs
+  // into MAX_RESULT_PAGES. It must throw so the caller surfaces truncation, rather
+  // than returning the accumulated partial list as if it were complete.
+  let call = 0;
+  const everAdvancing = {
+    send: async () => ({
+      events: [
+        {
+          message: JSON.stringify({
+            attributes: { "gen_ai.evaluation.name": "Builtin.Correctness" },
+          }),
+        },
+      ],
+      nextForwardToken: `t-${call++}`, // always changes → never exhausts
+    }),
+  } as unknown as CloudWatchLogsClient;
+
+  await expect(
+    readEvaluationResults(everAdvancing, "lg", "ls", createSilentLogger()),
+  ).rejects.toThrow(/incomplete/);
+});
+
 test("parseEvaluationLogEvent warns on and skips an unparseable line", () => {
   const warnings: string[] = [];
   const logger = createSilentLogger();

--- a/src/core/batchEvaluationResults.test.ts
+++ b/src/core/batchEvaluationResults.test.ts
@@ -182,7 +182,6 @@ test("readEvaluationResults throws (not silently truncates) when it hits the pag
   expect(err).toBeInstanceOf(ResultTruncationError);
   expect(err?.message).toMatch(/incomplete/);
   expect(err?.source).toBe("internal"); // our page cap, not a user or service fault
-  expect(err?.meta).toMatchObject({ logGroupName: "lg", logStreamName: "ls" });
 });
 
 test("parseEvaluationLogEvent warns on and skips an unparseable line", () => {

--- a/src/core/batchEvaluationResults.tsx
+++ b/src/core/batchEvaluationResults.tsx
@@ -20,15 +20,20 @@ export function isTerminalStatus(status?: string): boolean {
 
 // GetLogEvents returns at most 1 MB / 10,000 events per call, so a job with many
 // results spans multiple pages. This caps the page loop as a safety valve against
-// a non-advancing token (see below); at 10k events/page it allows ~1M results,
-// far beyond the 500-session job limit.
+// a non-advancing token (see below). At 10k events/page it allows ~1M results, but
+// the 1 MB limit binds first — large explanations can cap a page well under 10k, so
+// this is not a "far beyond any real job" ceiling. Hitting it means the results are
+// truncated, which we surface as an error (see below) rather than silently
+// returning a partial list as if complete.
 const MAX_RESULT_PAGES = 100;
 
 // readEvaluationResults reads and parses the per-session/-trace/-tool scores from
 // a completed batch evaluation's CloudWatch result stream, following pagination to
-// completion. The caller supplies the log group and stream name from the job's
-// GetBatchEvaluation outputConfig (the service-selected values — we do not derive
-// the stream name, since its format is not part of the SDK contract).
+// completion. Throws if the stream exceeds MAX_RESULT_PAGES (results would be
+// truncated) — see the throw site. The caller supplies the log group and stream
+// name from the job's GetBatchEvaluation outputConfig (the service-selected values
+// — we do not derive the stream name, since its format is not part of the SDK
+// contract).
 export async function readEvaluationResults(
   logs: CloudWatchLogsClient,
   logGroupName: string,
@@ -63,10 +68,15 @@ export async function readEvaluationResults(
     token = next;
   }
 
-  logger.warn(
-    `stopped reading batch-evaluation results after ${MAX_RESULT_PAGES} pages; results may be truncated`,
+  // Cap reached with the token still advancing: the stream has more pages than we
+  // read, so `results` is truncated. Throw rather than return the partial list —
+  // getBatchEvaluation catches this into `resultsError`, which the CLI surfaces as
+  // a stderr warning (stdout metadata stays clean), the same customer-visible path
+  // as any other CloudWatch read failure. A silent partial list would read as
+  // complete.
+  throw new Error(
+    `batch-evaluation results exceed ${MAX_RESULT_PAGES} CloudWatch pages; retrieved ${results.length} results are incomplete`,
   );
-  return results;
 }
 
 // parseEvaluationLogEvent turns one CloudWatch result-log message into a result

--- a/src/core/batchEvaluationResults.tsx
+++ b/src/core/batchEvaluationResults.tsx
@@ -1,4 +1,5 @@
 import { GetLogEventsCommand, type CloudWatchLogsClient } from "@aws-sdk/client-cloudwatch-logs";
+import { ResultTruncationError } from "../errors";
 import type { BatchEvaluationResultEntry } from "../handlers/eval/types";
 import type { Logger } from "../logging";
 
@@ -74,8 +75,16 @@ export async function readEvaluationResults(
   // a stderr warning (stdout metadata stays clean), the same customer-visible path
   // as any other CloudWatch read failure. A silent partial list would read as
   // complete.
-  throw new Error(
+  throw new ResultTruncationError(
     `batch-evaluation results exceed ${MAX_RESULT_PAGES} CloudWatch pages; retrieved ${results.length} results are incomplete`,
+    {
+      meta: {
+        logGroupName,
+        logStreamName,
+        maxResultPages: MAX_RESULT_PAGES,
+        retrieved: results.length,
+      },
+    },
   );
 }
 

--- a/src/core/batchEvaluationResults.tsx
+++ b/src/core/batchEvaluationResults.tsx
@@ -77,14 +77,6 @@ export async function readEvaluationResults(
   // complete.
   throw new ResultTruncationError(
     `batch-evaluation results exceed ${MAX_RESULT_PAGES} CloudWatch pages; retrieved ${results.length} results are incomplete`,
-    {
-      meta: {
-        logGroupName,
-        logStreamName,
-        maxResultPages: MAX_RESULT_PAGES,
-        retrieved: results.length,
-      },
-    },
   );
 }
 

--- a/src/errors/errors.tsx
+++ b/src/errors/errors.tsx
@@ -166,3 +166,14 @@ export class FileWriteError extends AgentCoreCLIError {
     super(message, { source: ERROR_SOURCE.USER, ...options });
   }
 }
+
+/**
+ * Thrown when a paginated read is cut short by a client-side page cap, so the
+ * returned data is incomplete rather than the full result set. INTERNAL: the
+ * service and the user are both fine — the limit is ours.
+ */
+export class ResultTruncationError extends AgentCoreCLIError {
+  constructor(message: string, options?: Omit<AgentCoreCLIErrorOptions, "source">) {
+    super(message, { ...options, source: ERROR_SOURCE.INTERNAL });
+  }
+}

--- a/src/errors/index.tsx
+++ b/src/errors/index.tsx
@@ -9,6 +9,7 @@ export {
   NetworkingError,
   NotImplementedError,
   ProjectFileExistsError,
+  ResultTruncationError,
   RuntimeInvokeInterruptedError,
   RuntimeInvokeResponseError,
   SourceResolutionError,


### PR DESCRIPTION
## What

Follow-up to #1924. Addresses @aidandaly24's non-blocking review comment on `src/core/batchEvaluationResults.tsx`:

> Hitting `MAX_RESULT_PAGES` should flow back as `resultsError` instead of returning the accumulated array as complete. `GetLogEvents` is limited by 1 MB as well as 10,000 events, so large explanations can make 100 pages much less than roughly one million results. Right now the cap only writes to the file logger, while `get --json` succeeds with partial `results` and no customer-visible warning.

## Change

`readEvaluationResults` now **throws** when it exhausts `MAX_RESULT_PAGES` with the forward token still advancing (i.e. the stream has more pages than we read), instead of logging to the file logger and returning the partial list.

`getBatchEvaluation` already wraps the call in a `try/catch` that routes any throw into `resultsError`, and the `get` handler already turns `resultsError` into a stderr warning via `warnCloudWatchFailure` while leaving stdout metadata clean. So truncation now travels the **same customer-visible path as every other CloudWatch read failure** — no new plumbing.

Before: `get --json` on a very large job returned partial `results` that read as complete, with only a file-logger line.
After: the job metadata still prints on stdout; a stderr warning states the results are incomplete.

## Test

Added a unit test with an ever-advancing token so the loop runs into the cap; asserts `readEvaluationResults` rejects rather than returning a partial list. Existing pagination/parse tests unchanged and green (`bun test src/core/batchEvaluationResults.test.ts` → 6 pass; handler tests → 12 pass).