### PR TITLE
fix(project): validate runtimeVersion on CodeZip runtimes

### DIFF
--- a/src/core/project/manager.test.ts
+++ b/src/core/project/manager.test.ts
@@ -333,4 +333,29 @@ describe("FsProjectManager.resolve", () => {
       DeserializationError,
     );
   });
+
+  test("names the offending field when the spec fails validation", async () => {
+    const root = await inTempDirectory();
+    await mkdir(join(root, "agentcore"), { recursive: true });
+    // Valid JSON, invalid spec: a CodeZip runtime with no runtimeVersion.
+    await writeFile(
+      join(root, "agentcore", "agentcore.json"),
+      JSON.stringify({
+        name: "example",
+        version: 1,
+        runtimes: [
+          {
+            name: "hello_world",
+            build: "CodeZip",
+            entrypoint: "main.py",
+            codeLocation: "app/hello-world",
+          },
+        ],
+      }),
+    );
+
+    await expect(manager().manager.resolve({ filePath: root })).rejects.toThrow(
+      "runtimeVersion is required for CodeZip builds",
+    );
+  });
 });

--- a/src/errors/errors.tsx
+++ b/src/errors/errors.tsx
@@ -108,8 +108,18 @@ export class SourceResolutionError extends InputValidationError {
 }
 
 export class DeserializationError extends AgentCoreCLIError {
-  constructor(path: string, options?: Omit<AgentCoreCLIErrorOptions, "source">) {
-    super(`Failed to deserialize file at "${path}"`, { ...options, source: ERROR_SOURCE.USER });
+  constructor(
+    path: string,
+    options?: Omit<AgentCoreCLIErrorOptions, "source"> & {
+      /** Rendered reasons the payload was rejected, appended so the user sees which field to fix. */
+      detail?: string;
+    },
+  ) {
+    const detail = options?.detail ? `\n${options.detail}` : "";
+    super(`Failed to deserialize file at "${path}"${detail}`, {
+      ...options,
+      source: ERROR_SOURCE.USER,
+    });
     this.name = "DeserializationError";
   }
 }

--- a/src/io/json.ts
+++ b/src/io/json.ts
@@ -2,6 +2,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 
 import type z from "zod";
+import { prettifyError } from "zod";
 
 import { DeserializationError } from "../errors";
 import type { Logger } from "../logging";
@@ -52,7 +53,10 @@ export class FsReadWriteJson implements ReadWriteJson {
           errorMessage: parseResult.error.message,
         })
         .error(`failed to validate parsed json file`);
-      throw new DeserializationError(filePath, { cause: parseResult.error });
+      throw new DeserializationError(filePath, {
+        cause: parseResult.error,
+        detail: prettifyError(parseResult.error),
+      });
     }
 
     return parseResult.data;

--- a/src/projectSchemas/project.test.ts
+++ b/src/projectSchemas/project.test.ts
@@ -8,6 +8,7 @@ const runtime = {
   build: "CodeZip" as const,
   entrypoint: "main.py",
   codeLocation: "./agent",
+  runtimeVersion: "PYTHON_3_12" as const,
   endpoints: { LIVE: { version: 1 } },
 };
 

--- a/src/projectSchemas/runtime.test.ts
+++ b/src/projectSchemas/runtime.test.ts
@@ -11,6 +11,7 @@ const codeZipAgent = {
   build: "CodeZip" as const,
   entrypoint: "main.py",
   codeLocation: "./agent",
+  runtimeVersion: "PYTHON_3_12" as const,
 };
 const containerAgent = {
   name: "agent",
@@ -71,6 +72,15 @@ describe("runtime custom validation", () => {
         },
       }).success,
     ).toBe(false);
+  });
+  it("requires runtimeVersion for CodeZip builds only", () => {
+    const { runtimeVersion: _omitted, ...withoutVersion } = codeZipAgent;
+    const result = ProjectRuntimeSchema.safeParse(withoutVersion);
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.path).toEqual(["runtimeVersion"]);
+
+    // Container builds take their version from the image.
+    expect(ProjectRuntimeSchema.safeParse(containerAgent).success).toBe(true);
   });
   it("restricts container-only fields to container builds", () => {
     for (const field of [

--- a/src/projectSchemas/runtime.ts
+++ b/src/projectSchemas/runtime.ts
@@ -308,6 +308,17 @@ export const ProjectRuntimeSchema = z
         path: ["authorizerConfiguration"],
       });
     }
+    // Mirrors the CDK construct library, which rejects a CodeZip runtime with no
+    // runtimeVersion: it is the field that selects the packager. Validating it here
+    // means the CLI reports it against agentcore.json instead of letting synthesis
+    // fail later with the same rule.
+    if (data.build !== "Container" && !data.runtimeVersion) {
+      ctx.addIssue({
+        code: "custom",
+        message: "runtimeVersion is required for CodeZip builds",
+        path: ["runtimeVersion"],
+      });
+    }
     for (const field of ["dockerfile", "buildContextPath", "customDockerBuildArgs"] as const) {
       if (data.build !== "Container" && data[field]) {
         ctx.addIssue({


### PR DESCRIPTION
Rebased onto current `refactor`. Both parents (#1969, #1970) have merged, and `refactor` has since landed two of this PR's three parts independently — see "What the rebase changed" below.

## The gap

The CDK construct library's `AgentEnvSpecSchema` refines:

```js
if (data.build !== 'Container' && !data.runtimeVersion) {
  // "runtimeVersion is required for CodeZip builds"
}
```

Our copy of that schema marked the field plain `.optional()`, with no such rule. So the CLI accepted a spec that synthesis would refuse, and the user only discovered it after a full `tsc` + `cdk synth` — from a stack trace inside the generated app rather than from the CLI.

Our `superRefine` already mirrors the library's checks almost one for one, including the identical container-only-fields loop directly beneath. This adds the one that was missing, in the same position the library has it:

```ts
if (data.build !== "Container" && !data.runtimeVersion) {
  ctx.addIssue({
    code: "custom",
    message: "runtimeVersion is required for CodeZip builds",
    path: ["runtimeVersion"],
  });
}
```

Container builds take their version from the image and stay exempt, consistent with the check below it.

## Reporting the rule earlier is only useful if it says what to fix

`DeserializationError` named the file and nothing else:

```
Failed to deserialize file at /path/to/agentcore/agentcore.json
```

The zod issues were attached as `cause`, which nothing renders — they were reachable only from the debug log. So the user traded CDK's precise `runtimes[0].runtimeVersion: runtimeVersion is required for CodeZip builds` for a message that doesn't name a field.

`DeserializationError` now takes an optional `detail`, and `json.read()` fills it with `z.prettifyError()`:

```
Failed to deserialize file at "/path/to/agentcore/agentcore.json"
✖ runtimeVersion is required for CodeZip builds
  → at runtimes[0].runtimeVersion
```

Putting it in `json.read()` rather than in the project manager means every caller of `json.read()` benefits, not just `agentcore.json`. A JSON *syntax* error carries no zod issues, so that path is unchanged and still covered by its existing test.

## Blast radius

`ProjectSpecSchema` has exactly one consumer: `resolve()` at `manager.tsx:56`. So the only configs this newly rejects are ones the CDK app would also reject at synth — no workflow that previously succeeded starts failing. It does mean the whole CLI now refuses to load such a config rather than failing at build time, which is the intent.

Two test fixtures were CodeZip runtimes without `runtimeVersion` and are now invalid by this rule, so they gain one (`projectSchemas/runtime.test.ts`, `projectSchemas/project.test.ts`). Worth a look during review that the surrounding assertions still test what they claim — the security-group-cap test at `runtime.test.ts` asserts a CodeZip spec *succeeds*, so it would have silently started passing for the wrong reason had the fixture not been fixed.

## What the rebase changed

Two of the three original commits are now redundant, so the branch is a single commit:

- Promoting `DeserializationError` to a USER-sourced `AgentCoreCLIError` landed on `refactor` independently. Only the `detail` option is new here.
- Removing the `try`/`catch` wrapper in `resolve()` also landed on `refactor` independently. `manager.tsx` is no longer touched by this PR at all.
- The earlier review round replaced a hand-rolled `describeValidationFailure` with `z.prettifyError` and moved the detail into `json.ts` (thanks @Hweinstock). That is the shape above; the intermediate commit no longer stood on its own after the rebase, so the two were squashed.

## Verification

Against the same real scaffolded project used to verify #1970, with `runtimeVersion` removed from its `agentcore.json`:

- Before: `tsc` ran, `cdk synth` ran, then the construct library's zod error.
- After: the CLI stops at config load naming `runtimes[0].runtimeVersion` — no compile, no synth, no `node_modules` needed.

New unit tests: the rule rejects a CodeZip runtime with no `runtimeVersion` and reports it at `path: ["runtimeVersion"]`; a container runtime without one still validates; and `resolve()` surfaces the reason in its message.

- `bun test` — 1600 pass, 2 fail. Both failures are `Cannot find package 'aws-cdk-lib'` loading the CDK *template* assets (`src/assets/cdk/test/cdk.test.ts`), which are meant to run inside a scaffolded project and are unrelated to this diff.
- `tsc --noEmit` clean, `oxlint` clean, `prettier --check` clean on all six touched files.
