### PR TITLE
feat(errors): add shared user cancellation error

### DIFF
--- a/src/errors/errors.test.tsx
+++ b/src/errors/errors.test.tsx
@@ -4,7 +4,8 @@ import {
   ValidationException,
   InternalServerException,
 } from "@aws-sdk/client-bedrock-agentcore-control";
-import { AgentCoreCLIError, InputValidationError } from "./errors";
+import { CommanderError } from "commander";
+import { AgentCoreCLIError, InputValidationError, UserCancellationError } from "./errors";
 
 describe("AgentCoreCLIError", () => {
   test("fromError preserves existing AgentCoreCLIError instances", () => {
@@ -15,6 +16,29 @@ describe("AgentCoreCLIError", () => {
   test("fromError preserves AgentCoreCLIError subclasses", () => {
     const err = new InputValidationError("bad input");
     expect(AgentCoreCLIError.fromError(err)).toBe(err);
+  });
+
+  test.each([
+    ["parse failures", new CommanderError(1, "commander.invalidArgument", "invalid option"), 2],
+    ["help", new CommanderError(0, "commander.helpDisplayed", "help displayed"), 0],
+  ])("fromError classifies Commander %s", (_label, err, exitCode) => {
+    expect(AgentCoreCLIError.fromError(err).json()).toMatchObject({
+      name: "CommanderError",
+      source: "user",
+      exitCode,
+      displayMessage: false,
+      meta: { code: err.code },
+    });
+  });
+
+  test("UserCancellationError is a silent user interruption", () => {
+    expect(new UserCancellationError().json()).toMatchObject({
+      name: "UserCancellationError",
+      message: "Operation cancelled by user",
+      source: "user",
+      exitCode: 130,
+      displayMessage: false,
+    });
   });
 
   test.each([
@@ -61,6 +85,7 @@ describe("AgentCoreCLIError", () => {
       name: "AgentCoreCLIError",
       source: "internal",
       message: expectedMessage,
+      displayMessage: true,
     });
   });
 });

--- a/src/errors/errors.test.tsx
+++ b/src/errors/errors.test.tsx
@@ -48,6 +48,18 @@ describe("AgentCoreCLIError", () => {
     });
   });
 
+  test("UserCancellationError resolves direct and signal-propagated cancellation", () => {
+    const cancellation = new UserCancellationError();
+    const controller = new AbortController();
+    controller.abort(cancellation);
+
+    expect(UserCancellationError.resolve(cancellation)).toBe(cancellation);
+    expect(UserCancellationError.resolve(new Error("transport aborted"), controller.signal)).toBe(
+      cancellation,
+    );
+    expect(UserCancellationError.resolve(new Error("failed"))).toBeUndefined();
+  });
+
   test.each([
     [
       "AccessDeniedException (403)",

--- a/src/errors/errors.test.tsx
+++ b/src/errors/errors.test.tsx
@@ -5,7 +5,12 @@ import {
   InternalServerException,
 } from "@aws-sdk/client-bedrock-agentcore-control";
 import { CommanderError } from "commander";
-import { AgentCoreCLIError, InputValidationError, UserCancellationError } from "./errors";
+import {
+  AgentCoreCLIError,
+  InputValidationError,
+  SilentCLIError,
+  UserCancellationError,
+} from "./errors";
 
 describe("AgentCoreCLIError", () => {
   test("fromError preserves existing AgentCoreCLIError instances", () => {
@@ -22,22 +27,24 @@ describe("AgentCoreCLIError", () => {
     ["parse failures", new CommanderError(1, "commander.invalidArgument", "invalid option"), 2],
     ["help", new CommanderError(0, "commander.helpDisplayed", "help displayed"), 0],
   ])("fromError classifies Commander %s", (_label, err, exitCode) => {
-    expect(AgentCoreCLIError.fromError(err).json()).toMatchObject({
+    const result = AgentCoreCLIError.fromError(err);
+    expect(result).toBeInstanceOf(SilentCLIError);
+    expect(result.json()).toMatchObject({
       name: "CommanderError",
       source: "user",
       exitCode,
-      displayMessage: false,
       meta: { code: err.code },
     });
   });
 
   test("UserCancellationError is a silent user interruption", () => {
-    expect(new UserCancellationError().json()).toMatchObject({
+    const error = new UserCancellationError();
+    expect(error).toBeInstanceOf(SilentCLIError);
+    expect(error.json()).toMatchObject({
       name: "UserCancellationError",
       message: "Operation cancelled by user",
       source: "user",
       exitCode: 130,
-      displayMessage: false,
     });
   });
 
@@ -85,7 +92,6 @@ describe("AgentCoreCLIError", () => {
       name: "AgentCoreCLIError",
       source: "internal",
       message: expectedMessage,
-      displayMessage: true,
     });
   });
 });

--- a/src/errors/errors.tsx
+++ b/src/errors/errors.tsx
@@ -12,8 +12,6 @@ export interface AgentCoreCLIErrorOptions extends ErrorOptions {
   exitCode?: number;
   /** Describes the name of the underlying error, defaults to AgentCoreCLIError */
   name?: string;
-  /** Whether the root handler should display this error's message */
-  displayMessage?: boolean;
 }
 
 /** Base error for CLI failures, including their source, metadata, and process exit code. */
@@ -21,7 +19,6 @@ export class AgentCoreCLIError extends Error {
   readonly source: ErrorSource;
   readonly meta: Record<string, unknown>;
   readonly exitCode: number;
-  readonly displayMessage: boolean;
 
   constructor(message?: string, options?: AgentCoreCLIErrorOptions) {
     super(message, options);
@@ -29,7 +26,6 @@ export class AgentCoreCLIError extends Error {
     this.source = options?.source ?? ERROR_SOURCE.INTERNAL;
     this.meta = options?.meta ?? {};
     this.exitCode = options?.exitCode ?? 1;
-    this.displayMessage = options?.displayMessage ?? true;
   }
   /** Convert the error into an object with its attributes enumerated as keys **/
   json(): Record<string, unknown> {
@@ -38,7 +34,6 @@ export class AgentCoreCLIError extends Error {
       message: this.message,
       stack: this.stack,
       exitCode: this.exitCode,
-      displayMessage: this.displayMessage,
       meta: this.meta,
       source: this.source,
     };
@@ -48,13 +43,12 @@ export class AgentCoreCLIError extends Error {
     if (error instanceof AgentCoreCLIError) return error;
 
     if (error instanceof CommanderError) {
-      return new AgentCoreCLIError(error.message, {
+      return new SilentCLIError(error.message, {
         cause: error,
         source: ERROR_SOURCE.USER,
         name: error.name,
         meta: { code: error.code },
         exitCode: error.exitCode === 0 ? 0 : 2,
-        displayMessage: false,
       });
     }
 
@@ -78,6 +72,9 @@ export class AgentCoreCLIError extends Error {
     return new AgentCoreCLIError(String(error), { cause: error });
   }
 }
+
+/** Base for CLI errors intentionally omitted from root stderr output. */
+export class SilentCLIError extends AgentCoreCLIError {}
 
 /** Error raised for invalid user input. */
 export class InputValidationError extends AgentCoreCLIError {
@@ -155,19 +152,18 @@ export class EmbeddedAssetNotFoundError extends AgentCoreCLIError {
 }
 
 /** Raised when a user intentionally cancels a headless CLI operation. */
-export class UserCancellationError extends AgentCoreCLIError {
+export class UserCancellationError extends SilentCLIError {
   constructor() {
     super("Operation cancelled by user", {
       source: ERROR_SOURCE.USER,
       exitCode: 130,
-      displayMessage: false,
     });
   }
 }
 
-export class RuntimeInvokeResponseError extends AgentCoreCLIError {
+export class RuntimeInvokeResponseError extends SilentCLIError {
   constructor(message: string, cause?: unknown) {
-    super(message, { cause, displayMessage: false });
+    super(message, { cause });
   }
 }
 

--- a/src/errors/errors.tsx
+++ b/src/errors/errors.tsx
@@ -1,4 +1,5 @@
 import { ServiceException } from "@smithy/core/client";
+import { CommanderError } from "commander";
 import { join } from "node:path";
 import { ERROR_SOURCE, type ErrorSource } from "./types";
 
@@ -11,6 +12,8 @@ export interface AgentCoreCLIErrorOptions extends ErrorOptions {
   exitCode?: number;
   /** Describes the name of the underlying error, defaults to AgentCoreCLIError */
   name?: string;
+  /** Whether the root handler should display this error's message */
+  displayMessage?: boolean;
 }
 
 /** Base error for CLI failures, including their source, metadata, and process exit code. */
@@ -18,6 +21,7 @@ export class AgentCoreCLIError extends Error {
   readonly source: ErrorSource;
   readonly meta: Record<string, unknown>;
   readonly exitCode: number;
+  readonly displayMessage: boolean;
 
   constructor(message?: string, options?: AgentCoreCLIErrorOptions) {
     super(message, options);
@@ -25,6 +29,7 @@ export class AgentCoreCLIError extends Error {
     this.source = options?.source ?? ERROR_SOURCE.INTERNAL;
     this.meta = options?.meta ?? {};
     this.exitCode = options?.exitCode ?? 1;
+    this.displayMessage = options?.displayMessage ?? true;
   }
   /** Convert the error into an object with its attributes enumerated as keys **/
   json(): Record<string, unknown> {
@@ -33,6 +38,7 @@ export class AgentCoreCLIError extends Error {
       message: this.message,
       stack: this.stack,
       exitCode: this.exitCode,
+      displayMessage: this.displayMessage,
       meta: this.meta,
       source: this.source,
     };
@@ -40,6 +46,17 @@ export class AgentCoreCLIError extends Error {
 
   static fromError(error: unknown): AgentCoreCLIError {
     if (error instanceof AgentCoreCLIError) return error;
+
+    if (error instanceof CommanderError) {
+      return new AgentCoreCLIError(error.message, {
+        cause: error,
+        source: ERROR_SOURCE.USER,
+        name: error.name,
+        meta: { code: error.code },
+        exitCode: error.exitCode === 0 ? 0 : 2,
+        displayMessage: false,
+      });
+    }
 
     if (ServiceException.isInstance(error)) {
       const httpStatusCode = error.$metadata.httpStatusCode;
@@ -137,23 +154,20 @@ export class EmbeddedAssetNotFoundError extends AgentCoreCLIError {
   }
 }
 
-export class CommandInterruptedError extends AgentCoreCLIError {
-  readonly reported: boolean;
-
-  constructor(cause?: unknown, reported = false) {
-    super("The operation was aborted", { cause, exitCode: 130 });
-    this.name = "AbortError";
-    this.reported = reported;
+/** Raised when a user intentionally cancels a headless CLI operation. */
+export class UserCancellationError extends AgentCoreCLIError {
+  constructor() {
+    super("Operation cancelled by user", {
+      source: ERROR_SOURCE.USER,
+      exitCode: 130,
+      displayMessage: false,
+    });
   }
 }
 
-export class RuntimeInvokeInterruptedError extends CommandInterruptedError {}
-
 export class RuntimeInvokeResponseError extends AgentCoreCLIError {
-  readonly reported = true;
-
   constructor(message: string, cause?: unknown) {
-    super(message, { cause });
+    super(message, { cause, displayMessage: false });
   }
 }
 

--- a/src/errors/errors.tsx
+++ b/src/errors/errors.tsx
@@ -159,6 +159,11 @@ export class UserCancellationError extends SilentCLIError {
       exitCode: 130,
     });
   }
+
+  static resolve(error: unknown, signal?: AbortSignal): UserCancellationError | undefined {
+    if (error instanceof UserCancellationError) return error;
+    return signal?.reason instanceof UserCancellationError ? signal.reason : undefined;
+  }
 }
 
 export class RuntimeInvokeResponseError extends SilentCLIError {
@@ -167,19 +172,7 @@ export class RuntimeInvokeResponseError extends SilentCLIError {
   }
 }
 
-export class GatewayInvokeInterruptedError extends AgentCoreCLIError {
-  readonly reported: boolean;
-
-  constructor(cause?: unknown, reported = false) {
-    super("The operation was aborted", { cause, exitCode: 130 });
-    this.name = "AbortError";
-    this.reported = reported;
-  }
-}
-
-export class GatewayInvokeResponseError extends AgentCoreCLIError {
-  readonly reported = true;
-
+export class GatewayInvokeResponseError extends SilentCLIError {
   constructor(message: string, cause?: unknown) {
     super(message, { cause });
   }

--- a/src/errors/index.tsx
+++ b/src/errors/index.tsx
@@ -16,9 +16,9 @@ export {
   ProjectFileExistsError,
   ResourceNotFoundError,
   ResultTruncationError,
-  RuntimeInvokeInterruptedError,
   RuntimeInvokeResponseError,
   SourceResolutionError,
+  UserCancellationError,
   type AgentCoreCLIErrorOptions,
 } from "./errors";
 export { ERROR_SOURCE } from "./types";

--- a/src/errors/index.tsx
+++ b/src/errors/index.tsx
@@ -17,6 +17,7 @@ export {
   ResourceNotFoundError,
   ResultTruncationError,
   RuntimeInvokeResponseError,
+  SilentCLIError,
   SourceResolutionError,
   UserCancellationError,
   type AgentCoreCLIErrorOptions,

--- a/src/errors/index.tsx
+++ b/src/errors/index.tsx
@@ -1,7 +1,6 @@
 export {
   AgentCoreCLIError,
   CloudWatchQueryError,
-  CommandInterruptedError,
   DeserializationError,
   EmbeddedAssetNotFoundError,
   FileWriteError,

--- a/src/errors/index.tsx
+++ b/src/errors/index.tsx
@@ -5,7 +5,6 @@ export {
   DeserializationError,
   EmbeddedAssetNotFoundError,
   FileWriteError,
-  GatewayInvokeInterruptedError,
   GatewayInvokeResponseError,
   InputValidationError,
   InvalidEnvironmentError,

--- a/src/handlers/eval/dataset/dataset.test.tsx
+++ b/src/handlers/eval/dataset/dataset.test.tsx
@@ -8,7 +8,9 @@ import {
   TestCoreClient,
   TestGlobalConfigAccessor,
   testIO,
+  waitFor,
 } from "../../../testing";
+import { UserCancellationError } from "../../../errors";
 import { createRootHandler } from "../../index";
 import type { CreateDatasetInput } from "../types";
 
@@ -440,6 +442,41 @@ describe("dataset get", () => {
 
     const call = core.eval.calls.find((c) => c.method === "downloadDataset");
     expect(call?.args.slice(0, 3)).toEqual(["dataset-orders-abc123", "2", "/tmp/v2.jsonl"]);
+  });
+
+  test("SIGINT cancels a download with the shared user cancellation error", async () => {
+    const { core, route } = testDatasetCommand();
+    core.eval.downloadDataset = async (id, version, filePath, options, signal) => {
+      core.eval.calls.push({
+        method: "downloadDataset",
+        args: [id, version, filePath, options, signal],
+      });
+      return new Promise<never>((_, reject) => {
+        const abort = () => reject(signal?.reason);
+        if (signal?.aborted) abort();
+        else signal?.addEventListener("abort", abort, { once: true });
+      });
+    };
+    const pending = route([
+      "eval",
+      "dataset",
+      "get",
+      "--id",
+      "dataset-orders-abc123",
+      "--file-path",
+      "/tmp/out.jsonl",
+    ]);
+
+    try {
+      await waitFor(() => core.eval.calls.some((call) => call.method === "downloadDataset"));
+      process.emit("SIGINT", "SIGINT");
+
+      const signal = core.eval.calls[0]!.args[4] as AbortSignal;
+      expect(signal.reason).toBeInstanceOf(UserCancellationError);
+      await expect(pending).rejects.toBe(signal.reason);
+    } finally {
+      await pending.catch(() => undefined);
+    }
   });
 
   test("requires --id", async () => {

--- a/src/handlers/eval/dataset/dataset.test.tsx
+++ b/src/handlers/eval/dataset/dataset.test.tsx
@@ -658,6 +658,42 @@ describe("dataset update", () => {
     });
   });
 
+  test("SIGINT cancels an update with the shared user cancellation error", async () => {
+    const path = writeTempJsonl(EXAMPLE_A);
+    const { core, route } = testDatasetCommand();
+    core.eval.updateDatasetExamples = async (id, filePath, options, signal, onProgress) => {
+      core.eval.calls.push({
+        method: "updateDatasetExamples",
+        args: [id, filePath, options, signal, onProgress],
+      });
+      return new Promise<never>((_, reject) => {
+        const abort = () => reject(signal?.reason);
+        if (signal?.aborted) abort();
+        else signal?.addEventListener("abort", abort, { once: true });
+      });
+    };
+    const pending = route([
+      "eval",
+      "dataset",
+      "update",
+      "--id",
+      "dataset-orders-abc123",
+      "--file-path",
+      path,
+    ]);
+
+    try {
+      await waitFor(() => core.eval.calls.some((call) => call.method === "updateDatasetExamples"));
+      process.emit("SIGINT", "SIGINT");
+
+      const signal = core.eval.calls[0]!.args[3] as AbortSignal;
+      expect(signal.reason).toBeInstanceOf(UserCancellationError);
+      await expect(pending).rejects.toBe(signal.reason);
+    } finally {
+      await pending.catch(() => undefined);
+    }
+  });
+
   test("takes only --id and --file-path", async () => {
     const root = createRootHandler(new TestCoreClient(), {
       io: testIO().io,

--- a/src/handlers/eval/dataset/get/index.tsx
+++ b/src/handlers/eval/dataset/get/index.tsx
@@ -1,7 +1,8 @@
 import z from "zod";
 import { createHandler, flag } from "../../../../router";
-import { InputValidationError, UserCancellationError } from "../../../../errors";
+import { InputValidationError } from "../../../../errors";
 import { JsonRendererKey } from "../../../../tui";
+import { withUserCancellation } from "../../../../runnable";
 import type { Core } from "../../../types";
 import { coreOptsFromCtx } from "../../../utils";
 
@@ -24,33 +25,29 @@ export const createGetDatasetHandler = (core: Core) =>
     ],
     handle: async (ctx, flags) => {
       if (!flags["id"]) throw new InputValidationError("required option '--id <id>' not specified");
+      const datasetId = flags["id"];
 
       const filePath = flags["file-path"];
       if (!filePath) {
         ctx
           .require(JsonRendererKey)
           .renderJson(
-            await core.eval.getDataset(flags["id"], flags["version"], coreOptsFromCtx(ctx)),
+            await core.eval.getDataset(datasetId, flags["version"], coreOptsFromCtx(ctx)),
           );
         return;
       }
 
       // --file-path downloads the contents via the presigned download URL in metadata
-      const controller = new AbortController();
-      const interrupt = () => controller.abort(new UserCancellationError());
-      process.once("SIGINT", interrupt);
-      try {
-        const response = await core.eval.downloadDataset(
-          flags["id"],
+      const response = await withUserCancellation((signal) =>
+        core.eval.downloadDataset(
+          datasetId,
           flags["version"],
           filePath,
           coreOptsFromCtx(ctx),
-          controller.signal,
-        );
-        // file is written in addition to the normal metadata output
-        ctx.require(JsonRendererKey).renderJson({ ...response, filePath });
-      } finally {
-        process.removeListener("SIGINT", interrupt);
-      }
+          signal,
+        ),
+      );
+      // file is written in addition to the normal metadata output
+      ctx.require(JsonRendererKey).renderJson({ ...response, filePath });
     },
   });

--- a/src/handlers/eval/dataset/get/index.tsx
+++ b/src/handlers/eval/dataset/get/index.tsx
@@ -1,6 +1,6 @@
 import z from "zod";
 import { createHandler, flag } from "../../../../router";
-import { InputValidationError } from "../../../../errors";
+import { InputValidationError, UserCancellationError } from "../../../../errors";
 import { JsonRendererKey } from "../../../../tui";
 import type { Core } from "../../../types";
 import { coreOptsFromCtx } from "../../../utils";
@@ -37,7 +37,7 @@ export const createGetDatasetHandler = (core: Core) =>
 
       // --file-path downloads the contents via the presigned download URL in metadata
       const controller = new AbortController();
-      const interrupt = () => controller.abort();
+      const interrupt = () => controller.abort(new UserCancellationError());
       process.once("SIGINT", interrupt);
       try {
         const response = await core.eval.downloadDataset(

--- a/src/handlers/eval/dataset/update/index.tsx
+++ b/src/handlers/eval/dataset/update/index.tsx
@@ -1,8 +1,9 @@
 import z from "zod";
 import { createHandler, flag } from "../../../../router";
-import { InputValidationError, UserCancellationError } from "../../../../errors";
+import { InputValidationError } from "../../../../errors";
 import type { AppIO } from "../../../../io";
 import { JsonRendererKey } from "../../../../tui";
+import { withUserCancellation } from "../../../../runnable";
 import type { Core } from "../../../types";
 import { coreOptsFromCtx } from "../../../utils";
 
@@ -16,27 +17,24 @@ export const createUpdateDatasetHandler = (core: Core, io: AppIO) =>
     ],
     handle: async (ctx, flags) => {
       if (!flags["id"]) throw new InputValidationError("required option '--id <id>' not specified");
+      const datasetId = flags["id"];
       if (!flags["file-path"]) {
         throw new InputValidationError("required option '--file-path <file-path>' not specified");
       }
+      const filePath = flags["file-path"];
 
-      const controller = new AbortController();
-      const interrupt = () => controller.abort(new UserCancellationError());
-      process.once("SIGINT", interrupt);
-      try {
-        ctx
-          .require(JsonRendererKey)
-          .renderJson(
-            await core.eval.updateDatasetExamples(
-              flags["id"],
-              flags["file-path"],
+      ctx
+        .require(JsonRendererKey)
+        .renderJson(
+          await withUserCancellation((signal) =>
+            core.eval.updateDatasetExamples(
+              datasetId,
+              filePath,
               coreOptsFromCtx(ctx),
-              controller.signal,
+              signal,
               (event) => io.stderr.write(`${event.message}\n`),
             ),
-          );
-      } finally {
-        process.removeListener("SIGINT", interrupt);
-      }
+          ),
+        );
     },
   });

--- a/src/handlers/eval/dataset/update/index.tsx
+++ b/src/handlers/eval/dataset/update/index.tsx
@@ -1,6 +1,6 @@
 import z from "zod";
 import { createHandler, flag } from "../../../../router";
-import { InputValidationError } from "../../../../errors";
+import { InputValidationError, UserCancellationError } from "../../../../errors";
 import type { AppIO } from "../../../../io";
 import { JsonRendererKey } from "../../../../tui";
 import type { Core } from "../../../types";
@@ -21,7 +21,7 @@ export const createUpdateDatasetHandler = (core: Core, io: AppIO) =>
       }
 
       const controller = new AbortController();
-      const interrupt = () => controller.abort();
+      const interrupt = () => controller.abort(new UserCancellationError());
       process.once("SIGINT", interrupt);
       try {
         ctx

--- a/src/handlers/gateway/invoke/index.tsx
+++ b/src/handlers/gateway/invoke/index.tsx
@@ -1,8 +1,8 @@
 import z from "zod";
 import {
-  GatewayInvokeInterruptedError,
   GatewayInvokeResponseError,
   InputValidationError,
+  UserCancellationError,
 } from "../../../errors";
 import { SourceResolver, type AppIO } from "../../../io";
 import { ExitCode } from "../../../runnable";
@@ -109,7 +109,7 @@ export const createInvokeGatewayHandler = (
       }
 
       const controller = new AbortController();
-      const interrupt = () => controller.abort();
+      const interrupt = () => controller.abort(new UserCancellationError());
       process.once("SIGINT", interrupt);
       try {
         const applicationHeaders = parseGatewayInvokeHeaders(flags.header);
@@ -145,10 +145,7 @@ export const createInvokeGatewayHandler = (
           throw new GatewayInvokeResponseError(`HTTP ${response.statusCode}`);
         }
       } catch (error) {
-        if (controller.signal.aborted && (error as Error)?.name === "AbortError") {
-          if (error instanceof GatewayInvokeInterruptedError) throw error;
-          throw new GatewayInvokeInterruptedError(error);
-        }
+        controller.signal.throwIfAborted();
         throw error;
       } finally {
         controller.abort();

--- a/src/handlers/gateway/invoke/index.tsx
+++ b/src/handlers/gateway/invoke/index.tsx
@@ -1,11 +1,7 @@
 import z from "zod";
-import {
-  GatewayInvokeResponseError,
-  InputValidationError,
-  UserCancellationError,
-} from "../../../errors";
+import { GatewayInvokeResponseError, InputValidationError } from "../../../errors";
 import { SourceResolver, type AppIO } from "../../../io";
-import { ExitCode } from "../../../runnable";
+import { ExitCode, withUserCancellation } from "../../../runnable";
 import { createHandler, flag, PathKey } from "../../../router";
 import { renderTuiAt } from "../../../tui";
 import { JsonKey } from "../../keys";
@@ -107,21 +103,20 @@ export const createInvokeGatewayHandler = (
       if (jsonOutput && flags["output-file"] !== undefined) {
         throw new InputValidationError("--json cannot be used with --output-file");
       }
+      const gatewayId = flags.id;
+      const payload = flags.payload;
 
-      const controller = new AbortController();
-      const interrupt = () => controller.abort(new UserCancellationError());
-      process.once("SIGINT", interrupt);
-      try {
+      await withUserCancellation(async (signal) => {
         const applicationHeaders = parseGatewayInvokeHeaders(flags.header);
         const sources = await resolveGatewayInvokeSources(
-          { payload: flags.payload, bearerToken: flags["bearer-token"] },
+          { payload, bearerToken: flags["bearer-token"] },
           io.stdin,
-          controller.signal,
+          signal,
         );
         const options = coreOptsFromCtx(ctx);
-        const gateway = await core.gateway.getGateway(flags.id, options, controller.signal);
+        const gateway = await core.gateway.getGateway(gatewayId, options, signal);
         const request = normalizeGatewayInvokeRequest(gateway, {
-          gatewayId: flags.id,
+          gatewayId,
           path: flags.path,
           method: flags.method as GatewayInvokeMethod | undefined,
           payload: sources.payload,
@@ -133,23 +128,17 @@ export const createInvokeGatewayHandler = (
           mcpSessionId: flags["mcp-session-id"],
           mcpProtocolVersion: flags["mcp-protocol-version"],
         });
-        const response = await core.gateway.invokeGateway(request, options, controller.signal);
+        const response = await core.gateway.invokeGateway(request, options, signal);
         await writeGatewayInvokeResponse(response, {
           stdout: io.stdout,
           stderr: io.stderr,
           outputFile: flags["output-file"],
           json: jsonOutput,
-          signal: controller.signal,
+          signal,
         });
         if (response.statusCode < 200 || response.statusCode >= 300) {
           throw new GatewayInvokeResponseError(`HTTP ${response.statusCode}`);
         }
-      } catch (error) {
-        controller.signal.throwIfAborted();
-        throw error;
-      } finally {
-        controller.abort();
-        process.off("SIGINT", interrupt);
-      }
+      });
     },
   });

--- a/src/handlers/gateway/invoke/invoke.test.tsx
+++ b/src/handlers/gateway/invoke/invoke.test.tsx
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { PassThrough } from "node:stream";
 import type { GetGatewayResponse } from "@aws-sdk/client-bedrock-agentcore-control";
 import type { AppIO } from "../../../io";
+import { UserCancellationError } from "../../../errors";
 import { ExitCode, runWithExitCode } from "../../../runnable";
 import {
   createSilentLogger,
@@ -485,11 +486,12 @@ describe("gateway invoke", () => {
       await waitFor(() => core.gateway.calls.some((call) => call.method === "invokeGateway"));
       process.emit("SIGINT", "SIGINT");
 
-      await expect(pending).rejects.toMatchObject({ name: "AbortError", reported: false });
       const lookupSignal = core.gateway.calls[0]!.args[2] as AbortSignal;
       const invokeSignal = core.gateway.calls[1]!.args[2] as AbortSignal;
       expect(lookupSignal).toBe(invokeSignal);
       expect(invokeSignal.aborted).toBe(true);
+      expect(invokeSignal.reason).toBeInstanceOf(UserCancellationError);
+      await expect(pending).rejects.toBe(invokeSignal.reason);
     } finally {
       await pending.catch(() => undefined);
     }

--- a/src/handlers/gateway/invoke/response.test.ts
+++ b/src/handlers/gateway/invoke/response.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { PassThrough } from "node:stream";
+import { SilentCLIError, UserCancellationError } from "../../../errors";
 import type { GatewayInvokeResponse } from "../types";
 import { writeGatewayInvokeResponse } from "./response";
 
@@ -103,22 +104,45 @@ describe("Gateway invoke response output", () => {
     const stderr = capture();
     const upstream = new Error("secret upstream response");
 
-    await expect(
-      writeGatewayInvokeResponse(
-        response({
-          body: (async function* () {
-            yield Buffer.from("partial");
-            throw upstream;
-          })(),
-        }),
-        { stdout: stdout.stream, stderr: stderr.stream },
-      ),
-    ).rejects.toMatchObject({ message: "response stream failed", reported: true });
+    const pending = writeGatewayInvokeResponse(
+      response({
+        body: (async function* () {
+          yield Buffer.from("partial");
+          throw upstream;
+        })(),
+      }),
+      { stdout: stdout.stream, stderr: stderr.stream },
+    );
+
+    await expect(pending).rejects.toBeInstanceOf(SilentCLIError);
+    await expect(pending).rejects.toThrow("response stream failed");
 
     expect(stdout.bytes().toString()).toBe("partial");
     expect(stderr.bytes().toString()).toContain(
       "complete=false bytes=7 error=response-stream-failed",
     );
     expect(stderr.bytes().toString()).not.toContain(upstream.message);
+  });
+
+  test("preserves the shared cancellation reason after reporting an interruption", async () => {
+    const controller = new AbortController();
+    const cancellation = new UserCancellationError();
+    const stdout = capture();
+    const stderr = capture();
+    const source = (async function* () {
+      yield Buffer.from("partial");
+      controller.abort(cancellation);
+      throw Object.assign(new Error("The operation was aborted"), { name: "AbortError" });
+    })();
+
+    await expect(
+      writeGatewayInvokeResponse(response({ body: source }), {
+        stdout: stdout.stream,
+        stderr: stderr.stream,
+        signal: controller.signal,
+      }),
+    ).rejects.toBe(cancellation);
+    expect(stdout.bytes().toString()).toBe("partial");
+    expect(stderr.bytes().toString()).toContain("complete=false bytes=7 error=interrupted");
   });
 });

--- a/src/handlers/gateway/invoke/response.ts
+++ b/src/handlers/gateway/invoke/response.ts
@@ -1,12 +1,12 @@
-import { GatewayInvokeInterruptedError, GatewayInvokeResponseError } from "../../../errors";
+import { GatewayInvokeResponseError, UserCancellationError } from "../../../errors";
 import { writeStreamingResponse, type StreamingResponseOutput } from "../../../io";
 import type { GatewayInvokeResponse } from "../types";
 
 const RESPONSE_STREAM_FAILED = "response stream failed";
 
-function failure(error: unknown): never {
-  const interrupted = (error as Error)?.name === "AbortError";
-  if (interrupted) throw new GatewayInvokeInterruptedError(error, true);
+function failure(error: unknown, signal?: AbortSignal): never {
+  const cancellation = UserCancellationError.resolve(error, signal);
+  if (cancellation) throw cancellation;
   throw new GatewayInvokeResponseError(RESPONSE_STREAM_FAILED, error);
 }
 
@@ -34,7 +34,7 @@ export async function writeGatewayInvokeResponse(
   await writeStreamingResponse(response, output, {
     metadata: ({ body: _body, ...metadata }) => metadata,
     summary,
-    fail: failure,
+    fail: (error) => failure(error, output.signal),
     binaryTtyError: "Binary or unknown response content requires --output-file or --json",
   });
 }

--- a/src/handlers/project/dev/index.test.ts
+++ b/src/handlers/project/dev/index.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import type { ProjectRuntime } from "../../../projectSchemas/runtime";
-import { InputValidationError, ResourceNotFoundError } from "../../../errors";
+import {
+  InputValidationError,
+  ResourceNotFoundError,
+  UserCancellationError,
+} from "../../../errors";
 import type { PortChecker } from "../../../io";
 import { ProjectKey, ValueContext } from "../../../router";
 import { testIO } from "../../../testing";
@@ -192,11 +196,9 @@ describe("project dev interruption", () => {
       codeZip.release();
 
       expect(input.signal.aborted).toBe(true);
-      await expect(pending).rejects.toMatchObject({
-        name: "AbortError",
-        reported: true,
-        exitCode: 130,
-      });
+      expect(input.signal.reason).toBeInstanceOf(UserCancellationError);
+      await expect(pending).rejects.toBe(input.signal.reason);
+      expect((input.signal.reason as UserCancellationError).exitCode).toBe(130);
       expect(subject.io.stderr()).toBe("Shutting down…");
       expect(process.listenerCount(signal)).toBe(before);
     },

--- a/src/handlers/project/dev/index.ts
+++ b/src/handlers/project/dev/index.ts
@@ -2,9 +2,9 @@ import z from "zod";
 import { resolveDevPort } from "../../../core/dev/port";
 import type { ProjectRuntime } from "../../../projectSchemas/runtime";
 import {
-  CommandInterruptedError,
   InputValidationError,
   ResourceNotFoundError,
+  UserCancellationError,
 } from "../../../errors";
 import type { AppIO, PortChecker } from "../../../io";
 import { createHandler, flag, ProjectKey } from "../../../router";
@@ -71,7 +71,7 @@ export const createDevProjectHandler = (config: DevProjectHandlerConfig) =>
       const interrupt = () => {
         if (controller.signal.aborted) return;
         config.io.stderr.write("Shutting down…\n");
-        controller.abort();
+        controller.abort(new UserCancellationError());
       };
 
       const signals = ["SIGINT", "SIGTERM"] as const;
@@ -114,8 +114,8 @@ export const createDevProjectHandler = (config: DevProjectHandlerConfig) =>
           renderEvent(config.io, event, json);
         }
       } catch (error) {
-        if (!controller.signal.aborted) throw error;
-        throw new CommandInterruptedError(error, true);
+        controller.signal.throwIfAborted();
+        throw error;
       } finally {
         for (const signal of signals) process.removeListener(signal, interrupt);
       }

--- a/src/handlers/runtime/invoke/index.tsx
+++ b/src/handlers/runtime/invoke/index.tsx
@@ -1,5 +1,5 @@
 import z from "zod";
-import { InputValidationError, RuntimeInvokeInterruptedError } from "../../../errors";
+import { InputValidationError, UserCancellationError } from "../../../errors";
 import { createHandler, flag, PathKey } from "../../../router";
 import type { AppIO } from "../../../io";
 import type { Core } from "../../types";
@@ -105,7 +105,7 @@ export const createInvokeRuntimeHandler = (core: Core, io: AppIO) =>
         throw new InputValidationError("--json cannot be used with --output-file");
       }
       const controller = new AbortController();
-      const interrupt = () => controller.abort();
+      const interrupt = () => controller.abort(new UserCancellationError());
       process.once("SIGINT", interrupt);
       try {
         const applicationHeaders = parseRuntimeInvokeHeaders(flags.header);
@@ -144,10 +144,7 @@ export const createInvokeRuntimeHandler = (core: Core, io: AppIO) =>
           signal: controller.signal,
         });
       } catch (error) {
-        if (controller.signal.aborted && (error as Error)?.name === "AbortError") {
-          if (error instanceof RuntimeInvokeInterruptedError) throw error;
-          throw new RuntimeInvokeInterruptedError(error);
-        }
+        controller.signal.throwIfAborted();
         throw error;
       } finally {
         controller.abort();

--- a/src/handlers/runtime/invoke/index.tsx
+++ b/src/handlers/runtime/invoke/index.tsx
@@ -1,11 +1,11 @@
 import z from "zod";
-import { InputValidationError, UserCancellationError } from "../../../errors";
+import { InputValidationError } from "../../../errors";
 import { createHandler, flag, PathKey } from "../../../router";
 import type { AppIO } from "../../../io";
 import type { Core } from "../../types";
 import { coreOptsFromCtx } from "../../utils";
 import { JsonKey } from "../../keys";
-import { ExitCode } from "../../../runnable";
+import { ExitCode, withUserCancellation } from "../../../runnable";
 import { renderTuiAt } from "../../../tui";
 import {
   normalizeRuntimeInvokeRequest,
@@ -104,20 +104,19 @@ export const createInvokeRuntimeHandler = (core: Core, io: AppIO) =>
       if (jsonOutput && flags["output-file"] !== undefined) {
         throw new InputValidationError("--json cannot be used with --output-file");
       }
-      const controller = new AbortController();
-      const interrupt = () => controller.abort(new UserCancellationError());
-      process.once("SIGINT", interrupt);
-      try {
+      const runtimeId = flags.id;
+      const payload = flags.payload;
+      await withUserCancellation(async (signal) => {
         const applicationHeaders = parseRuntimeInvokeHeaders(flags.header);
         const sources = await resolveRuntimeInvokeSources(
-          { payload: flags.payload, bearerToken: flags["bearer-token"] },
+          { payload, bearerToken: flags["bearer-token"] },
           io.stdin,
-          controller.signal,
+          signal,
         );
         const options = coreOptsFromCtx(ctx);
-        const runtime = await core.runtime.getRuntime(flags.id, options, controller.signal);
+        const runtime = await core.runtime.getRuntime(runtimeId, options, signal);
         const request = normalizeRuntimeInvokeRequest(runtime, {
-          runtimeId: flags.id,
+          runtimeId,
           qualifier: flags.qualifier,
           payload: sources.payload,
           contentType: flags["content-type"],
@@ -135,20 +134,14 @@ export const createInvokeRuntimeHandler = (core: Core, io: AppIO) =>
           traceState: flags["trace-state"],
           baggage: flags.baggage,
         });
-        const response = await core.runtime.invokeRuntime(request, options, controller.signal);
+        const response = await core.runtime.invokeRuntime(request, options, signal);
         await writeRuntimeInvokeResponse(response, {
           stdout: io.stdout,
           stderr: io.stderr,
           outputFile: flags["output-file"],
           json: jsonOutput,
-          signal: controller.signal,
+          signal,
         });
-      } catch (error) {
-        controller.signal.throwIfAborted();
-        throw error;
-      } finally {
-        controller.abort();
-        process.off("SIGINT", interrupt);
-      }
+      });
     },
   });

--- a/src/handlers/runtime/invoke/invoke.test.tsx
+++ b/src/handlers/runtime/invoke/invoke.test.tsx
@@ -247,6 +247,64 @@ describe("runtime invoke", () => {
     expect((invoke.args[0] as RuntimeInvokeRequest).payload).toEqual(new Uint8Array());
   });
 
+  test("SIGINT cancels payload stdin resolution with the typed reason", async () => {
+    const core = new TestCoreClient();
+    const output = captureIO();
+    const initialListeners = process.listenerCount("SIGINT");
+    const pending = runCommand(core, output.io, [
+      "runtime",
+      "invoke",
+      "--id",
+      RUNTIME_ID,
+      "--payload",
+      "-",
+    ]);
+
+    try {
+      await waitFor(() => process.listenerCount("SIGINT") > initialListeners);
+      process.emit("SIGINT", "SIGINT");
+
+      await expect(pending).rejects.toBeInstanceOf(UserCancellationError);
+      expect(core.runtime.calls).toEqual([]);
+    } finally {
+      await pending.catch(() => undefined);
+    }
+  });
+
+  test("SIGINT replaces a raw Runtime lookup abort with the typed reason", async () => {
+    const core = new TestCoreClient();
+    const output = captureIO();
+    core.runtime.getRuntime = async (id, options, signal) => {
+      core.runtime.calls.push({ method: "getRuntime", args: [id, options, signal] });
+      return new Promise<never>((_, reject) => {
+        const abort = () =>
+          reject(Object.assign(new Error("lookup aborted"), { name: "AbortError" }));
+        if (signal?.aborted) abort();
+        else signal?.addEventListener("abort", abort, { once: true });
+      });
+    };
+    const pending = runCommand(core, output.io, [
+      "runtime",
+      "invoke",
+      "--id",
+      RUNTIME_ID,
+      "--payload",
+      "{}",
+    ]);
+
+    try {
+      await waitFor(() => core.runtime.calls.some((call) => call.method === "getRuntime"));
+      process.emit("SIGINT", "SIGINT");
+
+      const signal = core.runtime.calls[0]!.args[2] as AbortSignal;
+      expect(signal.reason).toBeInstanceOf(UserCancellationError);
+      await expect(pending).rejects.toBe(signal.reason);
+      expect(core.runtime.calls.map((call) => call.method)).toEqual(["getRuntime"]);
+    } finally {
+      await pending.catch(() => undefined);
+    }
+  });
+
   test("SIGINT aborts an active headless invocation after preserving emitted bytes", async () => {
     const core = new TestCoreClient();
     const output = captureIO();

--- a/src/handlers/runtime/invoke/invoke.test.tsx
+++ b/src/handlers/runtime/invoke/invoke.test.tsx
@@ -12,6 +12,7 @@ import {
   waitFor,
 } from "../../../testing";
 import { ExitCode, runWithExitCode } from "../../../runnable";
+import { UserCancellationError } from "../../../errors";
 import { createRootHandler } from "../../index";
 import * as tui from "../../../tui";
 import { RuntimeInvokeLaunchContextKey } from "./launchContext";
@@ -284,14 +285,14 @@ describe("runtime invoke", () => {
       process.emit("SIGINT", "SIGINT");
 
       expect(signal!.aborted).toBe(true);
-      await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+      await expect(pending).rejects.toBeInstanceOf(UserCancellationError);
       expect(output.bytes().toString()).toBe("partial");
     } finally {
       await pending.catch(() => undefined);
     }
   });
 
-  test("wraps a raw Core abort after SIGINT", async () => {
+  test("replaces a raw Core abort with the typed SIGINT reason", async () => {
     const core = new TestCoreClient();
     const output = captureIO();
     const rawAbort = Object.assign(new Error("transport aborted"), { name: "AbortError" });
@@ -317,11 +318,10 @@ describe("runtime invoke", () => {
       await waitFor(() => core.runtime.calls.some((call) => call.method === "invokeRuntime"));
       process.emit("SIGINT", "SIGINT");
 
-      await expect(pending).rejects.toMatchObject({
-        name: "AbortError",
-        cause: rawAbort,
-        reported: false,
-      });
+      const signal = core.runtime.calls.find((call) => call.method === "invokeRuntime")!
+        .args[2] as AbortSignal;
+      expect(signal.reason).toBeInstanceOf(UserCancellationError);
+      await expect(pending).rejects.toBe(signal.reason);
     } finally {
       await pending.catch(() => undefined);
     }

--- a/src/handlers/runtime/invoke/response.test.ts
+++ b/src/handlers/runtime/invoke/response.test.ts
@@ -3,6 +3,7 @@ import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { PassThrough, Writable } from "node:stream";
+import { UserCancellationError } from "../../../errors";
 import { waitFor } from "../../../testing";
 import type { RuntimeInvokeResponse } from "../types";
 import { writeRuntimeInvokeResponse } from "./response";
@@ -128,7 +129,7 @@ describe("Runtime invoke response output", () => {
       }),
     ).rejects.toMatchObject({
       message: "response stream failed",
-      reported: true,
+      displayMessage: false,
     });
   });
 
@@ -266,11 +267,12 @@ describe("Runtime invoke response output", () => {
 
   test("writes an interruption summary after the output signal is aborted", async () => {
     const controller = new AbortController();
+    const cancellation = new UserCancellationError();
     const stdout = capture();
     const stderr = capture();
     const source = (async function* () {
       yield Buffer.from("partial");
-      controller.abort();
+      controller.abort(cancellation);
       throw Object.assign(new Error("The operation was aborted"), { name: "AbortError" });
     })();
 
@@ -280,7 +282,7 @@ describe("Runtime invoke response output", () => {
         stderr: stderr.stream,
         signal: controller.signal,
       }),
-    ).rejects.toMatchObject({ name: "AbortError" });
+    ).rejects.toBe(cancellation);
     expect(stdout.bytes().toString()).toBe("partial");
     expect(stderr.bytes().toString()).toBe(
       "status=200 content-type=text/event-stream runtime-session-id=- mcp-session-id=- " +

--- a/src/handlers/runtime/invoke/response.test.ts
+++ b/src/handlers/runtime/invoke/response.test.ts
@@ -3,7 +3,7 @@ import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { PassThrough, Writable } from "node:stream";
-import { UserCancellationError } from "../../../errors";
+import { SilentCLIError, UserCancellationError } from "../../../errors";
 import { waitFor } from "../../../testing";
 import type { RuntimeInvokeResponse } from "../types";
 import { writeRuntimeInvokeResponse } from "./response";
@@ -122,15 +122,13 @@ describe("Runtime invoke response output", () => {
       },
     }) as unknown as NodeJS.WriteStream;
 
-    await expect(
-      writeRuntimeInvokeResponse(response(), {
-        stdout: stdout.stream,
-        stderr,
-      }),
-    ).rejects.toMatchObject({
-      message: "response stream failed",
-      displayMessage: false,
+    const pending = writeRuntimeInvokeResponse(response(), {
+      stdout: stdout.stream,
+      stderr,
     });
+
+    await expect(pending).rejects.toBeInstanceOf(SilentCLIError);
+    await expect(pending).rejects.toThrow("response stream failed");
   });
 
   test("streams exact bytes to a file and leaves stdout empty", async () => {

--- a/src/handlers/runtime/invoke/response.test.ts
+++ b/src/handlers/runtime/invoke/response.test.ts
@@ -291,6 +291,33 @@ describe("Runtime invoke response output", () => {
     );
   });
 
+  test("JSON cancellation emits no partial envelope and preserves the typed reason", async () => {
+    const controller = new AbortController();
+    const cancellation = new UserCancellationError();
+    const stdout = capture();
+    const stderr = capture();
+    const source = (async function* () {
+      yield Buffer.from("partial");
+      controller.abort(cancellation);
+      throw Object.assign(new Error("The operation was aborted"), { name: "AbortError" });
+    })();
+
+    await expect(
+      writeRuntimeInvokeResponse(response({ body: source }), {
+        stdout: stdout.stream,
+        stderr: stderr.stream,
+        json: true,
+        signal: controller.signal,
+      }),
+    ).rejects.toBe(cancellation);
+    expect(stdout.bytes()).toHaveLength(0);
+    expect(stderr.bytes().toString()).toBe(
+      "status=200 content-type=text/plain runtime-session-id=- mcp-session-id=- " +
+        "mcp-protocol-version=- trace-id=- trace-parent=- trace-state=- baggage=- " +
+        "complete=false bytes=7 error=interrupted\n",
+    );
+  });
+
   test("preserves partial raw output regardless of response media type", async () => {
     const stdout = capture();
     const stderr = capture();

--- a/src/handlers/runtime/invoke/response.ts
+++ b/src/handlers/runtime/invoke/response.ts
@@ -1,4 +1,4 @@
-import { RuntimeInvokeInterruptedError, RuntimeInvokeResponseError } from "../../../errors";
+import { RuntimeInvokeResponseError, UserCancellationError } from "../../../errors";
 import {
   classifyStreamingResponse,
   writeStreamingResponse,
@@ -22,9 +22,14 @@ export async function writeRuntimeInvokeFile(
   await writeStreamingResponseFile(response, path, signal, onBytes);
 }
 
-function failure(error: unknown): never {
-  const interrupted = (error as Error)?.name === "AbortError";
-  if (interrupted) throw new RuntimeInvokeInterruptedError(error, true);
+function userCancellation(error: unknown, signal?: AbortSignal): UserCancellationError | undefined {
+  if (error instanceof UserCancellationError) return error;
+  return signal?.reason instanceof UserCancellationError ? signal.reason : undefined;
+}
+
+function failure(error: unknown, signal?: AbortSignal): never {
+  const cancellation = userCancellation(error, signal);
+  if (cancellation) throw cancellation;
   throw new RuntimeInvokeResponseError(RESPONSE_STREAM_FAILED, error);
 }
 
@@ -53,7 +58,7 @@ export async function writeRuntimeInvokeResponse(
   await writeStreamingResponse(response, output, {
     metadata: ({ body: _body, ...metadata }) => metadata,
     summary,
-    fail: failure,
+    fail: (error) => failure(error, output.signal),
     binaryTtyError: "Binary or unknown response content requires --output-file or --json",
   });
 }

--- a/src/handlers/runtime/invoke/response.ts
+++ b/src/handlers/runtime/invoke/response.ts
@@ -22,13 +22,8 @@ export async function writeRuntimeInvokeFile(
   await writeStreamingResponseFile(response, path, signal, onBytes);
 }
 
-function userCancellation(error: unknown, signal?: AbortSignal): UserCancellationError | undefined {
-  if (error instanceof UserCancellationError) return error;
-  return signal?.reason instanceof UserCancellationError ? signal.reason : undefined;
-}
-
 function failure(error: unknown, signal?: AbortSignal): never {
-  const cancellation = userCancellation(error, signal);
+  const cancellation = UserCancellationError.resolve(error, signal);
   if (cancellation) throw cancellation;
   throw new RuntimeInvokeResponseError(RESPONSE_STREAM_FAILED, error);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,12 +91,14 @@ process.exit(
       await rootHandler.route(argv, context);
     } catch (e) {
       const error = AgentCoreCLIError.fromError(e);
-      rootLogger.child({ error: error.json() }).error();
-      commandRunMetricEvent.setAttributes({
-        exit_reason: "failure",
-        error_name: error.name,
-        error_source: error.source,
-      });
+      if (error.exitCode !== 0) {
+        rootLogger.child({ error: error.json() }).error();
+        commandRunMetricEvent.setAttributes({
+          exit_reason: "failure",
+          error_name: error.name,
+          error_source: error.source,
+        });
+      }
       throw error;
     } finally {
       try {

--- a/src/io/streamingResponse.ts
+++ b/src/io/streamingResponse.ts
@@ -163,7 +163,9 @@ export async function writeStreamingResponse<T extends StreamingResponse>(
         response,
         byteCount,
         false,
-        (error as Error)?.name === "AbortError" ? "interrupted" : "response-stream-failed",
+        output.signal?.aborted || (error as Error)?.name === "AbortError"
+          ? "interrupted"
+          : "response-stream-failed",
       ),
       output.signal,
       writer.fail,

--- a/src/runnable/index.test.ts
+++ b/src/runnable/index.test.ts
@@ -1,7 +1,7 @@
 import { expect, spyOn, test } from "bun:test";
 import { CommanderError } from "commander";
 
-import { AgentCoreCLIError, CommandInterruptedError, InputValidationError } from "../errors";
+import { AgentCoreCLIError, InputValidationError, UserCancellationError } from "../errors";
 import { ExitCode, runRunnable, runWithExitCode, type Runnable } from "./index.tsx";
 
 async function captureErrors(run: () => Promise<number>) {
@@ -75,37 +75,16 @@ test.each([
     ExitCode.USAGE,
     ["Error: bad request"],
   ],
+  ["user cancellation", new UserCancellationError(), ExitCode.INTERRUPTED, []],
   [
-    "interruption",
+    "raw AbortError",
     Object.assign(new Error("The operation was aborted"), { name: "AbortError" }),
-    ExitCode.INTERRUPTED,
-    ["AbortError: The operation was aborted"],
-  ],
-  [
-    "classified interruption",
-    AgentCoreCLIError.fromError(
-      Object.assign(new Error("The operation was aborted"), { name: "AbortError" }),
-    ),
-    ExitCode.INTERRUPTED,
-    ["AbortError: The operation was aborted"],
-  ],
-  [
-    "reported command interruption",
-    new CommandInterruptedError(undefined, true),
-    ExitCode.INTERRUPTED,
-    [],
+    ExitCode.FAILURE,
+    ["Error: The operation was aborted"],
   ],
   [
     "Commander parse failure",
     new CommanderError(1, "commander.invalidArgument", "invalid option"),
-    ExitCode.USAGE,
-    [],
-  ],
-  [
-    "classified Commander parse failure",
-    AgentCoreCLIError.fromError(
-      new CommanderError(1, "commander.invalidArgument", "invalid option"),
-    ),
     ExitCode.USAGE,
     [],
   ],
@@ -116,20 +95,8 @@ test.each([
     [],
   ],
   [
-    "classified Commander help",
-    AgentCoreCLIError.fromError(new CommanderError(0, "commander.helpDisplayed", "help displayed")),
-    ExitCode.SUCCESS,
-    [],
-  ],
-  [
-    "classified reported failure",
-    AgentCoreCLIError.fromError(Object.assign(new Error("already reported"), { reported: true })),
-    ExitCode.FAILURE,
-    [],
-  ],
-  [
-    "reported failure",
-    Object.assign(new Error("already reported"), { reported: true }),
+    "hidden failure",
+    new AgentCoreCLIError("already displayed", { displayMessage: false }),
     ExitCode.FAILURE,
     [],
   ],
@@ -137,7 +104,7 @@ test.each([
     "arbitrary TypeError",
     new TypeError("transport failed"),
     ExitCode.FAILURE,
-    ["TypeError: transport failed"],
+    ["Error: transport failed"],
   ],
 ])("runWithExitCode maps %s", async (_name, error, expected, expectedErrors) => {
   const result = await captureErrors(() => runWithExitCode(async () => Promise.reject(error)));

--- a/src/runnable/index.test.ts
+++ b/src/runnable/index.test.ts
@@ -7,7 +7,13 @@ import {
   SilentCLIError,
   UserCancellationError,
 } from "../errors";
-import { ExitCode, runRunnable, runWithExitCode, type Runnable } from "./index.tsx";
+import {
+  ExitCode,
+  runRunnable,
+  runWithExitCode,
+  withUserCancellation,
+  type Runnable,
+} from "./index.tsx";
 
 async function captureErrors(run: () => Promise<number>) {
   const errors: string[] = [];
@@ -71,6 +77,49 @@ test("respects custom errors codes from known errors", async () => {
 
   expect(code).toBe(42);
   expect(errors).toEqual(["Error: custom failure"]);
+});
+
+test("withUserCancellation returns the result and removes its SIGINT listener", async () => {
+  const initialListeners = process.listenerCount("SIGINT");
+  let signal: AbortSignal | undefined;
+
+  const result = await withUserCancellation(async (current) => {
+    signal = current;
+    return "done";
+  });
+
+  expect(result).toBe("done");
+  expect(signal?.aborted).toBe(true);
+  expect(process.listenerCount("SIGINT")).toBe(initialListeners);
+});
+
+test("withUserCancellation replaces transport aborts with the shared reason", async () => {
+  const initialListeners = process.listenerCount("SIGINT");
+  let signal: AbortSignal | undefined;
+  const pending = withUserCancellation((current) => {
+    signal = current;
+    return new Promise<never>((_, reject) => {
+      const abort = () => reject(new Error("transport aborted"));
+      if (current.aborted) abort();
+      else current.addEventListener("abort", abort, { once: true });
+    });
+  });
+
+  process.emit("SIGINT", "SIGINT");
+
+  expect(signal?.reason).toBeInstanceOf(UserCancellationError);
+  await expect(pending).rejects.toBe(signal?.reason);
+  expect(process.listenerCount("SIGINT")).toBe(initialListeners);
+});
+
+test("withUserCancellation preserves non-cancellation failures", async () => {
+  const failure = new TypeError("operation failed");
+
+  await expect(
+    withUserCancellation(async () => {
+      throw failure;
+    }),
+  ).rejects.toBe(failure);
 });
 
 test.each([

--- a/src/runnable/index.test.ts
+++ b/src/runnable/index.test.ts
@@ -1,7 +1,12 @@
 import { expect, spyOn, test } from "bun:test";
 import { CommanderError } from "commander";
 
-import { AgentCoreCLIError, InputValidationError, UserCancellationError } from "../errors";
+import {
+  AgentCoreCLIError,
+  InputValidationError,
+  SilentCLIError,
+  UserCancellationError,
+} from "../errors";
 import { ExitCode, runRunnable, runWithExitCode, type Runnable } from "./index.tsx";
 
 async function captureErrors(run: () => Promise<number>) {
@@ -94,12 +99,7 @@ test.each([
     ExitCode.SUCCESS,
     [],
   ],
-  [
-    "hidden failure",
-    new AgentCoreCLIError("already displayed", { displayMessage: false }),
-    ExitCode.FAILURE,
-    [],
-  ],
+  ["hidden failure", new SilentCLIError("already displayed"), ExitCode.FAILURE, []],
   [
     "arbitrary TypeError",
     new TypeError("transport failed"),

--- a/src/runnable/index.tsx
+++ b/src/runnable/index.tsx
@@ -1,4 +1,4 @@
-import { AgentCoreCLIError, SilentCLIError } from "../errors";
+import { AgentCoreCLIError, SilentCLIError, UserCancellationError } from "../errors";
 
 // ExitCode provides names for default Unix exit codes.
 export enum ExitCode {
@@ -6,6 +6,24 @@ export enum ExitCode {
   FAILURE = 1,
   USAGE = 2,
   INTERRUPTED = 130,
+}
+
+/** Runs a headless operation with process SIGINT mapped to UserCancellationError. */
+export async function withUserCancellation<T>(fn: (signal: AbortSignal) => Promise<T>): Promise<T> {
+  const controller = new AbortController();
+  const interrupt = () => controller.abort(new UserCancellationError());
+  process.once("SIGINT", interrupt);
+  try {
+    const result = await fn(controller.signal);
+    controller.signal.throwIfAborted();
+    return result;
+  } catch (error) {
+    controller.signal.throwIfAborted();
+    throw error;
+  } finally {
+    controller.abort();
+    process.off("SIGINT", interrupt);
+  }
 }
 
 // Runnable can be implemented by any application's main entrypoint.

--- a/src/runnable/index.tsx
+++ b/src/runnable/index.tsx
@@ -1,4 +1,4 @@
-import { AgentCoreCLIError } from "../errors";
+import { AgentCoreCLIError, SilentCLIError } from "../errors";
 
 // ExitCode provides names for default Unix exit codes.
 export enum ExitCode {
@@ -33,7 +33,7 @@ export async function runWithExitCode(
     return ExitCode.SUCCESS;
   } catch (caught) {
     const error = AgentCoreCLIError.fromError(caught);
-    if (error.displayMessage) console.error(`Error: ${error.message}`);
+    if (!(error instanceof SilentCLIError)) console.error(`Error: ${error.message}`);
     return error.exitCode;
   }
 }

--- a/src/runnable/index.tsx
+++ b/src/runnable/index.tsx
@@ -1,4 +1,3 @@
-import { CommanderError } from "commander";
 import { AgentCoreCLIError } from "../errors";
 
 // ExitCode provides names for default Unix exit codes.
@@ -7,21 +6,6 @@ export enum ExitCode {
   FAILURE = 1,
   USAGE = 2,
   INTERRUPTED = 130,
-}
-
-function externallyHandledError(error: unknown): unknown {
-  if ((error as { reported?: boolean } | null)?.reported === true) return error;
-  if (!(error instanceof AgentCoreCLIError)) return error;
-
-  const cause = error.cause;
-  if (
-    cause instanceof CommanderError ||
-    (cause as { reported?: boolean } | null)?.reported === true ||
-    (cause as Error)?.name === "AbortError"
-  ) {
-    return cause;
-  }
-  return error;
 }
 
 // Runnable can be implemented by any application's main entrypoint.
@@ -48,20 +32,8 @@ export async function runWithExitCode(
     await fn(argv);
     return ExitCode.SUCCESS;
   } catch (caught) {
-    const error = externallyHandledError(caught);
-    if (
-      !(error instanceof CommanderError) &&
-      (error as { reported?: boolean } | null)?.reported !== true
-    ) {
-      const reported = error instanceof Error ? error : new Error(String(error));
-      const name = reported instanceof AgentCoreCLIError ? "Error" : reported.name;
-      console.error(`${name}: ${reported.message}`);
-    }
-    if (error instanceof CommanderError) {
-      return error.exitCode === 0 ? ExitCode.SUCCESS : ExitCode.USAGE;
-    }
-    if ((error as Error)?.name === "AbortError") return ExitCode.INTERRUPTED;
-    if (caught instanceof AgentCoreCLIError) return caught.exitCode;
-    return ExitCode.FAILURE;
+    const error = AgentCoreCLIError.fromError(caught);
+    if (error.displayMessage) console.error(`Error: ${error.message}`);
+    return error.exitCode;
   }
 }


### PR DESCRIPTION
### Problem

Commander exits and user cancellations bypass the shared CLI error model. Runtime and Gateway invoke define resource-specific interruption errors, while Project dev defines a separate command interruption type for the same user cancellation outcome.

### Solution

- classify `CommanderError` in `AgentCoreCLIError.fromError`, preserving help as exit `0` and mapping parse failures to usage exit `2`
- add an opt-in `SilentCLIError` category so only intentionally silent errors skip generic root stderr output
- add a silent, user-sourced `UserCancellationError` with exit code `130`
- centralize process SIGINT listener lifecycle in `withUserCancellation` for Runtime invoke, Gateway invoke, dataset get, and dataset update
- use the shared cancellation error as each operation's `AbortSignal.reason`, including Project dev
- preserve Project dev's SIGINT/SIGTERM handling, single `Shutting down…` message, repeated-signal behavior, and listener cleanup
- preserve Runtime and Gateway partial-response interruption summaries while propagating the original typed cancellation reason
- leave TUI-local cancellation and low-level platform `AbortError` handling unchanged

### Verification

- focused cancellation suites across errors, root handling, Runtime, Gateway, Project dev, and datasets (`146 pass, 0 fail`)
- full local source suite (`1544 pass, 0 fail`)
- `bun run typecheck`
- `bun run lint:check`
- Prettier check for every changed file
- `bun run build`
- `git diff --check`
- GitHub full unit suites:
  - Linux: `1544 pass, 0 fail`
  - Windows: `1544 pass, 0 fail`
  - macOS: `1544 pass, 0 fail`
- Linux, Windows, and macOS builds
- AgentCore E2E CodeBuild
- bundled CLI smoke checks:
  - nested help: exit `0`, help on stdout, no stderr or error log
  - nested unknown option: exit `2`, one Commander error line, classified as a user error
