### PR TITLE
chore: skip guardrail test in e2e test suite

### DIFF
--- a/e2e-tests/guardrail-block.test.ts
+++ b/e2e-tests/guardrail-block.test.ts
@@ -28,7 +28,7 @@ const canRun = prereqs.npm && prereqs.git && prereqs.uv && hasAws;
  * The contentFilter/VIOLENCE forbid policy blocks only violating content, while the allowall policy
  * permits the rest — proving the policy engine ENFORCE mechanism works end-to-end in both directions.
  */
-describe.skipIf(!canRun).sequential('e2e: policy engine blocks violating gateway invoke', () => {
+describe.skip('e2e: policy engine blocks violating gateway invoke', () => {
   const suffix = Date.now().toString().slice(-8);
   const agentName = `E2eGrd${suffix}`;
   const gatewayName = 'grdgw';


### PR DESCRIPTION
## Description

Temporarily skip `guardrail-block.test.ts` while we address regressions affecting gateway targets using `--type http-runtime`.

Tracked in issue: #1985 


## Related Issue

<!-- Every PR must be associated with an issue. Link it below using #issue-number format. -->

Closes #

## Documentation PR

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:unit` and `npm run test:integ`
- [ ] I ran `npm run typecheck`
- [ ] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [ ] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
