### PR TITLE
refactor(project): tighten the ProjectEvent and create() contracts

### DIFF
--- a/src/core/project/manager.test.ts
+++ b/src/core/project/manager.test.ts
@@ -56,7 +56,7 @@ async function runCreate(
   while (true) {
     const next = await iterator.next();
     if (next.done) {
-      return { events, project: next.value as Project };
+      return { events, project: next.value };
     }
     events.push(next.value);
   }

--- a/src/core/project/manager.tsx
+++ b/src/core/project/manager.tsx
@@ -66,7 +66,7 @@ export class FsProjectManager implements ProjectManager {
     }
   }
 
-  public async *create(input: CreateProjectInput): AsyncGenerator<ProjectEvent> {
+  public async *create(input: CreateProjectInput): AsyncGenerator<ProjectEvent, Project> {
     // Scaffold into a fresh directory, refusing to nest inside an existing project.
     const enclosing = enclosingProjectRoot(process.cwd());
     if (enclosing) {
@@ -106,12 +106,16 @@ export class FsProjectManager implements ProjectManager {
       await this.run(["git", "init"], destination);
     }
 
-    // Return the same shape resolve() would: a created project is a resolvable one.
-    return {
-      name: input.name,
-      rootPath: destination,
-      runtimes: TEMPLATES[input.template].spec.runtimes ?? [],
-    };
+    // A created project is a resolvable one, so read it back rather than
+    // duplicating the template's shape: the returned runtimes are then
+    // schema-validated instead of the template's loosely-typed spec sections.
+    const project = await this.resolve({ filePath: destination });
+    if (!project) {
+      throw new ProjectStateError(
+        `the project scaffolded at ${destination} could not be read back`,
+      );
+    }
+    return project;
   }
 
   // Runs a command with its output streamed to the file logger.

--- a/src/handlers/project/create/index.ts
+++ b/src/handlers/project/create/index.ts
@@ -34,9 +34,7 @@ export const createCreateProjectHandler = (config: CreateProjectHandlerConfig) =
         skipInstall: flags["skip-install"],
         skipGit: flags["skip-git"],
       })) {
-        if (event.message) {
-          config.io.stderr.write(`${event.message}\n`);
-        }
+        config.io.stderr.write(`${event.message}\n`);
       }
 
       config.io.stderr.write(`Created project '${flags["name"]}' in ./${flags["name"]}\n`);

--- a/src/handlers/project/types.ts
+++ b/src/handlers/project/types.ts
@@ -22,10 +22,9 @@ export type CreateProjectInput = {
   skipGit?: boolean;
 };
 
+/** A progress step reported while a long-running project operation runs. */
 export type ProjectEvent = {
-  message?: string;
-  subprocessOutput?: string;
-  project?: Project;
+  message: string;
 };
 
 export type ResolveProjectInput = {
@@ -46,7 +45,7 @@ export type Project = {
  */
 export interface ProjectManager {
   /** Scaffold a new AgentCore project from the given template. */
-  create(input: CreateProjectInput): AsyncGenerator<ProjectEvent>;
+  create(input: CreateProjectInput): AsyncGenerator<ProjectEvent, Project>;
 
   /** Locate an existing AgentCore project. Returns undefined if no project can be found. */
   resolve(input: ResolveProjectInput): Promise<Project | undefined>;


### PR DESCRIPTION
Groundwork for `agentcore project build`, split out so the contract change is reviewable on its own.

## What

`ProjectEvent` was a three-field bag with every field optional:

```ts
export type ProjectEvent = {
  message?: string;
  subprocessOutput?: string;
  project?: Project;
};
```

`subprocessOutput` and `project` were never written and never read — I checked every producer and consumer. Only `message` was ever used, and because it was optional the `create` handler had to guard it (`if (event.message)`) on every iteration. So the type is now just:

```ts
export type ProjectEvent = { message: string };
```

and the guard in `handlers/project/create/index.ts` is gone.

`create` also declared `AsyncGenerator<ProjectEvent>`, leaving `TReturn` as the default `any`. It is now `AsyncGenerator<ProjectEvent, Project>`.

## The type hole that tightening exposed

Naming the return type surfaced a real mismatch: `create` was building its return value out of `TemplateSpec.runtimes`, which is `unknown[]`, while `Project.runtimes` is `ProjectRuntime[]`. `any` had been hiding it.

Rather than cast, `create` now reads the project back through `resolve()`:

```ts
const project = await this.resolve({ filePath: destination });
```

That honours a comment already sitting in the code ("Return the same shape resolve() would: a created project is a resolvable one"), and means the returned runtimes are schema-validated instead of being the template's loosely-typed spec sections passed through unchecked.

The matching `as Project` cast in `manager.test.ts` is dropped too, so the test now type-checks the real thing.

## Verification

- `bun test` — 1061 pass, 0 fail
- `tsc --noEmit` clean, `oxlint` clean

No behaviour change; the only user-visible difference is that progress messages are no longer conditionally skipped, and they were never absent in practice.