### PR TITLE
feat(project): wire dev handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "agentcore": "./dist/index.js"
   },
   "main": "./dist/index.js",
+  "engines": {
+    "node": ">=20.12.0"
+  },
   "files": [
     "dist"
   ],

--- a/src/assets/templates/shared/env.local.template
+++ b/src/assets/templates/shared/env.local.template
@@ -1,7 +1,7 @@
 # Environment variables for local development.
-# `agentcore dev` loads this file into your agent's process. Values here
-# override anything the CLI injects. This file is gitignored — keep secrets
-# out of version control, but they are safe here.
+# `agentcore project dev` loads this file into your agent's process. Values here
+# override injected values except PORT, FASTMCP_PORT, and LOCAL_DEV, which the
+# CLI owns. This file is gitignored — keep secrets out of version control.
 #
 # Example:
 # MY_API_KEY=...

--- a/src/core/dev/codezip.test.ts
+++ b/src/core/dev/codezip.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, relative } from "node:path";
+import { InputValidationError } from "../../errors";
 import type { ProjectRuntime } from "../../projectSchemas/runtime";
 import type { DevEvent, DevServerInput } from "../../handlers/project/dev/types";
 import type { ProcessEvent, ProcessStreamer, StreamProcessOptions } from "../../io";
@@ -21,7 +22,11 @@ afterEach(async () => {
 });
 
 function runtime(
-  overrides: { entrypoint?: string; protocol?: ProjectRuntime["protocol"] } = {},
+  overrides: {
+    codeLocation?: string;
+    entrypoint?: string;
+    protocol?: ProjectRuntime["protocol"];
+  } = {},
 ): ProjectRuntime {
   return {
     name: "hello_world",
@@ -37,6 +42,12 @@ async function projectRoot(withNodeModules = false): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), "agentcore-codezip-"));
   tempDirectories.push(root);
   await mkdir(join(root, "app", "hello-world"), { recursive: true });
+  await mkdir(join(root, "app", "hello-world", "src"));
+  await Promise.all(
+    ["main.py", "index.js", "src/main.py", "src/index.ts"].map((path) =>
+      writeFile(join(root, "app", "hello-world", path), ""),
+    ),
+  );
   if (withNodeModules) {
     await mkdir(join(root, "app", "hello-world", "node_modules"));
   }
@@ -79,6 +90,35 @@ describe("CodeZipDevRunner", () => {
     await expect(collect(harness().runner.run(input(root, runtime())))).rejects.toThrow(
       /runtime code directory not found/,
     );
+  });
+
+  test("rejects code and entrypoint paths outside the project root", async () => {
+    const root = await projectRoot();
+    const outside = await mkdtemp(join(tmpdir(), "agentcore-codezip-outside-"));
+    tempDirectories.push(outside);
+    await writeFile(join(outside, "main.py"), "");
+    await symlink(outside, join(root, "linked"), process.platform === "win32" ? "junction" : "dir");
+    await symlink(
+      outside,
+      join(root, "app", "hello-world", "linked"),
+      process.platform === "win32" ? "junction" : "dir",
+    );
+    const directory = join(root, "app", "hello-world");
+
+    const unsafeRuntimes = [
+      runtime({ codeLocation: relative(root, outside) }),
+      runtime({ codeLocation: "linked" }),
+      runtime({ entrypoint: relative(directory, join(outside, "main.py")) }),
+      runtime({ entrypoint: join("linked", "main.py") }),
+    ];
+
+    for (const projectRuntime of unsafeRuntimes) {
+      const { calls, runner } = harness();
+      const result = collect(runner.run(input(root, projectRuntime)));
+      await expect(result).rejects.toBeInstanceOf(InputValidationError);
+      await expect(result).rejects.toThrow("must be within the project root");
+      expect(calls).toHaveLength(0);
+    }
   });
 
   test("runs HTTP Python entrypoints with uvicorn", async () => {

--- a/src/core/dev/codezip.ts
+++ b/src/core/dev/codezip.ts
@@ -1,8 +1,9 @@
 import { existsSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { InputValidationError } from "../../errors";
 import type { DevEvent, DevRunner, DevServerInput } from "../../handlers/project/dev/types";
 import { streamProcess, type ProcessStreamer, type StreamProcessOptions } from "../../io";
+import { isDirectory, isFile, resolvePathWithinProject } from "./path";
 
 type CodeZipDevRunnerConfig = {
   streamProcess?: ProcessStreamer;
@@ -16,12 +17,19 @@ export class CodeZipDevRunner implements DevRunner {
   }
 
   public async *run(input: DevServerInput): AsyncGenerator<DevEvent, void> {
-    const directory = join(input.projectRoot, input.runtime.codeLocation);
-    if (!existsSync(directory)) {
+    const directory = resolve(input.projectRoot, input.runtime.codeLocation);
+    if (!isDirectory(directory)) {
       throw new InputValidationError(`runtime code directory not found: ${directory}`);
     }
+    resolvePathWithinProject(input.projectRoot, directory, "runtime code directory");
 
     const [entrypoint] = input.runtime.entrypoint.split(":");
+    const entrypointPath = resolve(directory, entrypoint!);
+    if (!isFile(entrypointPath)) {
+      throw new InputValidationError(`runtime entrypoint not found: ${entrypointPath}`);
+    }
+    resolvePathWithinProject(input.projectRoot, entrypointPath, "runtime entrypoint");
+
     if (!entrypoint!.endsWith(".py") && !existsSync(join(directory, "node_modules"))) {
       yield { type: "status", message: "Installing Node dependencies with npm" };
       yield* this.streamProcess(["npm", "install"], {

--- a/src/core/dev/container.test.ts
+++ b/src/core/dev/container.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
-import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { parseEnv } from "node:util";
 import { InputValidationError, InvalidEnvironmentError } from "../../errors";
 import type { DevEvent, DevServerInput } from "../../handlers/project/dev/types";
 import {
@@ -17,6 +18,7 @@ import { ContainerDevRunner } from "./container";
 type ProcessCall = {
   command: string[];
   options: StreamProcessOptions;
+  envFile?: { path: string; contents: string; mode: number };
 };
 
 type StreamBehavior = (
@@ -67,7 +69,14 @@ function harness(
 ) {
   const calls: ProcessCall[] = [];
   const fakeStreamProcess: ProcessStreamer = async function* (command, options) {
-    calls.push({ command, options });
+    const call: ProcessCall = { command, options };
+    calls.push(call);
+    const envFileFlag = command.indexOf("--env-file");
+    if (envFileFlag >= 0) {
+      const path = command[envFileFlag + 1]!;
+      const [contents, metadata] = await Promise.all([readFile(path, "utf8"), stat(path)]);
+      call.envFile = { path, contents, mode: metadata.mode & 0o777 };
+    }
     if (config.stream) yield* config.stream(command, options);
   };
   return {
@@ -161,7 +170,10 @@ describe("ContainerDevRunner", () => {
       ".",
     ]);
     expect(build.options.cwd).toBe(root);
-    expect(build.options.env).toBe(process.env);
+    expect(build.options.env).toEqual({
+      AWS_ACCESS_KEY_ID: "test-access-key",
+      AWS_SECRET_ACCESS_KEY: "test-secret-key",
+    });
     expect(build.options.redactedCommand).toContain("AGENT_NAME=<redacted>");
     expect(build.options.redactedCommand).toContain("TARGET=<redacted>");
     expect(build.options.redactedCommand?.join(" ")).not.toContain("hello-world");
@@ -195,20 +207,15 @@ describe("ContainerDevRunner", () => {
       containerName(root),
       "-p",
       `127.0.0.1:3000:${containerPort}`,
-      "-e",
-      "AWS_ACCESS_KEY_ID",
-      "-e",
-      "AWS_SECRET_ACCESS_KEY",
-      "-e",
-      "API_KEY",
-      "-e",
-      "PORT",
-      "-e",
-      "LOCAL_DEV",
-      ...(protocol === "MCP" ? ["-e", "FASTMCP_PORT"] : []),
+      "--env-file",
+      run.envFile!.path,
       imageTag(root),
     ]);
-    expect(run.options.env).toMatchObject({
+    expect(run.options.env).toEqual({
+      AWS_ACCESS_KEY_ID: "test-access-key",
+      AWS_SECRET_ACCESS_KEY: "test-secret-key",
+    });
+    expect(parseEnv(run.envFile!.contents)).toEqual({
       AWS_ACCESS_KEY_ID: "test-access-key",
       AWS_SECRET_ACCESS_KEY: "test-secret-key",
       API_KEY: "super-secret",
@@ -216,6 +223,8 @@ describe("ContainerDevRunner", () => {
       LOCAL_DEV: "1",
       ...(protocol === "MCP" ? { FASTMCP_PORT: "8000" } : {}),
     });
+    if (process.platform !== "win32") expect(run.envFile!.mode).toBe(0o600);
+    await expect(readFile(run.envFile!.path, "utf8")).rejects.toThrow();
     expect(run.command.join(" ")).not.toContain("super-secret");
     expect(run.command.join(" ")).not.toContain("test-secret-key");
   });
@@ -235,9 +244,9 @@ describe("ContainerDevRunner", () => {
 
     const run = commandCall(calls, "run");
     expect(run.command).toContain(`${awsDirectory}:/aws-config:ro`);
-    expect(run.command).toContain("AWS_PROFILE");
-    expect(run.command).toContain("AWS_CONFIG_FILE");
-    expect(run.options.env).toMatchObject({
+    expect(run.command).not.toContain("AWS_PROFILE");
+    expect(run.command).not.toContain("AWS_CONFIG_FILE");
+    expect(parseEnv(run.envFile!.contents)).toMatchObject({
       AWS_PROFILE: "sandbox",
       AWS_REGION: "us-east-1",
       AWS_CONFIG_FILE: "/aws-config/config",
@@ -299,7 +308,7 @@ describe("ContainerDevRunner", () => {
     );
   });
 
-  test("supplies app variable values through the container CLI environment", async () => {
+  test("keeps app variables out of the container CLI control environment", async () => {
     const projectRuntime = runtime();
     const root = await projectRoot(projectRuntime);
     const { calls, runner } = harness();
@@ -309,9 +318,10 @@ describe("ContainerDevRunner", () => {
     await collect(runner.run(runInput));
 
     const run = commandCall(calls, "run");
-    expect(run.command).toContain("DOCKER_HOST");
+    expect(run.command).not.toContain("DOCKER_HOST");
     expect(run.command.join(" ")).not.toContain("tcp://application-value");
-    expect(run.options.env?.DOCKER_HOST).toBe("tcp://application-value");
+    expect(run.options.env?.DOCKER_HOST).toBeUndefined();
+    expect(parseEnv(run.envFile!.contents).DOCKER_HOST).toBe("tcp://application-value");
   });
 
   test("selects the first tool that supports container builds", async () => {

--- a/src/core/dev/container.test.ts
+++ b/src/core/dev/container.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { InputValidationError, InvalidEnvironmentError } from "../../errors";
@@ -61,6 +61,8 @@ function harness(
   config: {
     available?: (tool: string, probeArgs?: string[]) => Promise<boolean>;
     stream?: StreamBehavior;
+    awsDirectory?: string;
+    processEnv?: NodeJS.ProcessEnv;
   } = {},
 ) {
   const calls: ProcessCall[] = [];
@@ -77,6 +79,11 @@ function harness(
         (async (tool) => {
           return tool === "docker";
         }),
+      awsDirectory: config.awsDirectory ?? join(tmpdir(), "agentcore-container-no-aws"),
+      processEnv: config.processEnv ?? {
+        AWS_ACCESS_KEY_ID: "test-access-key",
+        AWS_SECRET_ACCESS_KEY: "test-secret-key",
+      },
     }),
   };
 }
@@ -189,17 +196,65 @@ describe("ContainerDevRunner", () => {
       "-p",
       `127.0.0.1:3000:${containerPort}`,
       "-e",
-      "API_KEY=super-secret",
+      "AWS_ACCESS_KEY_ID",
       "-e",
-      `PORT=${containerPort}`,
+      "AWS_SECRET_ACCESS_KEY",
       "-e",
-      "LOCAL_DEV=1",
-      ...(protocol === "MCP" ? ["-e", "FASTMCP_PORT=8000"] : []),
+      "API_KEY",
+      "-e",
+      "PORT",
+      "-e",
+      "LOCAL_DEV",
+      ...(protocol === "MCP" ? ["-e", "FASTMCP_PORT"] : []),
       imageTag(root),
     ]);
-    expect(run.options.env).toBe(process.env);
-    expect(run.options.redactedCommand).toContain("API_KEY=<redacted>");
-    expect(run.options.redactedCommand?.join(" ")).not.toContain("super-secret");
+    expect(run.options.env).toMatchObject({
+      AWS_ACCESS_KEY_ID: "test-access-key",
+      AWS_SECRET_ACCESS_KEY: "test-secret-key",
+      API_KEY: "super-secret",
+      PORT: String(containerPort),
+      LOCAL_DEV: "1",
+      ...(protocol === "MCP" ? { FASTMCP_PORT: "8000" } : {}),
+    });
+    expect(run.command.join(" ")).not.toContain("super-secret");
+    expect(run.command.join(" ")).not.toContain("test-secret-key");
+  });
+
+  test("uses a shared AWS config and rejects missing credentials", async () => {
+    const projectRuntime = runtime();
+    const root = await projectRoot(projectRuntime);
+    const awsDirectory = join(root, ".aws");
+    await mkdir(awsDirectory);
+    await writeFile(join(awsDirectory, "config"), "[profile sandbox]\nregion=us-east-1\n");
+    const { calls, runner } = harness({
+      awsDirectory,
+      processEnv: { AWS_PROFILE: "sandbox", AWS_REGION: "us-east-1" },
+    });
+
+    await collect(runner.run(input(root, projectRuntime)));
+
+    const run = commandCall(calls, "run");
+    expect(run.command).toContain(`${awsDirectory}:/aws-config:ro`);
+    expect(run.command).toContain("AWS_PROFILE");
+    expect(run.command).toContain("AWS_CONFIG_FILE");
+    expect(run.options.env).toMatchObject({
+      AWS_PROFILE: "sandbox",
+      AWS_REGION: "us-east-1",
+      AWS_CONFIG_FILE: "/aws-config/config",
+      AWS_SHARED_CREDENTIALS_FILE: "/aws-config/credentials",
+    });
+    expect(run.command.join(" ")).not.toContain("sandbox");
+
+    const missing = harness({
+      awsDirectory: join(root, "missing-aws"),
+      processEnv: {},
+    });
+    const missingCredentials = collect(missing.runner.run(input(root, projectRuntime)));
+    await expect(missingCredentials).rejects.toBeInstanceOf(InvalidEnvironmentError);
+    await expect(missingCredentials).rejects.toThrow(
+      "Unable to resolve AWS credentials for the container",
+    );
+    expect(missing.calls).toHaveLength(0);
   });
 
   test("preserves an existing build context .dockerignore", async () => {
@@ -244,7 +299,7 @@ describe("ContainerDevRunner", () => {
     );
   });
 
-  test("keeps app variables out of the container CLI environment", async () => {
+  test("supplies app variable values through the container CLI environment", async () => {
     const projectRuntime = runtime();
     const root = await projectRoot(projectRuntime);
     const { calls, runner } = harness();
@@ -254,9 +309,9 @@ describe("ContainerDevRunner", () => {
     await collect(runner.run(runInput));
 
     const run = commandCall(calls, "run");
-    expect(run.command).toContain("DOCKER_HOST=tcp://application-value");
-    expect(run.options.env).toBe(process.env);
-    expect(run.options.redactedCommand).toContain("DOCKER_HOST=<redacted>");
+    expect(run.command).toContain("DOCKER_HOST");
+    expect(run.command.join(" ")).not.toContain("tcp://application-value");
+    expect(run.options.env?.DOCKER_HOST).toBe("tcp://application-value");
   });
 
   test("selects the first tool that supports container builds", async () => {
@@ -407,6 +462,33 @@ describe("ContainerDevRunner", () => {
     ).rejects.toMatchObject({ name: "AbortError" });
 
     expect(calls.map(({ command }) => command[1])).toEqual(["rm"]);
+  });
+
+  test("rejects build contexts outside the project root, including symlinks", async () => {
+    const root = await mkdtemp(join(tmpdir(), "agentcore-container-"));
+    const outside = await mkdtemp(join(tmpdir(), "agentcore-container-outside-"));
+    tempDirectories.push(root, outside);
+    await symlink(outside, join(root, "linked"), process.platform === "win32" ? "junction" : "dir");
+    const probes: string[] = [];
+
+    for (const buildContextPath of ["..", "linked"]) {
+      const { calls, runner } = harness({
+        available: async (tool) => {
+          probes.push(tool);
+          return true;
+        },
+      });
+
+      const escapedContext = collect(runner.run(input(root, runtime({ buildContextPath }))));
+      await expect(escapedContext).rejects.toBeInstanceOf(InputValidationError);
+      await expect(escapedContext).rejects.toThrow(
+        "container build context must be within the project root",
+      );
+      expect(calls).toHaveLength(0);
+    }
+
+    expect(probes).toHaveLength(0);
+    await expect(readFile(join(outside, ".dockerignore"), "utf8")).rejects.toThrow();
   });
 
   test("rejects a build context that is not a directory", async () => {

--- a/src/core/dev/container.ts
+++ b/src/core/dev/container.ts
@@ -1,7 +1,8 @@
-import { createHash } from "node:crypto";
-import { existsSync, realpathSync, statSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { isAbsolute, join, relative, resolve, sep } from "node:path";
+import { createHash, randomUUID } from "node:crypto";
+import { existsSync, writeFileSync } from "node:fs";
+import { rm, writeFile } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import { InputValidationError, InvalidEnvironmentError } from "../../errors";
 import type { DevEvent, DevRunner, DevServerInput } from "../../handlers/project/dev/types";
 import {
@@ -11,6 +12,7 @@ import {
   type ProcessStreamer,
   type StreamProcessOptions,
 } from "../../io";
+import { isDirectory, isFile, resolvePathWithinProject } from "./path";
 import { DEV_PORTS } from "./port";
 
 const CONTAINER_TOOLS = ["docker", "podman", "finch"] as const;
@@ -81,17 +83,7 @@ export class ContainerDevRunner implements DevRunner {
       throw new InputValidationError(`container build context directory not found: ${context}`);
     }
 
-    const canonicalContext = realpathSync(context);
-    const relativeContext = relative(realpathSync(input.projectRoot), canonicalContext);
-    if (
-      relativeContext === ".." ||
-      relativeContext.startsWith(`..${sep}`) ||
-      isAbsolute(relativeContext)
-    ) {
-      throw new InputValidationError(
-        `container build context must be within the project root: ${canonicalContext}`,
-      );
-    }
+    resolvePathWithinProject(input.projectRoot, context, "container build context");
 
     const dockerfile = input.runtime.dockerfile ?? DOCKERFILE_NAME;
     const dockerfilePath = join(context, dockerfile);
@@ -139,7 +131,7 @@ export class ContainerDevRunner implements DevRunner {
     const buildCommand = [tool, "build", "-f", dockerfile, "-t", imageTag, ...buildArgFlags, "."];
     const buildOptions: StreamProcessOptions = {
       cwd: context,
-      env: process.env,
+      env: this.processEnv,
       redactedCommand: [
         tool,
         "build",
@@ -173,7 +165,16 @@ export class ContainerDevRunner implements DevRunner {
       forwardedEnv.AWS_CONFIG_FILE = "/aws-config/config";
       forwardedEnv.AWS_SHARED_CREDENTIALS_FILE = "/aws-config/credentials";
     }
-    const envFlags = Object.keys(forwardedEnv).flatMap((key) => ["-e", key]);
+    const envFile = join(tmpdir(), `agentcore-dev-${randomUUID()}.env`);
+    try {
+      await writeFile(envFile, serializeEnvironment(forwardedEnv), {
+        flag: "wx",
+        mode: 0o600,
+      });
+    } catch (error) {
+      await rm(envFile, { force: true });
+      throw error;
+    }
     const runCommand = [
       tool,
       "run",
@@ -183,7 +184,8 @@ export class ContainerDevRunner implements DevRunner {
       "-p",
       `127.0.0.1:${input.port}:${containerPort}`,
       ...awsMount,
-      ...envFlags,
+      "--env-file",
+      envFile,
       imageTag,
     ];
 
@@ -191,11 +193,15 @@ export class ContainerDevRunner implements DevRunner {
     try {
       yield* this.streamProcess(runCommand, {
         cwd: context,
-        env: { ...this.processEnv, ...forwardedEnv },
+        env: this.processEnv,
         signal: input.signal,
       });
     } finally {
-      await this.removeContainer(tool, containerName, context);
+      try {
+        await this.removeContainer(tool, containerName, context);
+      } finally {
+        await rm(envFile, { force: true });
+      }
     }
   }
 
@@ -225,6 +231,7 @@ export class ContainerDevRunner implements DevRunner {
     try {
       for await (const _event of this.streamProcess([tool, "rm", "-f", containerName], {
         cwd,
+        env: this.processEnv,
         signal: AbortSignal.timeout(CLEANUP_TIMEOUT_MS),
       })) {
         // Best-effort cleanup intentionally discards command output.
@@ -235,27 +242,26 @@ export class ContainerDevRunner implements DevRunner {
   }
 }
 
-function isDirectory(path: string): boolean {
-  try {
-    return statSync(path).isDirectory();
-  } catch {
-    return false;
-  }
-}
-
-function isFile(path: string): boolean {
-  try {
-    return statSync(path).isFile();
-  } catch {
-    return false;
-  }
-}
-
 function ensureBuildContextDockerignore(context: string): string | undefined {
   const dockerignore = join(context, ".dockerignore");
   if (existsSync(dockerignore)) return undefined;
   writeFileSync(dockerignore, BUILD_CONTEXT_DOCKERIGNORE);
   return dockerignore;
+}
+
+function serializeEnvironment(env: Record<string, string>): string {
+  return (
+    Object.entries(env)
+      .map(([key, value]) => {
+        if (/[\r\n]/.test(value)) {
+          throw new InputValidationError(
+            `container environment variable '${key}' cannot contain a newline`,
+          );
+        }
+        return `${key}=${value}`;
+      })
+      .join("\n") + "\n"
+  );
 }
 
 function hashString(value: string): string {

--- a/src/core/dev/container.ts
+++ b/src/core/dev/container.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
-import { existsSync, statSync, writeFileSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { existsSync, realpathSync, statSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
 import { InputValidationError, InvalidEnvironmentError } from "../../errors";
 import type { DevEvent, DevRunner, DevServerInput } from "../../handlers/project/dev/types";
 import {
@@ -10,8 +11,17 @@ import {
   type ProcessStreamer,
   type StreamProcessOptions,
 } from "../../io";
+import { DEV_PORTS } from "./port";
 
 const CONTAINER_TOOLS = ["docker", "podman", "finch"] as const;
+const AWS_ENV_KEYS = [
+  "AWS_ACCESS_KEY_ID",
+  "AWS_SECRET_ACCESS_KEY",
+  "AWS_SESSION_TOKEN",
+  "AWS_REGION",
+  "AWS_DEFAULT_REGION",
+  "AWS_PROFILE",
+] as const;
 const CLEANUP_TIMEOUT_MS = 2_000;
 const DOCKERFILE_NAME = "Dockerfile";
 const CONTAINER_RUNTIME_INSTALL_HINT =
@@ -44,15 +54,21 @@ type ToolAvailable = typeof toolAvailable;
 type ContainerDevRunnerConfig = {
   streamProcess?: ProcessStreamer;
   toolAvailable?: ToolAvailable;
+  awsDirectory?: string;
+  processEnv?: NodeJS.ProcessEnv;
 };
 
 export class ContainerDevRunner implements DevRunner {
   private readonly streamProcess: ProcessStreamer;
   private readonly toolAvailable: ToolAvailable;
+  private readonly awsDirectory: string;
+  private readonly processEnv: NodeJS.ProcessEnv;
 
   constructor(config: ContainerDevRunnerConfig = {}) {
     this.streamProcess = config.streamProcess ?? streamProcess;
     this.toolAvailable = config.toolAvailable ?? toolAvailable;
+    this.awsDirectory = config.awsDirectory ?? join(homedir(), ".aws");
+    this.processEnv = config.processEnv ?? process.env;
   }
 
   public async *run(input: DevServerInput): AsyncGenerator<DevEvent, void> {
@@ -65,10 +81,34 @@ export class ContainerDevRunner implements DevRunner {
       throw new InputValidationError(`container build context directory not found: ${context}`);
     }
 
+    const canonicalContext = realpathSync(context);
+    const relativeContext = relative(realpathSync(input.projectRoot), canonicalContext);
+    if (
+      relativeContext === ".." ||
+      relativeContext.startsWith(`..${sep}`) ||
+      isAbsolute(relativeContext)
+    ) {
+      throw new InputValidationError(
+        `container build context must be within the project root: ${canonicalContext}`,
+      );
+    }
+
     const dockerfile = input.runtime.dockerfile ?? DOCKERFILE_NAME;
     const dockerfilePath = join(context, dockerfile);
     if (!isFile(dockerfilePath)) {
       throw new InputValidationError(`container Dockerfile not found: ${dockerfilePath}`);
+    }
+
+    const hasAwsCredentials = Boolean(
+      (input.env?.AWS_ACCESS_KEY_ID ?? this.processEnv.AWS_ACCESS_KEY_ID) &&
+      (input.env?.AWS_SECRET_ACCESS_KEY ?? this.processEnv.AWS_SECRET_ACCESS_KEY),
+    );
+    const hasAwsConfig = existsSync(this.awsDirectory);
+    if (!hasAwsCredentials && !hasAwsConfig) {
+      throw new InvalidEnvironmentError(
+        "Unable to resolve AWS credentials for the container. Configure AWS credentials " +
+          "or set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, then retry.",
+      );
     }
 
     const tool = await this.resolveContainerTool(input.signal);
@@ -116,23 +156,24 @@ export class ContainerDevRunner implements DevRunner {
     yield { type: "status", message: `Building image with ${tool}` };
     yield* this.streamProcess(buildCommand, buildOptions);
 
-    const containerPort = portForProtocol(input.runtime.protocol);
-    const forwardedEnv: Record<string, string> = {
-      ...input.env,
+    const containerPort = DEV_PORTS[input.runtime.protocol ?? "HTTP"];
+    const forwardedEnv: Record<string, string> = {};
+    for (const key of AWS_ENV_KEYS) {
+      if (this.processEnv[key]) forwardedEnv[key] = this.processEnv[key];
+    }
+    Object.assign(forwardedEnv, input.env, {
       PORT: String(containerPort),
       LOCAL_DEV: "1",
-    };
+    });
     if (input.runtime.protocol === "MCP") {
       forwardedEnv.FASTMCP_PORT = String(containerPort);
     }
-    const envFlags = Object.entries(forwardedEnv).flatMap(([key, value]) => [
-      "-e",
-      `${key}=${value}`,
-    ]);
-    const redactedEnvFlags = Object.keys(forwardedEnv).flatMap((key) => [
-      "-e",
-      `${key}=<redacted>`,
-    ]);
+    const awsMount = hasAwsConfig ? ["-v", `${this.awsDirectory}:/aws-config:ro`] : [];
+    if (awsMount.length) {
+      forwardedEnv.AWS_CONFIG_FILE = "/aws-config/config";
+      forwardedEnv.AWS_SHARED_CREDENTIALS_FILE = "/aws-config/credentials";
+    }
+    const envFlags = Object.keys(forwardedEnv).flatMap((key) => ["-e", key]);
     const runCommand = [
       tool,
       "run",
@@ -141,6 +182,7 @@ export class ContainerDevRunner implements DevRunner {
       containerName,
       "-p",
       `127.0.0.1:${input.port}:${containerPort}`,
+      ...awsMount,
       ...envFlags,
       imageTag,
     ];
@@ -149,18 +191,7 @@ export class ContainerDevRunner implements DevRunner {
     try {
       yield* this.streamProcess(runCommand, {
         cwd: context,
-        env: process.env,
-        redactedCommand: [
-          tool,
-          "run",
-          "--rm",
-          "--name",
-          containerName,
-          "-p",
-          `127.0.0.1:${input.port}:${containerPort}`,
-          ...redactedEnvFlags,
-          imageTag,
-        ],
+        env: { ...this.processEnv, ...forwardedEnv },
         signal: input.signal,
       });
     } finally {
@@ -202,12 +233,6 @@ export class ContainerDevRunner implements DevRunner {
       // A missing container and an unavailable daemon are both safe to ignore here.
     }
   }
-}
-
-function portForProtocol(protocol: DevServerInput["runtime"]["protocol"]): number {
-  if (protocol === "MCP") return 8000;
-  if (protocol === "A2A") return 9000;
-  return 8080;
 }
 
 function isDirectory(path: string): boolean {

--- a/src/core/dev/path.ts
+++ b/src/core/dev/path.ts
@@ -1,0 +1,35 @@
+import { realpathSync, statSync } from "node:fs";
+import { isAbsolute, relative, sep } from "node:path";
+import { InputValidationError } from "../../errors";
+
+export function resolvePathWithinProject(
+  projectRoot: string,
+  path: string,
+  description: string,
+): string {
+  const canonicalRoot = realpathSync(projectRoot);
+  const canonicalPath = realpathSync(path);
+  const relativePath = relative(canonicalRoot, canonicalPath);
+  if (relativePath === ".." || relativePath.startsWith(`..${sep}`) || isAbsolute(relativePath)) {
+    throw new InputValidationError(
+      `${description} must be within the project root: ${canonicalPath}`,
+    );
+  }
+  return canonicalPath;
+}
+
+export function isDirectory(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+export function isFile(path: string): boolean {
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
+}

--- a/src/core/dev/port.test.ts
+++ b/src/core/dev/port.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import type { PortChecker } from "../../io";
+import { PortInUseError, resolveDevPort } from "./port";
+
+const signal = new AbortController().signal;
+
+describe("resolveDevPort", () => {
+  test.each([
+    ["HTTP", 8080],
+    ["AGUI", 8080],
+    ["MCP", 8000],
+    ["A2A", 9000],
+  ] as const)("uses the %s default", async (protocol, port) => {
+    expect(await resolveDevPort(protocol, undefined, async () => true, signal)).toEqual({
+      port,
+      requestedPort: port,
+    });
+  });
+
+  test("walks up from occupied defaults", async () => {
+    const checked: number[] = [];
+    const check: PortChecker = async (port) => {
+      checked.push(port);
+      return port === 8002;
+    };
+
+    expect(await resolveDevPort("MCP", undefined, check, signal)).toEqual({
+      port: 8002,
+      requestedPort: 8000,
+    });
+    expect(checked).toEqual([8000, 8001, 8002]);
+  });
+
+  test("accepts a free explicit port and rejects an occupied one", async () => {
+    expect(await resolveDevPort("A2A", 4567, async () => true, signal)).toEqual({
+      port: 4567,
+      requestedPort: 4567,
+    });
+    const occupied = resolveDevPort("A2A", 4567, async () => false, signal);
+    await expect(occupied).rejects.toBeInstanceOf(PortInUseError);
+    await expect(occupied).rejects.toThrow("lsof -i :4567");
+  });
+
+  test("bounds the default search", async () => {
+    await expect(resolveDevPort("HTTP", undefined, async () => false, signal)).rejects.toThrow(
+      "No free port found in range 8080-8179",
+    );
+  });
+});

--- a/src/core/dev/port.ts
+++ b/src/core/dev/port.ts
@@ -1,0 +1,47 @@
+import { InputValidationError } from "../../errors";
+import type { ProjectRuntime } from "../../projectSchemas/runtime";
+import type { PortChecker } from "../../io";
+
+const MAX_PORT_ATTEMPTS = 100;
+export const DEV_PORTS = { HTTP: 8080, AGUI: 8080, MCP: 8000, A2A: 9000 } as const;
+
+export type DevPort = {
+  port: number;
+  requestedPort: number;
+};
+
+export class PortInUseError extends InputValidationError {
+  constructor(port: number) {
+    super(
+      `Port ${port} is already in use. Find the process with ` +
+        `'lsof -i :${port}' (macOS/Linux) or 'netstat -ano | findstr :${port}' (Windows), ` +
+        "then stop it or choose a different --port.",
+    );
+  }
+}
+
+export async function resolveDevPort(
+  protocol: ProjectRuntime["protocol"],
+  explicitPort: number | undefined,
+  checkPort: PortChecker,
+  signal: AbortSignal,
+): Promise<DevPort> {
+  const defaultPort = DEV_PORTS[protocol ?? "HTTP"];
+  const requestedPort = explicitPort ?? defaultPort;
+
+  if (await checkPort(requestedPort, signal)) {
+    return { port: requestedPort, requestedPort };
+  }
+
+  if (explicitPort !== undefined) {
+    throw new PortInUseError(requestedPort);
+  }
+
+  for (let port = requestedPort + 1; port < requestedPort + MAX_PORT_ATTEMPTS; port++) {
+    if (await checkPort(port, signal)) return { port, requestedPort };
+  }
+
+  throw new InputValidationError(
+    `No free port found in range ${requestedPort}-${requestedPort + MAX_PORT_ATTEMPTS - 1}.`,
+  );
+}

--- a/src/errors/errors.tsx
+++ b/src/errors/errors.tsx
@@ -69,6 +69,9 @@ export class InputValidationError extends AgentCoreCLIError {
   }
 }
 
+/** Error raised when valid user input references a resource that does not exist. */
+export class ResourceNotFoundError extends InputValidationError {}
+
 /** Error raised when a command or operation has not been implemented yet. */
 export class NotImplementedError extends AgentCoreCLIError {
   constructor(message?: string, options?: Omit<AgentCoreCLIErrorOptions, "source">) {
@@ -135,7 +138,7 @@ export class EmbeddedAssetNotFoundError extends AgentCoreCLIError {
   }
 }
 
-export class RuntimeInvokeInterruptedError extends AgentCoreCLIError {
+export class CommandInterruptedError extends AgentCoreCLIError {
   readonly reported: boolean;
 
   constructor(cause?: unknown, reported = false) {
@@ -144,6 +147,8 @@ export class RuntimeInvokeInterruptedError extends AgentCoreCLIError {
     this.reported = reported;
   }
 }
+
+export class RuntimeInvokeInterruptedError extends CommandInterruptedError {}
 
 export class RuntimeInvokeResponseError extends AgentCoreCLIError {
   readonly reported = true;

--- a/src/errors/index.tsx
+++ b/src/errors/index.tsx
@@ -1,5 +1,6 @@
 export {
   AgentCoreCLIError,
+  CommandInterruptedError,
   DeserializationError,
   EmbeddedAssetNotFoundError,
   FileWriteError,
@@ -12,6 +13,7 @@ export {
   NetworkingError,
   NotImplementedError,
   ProjectFileExistsError,
+  ResourceNotFoundError,
   ResultTruncationError,
   RuntimeInvokeInterruptedError,
   RuntimeInvokeResponseError,

--- a/src/handlers/project/dev/environment.test.ts
+++ b/src/handlers/project/dev/environment.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import type { ProjectRuntime } from "../../../projectSchemas/runtime";
+import { createDevEnvironmentLoader } from "./environment";
+
+const projectRoot = "/workspace/project";
+
+const runtime = (envVars: { name: string; value: string }[] = []) =>
+  ({ name: "orders", build: "Container", envVars }) as ProjectRuntime;
+
+const input = (envVars: { name: string; value: string }[] = []) => ({
+  projectRoot,
+  runtime: runtime(envVars),
+  region: "us-east-1",
+});
+
+describe("createDevEnvironmentLoader", () => {
+  test("merges runtime, region, and .env.local while removing runner-owned keys", async () => {
+    const loader = createDevEnvironmentLoader({
+      readFile: async () => `
+SHARED="local value"
+AWS_REGION=local-region
+PORT=9999
+FASTMCP_PORT=9998
+LOCAL_DEV=0
+MULTILINE="first
+second"
+`,
+    });
+
+    await expect(
+      loader(
+        input([
+          { name: "SHARED", value: "runtime" },
+          { name: "RUNTIME_ONLY", value: "yes" },
+          { name: "PORT", value: "1234" },
+        ]),
+      ),
+    ).resolves.toEqual({
+      env: {
+        SHARED: "local value",
+        RUNTIME_ONLY: "yes",
+        AWS_REGION: "local-region",
+        MULTILINE: "first\nsecond",
+      },
+    });
+  });
+
+  test.each([
+    ["ENOENT", undefined],
+    [
+      "EACCES",
+      `Unable to read local environment file at ${join(projectRoot, "agentcore", ".env.local")}`,
+    ],
+  ] as const)("handles .env.local read error %s", async (code, expectedError) => {
+    const loader = createDevEnvironmentLoader({
+      readFile: async () => {
+        throw Object.assign(new Error("read failed"), { code });
+      },
+    });
+
+    const pending = loader(input([{ name: "RUNTIME_ONLY", value: "yes" }]));
+    if (expectedError) {
+      await expect(pending).rejects.toThrow(expectedError);
+    } else {
+      await expect(pending).resolves.toEqual({
+        env: { RUNTIME_ONLY: "yes", AWS_REGION: "us-east-1" },
+      });
+    }
+  });
+});

--- a/src/handlers/project/dev/environment.ts
+++ b/src/handlers/project/dev/environment.ts
@@ -1,0 +1,65 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { parseEnv } from "node:util";
+import type { ProjectRuntime } from "../../../projectSchemas/runtime";
+import { InputValidationError } from "../../../errors";
+
+const RESERVED_ENV_KEYS = ["PORT", "FASTMCP_PORT", "LOCAL_DEV"] as const;
+
+export type DevEnvironmentInput = {
+  projectRoot: string;
+  runtime: ProjectRuntime;
+  region?: string;
+};
+
+export type DevEnvironment = {
+  env: Record<string, string>;
+};
+
+export type DevEnvironmentLoader = (input: DevEnvironmentInput) => Promise<DevEnvironment>;
+
+type DevEnvironmentLoaderConfig = {
+  readFile?: (path: string, encoding: BufferEncoding) => Promise<string>;
+};
+
+async function localEnvironment(
+  projectRoot: string,
+  read: (path: string, encoding: BufferEncoding) => Promise<string>,
+): Promise<Record<string, string>> {
+  const path = join(projectRoot, "agentcore", ".env.local");
+  let contents: string;
+  try {
+    contents = await read(path, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return {};
+    throw new InputValidationError(`Unable to read local environment file at ${path}`, {
+      cause: error,
+    });
+  }
+
+  try {
+    return parseEnv(contents) as Record<string, string>;
+  } catch (error) {
+    throw new InputValidationError(`Invalid local environment file at ${path}`, { cause: error });
+  }
+}
+
+export function createDevEnvironmentLoader(
+  config: DevEnvironmentLoaderConfig = {},
+): DevEnvironmentLoader {
+  const read = config.readFile ?? readFile;
+
+  return async (input) => {
+    const env = Object.fromEntries(
+      (input.runtime.envVars ?? []).map(({ name, value }) => [name, value]),
+    );
+    if (input.region) env.AWS_REGION = input.region;
+
+    Object.assign(env, await localEnvironment(input.projectRoot, read));
+    for (const key of RESERVED_ENV_KEYS) delete env[key];
+
+    return { env };
+  };
+}
+
+export const loadDevEnvironment = createDevEnvironmentLoader();

--- a/src/handlers/project/dev/index.test.ts
+++ b/src/handlers/project/dev/index.test.ts
@@ -22,7 +22,11 @@ function runtime(name = "orders", build: ProjectRuntime["build"] = "CodeZip"): P
 }
 
 function project(...runtimes: ProjectRuntime[]): Project {
-  return { name: "test-project", rootPath: "/workspace/project", managedBy: "CDK", runtimes };
+  return {
+    name: "test-project",
+    rootPath: "/workspace/project",
+    spec: { runtimes } as Project["spec"],
+  };
 }
 
 function captureRunner(events: DevEvent[] = []) {

--- a/src/handlers/project/dev/index.test.ts
+++ b/src/handlers/project/dev/index.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, test } from "bun:test";
+import type { ProjectRuntime } from "../../../projectSchemas/runtime";
+import { InputValidationError, ResourceNotFoundError } from "../../../errors";
+import type { PortChecker } from "../../../io";
+import { ProjectKey, ValueContext } from "../../../router";
+import { testIO } from "../../../testing";
+import { JsonRendererKey } from "../../../tui";
+import { JsonKey, RegionKey } from "../../keys";
+import type { Project } from "../types";
+import { createDevProjectHandler, type DevProjectHandlerConfig } from ".";
+import type { DevEnvironmentInput } from "./environment";
+import type { DevEvent, DevRunner, DevServerInput } from "./types";
+
+function runtime(name = "orders", build: ProjectRuntime["build"] = "CodeZip"): ProjectRuntime {
+  return {
+    name,
+    build,
+    protocol: "HTTP",
+    entrypoint: "main.py",
+    codeLocation: `app/${name}`,
+  } as ProjectRuntime;
+}
+
+function project(...runtimes: ProjectRuntime[]): Project {
+  return { name: "test-project", rootPath: "/workspace/project", managedBy: "CDK", runtimes };
+}
+
+function captureRunner(events: DevEvent[] = []) {
+  const inputs: DevServerInput[] = [];
+  const runner: DevRunner = {
+    run: async function* (input) {
+      inputs.push(input);
+      yield* events;
+    },
+  };
+  return { runner, inputs };
+}
+
+type HarnessOptions = {
+  project?: Project;
+  codeZip?: ReturnType<typeof captureRunner>;
+  container?: ReturnType<typeof captureRunner>;
+  checkPort?: PortChecker;
+  json?: boolean;
+  loadEnvironment?: DevProjectHandlerConfig["loadDevEnvironment"];
+};
+
+function harness(options: HarnessOptions = {}) {
+  const io = testIO();
+  const codeZip = options.codeZip ?? captureRunner();
+  const container = options.container ?? captureRunner();
+  const environmentInputs: DevEnvironmentInput[] = [];
+  const handler = createDevProjectHandler({
+    io: io.io,
+    runners: { CodeZip: codeZip.runner, Container: container.runner },
+    loadDevEnvironment:
+      options.loadEnvironment ??
+      (async (input) => {
+        environmentInputs.push(input);
+        return { env: { FROM_LOADER: "yes" } };
+      }),
+    checkPort: options.checkPort ?? (async () => true),
+  });
+  const ctx = ValueContext.EmptyContext()
+    .withValue(ProjectKey, options.project ?? project(runtime()))
+    .withValue(JsonKey, options.json ?? false)
+    .withValue(RegionKey, "us-west-2")
+    .withValue(JsonRendererKey, {
+      renderJson: (data) => io.io.stdout.write(`${JSON.stringify(data, null, 2)}\n`),
+      renderJsonLine: (data) => io.io.stdout.write(`${JSON.stringify(data)}\n`),
+    });
+
+  return {
+    codeZip,
+    container,
+    environmentInputs,
+    io,
+    run: (flags: { agent?: string; port?: number } = {}) => handler.handle(ctx, flags, {}),
+  };
+}
+
+describe("project dev selection and dispatch", () => {
+  test.each([
+    [project(), {}, "This project has no runtimes", InputValidationError],
+    [
+      project(runtime("orders"), runtime("support", "Container")),
+      {},
+      "Use --agent to select one. Available runtimes: orders, support",
+      InputValidationError,
+    ],
+    [
+      project(runtime("orders"), runtime("support", "Container")),
+      { agent: "missing" },
+      "Runtime 'missing' was not found. Available runtimes: orders, support",
+      ResourceNotFoundError,
+    ],
+  ] as const)(
+    "rejects invalid runtime selection",
+    async (configuredProject, flags, message, ErrorType) => {
+      const pending = harness({ project: configuredProject }).run(flags);
+      await expect(pending).rejects.toBeInstanceOf(ErrorType);
+      await expect(pending).rejects.toThrow(message);
+    },
+  );
+
+  test("loads the environment and dispatches the selected runtime", async () => {
+    const subject = harness({
+      project: project(runtime("orders"), runtime("support", "Container")),
+    });
+    await subject.run({ agent: "support", port: 4567 });
+
+    expect(subject.codeZip.inputs).toHaveLength(0);
+    expect(subject.environmentInputs).toEqual([
+      {
+        projectRoot: "/workspace/project",
+        runtime: expect.objectContaining({ name: "support" }),
+        region: "us-west-2",
+      },
+    ]);
+    expect(subject.container.inputs[0]).toMatchObject({
+      projectRoot: "/workspace/project",
+      port: 4567,
+      env: { FROM_LOADER: "yes" },
+      runtime: { name: "support", build: "Container" },
+    });
+  });
+
+  test("announces an automatically selected port", async () => {
+    const checked: number[] = [];
+    const subject = harness({
+      checkPort: async (port) => {
+        checked.push(port);
+        return port === 8081;
+      },
+    });
+    await subject.run();
+
+    expect(checked).toEqual([8080, 8081]);
+    expect(subject.codeZip.inputs[0]?.port).toBe(8081);
+    expect(subject.io.stderr()).toBe("Port 8080 is in use; using 8081.");
+  });
+});
+
+test("project dev renders human and NDJSON output", async () => {
+  const events: DevEvent[] = [
+    { type: "status", message: "Starting" },
+    { type: "stdout", line: "agent output" },
+    { type: "stderr", line: "agent warning" },
+  ];
+
+  for (const json of [false, true]) {
+    const subject = harness({ codeZip: captureRunner(events), json });
+    await subject.run();
+    expect(subject.io.stdout()).toBe(
+      json ? events.map((event) => JSON.stringify(event)).join("\n") : "agent output",
+    );
+    expect(subject.io.stderr()).toBe(json ? "" : "Starting\nagent warning");
+  }
+});
+
+function heldRunner() {
+  let start!: (input: DevServerInput) => void;
+  let release: (() => void) | undefined;
+  const started = new Promise<DevServerInput>((resolve) => (start = resolve));
+  const runner: DevRunner = {
+    run: async function* (input) {
+      yield* [];
+      start(input);
+      await new Promise<void>((resolve) => (release = resolve));
+      input.signal.throwIfAborted();
+    },
+  };
+  return { runner, inputs: [], started, release: () => release?.() };
+}
+
+describe("project dev interruption", () => {
+  test.each(["SIGINT", "SIGTERM"] as const)(
+    "%s aborts, reports exit 130, and removes its listener",
+    async (signal) => {
+      const codeZip = heldRunner();
+      const before = process.listenerCount(signal);
+      const subject = harness({ codeZip });
+      const pending = subject.run();
+      const input = await codeZip.started;
+
+      process.emit(signal, signal);
+      process.emit(signal, signal);
+      codeZip.release();
+
+      expect(input.signal.aborted).toBe(true);
+      await expect(pending).rejects.toMatchObject({
+        name: "AbortError",
+        reported: true,
+        exitCode: 130,
+      });
+      expect(subject.io.stderr()).toBe("Shutting down…");
+      expect(process.listenerCount(signal)).toBe(before);
+    },
+  );
+
+  test("preserves an ordinary runner failure", async () => {
+    const failure = new InputValidationError("runner failed");
+    const codeZip = captureRunner();
+    codeZip.runner.run = async function* () {
+      yield* [];
+      throw failure;
+    };
+
+    await expect(harness({ codeZip }).run()).rejects.toBe(failure);
+  });
+});

--- a/src/handlers/project/dev/index.ts
+++ b/src/handlers/project/dev/index.ts
@@ -22,22 +22,22 @@ export type DevProjectHandlerConfig = {
 };
 
 function selectRuntime(project: Project, name?: string): ProjectRuntime {
-  if (project.runtimes.length === 0) {
+  if (project.spec.runtimes.length === 0) {
     throw new InputValidationError(
       "This project has no runtimes. Add a runtime to agentcore/agentcore.json and retry.",
     );
   }
-  const available = project.runtimes.map(({ name }) => name).join(", ");
+  const available = project.spec.runtimes.map(({ name }) => name).join(", ");
 
   if (name) {
-    const runtime = project.runtimes.find((candidate) => candidate.name === name);
+    const runtime = project.spec.runtimes.find((candidate) => candidate.name === name);
     if (runtime) return runtime;
     throw new ResourceNotFoundError(
       `Runtime '${name}' was not found. Available runtimes: ${available}.`,
     );
   }
 
-  if (project.runtimes.length === 1) return project.runtimes[0]!;
+  if (project.spec.runtimes.length === 1) return project.spec.runtimes[0]!;
   throw new InputValidationError(
     `Multiple runtimes found. Use --agent to select one. Available runtimes: ${available}.`,
   );

--- a/src/handlers/project/dev/index.ts
+++ b/src/handlers/project/dev/index.ts
@@ -1,11 +1,123 @@
-import { createHandler } from "../../../router";
-import { NotImplementedError } from "../../../errors";
+import z from "zod";
+import { resolveDevPort } from "../../../core/dev/port";
+import type { ProjectRuntime } from "../../../projectSchemas/runtime";
+import {
+  CommandInterruptedError,
+  InputValidationError,
+  ResourceNotFoundError,
+} from "../../../errors";
+import type { AppIO, PortChecker } from "../../../io";
+import { createHandler, flag, ProjectKey } from "../../../router";
+import { JsonRendererKey, type JsonRenderer } from "../../../tui";
+import { JsonKey, RegionKey } from "../../keys";
+import type { Project } from "../types";
+import type { DevEnvironmentLoader } from "./environment";
+import type { DevEvent, DevRunner } from "./types";
 
-export const createDevProjectHandler = () =>
+export type DevProjectHandlerConfig = {
+  io: AppIO;
+  runners: { CodeZip: DevRunner; Container: DevRunner };
+  loadDevEnvironment: DevEnvironmentLoader;
+  checkPort: PortChecker;
+};
+
+function selectRuntime(project: Project, name?: string): ProjectRuntime {
+  if (project.runtimes.length === 0) {
+    throw new InputValidationError(
+      "This project has no runtimes. Add a runtime to agentcore/agentcore.json and retry.",
+    );
+  }
+  const available = project.runtimes.map(({ name }) => name).join(", ");
+
+  if (name) {
+    const runtime = project.runtimes.find((candidate) => candidate.name === name);
+    if (runtime) return runtime;
+    throw new ResourceNotFoundError(
+      `Runtime '${name}' was not found. Available runtimes: ${available}.`,
+    );
+  }
+
+  if (project.runtimes.length === 1) return project.runtimes[0]!;
+  throw new InputValidationError(
+    `Multiple runtimes found. Use --agent to select one. Available runtimes: ${available}.`,
+  );
+}
+
+function renderEvent(io: AppIO, event: DevEvent, json?: JsonRenderer): void {
+  if (json) {
+    json.renderJsonLine(event);
+    return;
+  }
+
+  const output = event.type === "stdout" ? io.stdout : io.stderr;
+  output.write(`${event.type === "status" ? event.message : event.line}\n`);
+}
+
+export const createDevProjectHandler = (config: DevProjectHandlerConfig) =>
   createHandler({
     name: "dev",
     description: "run the project locally for development",
-    handle: async () => {
-      throw new NotImplementedError("agentcore project dev is not implemented yet");
+    flags: [
+      flag("agent", "runtime to run", z.string().optional()),
+      flag(
+        "port",
+        "port for the development server",
+        z.coerce.number().int().min(1).max(65535).optional(),
+      ),
+    ],
+    handle: async (ctx, flags) => {
+      const controller = new AbortController();
+      const json = ctx.require(JsonKey) ? ctx.require(JsonRendererKey) : undefined;
+      const interrupt = () => {
+        if (controller.signal.aborted) return;
+        config.io.stderr.write("Shutting down…\n");
+        controller.abort();
+      };
+
+      const signals = ["SIGINT", "SIGTERM"] as const;
+      for (const signal of signals) process.on(signal, interrupt);
+      try {
+        const project = ctx.require(ProjectKey);
+        const runtime = selectRuntime(project, flags.agent);
+        const devPort = await resolveDevPort(
+          runtime.protocol,
+          flags.port,
+          config.checkPort,
+          controller.signal,
+        );
+        if (devPort.port !== devPort.requestedPort) {
+          renderEvent(
+            config.io,
+            {
+              type: "status",
+              message: `Port ${devPort.requestedPort} is in use; using ${devPort.port}.`,
+            },
+            json,
+          );
+        }
+
+        const { env } = await config.loadDevEnvironment({
+          projectRoot: project.rootPath,
+          runtime,
+          region: ctx.require(RegionKey),
+        });
+        controller.signal.throwIfAborted();
+
+        const runner = config.runners[runtime.build];
+        for await (const event of runner.run({
+          runtime,
+          projectRoot: project.rootPath,
+          port: devPort.port,
+          env,
+          signal: controller.signal,
+        })) {
+          renderEvent(config.io, event, json);
+        }
+      } catch (error) {
+        if (!controller.signal.aborted) throw error;
+        throw new CommandInterruptedError(error, true);
+      } finally {
+        for (const signal of signals) process.removeListener(signal, interrupt);
+      }
     },
   });

--- a/src/handlers/project/index.ts
+++ b/src/handlers/project/index.ts
@@ -1,9 +1,12 @@
 import { Router } from "../../router";
+import { checkPort, type AppIO } from "../../io";
+import { CodeZipDevRunner } from "../../core/dev/codezip";
+import { ContainerDevRunner } from "../../core/dev/container";
 import { withProject } from "../../middleware";
-import type { AppIO } from "../../io";
 import { createCreateProjectHandler } from "./create";
 import { createRemoveProjectHandler } from "./remove";
 import { createDevProjectHandler } from "./dev";
+import { loadDevEnvironment } from "./dev/environment";
 import { createDeployProjectHandler } from "./deploy";
 import { createStatusProjectHandler } from "./status";
 import { createBuildProjectHandler } from "./build";
@@ -23,7 +26,19 @@ export function createProjectHandler(config: ProjectHandlerConfig): Router {
   );
   project.handler(createAddProjectResourceHandler(config));
   project.handler(createRemoveProjectHandler());
-  project.handler(createDevProjectHandler());
+  project.handler(
+    withProject({ projectManager: config.projectManager })(
+      createDevProjectHandler({
+        io: config.io,
+        runners: {
+          CodeZip: new CodeZipDevRunner(),
+          Container: new ContainerDevRunner(),
+        },
+        loadDevEnvironment,
+        checkPort,
+      }),
+    ),
+  );
   project.handler(createDeployProjectHandler());
   project.handler(createStatusProjectHandler());
   // withProject wraps only the commands that require an existing project, so

--- a/src/handlers/project/project.test.ts
+++ b/src/handlers/project/project.test.ts
@@ -25,10 +25,15 @@ async function run(args: string[], opts?: { core?: TestCoreClient }) {
   return { io, core };
 }
 
-describe.each(["remove", "dev", "deploy", "status"])("project %s", (command) => {
+describe.each(["remove", "deploy", "status"])("project %s", (command) => {
   test("throws because it is not implemented yet", async () => {
     await expect(run([command])).rejects.toThrow(/not implemented/);
   });
+});
+
+test("project dev requires an AgentCore project", async () => {
+  await inTempDirectory();
+  await expect(run(["dev"])).rejects.toThrow(/No AgentCore project found/);
 });
 
 const originalCwd = process.cwd();

--- a/src/handlers/runtime/invoke/index.tsx
+++ b/src/handlers/runtime/invoke/index.tsx
@@ -1,9 +1,5 @@
 import z from "zod";
-import {
-  InputValidationError,
-  InvalidEnvironmentError,
-  RuntimeInvokeInterruptedError,
-} from "../../../errors";
+import { InputValidationError, RuntimeInvokeInterruptedError } from "../../../errors";
 import { createHandler, flag, PathKey } from "../../../router";
 import type { AppIO } from "../../../io";
 import type { Core } from "../../types";
@@ -95,22 +91,12 @@ export const createInvokeRuntimeHandler = (core: Core, io: AppIO) =>
           applicationHeaders,
           bearerToken,
         };
-        try {
-          await renderTuiAt(
-            path,
-            ctx.withValue(RuntimeInvokeLaunchContextKey, launchContext),
-            core,
-            io,
-          );
-        } catch (error) {
-          if (error instanceof InvalidEnvironmentError) {
-            throw new InputValidationError(error.message, {
-              cause: error,
-              exitCode: ExitCode.USAGE,
-            });
-          }
-          throw error;
-        }
+        await renderTuiAt(
+          path,
+          ctx.withValue(RuntimeInvokeLaunchContextKey, launchContext),
+          core,
+          io,
+        );
         return;
       }
 

--- a/src/handlers/runtime/invoke/index.tsx
+++ b/src/handlers/runtime/invoke/index.tsx
@@ -1,5 +1,9 @@
 import z from "zod";
-import { InputValidationError, RuntimeInvokeInterruptedError } from "../../../errors";
+import {
+  InputValidationError,
+  InvalidEnvironmentError,
+  RuntimeInvokeInterruptedError,
+} from "../../../errors";
 import { createHandler, flag, PathKey } from "../../../router";
 import type { AppIO } from "../../../io";
 import type { Core } from "../../types";
@@ -91,12 +95,22 @@ export const createInvokeRuntimeHandler = (core: Core, io: AppIO) =>
           applicationHeaders,
           bearerToken,
         };
-        await renderTuiAt(
-          path,
-          ctx.withValue(RuntimeInvokeLaunchContextKey, launchContext),
-          core,
-          io,
-        );
+        try {
+          await renderTuiAt(
+            path,
+            ctx.withValue(RuntimeInvokeLaunchContextKey, launchContext),
+            core,
+            io,
+          );
+        } catch (error) {
+          if (error instanceof InvalidEnvironmentError) {
+            throw new InputValidationError(error.message, {
+              cause: error,
+              exitCode: ExitCode.USAGE,
+            });
+          }
+          throw error;
+        }
         return;
       }
 

--- a/src/io/index.ts
+++ b/src/io/index.ts
@@ -36,3 +36,4 @@ export {
 } from "./streamingResponse";
 export type { AppIO, ReadWriteJson } from "./types";
 export { warn } from "./warn";
+export { checkPort, type PortChecker } from "./port";

--- a/src/io/port.test.ts
+++ b/src/io/port.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "bun:test";
+import { createServer, type Server } from "node:net";
+import { checkPort } from "./port";
+
+function listen(): Promise<Server> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve(server));
+  });
+}
+
+test("checkPort rejects an occupied loopback port and accepts it after release", async () => {
+  const server = await listen();
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("expected a TCP address");
+  const signal = new AbortController().signal;
+
+  expect(await checkPort(address.port, signal)).toBe(false);
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  expect(await checkPort(address.port, signal)).toBe(true);
+});
+
+test("checkPort respects an aborted signal", async () => {
+  const controller = new AbortController();
+  controller.abort();
+
+  await expect(checkPort(49152, controller.signal)).rejects.toHaveProperty("name", "AbortError");
+});

--- a/src/io/port.ts
+++ b/src/io/port.ts
@@ -1,0 +1,27 @@
+import { createServer } from "node:net";
+
+export type PortChecker = (port: number, signal: AbortSignal) => Promise<boolean>;
+
+function canBind(port: number, host: string, signal: AbortSignal): Promise<boolean> {
+  signal.throwIfAborted();
+
+  return new Promise<boolean>((resolve, reject) => {
+    const server = createServer().unref();
+    server.once("error", () => resolve(false));
+    server.once("close", () => {
+      if (signal.aborted) reject(signal.reason);
+    });
+    server.listen({ port, host, exclusive: true, signal }, () => {
+      server.close(() => resolve(true));
+    });
+  });
+}
+
+/** Checks that a port can be bound by both loopback-only and all-interface servers. */
+export const checkPort: PortChecker = async (port, signal) => {
+  if (!(await canBind(port, "127.0.0.1", signal))) return false;
+  signal.throwIfAborted();
+  const available = await canBind(port, "0.0.0.0", signal);
+  signal.throwIfAborted();
+  return available;
+};

--- a/src/middleware/withJsonRenderer.tsx
+++ b/src/middleware/withJsonRenderer.tsx
@@ -11,6 +11,7 @@ import type { AppIO } from "../io";
 export function withJsonRenderer(io: AppIO): Middleware {
   const renderer = {
     renderJson: (data: unknown) => renderJson(data, (line) => io.stdout.write(line + "\n")),
+    renderJsonLine: (data: unknown) => io.stdout.write(JSON.stringify(data) + "\n"),
   };
 
   return (h) => ({

--- a/src/runnable/index.test.ts
+++ b/src/runnable/index.test.ts
@@ -1,7 +1,7 @@
 import { expect, spyOn, test } from "bun:test";
 import { CommanderError } from "commander";
 
-import { AgentCoreCLIError, InputValidationError } from "../errors";
+import { AgentCoreCLIError, CommandInterruptedError, InputValidationError } from "../errors";
 import { ExitCode, runRunnable, runWithExitCode, type Runnable } from "./index.tsx";
 
 async function captureErrors(run: () => Promise<number>) {
@@ -88,6 +88,12 @@ test.each([
     ),
     ExitCode.INTERRUPTED,
     ["AbortError: The operation was aborted"],
+  ],
+  [
+    "reported command interruption",
+    new CommandInterruptedError(undefined, true),
+    ExitCode.INTERRUPTED,
+    [],
   ],
   [
     "Commander parse failure",

--- a/src/testing/renderScreen.tsx
+++ b/src/testing/renderScreen.tsx
@@ -43,7 +43,7 @@ function baseContext(core: TestCoreClient, endpointUrl?: string): Context {
     .withValue(EndpointKey, endpointUrl)
     .withValue(JsonKey, false)
     .withValue(DebugKey, false)
-    .withValue(JsonRendererKey, { renderJson: () => {} });
+    .withValue(JsonRendererKey, { renderJson: () => {}, renderJsonLine: () => {} });
 }
 
 // testQueryClient returns a QueryClient with retries and caching disabled so

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -30,6 +30,7 @@ export function renderJson(data: unknown, writer: (line: string) => void = conso
 // of any direct dependency on a global output stream.
 export interface JsonRenderer {
   renderJson(data: unknown): void;
+  renderJsonLine(data: unknown): void;
 }
 
 // JsonRendererKey exposes the prewired JsonRenderer on the context. Installed by


### PR DESCRIPTION
## Summary
- implement `agentcore project dev` runtime selection, port resolution, runner dispatch, structured output, and signal handling
- reuse `withProject` for project discovery and actionable missing-project guidance
- load runtime and `.env.local` values directly; containers forward host AWS variables, mount `~/.aws` read-only, and fail early when neither credential source exists
- reuse shared JSON rendering for NDJSON events and generalize command interruption handling

Stacks on #1962.

## Verification
- `bun test` (1107 pass)
- `bun run typecheck`
- `bun run lint:check`
- `bun run format:check`
- `bun run build`
- executable smoke: scaffolded a real Python project, ran `project dev`, received healthy `/ping`, interrupted with exit 130, and verified child cleanup and port release
- executable no-project probe verified the actionable `project create` guidance