### PR TITLE
[DRAFT] feat(iam): add execution role policy reconciliation

### DIFF
--- a/src/core/agentCorePolicyGrants.test.ts
+++ b/src/core/agentCorePolicyGrants.test.ts
@@ -18,15 +18,17 @@ describe("AgentCorePolicyGrants", () => {
       actions: ["bedrock-agentcore:GetPolicyEngine"],
       resources: ["engine"],
     });
-    expect(AgentCorePolicyGrants.authorizeGateway("gateway")).toEqual({
+    expect(AgentCorePolicyGrants.authorizeGateway("engine", "gateway")).toEqual({
       effect: "Allow",
       actions: ["bedrock-agentcore:AuthorizeAction", "bedrock-agentcore:PartiallyAuthorizeActions"],
-      resources: ["gateway"],
+      resources: ["engine", "gateway"],
     });
-    expect(AgentCorePolicyGrants.invokeWebSearch("web-search")).toEqual({
+    expect(
+      AgentCorePolicyGrants.invokeWebSearch(["global-web-search", "regional-web-search"]),
+    ).toEqual({
       effect: "Allow",
       actions: ["bedrock-agentcore:InvokeWebSearch"],
-      resources: ["web-search"],
+      resources: ["global-web-search", "regional-web-search"],
     });
     expect(AgentCorePolicyGrants.invokeGateway("gateway")).toEqual({
       effect: "Allow",

--- a/src/core/agentCorePolicyGrants.test.ts
+++ b/src/core/agentCorePolicyGrants.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+import { AgentCorePolicyGrants } from "./agentCorePolicyGrants";
+
+describe("AgentCorePolicyGrants", () => {
+  test("maps reusable AgentCore capabilities to structured Allow statements", () => {
+    expect(AgentCorePolicyGrants.invokeLambda("lambda")).toEqual({
+      effect: "Allow",
+      actions: ["lambda:InvokeFunction"],
+      resources: ["lambda"],
+    });
+    expect(AgentCorePolicyGrants.evaluateWithLambda("lambda")).toEqual({
+      effect: "Allow",
+      actions: ["lambda:GetFunction", "lambda:InvokeFunction"],
+      resources: ["lambda"],
+    });
+    expect(AgentCorePolicyGrants.usePolicyEngine("engine")).toEqual({
+      effect: "Allow",
+      actions: [
+        "bedrock-agentcore:GetPolicyEngine",
+        "bedrock-agentcore:AuthorizeAction",
+        "bedrock-agentcore:PartiallyAuthorizeActions",
+      ],
+      resources: ["engine"],
+    });
+    expect(AgentCorePolicyGrants.invokeWebSearch("web-search")).toEqual({
+      effect: "Allow",
+      actions: ["bedrock-agentcore:InvokeWebSearch"],
+      resources: ["web-search"],
+    });
+    expect(AgentCorePolicyGrants.invokeGateway("gateway")).toEqual({
+      effect: "Allow",
+      actions: ["bedrock-agentcore:InvokeGateway"],
+      resources: ["gateway"],
+    });
+    expect(AgentCorePolicyGrants.invokeRuntime(["runtime", "endpoint"])).toEqual({
+      effect: "Allow",
+      actions: ["bedrock-agentcore:InvokeAgentRuntime"],
+      resources: ["runtime", "endpoint"],
+    });
+    expect(AgentCorePolicyGrants.useMemory("memory")).toEqual({
+      effect: "Allow",
+      actions: [
+        "bedrock-agentcore:CreateEvent",
+        "bedrock-agentcore:DeleteEvent",
+        "bedrock-agentcore:GetEvent",
+        "bedrock-agentcore:ListEvents",
+        "bedrock-agentcore:RetrieveMemoryRecords",
+      ],
+      resources: ["memory"],
+    });
+    expect(AgentCorePolicyGrants.useBrowser("browser")).toEqual({
+      effect: "Allow",
+      actions: [
+        "bedrock-agentcore:StartBrowserSession",
+        "bedrock-agentcore:StopBrowserSession",
+        "bedrock-agentcore:GetBrowserSession",
+        "bedrock-agentcore:ListBrowserSessions",
+        "bedrock-agentcore:UpdateBrowserStream",
+        "bedrock-agentcore:ConnectBrowserAutomationStream",
+        "bedrock-agentcore:ConnectBrowserLiveViewStream",
+      ],
+      resources: ["browser"],
+    });
+    expect(AgentCorePolicyGrants.useCodeInterpreter("code-interpreter")).toEqual({
+      effect: "Allow",
+      actions: [
+        "bedrock-agentcore:StartCodeInterpreterSession",
+        "bedrock-agentcore:StopCodeInterpreterSession",
+        "bedrock-agentcore:GetCodeInterpreterSession",
+        "bedrock-agentcore:ListCodeInterpreterSessions",
+        "bedrock-agentcore:InvokeCodeInterpreter",
+      ],
+      resources: ["code-interpreter"],
+    });
+    expect(AgentCorePolicyGrants.readS3Object("object")).toEqual({
+      effect: "Allow",
+      actions: ["s3:GetObject"],
+      resources: ["object"],
+    });
+    expect(AgentCorePolicyGrants.invokeApiGateway("api")).toEqual({
+      effect: "Allow",
+      actions: ["execute-api:Invoke"],
+      resources: ["api"],
+    });
+    expect(AgentCorePolicyGrants.retrieveKnowledgeBase("knowledge-base")).toEqual({
+      effect: "Allow",
+      actions: ["bedrock:GetKnowledgeBase", "bedrock:Retrieve"],
+      resources: ["knowledge-base"],
+    });
+    expect(AgentCorePolicyGrants.decryptKmsKey("key")).toEqual({
+      effect: "Allow",
+      actions: ["kms:Decrypt", "kms:DescribeKey"],
+      resources: ["key"],
+    });
+    expect(AgentCorePolicyGrants.invokeModel(["model", "profile"])).toEqual({
+      effect: "Allow",
+      actions: ["bedrock:InvokeModel", "bedrock:InvokeModelWithResponseStream"],
+      resources: ["model", "profile"],
+    });
+    expect(AgentCorePolicyGrants.queryLogs(["logs"])).toEqual({
+      effect: "Allow",
+      actions: [
+        "logs:DescribeLogStreams",
+        "logs:FilterLogEvents",
+        "logs:GetLogEvents",
+        "logs:GetQueryResults",
+        "logs:StartQuery",
+      ],
+      resources: ["logs"],
+    });
+  });
+});

--- a/src/core/agentCorePolicyGrants.test.ts
+++ b/src/core/agentCorePolicyGrants.test.ts
@@ -13,14 +13,15 @@ describe("AgentCorePolicyGrants", () => {
       actions: ["lambda:GetFunction", "lambda:InvokeFunction"],
       resources: ["lambda"],
     });
-    expect(AgentCorePolicyGrants.usePolicyEngine("engine")).toEqual({
+    expect(AgentCorePolicyGrants.getPolicyEngine("engine")).toEqual({
       effect: "Allow",
-      actions: [
-        "bedrock-agentcore:GetPolicyEngine",
-        "bedrock-agentcore:AuthorizeAction",
-        "bedrock-agentcore:PartiallyAuthorizeActions",
-      ],
+      actions: ["bedrock-agentcore:GetPolicyEngine"],
       resources: ["engine"],
+    });
+    expect(AgentCorePolicyGrants.authorizeGateway("gateway")).toEqual({
+      effect: "Allow",
+      actions: ["bedrock-agentcore:AuthorizeAction", "bedrock-agentcore:PartiallyAuthorizeActions"],
+      resources: ["gateway"],
     });
     expect(AgentCorePolicyGrants.invokeWebSearch("web-search")).toEqual({
       effect: "Allow",

--- a/src/core/agentCorePolicyGrants.ts
+++ b/src/core/agentCorePolicyGrants.ts
@@ -9,14 +9,14 @@ export class AgentCorePolicyGrants {
     return allow(["lambda:GetFunction", "lambda:InvokeFunction"], [functionArn]);
   }
 
-  static usePolicyEngine(policyEngineArn: string): GeneratedPolicyStatement {
+  static getPolicyEngine(policyEngineArn: string): GeneratedPolicyStatement {
+    return allow(["bedrock-agentcore:GetPolicyEngine"], [policyEngineArn]);
+  }
+
+  static authorizeGateway(gatewayArn: string): GeneratedPolicyStatement {
     return allow(
-      [
-        "bedrock-agentcore:GetPolicyEngine",
-        "bedrock-agentcore:AuthorizeAction",
-        "bedrock-agentcore:PartiallyAuthorizeActions",
-      ],
-      [policyEngineArn],
+      ["bedrock-agentcore:AuthorizeAction", "bedrock-agentcore:PartiallyAuthorizeActions"],
+      [gatewayArn],
     );
   }
 

--- a/src/core/agentCorePolicyGrants.ts
+++ b/src/core/agentCorePolicyGrants.ts
@@ -1,0 +1,108 @@
+import { allow, type GeneratedPolicyStatement } from "./executionRolePolicy";
+
+export class AgentCorePolicyGrants {
+  static invokeLambda(functionArn: string): GeneratedPolicyStatement {
+    return allow(["lambda:InvokeFunction"], [functionArn]);
+  }
+
+  static evaluateWithLambda(functionArn: string): GeneratedPolicyStatement {
+    return allow(["lambda:GetFunction", "lambda:InvokeFunction"], [functionArn]);
+  }
+
+  static usePolicyEngine(policyEngineArn: string): GeneratedPolicyStatement {
+    return allow(
+      [
+        "bedrock-agentcore:GetPolicyEngine",
+        "bedrock-agentcore:AuthorizeAction",
+        "bedrock-agentcore:PartiallyAuthorizeActions",
+      ],
+      [policyEngineArn],
+    );
+  }
+
+  static invokeWebSearch(webSearchArn: string): GeneratedPolicyStatement {
+    return allow(["bedrock-agentcore:InvokeWebSearch"], [webSearchArn]);
+  }
+
+  static invokeGateway(gatewayArn: string): GeneratedPolicyStatement {
+    return allow(["bedrock-agentcore:InvokeGateway"], [gatewayArn]);
+  }
+
+  static invokeRuntime(runtimeArns: readonly string[]): GeneratedPolicyStatement {
+    return allow(["bedrock-agentcore:InvokeAgentRuntime"], runtimeArns);
+  }
+
+  static useMemory(memoryArn: string): GeneratedPolicyStatement {
+    return allow(
+      [
+        "bedrock-agentcore:CreateEvent",
+        "bedrock-agentcore:DeleteEvent",
+        "bedrock-agentcore:GetEvent",
+        "bedrock-agentcore:ListEvents",
+        "bedrock-agentcore:RetrieveMemoryRecords",
+      ],
+      [memoryArn],
+    );
+  }
+
+  static useBrowser(browserArn: string): GeneratedPolicyStatement {
+    return allow(
+      [
+        "bedrock-agentcore:StartBrowserSession",
+        "bedrock-agentcore:StopBrowserSession",
+        "bedrock-agentcore:GetBrowserSession",
+        "bedrock-agentcore:ListBrowserSessions",
+        "bedrock-agentcore:UpdateBrowserStream",
+        "bedrock-agentcore:ConnectBrowserAutomationStream",
+        "bedrock-agentcore:ConnectBrowserLiveViewStream",
+      ],
+      [browserArn],
+    );
+  }
+
+  static useCodeInterpreter(codeInterpreterArn: string): GeneratedPolicyStatement {
+    return allow(
+      [
+        "bedrock-agentcore:StartCodeInterpreterSession",
+        "bedrock-agentcore:StopCodeInterpreterSession",
+        "bedrock-agentcore:GetCodeInterpreterSession",
+        "bedrock-agentcore:ListCodeInterpreterSessions",
+        "bedrock-agentcore:InvokeCodeInterpreter",
+      ],
+      [codeInterpreterArn],
+    );
+  }
+
+  static readS3Object(objectArn: string): GeneratedPolicyStatement {
+    return allow(["s3:GetObject"], [objectArn]);
+  }
+
+  static invokeApiGateway(apiArn: string): GeneratedPolicyStatement {
+    return allow(["execute-api:Invoke"], [apiArn]);
+  }
+
+  static retrieveKnowledgeBase(knowledgeBaseArn: string): GeneratedPolicyStatement {
+    return allow(["bedrock:GetKnowledgeBase", "bedrock:Retrieve"], [knowledgeBaseArn]);
+  }
+
+  static decryptKmsKey(keyArn: string): GeneratedPolicyStatement {
+    return allow(["kms:Decrypt", "kms:DescribeKey"], [keyArn]);
+  }
+
+  static invokeModel(modelArns: readonly string[]): GeneratedPolicyStatement {
+    return allow(["bedrock:InvokeModel", "bedrock:InvokeModelWithResponseStream"], modelArns);
+  }
+
+  static queryLogs(logGroupArns: readonly string[]): GeneratedPolicyStatement {
+    return allow(
+      [
+        "logs:DescribeLogStreams",
+        "logs:FilterLogEvents",
+        "logs:GetLogEvents",
+        "logs:GetQueryResults",
+        "logs:StartQuery",
+      ],
+      logGroupArns,
+    );
+  }
+}

--- a/src/core/agentCorePolicyGrants.ts
+++ b/src/core/agentCorePolicyGrants.ts
@@ -13,15 +13,15 @@ export class AgentCorePolicyGrants {
     return allow(["bedrock-agentcore:GetPolicyEngine"], [policyEngineArn]);
   }
 
-  static authorizeGateway(gatewayArn: string): GeneratedPolicyStatement {
+  static authorizeGateway(policyEngineArn: string, gatewayArn: string): GeneratedPolicyStatement {
     return allow(
       ["bedrock-agentcore:AuthorizeAction", "bedrock-agentcore:PartiallyAuthorizeActions"],
-      [gatewayArn],
+      [policyEngineArn, gatewayArn],
     );
   }
 
-  static invokeWebSearch(webSearchArn: string): GeneratedPolicyStatement {
-    return allow(["bedrock-agentcore:InvokeWebSearch"], [webSearchArn]);
+  static invokeWebSearch(webSearchArns: readonly string[]): GeneratedPolicyStatement {
+    return allow(["bedrock-agentcore:InvokeWebSearch"], webSearchArns);
   }
 
   static invokeGateway(gatewayArn: string): GeneratedPolicyStatement {

--- a/src/core/executionRoleManager.test.ts
+++ b/src/core/executionRoleManager.test.ts
@@ -1,0 +1,434 @@
+import { describe, expect, test } from "bun:test";
+import {
+  CreateRoleCommand,
+  DeleteRoleCommand,
+  DeleteRolePolicyCommand,
+  GetRoleCommand,
+  type IAMClient,
+} from "@aws-sdk/client-iam";
+import { ExecutionRoleManager, ExecutionRoleTrustError } from "./executionRoleManager";
+
+const ACCOUNT = "123456789012";
+
+function roleArn(roleName: string): string {
+  return `arn:aws:iam::${ACCOUNT}:role/${roleName}`;
+}
+
+describe("ExecutionRoleManager policy ownership", () => {
+  test("recognizes only the documented AgentCore role prefixes", () => {
+    const recognizedRoleNames = [
+      "AgentCoreCliHarness-orders",
+      "AgentCoreCliGateway-orders",
+      "AgentCoreCliOnlineEval-orders",
+      "AmazonBedrockAgentCoreHarnessDefaultServiceRole-orders",
+      "AmazonBedrockAgentCoreGatewayDefaultServiceRole",
+      "AmazonBedrockAgentCoreRuntimeDefaultServiceRole-orders",
+      "AgentCoreEvalsSDK-orders",
+      "AmazonBedrockAgentCoreSDKRuntime-orders",
+      "AgentCoreGatewayExecutionRole",
+    ];
+
+    for (const roleName of recognizedRoleNames) {
+      expect(
+        ExecutionRoleManager.policyManagement({
+          associatedRoleArn: roleArn(roleName),
+        }),
+      ).toEqual({
+        mode: "managed",
+        roleArn: roleArn(roleName),
+        roleName,
+      });
+    }
+
+    expect(
+      ExecutionRoleManager.policyManagement({
+        associatedRoleArn: roleArn("AgentCoreMyCdkStack-ExecutionRole-A1B2C3"),
+      }),
+    ).toEqual({
+      mode: "external",
+      reason: "unknown-role",
+      roleArn: roleArn("AgentCoreMyCdkStack-ExecutionRole-A1B2C3"),
+    });
+  });
+
+  test("explicit and skipped role updates are always externally managed", () => {
+    const associatedRoleArn = roleArn("AgentCoreCliGateway-orders");
+    const explicitRoleArn = roleArn("AgentCoreCliGateway-explicit");
+
+    expect(
+      ExecutionRoleManager.policyManagement({
+        associatedRoleArn,
+        explicitRoleArn,
+      }),
+    ).toEqual({
+      mode: "external",
+      reason: "explicit-role",
+      roleArn: explicitRoleArn,
+    });
+    expect(
+      ExecutionRoleManager.policyManagement({
+        associatedRoleArn,
+        skipPolicyUpdate: true,
+      }),
+    ).toEqual({
+      mode: "external",
+      reason: "skipped",
+      roleArn: associatedRoleArn,
+    });
+  });
+
+  test("creates bounded deterministic role and per-parent policy names", () => {
+    expect(ExecutionRoleManager.cliRoleName("gateway", "orders")).toBe(
+      "AgentCoreCliGateway-orders",
+    );
+
+    const longName = "gateway_name_".repeat(10);
+    const firstLongRole = ExecutionRoleManager.cliRoleName("gateway", longName);
+    const secondLongRole = ExecutionRoleManager.cliRoleName("gateway", `${longName}different`);
+    expect(firstLongRole).toHaveLength(64);
+    expect(firstLongRole).toMatch(/^AgentCoreCliGateway-[A-Za-z0-9+=,.@_-]+-[0-9a-f]{12}$/);
+    expect(secondLongRole).not.toBe(firstLongRole);
+
+    const firstPolicy = ExecutionRoleManager.generatedPolicyName("gateway", {
+      accountId: ACCOUNT,
+      region: "us-west-2",
+      stableResourceKey: "gateway-abc123",
+    });
+    const repeatedPolicy = ExecutionRoleManager.generatedPolicyName("gateway", {
+      stableResourceKey: "gateway-abc123",
+      region: "us-west-2",
+      accountId: ACCOUNT,
+    });
+    const otherPolicy = ExecutionRoleManager.generatedPolicyName("gateway", {
+      accountId: ACCOUNT,
+      region: "us-west-2",
+      stableResourceKey: "gateway-def456",
+    });
+
+    expect(firstPolicy).toMatch(/^AgentCoreCliGatewayExecutionPolicy-[0-9a-f]{16}$/);
+    expect(repeatedPolicy).toBe(firstPolicy);
+    expect(otherPolicy).not.toBe(firstPolicy);
+  });
+});
+
+describe("ExecutionRoleManager role lifecycle", () => {
+  test("creates a missing CLI role with AgentCore trust and reports ownership", async () => {
+    const sent: (CreateRoleCommand | GetRoleCommand)[] = [];
+    const iam = {
+      send: async (command: CreateRoleCommand | GetRoleCommand) => {
+        sent.push(command);
+        if (command instanceof GetRoleCommand) {
+          const error = new Error("missing");
+          error.name = "NoSuchEntityException";
+          throw error;
+        }
+        return {
+          Role: {
+            Arn: roleArn("AgentCoreCliGateway-orders"),
+            RoleName: "AgentCoreCliGateway-orders",
+          },
+        };
+      },
+    } as unknown as IAMClient;
+
+    const role = await new ExecutionRoleManager(iam).ensureCliRole({
+      primitive: "gateway",
+      resourceName: "orders",
+    });
+
+    expect(role).toEqual({
+      arn: roleArn("AgentCoreCliGateway-orders"),
+      name: "AgentCoreCliGateway-orders",
+      created: true,
+    });
+    expect(sent.map((command) => command.constructor.name)).toEqual([
+      "GetRoleCommand",
+      "CreateRoleCommand",
+    ]);
+    expect(JSON.parse((sent[1] as CreateRoleCommand).input.AssumeRolePolicyDocument!)).toEqual({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Principal: { Service: "bedrock-agentcore.amazonaws.com" },
+          Action: "sts:AssumeRole",
+        },
+      ],
+    });
+  });
+
+  test("reuses an existing trusted role without rewriting trust", async () => {
+    const sent: (CreateRoleCommand | GetRoleCommand)[] = [];
+    const trust = encodeURIComponent(
+      JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Principal: {
+              Service: ["bedrock-agentcore.amazonaws.com", "lambda.amazonaws.com"],
+            },
+            Action: ["sts:AssumeRole"],
+          },
+        ],
+      }),
+    );
+    const iam = {
+      send: async (command: CreateRoleCommand | GetRoleCommand) => {
+        sent.push(command);
+        return {
+          Role: {
+            Arn: roleArn("AgentCoreCliGateway-orders"),
+            RoleName: "AgentCoreCliGateway-orders",
+            AssumeRolePolicyDocument: trust,
+          },
+        };
+      },
+    } as unknown as IAMClient;
+
+    const role = await new ExecutionRoleManager(iam).ensureCliRole({
+      primitive: "gateway",
+      resourceName: "orders",
+    });
+
+    expect(role.created).toBeFalse();
+    expect(sent.map((command) => command.constructor.name)).toEqual(["GetRoleCommand"]);
+  });
+
+  test("rejects an existing role that AgentCore cannot assume", async () => {
+    const iam = {
+      send: async () => ({
+        Role: {
+          Arn: roleArn("AgentCoreCliGateway-orders"),
+          RoleName: "AgentCoreCliGateway-orders",
+          AssumeRolePolicyDocument: JSON.stringify({
+            Version: "2012-10-17",
+            Statement: [
+              {
+                Effect: "Allow",
+                Principal: { Service: "lambda.amazonaws.com" },
+                Action: "sts:AssumeRole",
+              },
+            ],
+          }),
+        },
+      }),
+    } as unknown as IAMClient;
+
+    await expect(
+      new ExecutionRoleManager(iam).ensureCliRole({
+        primitive: "gateway",
+        resourceName: "orders",
+      }),
+    ).rejects.toBeInstanceOf(ExecutionRoleTrustError);
+  });
+
+  test("rejects malformed trust policy documents with the role context", async () => {
+    const iam = {
+      send: async () => ({
+        Role: {
+          Arn: roleArn("AgentCoreCliGateway-orders"),
+          RoleName: "AgentCoreCliGateway-orders",
+          AssumeRolePolicyDocument: "not-json",
+        },
+      }),
+    } as unknown as IAMClient;
+
+    await expect(
+      new ExecutionRoleManager(iam).ensureCliRole({
+        primitive: "gateway",
+        resourceName: "orders",
+      }),
+    ).rejects.toMatchObject({
+      name: "ExecutionRoleTrustError",
+      roleName: "AgentCoreCliGateway-orders",
+    });
+  });
+
+  test("rejects matching Deny statements and unproven trust conditions", async () => {
+    const policies = [
+      {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Principal: { Service: "bedrock-agentcore.amazonaws.com" },
+            Action: "sts:AssumeRole",
+          },
+          {
+            Effect: "Deny",
+            Principal: { Service: "bedrock-agentcore.amazonaws.com" },
+            Action: "sts:AssumeRole",
+          },
+        ],
+      },
+      {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Principal: { Service: "bedrock-agentcore.amazonaws.com" },
+            Action: "sts:AssumeRole",
+          },
+          {
+            Effect: "Deny",
+            Principal: { Service: "bedrock-agentcore.amazonaws.com" },
+            NotAction: "sts:TagSession",
+          },
+        ],
+      },
+      {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Principal: { Service: "bedrock-agentcore.amazonaws.com" },
+            Action: "sts:AssumeRole",
+          },
+          {
+            Effect: "Deny",
+            Principal: { Service: "bedrock-agentcore.amazonaws.com" },
+            Action: "STS:Assume*",
+          },
+        ],
+      },
+      {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Principal: { Service: "bedrock-agentcore.amazonaws.com" },
+            Action: "sts:AssumeRole",
+            Condition: {
+              StringEquals: { "aws:SourceAccount": ACCOUNT },
+            },
+          },
+        ],
+      },
+    ];
+
+    for (const policy of policies) {
+      const iam = {
+        send: async () => ({
+          Role: {
+            Arn: roleArn("AgentCoreCliGateway-orders"),
+            RoleName: "AgentCoreCliGateway-orders",
+            AssumeRolePolicyDocument: JSON.stringify(policy),
+          },
+        }),
+      } as unknown as IAMClient;
+
+      await expect(
+        new ExecutionRoleManager(iam).ensureCliRole({
+          primitive: "gateway",
+          resourceName: "orders",
+        }),
+      ).rejects.toBeInstanceOf(ExecutionRoleTrustError);
+    }
+  });
+
+  test("rolls back only a role created by the current parent create", async () => {
+    const sent: (DeleteRoleCommand | DeleteRolePolicyCommand)[] = [];
+    const iam = {
+      send: async (command: DeleteRoleCommand | DeleteRolePolicyCommand) => {
+        sent.push(command);
+        return {};
+      },
+    } as unknown as IAMClient;
+    const manager = new ExecutionRoleManager(iam);
+
+    await manager.rollbackCreatedRole(
+      {
+        arn: roleArn("AgentCoreCliGateway-orders"),
+        name: "AgentCoreCliGateway-orders",
+        created: true,
+      },
+      "AgentCoreCliGatewayExecutionPolicy-a1b2c3d4",
+    );
+    await manager.rollbackCreatedRole(
+      {
+        arn: roleArn("AgentCoreCliGateway-existing"),
+        name: "AgentCoreCliGateway-existing",
+        created: false,
+      },
+      "AgentCoreCliGatewayExecutionPolicy-existing",
+    );
+
+    expect(sent.map((command) => command.constructor.name)).toEqual([
+      "DeleteRolePolicyCommand",
+      "DeleteRoleCommand",
+    ]);
+    expect((sent[0] as DeleteRolePolicyCommand).input).toEqual({
+      RoleName: "AgentCoreCliGateway-orders",
+      PolicyName: "AgentCoreCliGatewayExecutionPolicy-a1b2c3d4",
+    });
+  });
+
+  test("retries IAM conflicts while cleaning up a failed create", async () => {
+    let policyAttempts = 0;
+    let roleAttempts = 0;
+    const sleeps: number[] = [];
+    const iam = {
+      send: async (command: DeleteRoleCommand | DeleteRolePolicyCommand) => {
+        if (command instanceof DeleteRolePolicyCommand && ++policyAttempts === 1) {
+          const error = new Error("concurrent policy update");
+          error.name = "ConcurrentModificationException";
+          throw error;
+        }
+        if (command instanceof DeleteRoleCommand && ++roleAttempts === 1) {
+          const error = new Error("policy deletion is still propagating");
+          error.name = "DeleteConflictException";
+          throw error;
+        }
+        return {};
+      },
+    } as unknown as IAMClient;
+    const manager = new ExecutionRoleManager(iam, {
+      cleanupMaxAttempts: 3,
+      cleanupRetryDelayMs: 7,
+      sleep: async (milliseconds) => {
+        sleeps.push(milliseconds);
+      },
+    });
+
+    await manager.rollbackCreatedRole(
+      {
+        arn: roleArn("AgentCoreCliGateway-orders"),
+        name: "AgentCoreCliGateway-orders",
+        created: true,
+      },
+      "AgentCoreCliGatewayExecutionPolicy-a1b2c3d4",
+    );
+
+    expect(policyAttempts).toBe(2);
+    expect(roleAttempts).toBe(2);
+    expect(sleeps).toEqual([7, 7]);
+  });
+
+  test("preserves both parent-create and cleanup failures", async () => {
+    const iam = {
+      send: async () => {
+        throw new Error("cleanup failed");
+      },
+    } as unknown as IAMClient;
+    const createError = new Error("Gateway create failed");
+
+    const error = await new ExecutionRoleManager(iam)
+      .rollbackFailedCreate(
+        {
+          arn: roleArn("AgentCoreCliGateway-orders"),
+          name: "AgentCoreCliGateway-orders",
+          created: true,
+        },
+        "AgentCoreCliGatewayExecutionPolicy-a1b2c3d4",
+        createError,
+      )
+      .catch((caught) => caught);
+
+    expect(error).toBeInstanceOf(AggregateError);
+    expect((error as AggregateError).errors).toEqual([
+      createError,
+      expect.objectContaining({ message: "cleanup failed" }),
+    ]);
+  });
+});

--- a/src/core/executionRoleManager.ts
+++ b/src/core/executionRoleManager.ts
@@ -1,0 +1,384 @@
+import { createHash } from "node:crypto";
+import {
+  CreateRoleCommand,
+  DeleteRoleCommand,
+  DeleteRolePolicyCommand,
+  GetRoleCommand,
+  type IAMClient,
+  type Role,
+} from "@aws-sdk/client-iam";
+
+export const RECOGNIZED_EXECUTION_ROLE_PREFIXES = [
+  "AgentCoreCliHarness-",
+  "AgentCoreCliGateway-",
+  "AgentCoreCliOnlineEval-",
+  "AmazonBedrockAgentCoreHarnessDefaultServiceRole-",
+  "AmazonBedrockAgentCoreGatewayDefaultServiceRole",
+  "AmazonBedrockAgentCoreRuntimeDefaultServiceRole-",
+  "AgentCoreEvalsSDK-",
+  "AmazonBedrockAgentCoreSDKRuntime-",
+  "AgentCoreGatewayExecutionRole",
+] as const;
+
+export type AgentCoreExecutionRolePrimitive = "harness" | "gateway" | "online-eval";
+
+export type GeneratedPolicyIdentity = {
+  accountId: string;
+  region: string;
+  stableResourceKey: string;
+};
+
+export type ExecutionRolePolicyManagement =
+  | {
+      mode: "managed";
+      roleArn: string;
+      roleName: string;
+    }
+  | {
+      mode: "external";
+      reason: "explicit-role" | "skipped" | "unknown-role";
+      roleArn: string;
+    };
+
+export type ExecutionRolePolicyManagementInput = {
+  associatedRoleArn: string;
+  explicitRoleArn?: string;
+  skipPolicyUpdate?: boolean;
+};
+
+export class InvalidExecutionRoleArnError extends Error {
+  constructor(readonly roleArn: string) {
+    super(`Invalid IAM role ARN: ${roleArn}`);
+    this.name = "InvalidExecutionRoleArnError";
+  }
+}
+
+export type ManagedExecutionRole = {
+  arn: string;
+  name: string;
+  created: boolean;
+};
+
+export type EnsureCliRoleInput = {
+  primitive: AgentCoreExecutionRolePrimitive;
+  resourceName: string;
+};
+
+export type ExecutionRoleManagerOptions = {
+  cleanupMaxAttempts?: number;
+  cleanupRetryDelayMs?: number;
+  sleep?: (milliseconds: number) => Promise<void>;
+};
+
+export class ExecutionRoleTrustError extends Error {
+  constructor(readonly roleName: string) {
+    super(`IAM role ${roleName} does not allow bedrock-agentcore.amazonaws.com to assume it.`);
+    this.name = "ExecutionRoleTrustError";
+  }
+}
+
+export class ExecutionRoleManager {
+  private readonly cleanupMaxAttempts: number;
+  private readonly cleanupRetryDelayMs: number;
+  private readonly sleep: (milliseconds: number) => Promise<void>;
+
+  constructor(
+    private readonly iam: IAMClient,
+    options: ExecutionRoleManagerOptions = {},
+  ) {
+    this.cleanupMaxAttempts = Math.max(1, options.cleanupMaxAttempts ?? 5);
+    this.cleanupRetryDelayMs = options.cleanupRetryDelayMs ?? 250;
+    this.sleep = options.sleep ?? delay;
+  }
+
+  static cliRoleName(primitive: AgentCoreExecutionRolePrimitive, resourceName: string): string {
+    const prefix = rolePrefix(primitive);
+    const normalizedName = resourceName.replace(/[^A-Za-z0-9+=,.@_-]/g, "-");
+    const unboundedName = `${prefix}${normalizedName}`;
+    if (normalizedName === resourceName && unboundedName.length <= 64) return unboundedName;
+
+    const hash = identityHash([primitive, resourceName], 12);
+    const prefixLength = 64 - prefix.length - hash.length - 1;
+    return `${prefix}${normalizedName.slice(0, prefixLength)}-${hash}`;
+  }
+
+  static generatedPolicyName(
+    primitive: AgentCoreExecutionRolePrimitive,
+    identity: GeneratedPolicyIdentity,
+  ): string {
+    const hash = identityHash(
+      [primitive, identity.accountId, identity.region, identity.stableResourceKey],
+      16,
+    );
+    return `${policyPrefix(primitive)}${hash}`;
+  }
+
+  static policyManagement(
+    input: ExecutionRolePolicyManagementInput,
+  ): ExecutionRolePolicyManagement {
+    if (input.explicitRoleArn) {
+      return {
+        mode: "external",
+        reason: "explicit-role",
+        roleArn: input.explicitRoleArn,
+      };
+    }
+    if (input.skipPolicyUpdate) {
+      return {
+        mode: "external",
+        reason: "skipped",
+        roleArn: input.associatedRoleArn,
+      };
+    }
+
+    const roleName = ExecutionRoleManager.roleNameFromArn(input.associatedRoleArn);
+    if (RECOGNIZED_EXECUTION_ROLE_PREFIXES.some((prefix) => roleName.startsWith(prefix))) {
+      return {
+        mode: "managed",
+        roleArn: input.associatedRoleArn,
+        roleName,
+      };
+    }
+    return {
+      mode: "external",
+      reason: "unknown-role",
+      roleArn: input.associatedRoleArn,
+    };
+  }
+
+  static roleNameFromArn(roleArn: string): string {
+    const match = roleArn.match(/^arn:[^:]+:iam::\d{12}:role\/(?:.+\/)?([^/]+)$/);
+    if (!match?.[1]) throw new InvalidExecutionRoleArnError(roleArn);
+    return match[1];
+  }
+
+  async ensureCliRole(input: EnsureCliRoleInput): Promise<ManagedExecutionRole> {
+    const roleName = ExecutionRoleManager.cliRoleName(input.primitive, input.resourceName);
+    try {
+      const response = await this.iam.send(new GetRoleCommand({ RoleName: roleName }));
+      return this.existingRole(response.Role, roleName);
+    } catch (error) {
+      if ((error as Error).name !== "NoSuchEntityException") throw error;
+    }
+
+    const response = await this.iam.send(
+      new CreateRoleCommand({
+        RoleName: roleName,
+        AssumeRolePolicyDocument: agentCoreTrustPolicy(),
+        Description: `AgentCore CLI managed execution role for ${input.primitive} "${input.resourceName}"`,
+      }),
+    );
+    const roleArn = requiredRoleArn(response.Role, roleName);
+    return { arn: roleArn, name: roleName, created: true };
+  }
+
+  async validateAgentCoreTrust(roleName: string): Promise<ManagedExecutionRole> {
+    const response = await this.iam.send(new GetRoleCommand({ RoleName: roleName }));
+    return this.existingRole(response.Role, roleName);
+  }
+
+  async rollbackCreatedRole(
+    role: ManagedExecutionRole,
+    generatedPolicyName: string,
+  ): Promise<void> {
+    if (!role.created) return;
+
+    await this.retryCleanup(async () => {
+      try {
+        await this.iam.send(
+          new DeleteRolePolicyCommand({
+            RoleName: role.name,
+            PolicyName: generatedPolicyName,
+          }),
+        );
+      } catch (error) {
+        if ((error as Error).name !== "NoSuchEntityException") throw error;
+      }
+    });
+    await this.retryCleanup(async () => {
+      try {
+        await this.iam.send(new DeleteRoleCommand({ RoleName: role.name }));
+      } catch (error) {
+        if ((error as Error).name !== "NoSuchEntityException") throw error;
+      }
+    });
+  }
+
+  async rollbackFailedCreate(
+    role: ManagedExecutionRole,
+    generatedPolicyName: string,
+    createError: unknown,
+  ): Promise<never> {
+    try {
+      await this.rollbackCreatedRole(role, generatedPolicyName);
+    } catch (cleanupError) {
+      throw new AggregateError(
+        [createError, cleanupError],
+        "AgentCore parent creation failed and its new execution role could not be removed.",
+      );
+    }
+    throw createError;
+  }
+
+  private async retryCleanup(operation: () => Promise<void>): Promise<void> {
+    for (let attempt = 1; ; attempt++) {
+      try {
+        await operation();
+        return;
+      } catch (error) {
+        if (attempt >= this.cleanupMaxAttempts || !isRetryableCleanupError(error)) throw error;
+        await this.sleep(this.cleanupRetryDelayMs);
+      }
+    }
+  }
+
+  private existingRole(role: Role | undefined, expectedRoleName: string): ManagedExecutionRole {
+    const roleArn = requiredRoleArn(role, expectedRoleName);
+    let trusted = false;
+    try {
+      trusted =
+        role?.AssumeRolePolicyDocument !== undefined &&
+        allowsAgentCoreAssumeRole(role.AssumeRolePolicyDocument);
+    } catch {
+      trusted = false;
+    }
+    if (!trusted) {
+      throw new ExecutionRoleTrustError(expectedRoleName);
+    }
+    return {
+      arn: roleArn,
+      name: role?.RoleName ?? expectedRoleName,
+      created: false,
+    };
+  }
+}
+
+function rolePrefix(primitive: AgentCoreExecutionRolePrimitive): string {
+  switch (primitive) {
+    case "harness":
+      return "AgentCoreCliHarness-";
+    case "gateway":
+      return "AgentCoreCliGateway-";
+    case "online-eval":
+      return "AgentCoreCliOnlineEval-";
+  }
+}
+
+function policyPrefix(primitive: AgentCoreExecutionRolePrimitive): string {
+  switch (primitive) {
+    case "harness":
+      return "AgentCoreCliHarnessExecutionPolicy-";
+    case "gateway":
+      return "AgentCoreCliGatewayExecutionPolicy-";
+    case "online-eval":
+      return "AgentCoreCliOnlineEvalExecutionPolicy-";
+  }
+}
+
+function identityHash(values: readonly string[], length: number): string {
+  return createHash("sha256").update(JSON.stringify(values)).digest("hex").slice(0, length);
+}
+
+function agentCoreTrustPolicy(): string {
+  return JSON.stringify({
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Principal: { Service: "bedrock-agentcore.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    ],
+  });
+}
+
+function requiredRoleArn(role: Role | undefined, roleName: string): string {
+  if (!role?.Arn) throw new Error(`IAM returned no ARN for role ${roleName}.`);
+  return role.Arn;
+}
+
+function allowsAgentCoreAssumeRole(policyDocument: string): boolean {
+  const policy = parseIamDocument(policyDocument);
+  const statements = Array.isArray(policy.Statement) ? policy.Statement : [policy.Statement];
+  const applicable = statements.filter((statement) => {
+    if (!isRecord(statement)) return false;
+    if (!statementAppliesToAssumeRole(statement)) return false;
+    if (statement.Principal !== undefined) {
+      return principalMatchesAgentCore(statement.Principal);
+    }
+    if (statement.NotPrincipal !== undefined) {
+      return !principalMatchesAgentCore(statement.NotPrincipal);
+    }
+    return false;
+  });
+  if (applicable.some((statement) => statement.Effect === "Deny")) return false;
+  return applicable.some(
+    (statement) => statement.Effect === "Allow" && statement.Condition === undefined,
+  );
+}
+
+function statementAppliesToAssumeRole(statement: Record<string, unknown>): boolean {
+  if (statement.Action !== undefined) {
+    return stringList(statement.Action).some((pattern) =>
+      iamGlobMatches(pattern, "sts:AssumeRole"),
+    );
+  }
+  if (statement.NotAction !== undefined) {
+    return !stringList(statement.NotAction).some((pattern) =>
+      iamGlobMatches(pattern, "sts:AssumeRole"),
+    );
+  }
+  return false;
+}
+
+function iamGlobMatches(pattern: string, value: string): boolean {
+  const expression = pattern
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*/g, ".*")
+    .replace(/\?/g, ".");
+  return new RegExp(`^${expression}$`, "i").test(value);
+}
+
+function principalMatchesAgentCore(principal: unknown): boolean {
+  if (principal === "*") return true;
+  if (!isRecord(principal)) return false;
+  return stringList(principal.Service).some(
+    (service) => service === "*" || service.toLowerCase() === "bedrock-agentcore.amazonaws.com",
+  );
+}
+
+function parseIamDocument(policyDocument: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(policyDocument);
+    if (!isRecord(parsed)) throw new Error("IAM policy document must be an object.");
+    return parsed;
+  } catch (originalError) {
+    try {
+      const parsed = JSON.parse(decodeURIComponent(policyDocument));
+      if (!isRecord(parsed)) throw new Error("IAM policy document must be an object.");
+      return parsed;
+    } catch {
+      throw originalError;
+    }
+  }
+}
+
+function stringList(value: unknown): string[] {
+  if (typeof value === "string") return [value];
+  if (Array.isArray(value) && value.every((entry) => typeof entry === "string")) return value;
+  return [];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isRetryableCleanupError(error: unknown): boolean {
+  return ["ConcurrentModificationException", "DeleteConflictException"].includes(
+    (error as Error).name,
+  );
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}

--- a/src/core/executionRolePolicy.scenario.test.ts
+++ b/src/core/executionRolePolicy.scenario.test.ts
@@ -6,6 +6,7 @@ const LAMBDA_ARN = "arn:aws:lambda:us-west-2:123456789012:function:evaluator";
 const MEMORY_ARN = "arn:aws:bedrock-agentcore:us-west-2:123456789012:memory/memory-id";
 const POLICY_ENGINE_ARN =
   "arn:aws:bedrock-agentcore:us-west-2:123456789012:policy-engine/engine-id";
+const GATEWAY_ARN = "arn:aws:bedrock-agentcore:us-west-2:123456789012:gateway/gateway-id";
 const KMS_KEY_ARN = "arn:aws:kms:us-west-2:123456789012:key/key-id";
 
 describe("execution-role policy scenarios", () => {
@@ -19,7 +20,10 @@ describe("execution-role policy scenarios", () => {
       {
         owner: "gateway:policy-engine",
         reason: "authorize Gateway requests",
-        statements: [AgentCorePolicyGrants.usePolicyEngine(POLICY_ENGINE_ARN)],
+        statements: [
+          AgentCorePolicyGrants.getPolicyEngine(POLICY_ENGINE_ARN),
+          AgentCorePolicyGrants.authorizeGateway(GATEWAY_ARN),
+        ],
       },
       {
         owner: "harness-tool:lambda",
@@ -64,7 +68,7 @@ describe("execution-role policy scenarios", () => {
     ]);
     expect(compiled.permissions.map(({ action, resource }) => `${action} ${resource}`)).toEqual(
       expect.arrayContaining([
-        `bedrock-agentcore:AuthorizeAction ${POLICY_ENGINE_ARN}`,
+        `bedrock-agentcore:AuthorizeAction ${GATEWAY_ARN}`,
         `bedrock-agentcore:CreateEvent ${MEMORY_ARN}`,
         `kms:Decrypt ${KMS_KEY_ARN}`,
         `lambda:GetFunction ${LAMBDA_ARN}`,

--- a/src/core/executionRolePolicy.scenario.test.ts
+++ b/src/core/executionRolePolicy.scenario.test.ts
@@ -22,7 +22,7 @@ describe("execution-role policy scenarios", () => {
         reason: "authorize Gateway requests",
         statements: [
           AgentCorePolicyGrants.getPolicyEngine(POLICY_ENGINE_ARN),
-          AgentCorePolicyGrants.authorizeGateway(GATEWAY_ARN),
+          AgentCorePolicyGrants.authorizeGateway(POLICY_ENGINE_ARN, GATEWAY_ARN),
         ],
       },
       {

--- a/src/core/executionRolePolicy.scenario.test.ts
+++ b/src/core/executionRolePolicy.scenario.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import { AgentCorePolicyGrants } from "./agentCorePolicyGrants";
+import { PolicyCompiler, type PolicyContribution } from "./executionRolePolicy";
+
+const LAMBDA_ARN = "arn:aws:lambda:us-west-2:123456789012:function:evaluator";
+const MEMORY_ARN = "arn:aws:bedrock-agentcore:us-west-2:123456789012:memory/memory-id";
+const POLICY_ENGINE_ARN =
+  "arn:aws:bedrock-agentcore:us-west-2:123456789012:policy-engine/engine-id";
+const KMS_KEY_ARN = "arn:aws:kms:us-west-2:123456789012:key/key-id";
+
+describe("execution-role policy scenarios", () => {
+  test("combines Gateway, Harness, and online-evaluation contributions without compiler features", () => {
+    const contributions: PolicyContribution[] = [
+      {
+        owner: "gateway-target:lambda",
+        reason: "invoke Lambda target",
+        statements: [AgentCorePolicyGrants.invokeLambda(LAMBDA_ARN)],
+      },
+      {
+        owner: "gateway:policy-engine",
+        reason: "authorize Gateway requests",
+        statements: [AgentCorePolicyGrants.usePolicyEngine(POLICY_ENGINE_ARN)],
+      },
+      {
+        owner: "harness-tool:lambda",
+        reason: "invoke Lambda from Harness",
+        statements: [AgentCorePolicyGrants.invokeLambda(LAMBDA_ARN)],
+      },
+      {
+        owner: "harness-memory:managed",
+        reason: "use managed Harness Memory",
+        statements: [AgentCorePolicyGrants.useMemory(MEMORY_ARN)],
+      },
+      {
+        owner: "online-eval:evaluator",
+        reason: "invoke code-based evaluator",
+        statements: [AgentCorePolicyGrants.evaluateWithLambda(LAMBDA_ARN)],
+      },
+      {
+        owner: "online-eval:kms",
+        reason: "decrypt evaluator configuration",
+        statements: [AgentCorePolicyGrants.decryptKmsKey(KMS_KEY_ARN)],
+      },
+    ];
+
+    const compiled = new PolicyCompiler().compile(contributions);
+    const sharedLambdaPermission = compiled.permissions.find(
+      ({ action, resource }) => action === "lambda:InvokeFunction" && resource === LAMBDA_ARN,
+    );
+
+    expect(sharedLambdaPermission?.owners).toEqual([
+      {
+        owner: "gateway-target:lambda",
+        reason: "invoke Lambda target",
+      },
+      {
+        owner: "harness-tool:lambda",
+        reason: "invoke Lambda from Harness",
+      },
+      {
+        owner: "online-eval:evaluator",
+        reason: "invoke code-based evaluator",
+      },
+    ]);
+    expect(compiled.permissions.map(({ action, resource }) => `${action} ${resource}`)).toEqual(
+      expect.arrayContaining([
+        `bedrock-agentcore:AuthorizeAction ${POLICY_ENGINE_ARN}`,
+        `bedrock-agentcore:CreateEvent ${MEMORY_ARN}`,
+        `kms:Decrypt ${KMS_KEY_ARN}`,
+        `lambda:GetFunction ${LAMBDA_ARN}`,
+        `lambda:InvokeFunction ${LAMBDA_ARN}`,
+      ]),
+    );
+  });
+});

--- a/src/core/executionRolePolicy.test.ts
+++ b/src/core/executionRolePolicy.test.ts
@@ -1,0 +1,293 @@
+import { describe, expect, test } from "bun:test";
+import {
+  PolicyCompilationError,
+  PolicyCompiler,
+  PolicySizeError,
+  allow,
+  type PolicyContribution,
+} from "./executionRolePolicy";
+
+const LAMBDA_A = "arn:aws:lambda:us-west-2:123456789012:function:a";
+const LAMBDA_B = "arn:aws:lambda:us-west-2:123456789012:function:b";
+
+describe("PolicyCompiler", () => {
+  test("produces one deterministic policy and retains every permission owner", () => {
+    const contributions: PolicyContribution[] = [
+      {
+        owner: "gateway-target:b",
+        reason: "invoke Lambda target b",
+        statements: [allow(["lambda:InvokeFunction"], [LAMBDA_B])],
+      },
+      {
+        owner: "gateway-target:a",
+        reason: "invoke Lambda target a",
+        statements: [allow(["lambda:InvokeFunction"], [LAMBDA_A])],
+      },
+      {
+        owner: "harness-tool:a",
+        reason: "invoke the same Lambda from a Harness tool",
+        statements: [allow(["lambda:InvokeFunction"], [LAMBDA_A])],
+      },
+    ];
+
+    const compiler = new PolicyCompiler();
+    const forward = compiler.compile(contributions);
+    const reverse = compiler.compile([...contributions].reverse());
+
+    expect(forward.document).toEqual({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Action: ["lambda:InvokeFunction"],
+          Resource: [LAMBDA_A, LAMBDA_B],
+        },
+      ],
+    });
+    expect(reverse.json).toBe(forward.json);
+    expect(reverse.hash).toBe(forward.hash);
+    expect(forward.permissions).toEqual([
+      {
+        action: "lambda:InvokeFunction",
+        resource: LAMBDA_A,
+        owners: [
+          {
+            owner: "gateway-target:a",
+            reason: "invoke Lambda target a",
+          },
+          {
+            owner: "harness-tool:a",
+            reason: "invoke the same Lambda from a Harness tool",
+          },
+        ],
+      },
+      {
+        action: "lambda:InvokeFunction",
+        resource: LAMBDA_B,
+        owners: [
+          {
+            owner: "gateway-target:b",
+            reason: "invoke Lambda target b",
+          },
+        ],
+      },
+    ]);
+  });
+
+  test("compacts identical permission neighborhoods without broadening access", () => {
+    const compiler = new PolicyCompiler();
+    const compiled = compiler.compile([
+      {
+        owner: "harness-s3-files:input",
+        reason: "read mounted input objects",
+        statements: [
+          allow(
+            ["s3:GetObjectVersion", "s3:GetObject"],
+            ["arn:aws:s3:::input-bucket/b", "arn:aws:s3:::input-bucket/a"],
+          ),
+          allow(["kms:Decrypt"], ["arn:aws:kms:us-west-2:123456789012:key/key-id"]),
+        ],
+      },
+    ]);
+
+    expect(compiled.document.Statement).toEqual([
+      {
+        Effect: "Allow",
+        Action: ["kms:Decrypt"],
+        Resource: ["arn:aws:kms:us-west-2:123456789012:key/key-id"],
+      },
+      {
+        Effect: "Allow",
+        Action: ["s3:GetObject", "s3:GetObjectVersion"],
+        Resource: ["arn:aws:s3:::input-bucket/a", "arn:aws:s3:::input-bucket/b"],
+      },
+    ]);
+    expect(compiled.permissions).not.toContainEqual(
+      expect.objectContaining({
+        action: "kms:Decrypt",
+        resource: "arn:aws:s3:::input-bucket/a",
+      }),
+    );
+  });
+
+  test("chooses the smaller exact resource-neighborhood cover when beneficial", () => {
+    const compiled = new PolicyCompiler().compile([
+      {
+        owner: "gateway-target:matrix",
+        reason: "exercise exact compaction",
+        statements: [
+          allow(["service:ActionA"], ["resource:X"]),
+          allow(["service:ActionB"], ["resource:Y"]),
+          allow(["service:ActionC"], ["resource:X", "resource:Y"]),
+        ],
+      },
+    ]);
+
+    expect(compiled.document.Statement).toEqual([
+      {
+        Effect: "Allow",
+        Action: ["service:ActionA", "service:ActionC"],
+        Resource: ["resource:X"],
+      },
+      {
+        Effect: "Allow",
+        Action: ["service:ActionB", "service:ActionC"],
+        Resource: ["resource:Y"],
+      },
+    ]);
+    expect(compiled.permissions).toHaveLength(4);
+  });
+
+  test("never merges permissions with different condition sets", () => {
+    const compiled = new PolicyCompiler().compile([
+      {
+        owner: "harness-mount:team-a",
+        reason: "mount team a access point",
+        statements: [
+          allow(["elasticfilesystem:ClientMount"], ["arn:aws:elasticfilesystem:::file-system/fs"], {
+            StringEquals: { "aws:PrincipalTag/team": "a" },
+          }),
+        ],
+      },
+      {
+        owner: "harness-mount:team-b",
+        reason: "mount team b access point",
+        statements: [
+          allow(["elasticfilesystem:ClientMount"], ["arn:aws:elasticfilesystem:::file-system/fs"], {
+            StringEquals: { "aws:PrincipalTag/team": "b" },
+          }),
+        ],
+      },
+    ]);
+
+    expect(compiled.document.Statement).toHaveLength(2);
+    expect(compiled.document.Statement.map((statement) => statement.Condition)).toEqual([
+      { StringEquals: { "aws:PrincipalTag/team": "a" } },
+      { StringEquals: { "aws:PrincipalTag/team": "b" } },
+    ]);
+    expect(compiled.permissions).toHaveLength(2);
+  });
+
+  test("canonicalizes unordered IAM condition value sets", () => {
+    const compiled = new PolicyCompiler().compile([
+      {
+        owner: "owner:a",
+        reason: "first condition order",
+        statements: [
+          allow(["s3:GetObject"], ["arn:aws:s3:::bucket/key"], {
+            StringEquals: { "aws:PrincipalTag/team": ["b", "a"] },
+          }),
+        ],
+      },
+      {
+        owner: "owner:b",
+        reason: "second condition order",
+        statements: [
+          allow(["s3:GetObject"], ["arn:aws:s3:::bucket/key"], {
+            StringEquals: { "aws:PrincipalTag/team": ["a", "b"] },
+          }),
+        ],
+      },
+    ]);
+
+    expect(compiled.permissions).toHaveLength(1);
+    expect(compiled.permissions[0]!.owners).toHaveLength(2);
+    expect(compiled.document.Statement[0]!.Condition).toEqual({
+      StringEquals: { "aws:PrincipalTag/team": ["a", "b"] },
+    });
+  });
+
+  test("preserves every small action-resource graph exactly", () => {
+    const actions = ["service:A", "service:B", "service:C"];
+    const resources = ["resource:1", "resource:2", "resource:3"];
+    const possibleEdges = actions.flatMap((action) =>
+      resources.map((resource) => ({ action, resource })),
+    );
+    const compiler = new PolicyCompiler();
+
+    for (let mask = 1; mask < 1 << possibleEdges.length; mask++) {
+      const edges = possibleEdges.filter((_, index) => (mask & (1 << index)) !== 0);
+      const statements = edges.map(({ action, resource }) => allow([action], [resource]));
+      const forward = compiler.compile([
+        {
+          owner: `graph:${mask}`,
+          reason: "exhaustive compaction invariant",
+          statements,
+        },
+      ]);
+      const reverse = compiler.compile([
+        {
+          owner: `graph:${mask}`,
+          reason: "exhaustive compaction invariant",
+          statements: [...statements].reverse(),
+        },
+      ]);
+      const expanded = forward.document.Statement.flatMap((statement) =>
+        statement.Action.flatMap((action) =>
+          statement.Resource.map((resource) => `${action}\u0000${resource}`),
+        ),
+      ).sort();
+      const expected = edges.map(({ action, resource }) => `${action}\u0000${resource}`).sort();
+
+      expect(expanded).toEqual(expected);
+      expect(reverse.json).toBe(forward.json);
+    }
+  });
+
+  test("rejects invalid generated contributions before rendering IAM JSON", () => {
+    const contributions = [
+      {
+        owner: "",
+        reason: "",
+        statements: [
+          {
+            effect: "Deny",
+            actions: [],
+            resources: [""],
+            conditions: { StringEquals: { "aws:PrincipalTag/team": undefined } },
+          },
+        ],
+      },
+    ] as unknown as PolicyContribution[];
+
+    expect(() => new PolicyCompiler().compile(contributions)).toThrow(PolicyCompilationError);
+    try {
+      new PolicyCompiler().compile(contributions);
+      throw new Error("expected compilation to fail");
+    } catch (error) {
+      expect((error as PolicyCompilationError).issues).toEqual([
+        "contribution[0].owner must not be empty",
+        "contribution[0].reason must not be empty",
+        'contribution[0].statements[0].effect must be "Allow"',
+        "contribution[0].statements[0].actions must contain at least one action",
+        "contribution[0].statements[0].resources[0] must not be empty",
+        "contribution[0].statements[0].conditions.StringEquals.aws:PrincipalTag/team must be valid JSON",
+      ]);
+    }
+  });
+
+  test("checks the compact policy against the configured IAM character quota", () => {
+    const contribution: PolicyContribution = {
+      owner: "gateway-schema:orders",
+      reason: "read the OpenAPI schema",
+      statements: [allow(["s3:GetObject"], ["arn:aws:s3:::bucket/key"])],
+    };
+
+    const exact = new PolicyCompiler({ maxPolicyCharacters: 122 }).compile([contribution]);
+    expect(exact.characterCount).toBe(122);
+
+    expect(() => new PolicyCompiler({ maxPolicyCharacters: 121 }).compile([contribution])).toThrow(
+      PolicySizeError,
+    );
+    try {
+      new PolicyCompiler({ maxPolicyCharacters: 121 }).compile([contribution]);
+      throw new Error("expected policy size validation to fail");
+    } catch (error) {
+      expect(error).toMatchObject({
+        name: "PolicySizeError",
+        characterCount: 122,
+        maxCharacters: 121,
+      });
+    }
+  });
+});

--- a/src/core/executionRolePolicy.ts
+++ b/src/core/executionRolePolicy.ts
@@ -1,0 +1,380 @@
+import { createHash } from "node:crypto";
+
+export type OwnerKey = string;
+
+export type GeneratedPolicyStatement = {
+  effect: "Allow";
+  actions: readonly string[];
+  resources: readonly string[];
+  conditions?: Readonly<Record<string, unknown>>;
+};
+
+export type PolicyContribution = {
+  owner: OwnerKey;
+  reason: string;
+  statements: readonly GeneratedPolicyStatement[];
+};
+
+export type PolicyPermissionOwner = {
+  owner: OwnerKey;
+  reason: string;
+};
+
+export type CompiledPermission = {
+  action: string;
+  resource: string;
+  conditions?: Readonly<Record<string, unknown>>;
+  owners: readonly PolicyPermissionOwner[];
+};
+
+export type IamPolicyStatement = {
+  Effect: "Allow";
+  Action: readonly string[];
+  Resource: readonly string[];
+  Condition?: Readonly<Record<string, unknown>>;
+};
+
+export type IamPolicyDocument = {
+  Version: "2012-10-17";
+  Statement: readonly IamPolicyStatement[];
+};
+
+export type CompiledPolicy = {
+  document: IamPolicyDocument;
+  json: string;
+  hash: string;
+  characterCount: number;
+  permissions: readonly CompiledPermission[];
+};
+
+type PermissionAtom = {
+  action: string;
+  resource: string;
+  conditions?: Readonly<Record<string, unknown>>;
+  owners: Map<string, PolicyPermissionOwner>;
+};
+
+export class PolicyCompilationError extends Error {
+  constructor(readonly issues: readonly string[]) {
+    super(`Invalid generated execution policy:\n${issues.map((issue) => `- ${issue}`).join("\n")}`);
+    this.name = "PolicyCompilationError";
+  }
+}
+
+export class PolicySizeError extends Error {
+  constructor(
+    readonly characterCount: number,
+    readonly maxCharacters: number,
+  ) {
+    super(
+      `The generated execution policy is ${characterCount} characters, exceeding the ${maxCharacters}-character IAM limit.`,
+    );
+    this.name = "PolicySizeError";
+  }
+}
+
+export const IAM_ROLE_INLINE_POLICY_MAX_CHARACTERS = 10_240;
+
+export type PolicyCompilerOptions = {
+  maxPolicyCharacters?: number;
+};
+
+export function allow(
+  actions: readonly string[],
+  resources: readonly string[],
+  conditions?: Readonly<Record<string, unknown>>,
+): GeneratedPolicyStatement {
+  return {
+    effect: "Allow",
+    actions,
+    resources,
+    ...(conditions ? { conditions } : {}),
+  };
+}
+
+export class PolicyCompiler {
+  private readonly maxPolicyCharacters: number;
+
+  constructor(options: PolicyCompilerOptions = {}) {
+    this.maxPolicyCharacters = options.maxPolicyCharacters ?? IAM_ROLE_INLINE_POLICY_MAX_CHARACTERS;
+  }
+
+  compile(contributions: readonly PolicyContribution[]): CompiledPolicy {
+    const issues = validateContributions(contributions);
+    if (issues.length > 0) throw new PolicyCompilationError(issues);
+
+    const atoms = new Map<string, PermissionAtom>();
+
+    for (const contribution of contributions) {
+      for (const statement of contribution.statements) {
+        const actions = [...new Set(statement.actions)].sort();
+        const resources = [...new Set(statement.resources)].sort();
+        const conditions = statement.conditions
+          ? (normalizeConditionValue(statement.conditions) as Readonly<Record<string, unknown>>)
+          : undefined;
+        const conditionsJson = conditions ? canonicalJson(conditions) : "";
+
+        for (const action of actions) {
+          for (const resource of resources) {
+            const key = canonicalJson([conditionsJson, action, resource]);
+            let atom = atoms.get(key);
+            if (!atom) {
+              atom = {
+                action,
+                resource,
+                ...(conditions ? { conditions } : {}),
+                owners: new Map(),
+              };
+              atoms.set(key, atom);
+            }
+            atom.owners.set(canonicalJson([contribution.owner, contribution.reason]), {
+              owner: contribution.owner,
+              reason: contribution.reason,
+            });
+          }
+        }
+      }
+    }
+
+    const permissions = [...atoms.values()].sort(compareAtoms).map<CompiledPermission>((atom) => ({
+      action: atom.action,
+      resource: atom.resource,
+      ...(atom.conditions ? { conditions: atom.conditions } : {}),
+      owners: [...atom.owners.values()].sort(compareOwners),
+    }));
+    const document: IamPolicyDocument = {
+      Version: "2012-10-17",
+      Statement: compactIdenticalNeighborhoods(permissions),
+    };
+    const json = canonicalJson(document);
+    const characterCount = json.length;
+    if (characterCount > this.maxPolicyCharacters) {
+      throw new PolicySizeError(characterCount, this.maxPolicyCharacters);
+    }
+
+    return {
+      document,
+      json,
+      hash: createHash("sha256").update(json).digest("hex"),
+      characterCount,
+      permissions,
+    };
+  }
+}
+
+function validateContributions(contributions: readonly PolicyContribution[]): string[] {
+  const issues: string[] = [];
+
+  contributions.forEach((contribution, contributionIndex) => {
+    const contributionPath = `contribution[${contributionIndex}]`;
+    if (!nonEmptyString(contribution.owner)) {
+      issues.push(`${contributionPath}.owner must not be empty`);
+    }
+    if (!nonEmptyString(contribution.reason)) {
+      issues.push(`${contributionPath}.reason must not be empty`);
+    }
+    if (!Array.isArray(contribution.statements)) {
+      issues.push(`${contributionPath}.statements must be an array`);
+      return;
+    }
+
+    contribution.statements.forEach((statement, statementIndex) => {
+      const statementPath = `${contributionPath}.statements[${statementIndex}]`;
+      if (statement.effect !== "Allow") {
+        issues.push(`${statementPath}.effect must be "Allow"`);
+      }
+      validateStringList(statement.actions, `${statementPath}.actions`, "action", issues);
+      validateStringList(statement.resources, `${statementPath}.resources`, "resource", issues);
+      if (statement.conditions !== undefined) {
+        validateJson(statement.conditions, `${statementPath}.conditions`, issues, new Set());
+      }
+    });
+  });
+
+  return issues;
+}
+
+function validateStringList(
+  values: readonly string[],
+  path: string,
+  itemName: string,
+  issues: string[],
+): void {
+  if (!Array.isArray(values)) {
+    issues.push(`${path} must be an array`);
+    return;
+  }
+  if (values.length === 0) {
+    issues.push(`${path} must contain at least one ${itemName}`);
+  }
+  values.forEach((value, index) => {
+    if (!nonEmptyString(value)) issues.push(`${path}[${index}] must not be empty`);
+  });
+}
+
+function validateJson(
+  value: unknown,
+  path: string,
+  issues: string[],
+  ancestors: Set<object>,
+): void {
+  if (
+    value === undefined ||
+    typeof value === "bigint" ||
+    typeof value === "function" ||
+    typeof value === "symbol" ||
+    (typeof value === "number" && !Number.isFinite(value))
+  ) {
+    issues.push(`${path} must be valid JSON`);
+    return;
+  }
+  if (value === null || typeof value !== "object") return;
+  if (ancestors.has(value)) {
+    issues.push(`${path} must be valid JSON`);
+    return;
+  }
+
+  ancestors.add(value);
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => validateJson(entry, `${path}[${index}]`, issues, ancestors));
+  } else {
+    Object.entries(value)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .forEach(([key, entry]) => validateJson(entry, `${path}.${key}`, issues, ancestors));
+  }
+  ancestors.delete(value);
+}
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function normalizeConditionValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    const normalized = value.map(normalizeConditionValue);
+    const byJson = new Map(normalized.map((entry) => [canonicalJson(entry), entry]));
+    return [...byJson.entries()]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([, entry]) => entry);
+  }
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entry]) => [key, normalizeConditionValue(entry)]),
+    );
+  }
+  return value;
+}
+
+function compactIdenticalNeighborhoods(
+  permissions: readonly CompiledPermission[],
+): IamPolicyStatement[] {
+  const conditionGroups = new Map<
+    string,
+    {
+      conditions?: Readonly<Record<string, unknown>>;
+      permissions: CompiledPermission[];
+    }
+  >();
+  for (const permission of permissions) {
+    const conditionsJson = permission.conditions ? canonicalJson(permission.conditions) : "";
+    let group = conditionGroups.get(conditionsJson);
+    if (!group) {
+      group = {
+        ...(permission.conditions ? { conditions: permission.conditions } : {}),
+        permissions: [],
+      };
+      conditionGroups.set(conditionsJson, group);
+    }
+    group.permissions.push(permission);
+  }
+
+  const statements: IamPolicyStatement[] = [];
+  for (const group of [...conditionGroups.values()].sort((left, right) =>
+    canonicalJson(left.conditions ?? {}).localeCompare(canonicalJson(right.conditions ?? {})),
+  )) {
+    const byActions = compactConditionGroup(group.permissions, group.conditions, "actions");
+    const byResources = compactConditionGroup(group.permissions, group.conditions, "resources");
+    const actionsJson = canonicalJson(byActions);
+    const resourcesJson = canonicalJson(byResources);
+    statements.push(
+      ...(resourcesJson.length < actionsJson.length ||
+      (resourcesJson.length === actionsJson.length && resourcesJson < actionsJson)
+        ? byResources
+        : byActions),
+    );
+  }
+
+  return statements.sort((left, right) => canonicalJson(left).localeCompare(canonicalJson(right)));
+}
+
+function compactConditionGroup(
+  permissions: readonly CompiledPermission[],
+  conditions: Readonly<Record<string, unknown>> | undefined,
+  orientation: "actions" | "resources",
+): IamPolicyStatement[] {
+  const neighborhoods = new Map<string, Set<string>>();
+  for (const permission of permissions) {
+    const primary = orientation === "actions" ? permission.action : permission.resource;
+    const secondary = orientation === "actions" ? permission.resource : permission.action;
+    let neighbors = neighborhoods.get(primary);
+    if (!neighbors) {
+      neighbors = new Set();
+      neighborhoods.set(primary, neighbors);
+    }
+    neighbors.add(secondary);
+  }
+
+  const groups = new Map<string, { primary: Set<string>; secondary: readonly string[] }>();
+  for (const [primary, neighbors] of neighborhoods) {
+    const secondary = [...neighbors].sort();
+    const key = canonicalJson(secondary);
+    let group = groups.get(key);
+    if (!group) {
+      group = { primary: new Set(), secondary };
+      groups.set(key, group);
+    }
+    group.primary.add(primary);
+  }
+
+  return [...groups.values()]
+    .map<IamPolicyStatement>((group) => ({
+      Effect: "Allow",
+      Action: orientation === "actions" ? [...group.primary].sort() : [...group.secondary].sort(),
+      Resource: orientation === "actions" ? [...group.secondary].sort() : [...group.primary].sort(),
+      ...(conditions ? { Condition: conditions } : {}),
+    }))
+    .sort((left, right) => canonicalJson(left).localeCompare(canonicalJson(right)));
+}
+
+function compareAtoms(left: PermissionAtom, right: PermissionAtom): number {
+  const conditionsOrder = canonicalJson(left.conditions ?? {}).localeCompare(
+    canonicalJson(right.conditions ?? {}),
+  );
+  return (
+    conditionsOrder ||
+    left.action.localeCompare(right.action) ||
+    left.resource.localeCompare(right.resource)
+  );
+}
+
+function compareOwners(left: PolicyPermissionOwner, right: PolicyPermissionOwner): number {
+  return left.owner.localeCompare(right.owner) || left.reason.localeCompare(right.reason);
+}
+
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(sortJson(value));
+}
+
+function sortJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortJson);
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entry]) => [key, sortJson(entry)]),
+    );
+  }
+  return value;
+}

--- a/src/core/executionRolePolicyUpdater.test.ts
+++ b/src/core/executionRolePolicyUpdater.test.ts
@@ -1,0 +1,698 @@
+import { describe, expect, test } from "bun:test";
+import {
+  DeleteRolePolicyCommand,
+  GetRolePolicyCommand,
+  ListRolePoliciesCommand,
+  PutRolePolicyCommand,
+  type IAMClient,
+} from "@aws-sdk/client-iam";
+import { allow, type PolicyContribution } from "./executionRolePolicy";
+import {
+  ExecutionRolePolicyUpdater,
+  PolicyDriftError,
+  PolicyFinalizationError,
+  RoleInlinePolicyQuotaError,
+} from "./executionRolePolicyUpdater";
+
+const ROLE_NAME = "AgentCoreCliGateway-orders";
+const POLICY_NAME = "AgentCoreCliGatewayExecutionPolicy-a1b2c3d4";
+const LAMBDA_A = "arn:aws:lambda:us-west-2:123456789012:function:a";
+const LAMBDA_B = "arn:aws:lambda:us-west-2:123456789012:function:b";
+
+type SentCommand =
+  DeleteRolePolicyCommand | GetRolePolicyCommand | ListRolePoliciesCommand | PutRolePolicyCommand;
+
+function contribution(owner: string, resource: string): PolicyContribution {
+  return {
+    owner,
+    reason: `invoke ${resource}`,
+    statements: [allow(["lambda:InvokeFunction"], [resource])],
+  };
+}
+
+function statefulIam(
+  events: string[],
+  options: { failPutAt?: number } = {},
+): {
+  iam: IAMClient;
+  writes: string[];
+  setPolicyDocument: (policyDocument: string) => void;
+} {
+  let policyDocument: string | undefined;
+  let putCount = 0;
+  const writes: string[] = [];
+  const iam = {
+    send: async (command: SentCommand) => {
+      events.push(command.constructor.name);
+      if (command instanceof PutRolePolicyCommand) {
+        putCount++;
+        if (putCount === options.failPutAt) throw new Error(`put ${putCount} failed`);
+        policyDocument = command.input.PolicyDocument;
+        writes.push(command.input.PolicyDocument!);
+        return {};
+      }
+      if (command instanceof GetRolePolicyCommand) {
+        if (!policyDocument) {
+          const error = new Error("policy does not exist");
+          error.name = "NoSuchEntityException";
+          throw error;
+        }
+        return { PolicyDocument: policyDocument };
+      }
+      if (command instanceof DeleteRolePolicyCommand) {
+        policyDocument = undefined;
+        return {};
+      }
+      if (command instanceof ListRolePoliciesCommand) {
+        return { PolicyNames: policyDocument ? [POLICY_NAME] : [], IsTruncated: false };
+      }
+      throw new Error("unexpected IAM command");
+    },
+  } as unknown as IAMClient;
+
+  return {
+    iam,
+    writes,
+    setPolicyDocument: (document) => {
+      policyDocument = document;
+    },
+  };
+}
+
+describe("ExecutionRolePolicyUpdater", () => {
+  test("stages current union desired, waits, mutates, and writes exact desired", async () => {
+    const events: string[] = [];
+    const { iam, writes } = statefulIam(events);
+    const updater = new ExecutionRolePolicyUpdater(iam, {
+      propagationDelayMs: 0,
+      retryDelayMs: 0,
+    });
+
+    const result = await updater.update({
+      roleName: ROLE_NAME,
+      policyName: POLICY_NAME,
+      current: [contribution("gateway-target:a", LAMBDA_A)],
+      desired: [contribution("gateway-target:b", LAMBDA_B)],
+      operation: async () => {
+        events.push("AgentCoreOperation");
+        return { status: "READY" };
+      },
+    });
+
+    expect(events).toEqual([
+      "ListRolePoliciesCommand",
+      "PutRolePolicyCommand",
+      "GetRolePolicyCommand",
+      "AgentCoreOperation",
+      "GetRolePolicyCommand",
+      "ListRolePoliciesCommand",
+      "PutRolePolicyCommand",
+      "GetRolePolicyCommand",
+    ]);
+    expect(writes.map((policy) => JSON.parse(policy))).toEqual([
+      {
+        Statement: [
+          {
+            Action: ["lambda:InvokeFunction"],
+            Effect: "Allow",
+            Resource: [LAMBDA_A, LAMBDA_B],
+          },
+        ],
+        Version: "2012-10-17",
+      },
+      {
+        Statement: [
+          {
+            Action: ["lambda:InvokeFunction"],
+            Effect: "Allow",
+            Resource: [LAMBDA_B],
+          },
+        ],
+        Version: "2012-10-17",
+      },
+    ]);
+    expect(result.value).toEqual({ status: "READY" });
+    expect(result.currentHash).not.toBe(result.desiredHash);
+    expect(result.transitionHash).not.toBe(result.desiredHash);
+  });
+
+  test("accounts for customer inline policies before writing the transition policy", async () => {
+    const externalPolicy = JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Action: ["service:Action"],
+          Resource: [`arn:aws:service:::${"x".repeat(10_050)}`],
+        },
+      ],
+    });
+    let putCalled = false;
+    let operationCalled = false;
+    const iam = {
+      send: async (command: SentCommand) => {
+        if (command instanceof ListRolePoliciesCommand) {
+          return {
+            PolicyNames: ["CustomerPolicy", POLICY_NAME],
+            IsTruncated: false,
+          };
+        }
+        if (
+          command instanceof GetRolePolicyCommand &&
+          command.input.PolicyName === "CustomerPolicy"
+        ) {
+          return { PolicyDocument: externalPolicy };
+        }
+        if (command instanceof PutRolePolicyCommand) {
+          putCalled = true;
+          return {};
+        }
+        throw new Error(`unexpected IAM command ${command.constructor.name}`);
+      },
+    } as unknown as IAMClient;
+    const updater = new ExecutionRolePolicyUpdater(iam, {
+      propagationDelayMs: 0,
+      retryDelayMs: 0,
+    });
+
+    const error = await updater
+      .update({
+        roleName: ROLE_NAME,
+        policyName: POLICY_NAME,
+        current: [contribution("gateway-target:a", LAMBDA_A)],
+        desired: [contribution("gateway-target:b", LAMBDA_B)],
+        operation: async () => {
+          operationCalled = true;
+        },
+      })
+      .catch((caught) => caught);
+
+    expect(error).toBeInstanceOf(RoleInlinePolicyQuotaError);
+    expect(error).toMatchObject({
+      roleName: ROLE_NAME,
+      policyName: POLICY_NAME,
+      externalCharacterCount: externalPolicy.length,
+      maxCharacters: 10_240,
+    });
+    expect((error as RoleInlinePolicyQuotaError).totalCharacterCount).toBeGreaterThan(10_240);
+    expect(putCalled).toBeFalse();
+    expect(operationCalled).toBeFalse();
+  });
+
+  test("restores exact current permissions when the AgentCore operation fails", async () => {
+    const events: string[] = [];
+    const { iam, writes } = statefulIam(events);
+    const updater = new ExecutionRolePolicyUpdater(iam, {
+      propagationDelayMs: 0,
+      retryDelayMs: 0,
+    });
+    const operationError = new Error("AgentCore reached FAILED");
+
+    const error = await updater
+      .update({
+        roleName: ROLE_NAME,
+        policyName: POLICY_NAME,
+        current: [contribution("gateway-target:a", LAMBDA_A)],
+        desired: [contribution("gateway-target:b", LAMBDA_B)],
+        operation: async () => {
+          events.push("AgentCoreOperation");
+          throw operationError;
+        },
+      })
+      .catch((caught) => caught);
+
+    expect(error).toBe(operationError);
+    expect(events).toEqual([
+      "ListRolePoliciesCommand",
+      "PutRolePolicyCommand",
+      "GetRolePolicyCommand",
+      "AgentCoreOperation",
+      "ListRolePoliciesCommand",
+      "PutRolePolicyCommand",
+      "GetRolePolicyCommand",
+    ]);
+    expect(writes.map((document) => JSON.parse(document).Statement[0].Resource)).toEqual([
+      [LAMBDA_A, LAMBDA_B],
+      [LAMBDA_A],
+    ]);
+  });
+
+  test("preserves both the AgentCore and restoration failures", async () => {
+    const events: string[] = [];
+    const { iam } = statefulIam(events, { failPutAt: 2 });
+    const updater = new ExecutionRolePolicyUpdater(iam, {
+      propagationDelayMs: 0,
+      retryDelayMs: 0,
+    });
+
+    const error = await updater
+      .update({
+        roleName: ROLE_NAME,
+        policyName: POLICY_NAME,
+        current: [contribution("gateway-target:a", LAMBDA_A)],
+        desired: [contribution("gateway-target:b", LAMBDA_B)],
+        operation: async () => {
+          throw new Error("AgentCore reached FAILED");
+        },
+      })
+      .catch((caught) => caught);
+
+    expect(error).toBeInstanceOf(AggregateError);
+    expect((error as AggregateError).errors.map((cause) => (cause as Error).message)).toEqual([
+      "AgentCore reached FAILED",
+      "put 2 failed",
+    ]);
+  });
+
+  test("reports partial success and retains the transition policy when finalization fails", async () => {
+    const events: string[] = [];
+    const { iam, writes } = statefulIam(events, { failPutAt: 2 });
+    const updater = new ExecutionRolePolicyUpdater(iam, {
+      propagationDelayMs: 0,
+      retryDelayMs: 0,
+    });
+
+    const error = await updater
+      .update({
+        roleName: ROLE_NAME,
+        policyName: POLICY_NAME,
+        current: [contribution("gateway-target:a", LAMBDA_A)],
+        desired: [contribution("gateway-target:b", LAMBDA_B)],
+        operation: async () => ({ status: "READY" }),
+      })
+      .catch((caught) => caught);
+
+    expect(error).toBeInstanceOf(PolicyFinalizationError);
+    expect(error).toMatchObject({
+      value: { status: "READY" },
+      cause: expect.objectContaining({ message: "put 2 failed" }),
+    });
+    expect(writes).toHaveLength(1);
+    expect(JSON.parse(writes[0]!).Statement[0].Resource).toEqual([LAMBDA_A, LAMBDA_B]);
+  });
+
+  test("does not overwrite a generated policy changed during the AgentCore operation", async () => {
+    const events: string[] = [];
+    const { iam, setPolicyDocument, writes } = statefulIam(events);
+    const updater = new ExecutionRolePolicyUpdater(iam, {
+      propagationDelayMs: 0,
+      retryDelayMs: 0,
+    });
+
+    const error = await updater
+      .update({
+        roleName: ROLE_NAME,
+        policyName: POLICY_NAME,
+        current: [contribution("gateway-target:a", LAMBDA_A)],
+        desired: [contribution("gateway-target:b", LAMBDA_B)],
+        operation: async () => {
+          setPolicyDocument('{"Version":"2012-10-17","Statement":[]}');
+          return { status: "READY" };
+        },
+      })
+      .catch((caught) => caught);
+
+    expect(error).toBeInstanceOf(PolicyFinalizationError);
+    expect((error as PolicyFinalizationError<unknown>).cause).toBeInstanceOf(PolicyDriftError);
+    expect(writes).toHaveLength(1);
+  });
+
+  test("restores current policy when transition propagation fails before AgentCore", async () => {
+    let policyDocument: string | undefined;
+    let putCount = 0;
+    let operationCalled = false;
+    const writes: string[] = [];
+    const iam = {
+      send: async (command: SentCommand) => {
+        if (command instanceof ListRolePoliciesCommand) {
+          return {
+            PolicyNames: policyDocument ? [POLICY_NAME] : [],
+            IsTruncated: false,
+          };
+        }
+        if (command instanceof PutRolePolicyCommand) {
+          putCount++;
+          policyDocument = command.input.PolicyDocument;
+          writes.push(command.input.PolicyDocument!);
+          return {};
+        }
+        if (command instanceof GetRolePolicyCommand) {
+          if (putCount === 1) {
+            const error = new Error("not visible");
+            error.name = "NoSuchEntityException";
+            throw error;
+          }
+          return { PolicyDocument: policyDocument };
+        }
+        throw new Error(`unexpected IAM command ${command.constructor.name}`);
+      },
+    } as unknown as IAMClient;
+    const updater = new ExecutionRolePolicyUpdater(iam, {
+      maxVisibilityAttempts: 1,
+      propagationDelayMs: 0,
+      retryDelayMs: 0,
+    });
+
+    await expect(
+      updater.update({
+        roleName: ROLE_NAME,
+        policyName: POLICY_NAME,
+        current: [contribution("gateway-target:a", LAMBDA_A)],
+        desired: [contribution("gateway-target:b", LAMBDA_B)],
+        operation: async () => {
+          operationCalled = true;
+        },
+      }),
+    ).rejects.toMatchObject({ name: "PolicyPropagationError" });
+
+    expect(writes.map((document) => JSON.parse(document).Statement[0].Resource)).toEqual([
+      [LAMBDA_A, LAMBDA_B],
+      [LAMBDA_A],
+    ]);
+    expect(operationCalled).toBeFalse();
+  });
+
+  test("keeps current permissions when inventory is incomplete", async () => {
+    const events: string[] = [];
+    const { iam, writes, setPolicyDocument } = statefulIam(events);
+    const updater = new ExecutionRolePolicyUpdater(iam, {
+      propagationDelayMs: 0,
+      retryDelayMs: 0,
+    });
+    const unreadLambdaArn = "arn:aws:lambda:us-west-2:123456789012:function:unread-child";
+    setPolicyDocument(
+      JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Action: ["lambda:InvokeFunction"],
+            Resource: [LAMBDA_A, unreadLambdaArn],
+          },
+        ],
+      }),
+    );
+
+    const result = await updater.update({
+      roleName: ROLE_NAME,
+      policyName: POLICY_NAME,
+      current: [contribution("gateway-target:a", LAMBDA_A)],
+      desired: [contribution("gateway-target:b", LAMBDA_B)],
+      inventoryComplete: false,
+      operation: async () => ({ status: "READY" }),
+    });
+
+    expect(writes).toHaveLength(1);
+    expect(JSON.parse(writes[0]!).Statement[0].Resource).toEqual([
+      LAMBDA_A,
+      LAMBDA_B,
+      unreadLambdaArn,
+    ]);
+    expect(result.tightened).toBeFalse();
+    expect(result.desiredHash).toBe(result.transitionHash);
+  });
+
+  test("resolves generated child permissions after AgentCore reaches READY", async () => {
+    const events: string[] = [];
+    const { iam, writes } = statefulIam(events);
+    const updater = new ExecutionRolePolicyUpdater(iam, {
+      propagationDelayMs: 0,
+      retryDelayMs: 0,
+    });
+    const stagedMemoryArn = "arn:aws:bedrock-agentcore:us-west-2:123456789012:memory/harness_*";
+    const exactMemoryArn =
+      "arn:aws:bedrock-agentcore:us-west-2:123456789012:memory/generated-memory-id";
+
+    const result = await updater.update({
+      roleName: ROLE_NAME,
+      policyName: POLICY_NAME,
+      current: [],
+      desired: [
+        {
+          owner: "harness-memory:managed",
+          reason: "stage managed Memory access",
+          statements: [allow(["bedrock-agentcore:ListEvents"], [stagedMemoryArn])],
+        },
+      ],
+      operation: async () => {
+        events.push("AgentCoreReady");
+        return { harnessId: "harness-id", status: "READY" };
+      },
+      resolveDesired: async (value) => {
+        events.push(`ResolveDesired:${value.harnessId}`);
+        return {
+          contributions: [
+            {
+              owner: "harness-memory:managed",
+              reason: "use generated managed Memory",
+              statements: [allow(["bedrock-agentcore:ListEvents"], [exactMemoryArn])],
+            },
+          ],
+          inventoryComplete: true,
+        };
+      },
+    });
+
+    expect(events.indexOf("AgentCoreReady")).toBeLessThan(
+      events.indexOf("ResolveDesired:harness-id"),
+    );
+    expect(writes.map((document) => JSON.parse(document).Statement[0].Resource)).toEqual([
+      [stagedMemoryArn],
+      [exactMemoryArn],
+    ]);
+    expect(result.desiredHash).not.toBe(result.transitionHash);
+  });
+
+  test("deletes only the generated policy after a successful capability removal", async () => {
+    const events: string[] = [];
+    const { iam, writes } = statefulIam(events);
+    const updater = new ExecutionRolePolicyUpdater(iam, {
+      propagationDelayMs: 0,
+      retryDelayMs: 0,
+    });
+
+    await updater.update({
+      roleName: ROLE_NAME,
+      policyName: POLICY_NAME,
+      current: [contribution("gateway-target:a", LAMBDA_A)],
+      desired: [],
+      operation: async () => {
+        events.push("AgentCoreDelete");
+      },
+    });
+
+    expect(events).toEqual([
+      "ListRolePoliciesCommand",
+      "PutRolePolicyCommand",
+      "GetRolePolicyCommand",
+      "AgentCoreDelete",
+      "GetRolePolicyCommand",
+      "DeleteRolePolicyCommand",
+      "GetRolePolicyCommand",
+    ]);
+    expect(writes).toHaveLength(1);
+  });
+
+  test("paginates customer policies and excludes insignificant JSON whitespace from quota", async () => {
+    const events: string[] = [];
+    let generatedPolicy: string | undefined;
+    const prettyExternalPolicy = `{
+      "Version": "2012-10-17",
+      "Statement": [${" ".repeat(6_000)}]
+    }`;
+    const iam = {
+      send: async (command: SentCommand) => {
+        events.push(command.constructor.name);
+        if (command instanceof ListRolePoliciesCommand) {
+          return command.input.Marker
+            ? {
+                PolicyNames: ["CustomerB", POLICY_NAME],
+                IsTruncated: false,
+              }
+            : {
+                PolicyNames: ["CustomerA"],
+                IsTruncated: true,
+                Marker: "next",
+              };
+        }
+        if (command instanceof GetRolePolicyCommand) {
+          if (command.input.PolicyName === "CustomerA") {
+            return { PolicyDocument: prettyExternalPolicy };
+          }
+          if (command.input.PolicyName === "CustomerB") {
+            return { PolicyDocument: encodeURIComponent(prettyExternalPolicy) };
+          }
+          return { PolicyDocument: generatedPolicy };
+        }
+        if (command instanceof PutRolePolicyCommand) {
+          generatedPolicy = command.input.PolicyDocument;
+          return {};
+        }
+        throw new Error(`unexpected IAM command ${command.constructor.name}`);
+      },
+    } as unknown as IAMClient;
+    const updater = new ExecutionRolePolicyUpdater(iam, {
+      propagationDelayMs: 0,
+      retryDelayMs: 0,
+    });
+
+    await updater.update({
+      roleName: ROLE_NAME,
+      policyName: POLICY_NAME,
+      current: [],
+      desired: [contribution("gateway-target:a", LAMBDA_A)],
+      operation: async () => {
+        events.push("AgentCoreOperation");
+      },
+    });
+
+    expect(events.slice(0, 5)).toEqual([
+      "ListRolePoliciesCommand",
+      "ListRolePoliciesCommand",
+      "GetRolePolicyCommand",
+      "GetRolePolicyCommand",
+      "PutRolePolicyCommand",
+    ]);
+  });
+
+  test("waits through IAM visibility delay before running AgentCore", async () => {
+    let generatedPolicy: string | undefined;
+    let visibilityReads = 0;
+    const sleeps: number[] = [];
+    let operationReads = 0;
+    const iam = {
+      send: async (command: SentCommand) => {
+        if (command instanceof ListRolePoliciesCommand) {
+          return { PolicyNames: [], IsTruncated: false };
+        }
+        if (command instanceof PutRolePolicyCommand) {
+          generatedPolicy = command.input.PolicyDocument;
+          return {};
+        }
+        if (command instanceof GetRolePolicyCommand) {
+          visibilityReads++;
+          if (visibilityReads < 3) {
+            const error = new Error("not visible");
+            error.name = "NoSuchEntityException";
+            throw error;
+          }
+          return { PolicyDocument: encodeURIComponent(generatedPolicy!) };
+        }
+        throw new Error(`unexpected IAM command ${command.constructor.name}`);
+      },
+    } as unknown as IAMClient;
+    const updater = new ExecutionRolePolicyUpdater(iam, {
+      retryDelayMs: 11,
+      propagationDelayMs: 22,
+      sleep: async (milliseconds) => {
+        sleeps.push(milliseconds);
+      },
+    });
+
+    await updater.update({
+      roleName: ROLE_NAME,
+      policyName: POLICY_NAME,
+      current: [],
+      desired: [contribution("gateway-target:a", LAMBDA_A)],
+      operation: async () => {
+        operationReads = visibilityReads;
+      },
+    });
+
+    expect(operationReads).toBe(3);
+    expect(sleeps).toEqual([11, 11, 22]);
+  });
+
+  test("serializes complete transactions targeting the same role", async () => {
+    const events: string[] = [];
+    const { iam } = statefulIam(events);
+    const updaterA = new ExecutionRolePolicyUpdater(iam, {
+      propagationDelayMs: 0,
+      retryDelayMs: 0,
+    });
+    const updaterB = new ExecutionRolePolicyUpdater(iam, {
+      propagationDelayMs: 0,
+      retryDelayMs: 0,
+    });
+    let releaseFirst!: () => void;
+    const holdFirst = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let firstStarted!: () => void;
+    const firstOperationStarted = new Promise<void>((resolve) => {
+      firstStarted = resolve;
+    });
+
+    const first = updaterA.update({
+      roleName: ROLE_NAME,
+      policyName: POLICY_NAME,
+      current: [contribution("gateway-target:a", LAMBDA_A)],
+      desired: [contribution("gateway-target:b", LAMBDA_B)],
+      operation: async () => {
+        events.push("FirstOperation");
+        firstStarted();
+        await holdFirst;
+      },
+    });
+    await firstOperationStarted;
+
+    const second = updaterB.update({
+      roleName: ROLE_NAME,
+      policyName: POLICY_NAME,
+      current: [contribution("gateway-target:b", LAMBDA_B)],
+      desired: [contribution("gateway-target:a", LAMBDA_A)],
+      operation: async () => {
+        events.push("SecondOperation");
+      },
+    });
+    await Bun.sleep(10);
+
+    expect(events.filter((event) => event === "PutRolePolicyCommand")).toHaveLength(1);
+    expect(events).not.toContain("SecondOperation");
+
+    releaseFirst();
+    await Promise.all([first, second]);
+    expect(events.indexOf("SecondOperation")).toBeGreaterThan(events.indexOf("FirstOperation"));
+  });
+
+  test("retries only caller-classified pre-mutation propagation failures", async () => {
+    const events: string[] = [];
+    const sleeps: number[] = [];
+    const { iam } = statefulIam(events);
+    const updater = new ExecutionRolePolicyUpdater(iam, {
+      propagationDelayMs: 0,
+      retryDelayMs: 0,
+      sleep: async (milliseconds) => {
+        sleeps.push(milliseconds);
+      },
+    });
+    let attempts = 0;
+
+    const result = await updater.update({
+      roleName: ROLE_NAME,
+      policyName: POLICY_NAME,
+      current: [contribution("gateway-target:a", LAMBDA_A)],
+      desired: [contribution("gateway-target:b", LAMBDA_B)],
+      operation: async () => {
+        attempts++;
+        if (attempts === 1) {
+          const error = new Error("execution role permissions have not propagated");
+          error.name = "ValidationException";
+          throw error;
+        }
+        return { status: "READY" };
+      },
+      operationRetry: {
+        maxAttempts: 3,
+        delayMs: 17,
+        shouldRetry: (error) =>
+          (error as Error).name === "ValidationException" &&
+          /permissions.*propagat/i.test((error as Error).message),
+      },
+    });
+
+    expect(attempts).toBe(2);
+    expect(sleeps.filter((milliseconds) => milliseconds > 0)).toEqual([17]);
+    expect(result.value).toEqual({ status: "READY" });
+  });
+});

--- a/src/core/executionRolePolicyUpdater.test.ts
+++ b/src/core/executionRolePolicyUpdater.test.ts
@@ -11,6 +11,7 @@ import {
   ExecutionRolePolicyUpdater,
   PolicyDriftError,
   PolicyFinalizationError,
+  PolicyOperationOutcomeUnknownError,
   RoleInlinePolicyQuotaError,
 } from "./executionRolePolicyUpdater";
 
@@ -694,5 +695,35 @@ describe("ExecutionRolePolicyUpdater", () => {
     expect(attempts).toBe(2);
     expect(sleeps.filter((milliseconds) => milliseconds > 0)).toEqual([17]);
     expect(result.value).toEqual({ status: "READY" });
+  });
+
+  test("retains the transition policy when the AgentCore outcome is unknown", async () => {
+    const events: string[] = [];
+    const { iam, writes } = statefulIam(events);
+    const updater = new ExecutionRolePolicyUpdater(iam, {
+      propagationDelayMs: 0,
+      retryDelayMs: 0,
+    });
+    const timeout = new Error("status polling timed out");
+    timeout.name = "GatewayOutcomeUnknownError";
+
+    const error = await updater
+      .update({
+        roleName: ROLE_NAME,
+        policyName: POLICY_NAME,
+        current: [contribution("gateway-target:a", LAMBDA_A)],
+        desired: [contribution("gateway-target:b", LAMBDA_B)],
+        operation: async () => {
+          throw timeout;
+        },
+        isOperationOutcomeUnknown: (caught) =>
+          (caught as Error).name === "GatewayOutcomeUnknownError",
+      })
+      .catch((caught) => caught);
+
+    expect(error).toBeInstanceOf(PolicyOperationOutcomeUnknownError);
+    expect((error as PolicyOperationOutcomeUnknownError).cause).toBe(timeout);
+    expect(writes).toHaveLength(1);
+    expect(JSON.parse(writes[0]!).Statement[0].Resource).toEqual([LAMBDA_A, LAMBDA_B]);
   });
 });

--- a/src/core/executionRolePolicyUpdater.ts
+++ b/src/core/executionRolePolicyUpdater.ts
@@ -1,0 +1,548 @@
+import {
+  DeleteRolePolicyCommand,
+  GetRolePolicyCommand,
+  ListRolePoliciesCommand,
+  PutRolePolicyCommand,
+  type IAMClient,
+} from "@aws-sdk/client-iam";
+import {
+  PolicyCompiler,
+  IAM_ROLE_INLINE_POLICY_MAX_CHARACTERS,
+  canonicalJson,
+  type CompiledPolicy,
+  type GeneratedPolicyStatement,
+  type PolicyContribution,
+} from "./executionRolePolicy";
+
+export type ExecutionRolePolicyUpdaterOptions = {
+  compiler?: PolicyCompiler;
+  maxVisibilityAttempts?: number;
+  retryDelayMs?: number;
+  propagationDelayMs?: number;
+  sleep?: (milliseconds: number) => Promise<void>;
+};
+
+export type ExecutionRolePolicyUpdate<T> = {
+  roleName: string;
+  policyName: string;
+  current: readonly PolicyContribution[];
+  desired: readonly PolicyContribution[];
+  inventoryComplete?: boolean;
+  operation: () => Promise<T>;
+  operationRetry?: OperationRetryPolicy;
+  resolveDesired?: (value: T) => Promise<ResolvedExecutionRolePolicy>;
+};
+
+export type OperationRetryPolicy = {
+  maxAttempts: number;
+  delayMs: number;
+  shouldRetry: (error: unknown, attempt: number) => boolean;
+};
+
+export type ResolvedExecutionRolePolicy = {
+  contributions: readonly PolicyContribution[];
+  inventoryComplete?: boolean;
+};
+
+export type ExecutionRolePolicyUpdateResult<T> = {
+  value: T;
+  currentHash: string;
+  transitionHash: string;
+  desiredHash: string;
+  tightened: boolean;
+};
+
+export class PolicyPropagationError extends Error {
+  constructor(
+    readonly roleName: string,
+    readonly policyName: string,
+  ) {
+    super(`IAM policy ${policyName} on role ${roleName} did not become visible after update.`);
+    this.name = "PolicyPropagationError";
+  }
+}
+
+export class PolicyDriftError extends Error {
+  constructor(
+    readonly roleName: string,
+    readonly policyName: string,
+  ) {
+    super(`IAM policy ${policyName} on role ${roleName} changed during the AgentCore operation.`);
+    this.name = "PolicyDriftError";
+  }
+}
+
+export class ExistingGeneratedPolicyError extends Error {
+  constructor(
+    readonly roleName: string,
+    readonly policyName: string,
+    message: string,
+  ) {
+    super(`Cannot preserve generated IAM policy ${policyName} on role ${roleName}: ${message}`);
+    this.name = "ExistingGeneratedPolicyError";
+  }
+}
+
+export class RoleInlinePolicyQuotaError extends Error {
+  readonly totalCharacterCount: number;
+
+  constructor(
+    readonly roleName: string,
+    readonly policyName: string,
+    readonly externalCharacterCount: number,
+    readonly generatedCharacterCount: number,
+    readonly maxCharacters: number,
+  ) {
+    const totalCharacterCount = externalCharacterCount + generatedCharacterCount;
+    super(
+      `The generated execution policy cannot fit on role ${roleName}: ` +
+        `${externalCharacterCount} existing inline-policy characters plus ` +
+        `${generatedCharacterCount} generated characters exceeds IAM's ` +
+        `${maxCharacters}-character role limit.`,
+    );
+    this.name = "RoleInlinePolicyQuotaError";
+    this.totalCharacterCount = totalCharacterCount;
+  }
+}
+
+export class PolicyFinalizationError<T> extends Error {
+  constructor(
+    readonly value: T,
+    readonly transitionHash: string,
+    readonly desiredHash: string,
+    options: ErrorOptions,
+  ) {
+    super("AgentCore succeeded but execution-role policy finalization failed.", options);
+    this.name = "PolicyFinalizationError";
+  }
+}
+
+export class ExecutionRolePolicyUpdater {
+  private readonly compiler: PolicyCompiler;
+  private readonly maxVisibilityAttempts: number;
+  private readonly retryDelayMs: number;
+  private readonly propagationDelayMs: number;
+  private readonly sleep: (milliseconds: number) => Promise<void>;
+
+  constructor(
+    private readonly iam: IAMClient,
+    options: ExecutionRolePolicyUpdaterOptions = {},
+  ) {
+    this.compiler = options.compiler ?? new PolicyCompiler();
+    this.maxVisibilityAttempts = options.maxVisibilityAttempts ?? 8;
+    this.retryDelayMs = options.retryDelayMs ?? 250;
+    this.propagationDelayMs = options.propagationDelayMs ?? 2_000;
+    this.sleep = options.sleep ?? delay;
+  }
+
+  async update<T>(
+    request: ExecutionRolePolicyUpdate<T>,
+  ): Promise<ExecutionRolePolicyUpdateResult<T>> {
+    return rolePolicyTransactions.run(request.roleName, () => this.updateUnlocked(request));
+  }
+
+  private async updateUnlocked<T>(
+    request: ExecutionRolePolicyUpdate<T>,
+  ): Promise<ExecutionRolePolicyUpdateResult<T>> {
+    const stagedInventoryComplete = request.inventoryComplete ?? true;
+    const existingPolicy = stagedInventoryComplete
+      ? undefined
+      : await this.readExistingPolicyContribution(request.roleName, request.policyName);
+    const safeCurrentContributions = existingPolicy
+      ? [existingPolicy, ...request.current]
+      : request.current;
+    const current = this.compiler.compile(safeCurrentContributions);
+    const stagedDesiredContributions = stagedInventoryComplete
+      ? request.desired
+      : [...safeCurrentContributions, ...request.desired];
+    let desired = this.compiler.compile(stagedDesiredContributions);
+    const transitionContributions = [...safeCurrentContributions, ...stagedDesiredContributions];
+    const transition = this.compiler.compile(transitionContributions);
+    const transitionStaged = transition.document.Statement.length > 0;
+
+    if (transitionStaged) {
+      await this.preflightRoleQuota(request.roleName, request.policyName, transition);
+      try {
+        await this.putAndWait(request.roleName, request.policyName, transition);
+      } catch (transitionError) {
+        try {
+          await this.writeExact(request.roleName, request.policyName, current);
+        } catch (rollbackError) {
+          throw new AggregateError(
+            [transitionError, rollbackError],
+            "Execution-role transition failed and the current policy could not be restored.",
+          );
+        }
+        throw transitionError;
+      }
+    }
+
+    let value: T;
+    try {
+      value = await this.runOperation(request.operation, request.operationRetry);
+    } catch (operationError) {
+      if (transitionStaged) {
+        try {
+          await this.writeExact(request.roleName, request.policyName, current);
+        } catch (rollbackError) {
+          throw new AggregateError(
+            [operationError, rollbackError],
+            "AgentCore operation failed and its execution-role policy could not be restored.",
+          );
+        }
+      }
+      throw operationError;
+    }
+
+    let finalInventoryComplete = stagedInventoryComplete;
+    try {
+      if (request.resolveDesired) {
+        const resolved = await request.resolveDesired(value);
+        finalInventoryComplete = resolved.inventoryComplete ?? true;
+        const finalContributions = finalInventoryComplete
+          ? resolved.contributions
+          : [...transitionContributions, ...resolved.contributions];
+        desired = this.compiler.compile(finalContributions);
+      }
+      if (transitionStaged) {
+        await this.assertExact(request.roleName, request.policyName, transition);
+      }
+      if (!transitionStaged || transition.hash !== desired.hash) {
+        await this.writeExact(request.roleName, request.policyName, desired);
+      }
+    } catch (error) {
+      throw new PolicyFinalizationError(value, transition.hash, desired.hash, { cause: error });
+    }
+
+    return {
+      value,
+      currentHash: current.hash,
+      transitionHash: transition.hash,
+      desiredHash: desired.hash,
+      tightened: finalInventoryComplete && transition.hash !== desired.hash,
+    };
+  }
+
+  private async runOperation<T>(
+    operation: () => Promise<T>,
+    retry: OperationRetryPolicy | undefined,
+  ): Promise<T> {
+    const maxAttempts = Math.max(1, retry?.maxAttempts ?? 1);
+    for (let attempt = 1; ; attempt++) {
+      try {
+        return await operation();
+      } catch (error) {
+        if (!retry || attempt >= maxAttempts || !retry.shouldRetry(error, attempt)) throw error;
+        await this.sleep(retry.delayMs);
+      }
+    }
+  }
+
+  private async writeExact(
+    roleName: string,
+    policyName: string,
+    policy: CompiledPolicy,
+  ): Promise<void> {
+    if (policy.document.Statement.length === 0) {
+      await this.deletePolicy(roleName, policyName);
+      await this.waitUntilAbsent(roleName, policyName);
+      return;
+    }
+
+    await this.preflightRoleQuota(roleName, policyName, policy);
+    await this.putAndWait(roleName, policyName, policy);
+  }
+
+  private async putAndWait(
+    roleName: string,
+    policyName: string,
+    policy: CompiledPolicy,
+  ): Promise<void> {
+    await this.iam.send(
+      new PutRolePolicyCommand({
+        RoleName: roleName,
+        PolicyName: policyName,
+        PolicyDocument: policy.json,
+      }),
+    );
+    await this.waitUntilExact(roleName, policyName, policy);
+  }
+
+  private async preflightRoleQuota(
+    roleName: string,
+    policyName: string,
+    policy: CompiledPolicy,
+  ): Promise<void> {
+    const policyNames = await this.listRolePolicyNames(roleName);
+    let externalCharacterCount = 0;
+
+    for (const existingPolicyName of policyNames.sort()) {
+      if (existingPolicyName === policyName) continue;
+      const response = await this.iam.send(
+        new GetRolePolicyCommand({
+          RoleName: roleName,
+          PolicyName: existingPolicyName,
+        }),
+      );
+      if (response.PolicyDocument === undefined) {
+        throw new Error(
+          `IAM returned no policy document for ${existingPolicyName} on role ${roleName}.`,
+        );
+      }
+      externalCharacterCount += countPolicyCharacters(response.PolicyDocument);
+    }
+
+    if (externalCharacterCount + policy.characterCount > IAM_ROLE_INLINE_POLICY_MAX_CHARACTERS) {
+      throw new RoleInlinePolicyQuotaError(
+        roleName,
+        policyName,
+        externalCharacterCount,
+        policy.characterCount,
+        IAM_ROLE_INLINE_POLICY_MAX_CHARACTERS,
+      );
+    }
+  }
+
+  private async readExistingPolicyContribution(
+    roleName: string,
+    policyName: string,
+  ): Promise<PolicyContribution | undefined> {
+    let policyDocument: string;
+    try {
+      const response = await this.iam.send(
+        new GetRolePolicyCommand({ RoleName: roleName, PolicyName: policyName }),
+      );
+      if (response.PolicyDocument === undefined) {
+        throw new ExistingGeneratedPolicyError(
+          roleName,
+          policyName,
+          "IAM returned no policy document.",
+        );
+      }
+      policyDocument = response.PolicyDocument;
+    } catch (error) {
+      if ((error as Error).name === "NoSuchEntityException") return undefined;
+      throw error;
+    }
+
+    try {
+      const parsed = JSON.parse(decodePolicyDocument(policyDocument)) as unknown;
+      if (!isRecord(parsed)) throw new Error("policy document must be an object");
+      const rawStatements = Array.isArray(parsed.Statement) ? parsed.Statement : [parsed.Statement];
+      const statements = rawStatements.map<GeneratedPolicyStatement>((rawStatement, index) => {
+        if (!isRecord(rawStatement)) throw new Error(`statement[${index}] must be an object`);
+        if (rawStatement.Effect !== "Allow") {
+          throw new Error(`statement[${index}] must use Effect Allow`);
+        }
+        if ("NotAction" in rawStatement || "NotResource" in rawStatement) {
+          throw new Error(`statement[${index}] cannot use NotAction or NotResource`);
+        }
+        const actions = policyStringList(rawStatement.Action, `statement[${index}].Action`);
+        const resources = policyStringList(rawStatement.Resource, `statement[${index}].Resource`);
+        if (rawStatement.Condition !== undefined && !isRecord(rawStatement.Condition)) {
+          throw new Error(`statement[${index}].Condition must be an object`);
+        }
+        return {
+          effect: "Allow",
+          actions,
+          resources,
+          ...(rawStatement.Condition
+            ? { conditions: rawStatement.Condition as Readonly<Record<string, unknown>> }
+            : {}),
+        };
+      });
+      return {
+        owner: `existing-policy:${policyName}`,
+        reason: "preserve permissions from incomplete inventory",
+        statements,
+      };
+    } catch (error) {
+      if (error instanceof ExistingGeneratedPolicyError) throw error;
+      throw new ExistingGeneratedPolicyError(roleName, policyName, (error as Error).message);
+    }
+  }
+
+  private async listRolePolicyNames(roleName: string): Promise<string[]> {
+    const policyNames = new Set<string>();
+    let marker: string | undefined;
+
+    do {
+      const response = await this.iam.send(
+        new ListRolePoliciesCommand({
+          RoleName: roleName,
+          ...(marker ? { Marker: marker } : {}),
+        }),
+      );
+      for (const policyName of response.PolicyNames ?? []) policyNames.add(policyName);
+      if (response.IsTruncated && !response.Marker) {
+        throw new Error(`IAM truncated inline policies for role ${roleName} without a marker.`);
+      }
+      marker = response.IsTruncated ? response.Marker : undefined;
+    } while (marker);
+
+    return [...policyNames];
+  }
+
+  private async assertExact(
+    roleName: string,
+    policyName: string,
+    policy: CompiledPolicy,
+  ): Promise<void> {
+    try {
+      const response = await this.iam.send(
+        new GetRolePolicyCommand({ RoleName: roleName, PolicyName: policyName }),
+      );
+      if (
+        response.PolicyDocument === undefined ||
+        normalizePolicyDocument(response.PolicyDocument) !== policy.json
+      ) {
+        throw new PolicyDriftError(roleName, policyName);
+      }
+    } catch (error) {
+      if ((error as Error).name === "NoSuchEntityException") {
+        throw new PolicyDriftError(roleName, policyName);
+      }
+      throw error;
+    }
+  }
+
+  private async waitUntilExact(
+    roleName: string,
+    policyName: string,
+    policy: CompiledPolicy,
+  ): Promise<void> {
+    for (let attempt = 1; attempt <= this.maxVisibilityAttempts; attempt++) {
+      try {
+        const response = await this.iam.send(
+          new GetRolePolicyCommand({ RoleName: roleName, PolicyName: policyName }),
+        );
+        if (
+          response.PolicyDocument !== undefined &&
+          normalizePolicyDocument(response.PolicyDocument) === policy.json
+        ) {
+          await this.sleep(this.propagationDelayMs);
+          return;
+        }
+      } catch (error) {
+        if ((error as Error).name !== "NoSuchEntityException") throw error;
+      }
+      if (attempt < this.maxVisibilityAttempts) await this.sleep(this.retryDelayMs);
+    }
+    throw new PolicyPropagationError(roleName, policyName);
+  }
+
+  private async deletePolicy(roleName: string, policyName: string): Promise<void> {
+    try {
+      await this.iam.send(
+        new DeleteRolePolicyCommand({ RoleName: roleName, PolicyName: policyName }),
+      );
+    } catch (error) {
+      if ((error as Error).name !== "NoSuchEntityException") throw error;
+    }
+  }
+
+  private async waitUntilAbsent(roleName: string, policyName: string): Promise<void> {
+    for (let attempt = 1; attempt <= this.maxVisibilityAttempts; attempt++) {
+      try {
+        await this.iam.send(
+          new GetRolePolicyCommand({ RoleName: roleName, PolicyName: policyName }),
+        );
+      } catch (error) {
+        if ((error as Error).name === "NoSuchEntityException") {
+          await this.sleep(this.propagationDelayMs);
+          return;
+        }
+        throw error;
+      }
+      if (attempt < this.maxVisibilityAttempts) await this.sleep(this.retryDelayMs);
+    }
+    throw new PolicyPropagationError(roleName, policyName);
+  }
+}
+
+class KeyedTransactionSerializer {
+  private readonly tails = new Map<string, Promise<void>>();
+
+  async run<T>(key: string, operation: () => Promise<T>): Promise<T> {
+    const previous = this.tails.get(key) ?? Promise.resolve();
+    let release!: () => void;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const tail = previous.then(
+      () => current,
+      () => current,
+    );
+    this.tails.set(key, tail);
+
+    await previous.catch(() => undefined);
+    try {
+      return await operation();
+    } finally {
+      release();
+      if (this.tails.get(key) === tail) this.tails.delete(key);
+    }
+  }
+}
+
+const rolePolicyTransactions = new KeyedTransactionSerializer();
+
+function normalizePolicyDocument(policyDocument: string): string {
+  return canonicalJson(JSON.parse(decodePolicyDocument(policyDocument)));
+}
+
+function countPolicyCharacters(policyDocument: string): number {
+  const decoded = decodePolicyDocument(policyDocument);
+  let count = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (const character of decoded) {
+    if (inString) {
+      count++;
+      if (escaped) {
+        escaped = false;
+      } else if (character === "\\") {
+        escaped = true;
+      } else if (character === '"') {
+        inString = false;
+      }
+    } else if (character === '"') {
+      count++;
+      inString = true;
+    } else if (!/\s/.test(character)) {
+      count++;
+    }
+  }
+
+  return count;
+}
+
+function decodePolicyDocument(policyDocument: string): string {
+  try {
+    JSON.parse(policyDocument);
+    return policyDocument;
+  } catch (originalError) {
+    try {
+      const decoded = decodeURIComponent(policyDocument);
+      JSON.parse(decoded);
+      return decoded;
+    } catch {
+      throw originalError;
+    }
+  }
+}
+
+function policyStringList(value: unknown, path: string): string[] {
+  if (typeof value === "string") return [value];
+  if (Array.isArray(value) && value.every((entry) => typeof entry === "string")) return value;
+  throw new Error(`${path} must be a string or string array`);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}

--- a/src/core/executionRolePolicyUpdater.ts
+++ b/src/core/executionRolePolicyUpdater.ts
@@ -30,6 +30,7 @@ export type ExecutionRolePolicyUpdate<T> = {
   inventoryComplete?: boolean;
   operation: () => Promise<T>;
   operationRetry?: OperationRetryPolicy;
+  isOperationOutcomeUnknown?: (error: unknown) => boolean;
   resolveDesired?: (value: T) => Promise<ResolvedExecutionRolePolicy>;
 };
 
@@ -69,6 +70,22 @@ export class PolicyDriftError extends Error {
   ) {
     super(`IAM policy ${policyName} on role ${roleName} changed during the AgentCore operation.`);
     this.name = "PolicyDriftError";
+  }
+}
+
+export class PolicyOperationOutcomeUnknownError extends Error {
+  constructor(
+    readonly roleName: string,
+    readonly policyName: string,
+    readonly transitionHash: string,
+    options: ErrorOptions,
+  ) {
+    super(
+      "AgentCore operation outcome is unknown; the transition IAM policy was retained. " +
+        "Inspect the resource before retrying, then rerun the command to reconcile IAM.",
+      options,
+    );
+    this.name = "PolicyOperationOutcomeUnknownError";
   }
 }
 
@@ -112,7 +129,12 @@ export class PolicyFinalizationError<T> extends Error {
     readonly desiredHash: string,
     options: ErrorOptions,
   ) {
-    super("AgentCore succeeded but execution-role policy finalization failed.", options);
+    const identity = resourceIdentity(value);
+    super(
+      `AgentCore succeeded${identity ? ` for ${identity}` : ""}, but execution-role policy finalization failed. ` +
+        "The resource may not be invokable. Rerun the same command without changing its configuration to reconcile IAM; do not recreate the resource.",
+      options,
+    );
     this.name = "PolicyFinalizationError";
   }
 }
@@ -181,6 +203,14 @@ export class ExecutionRolePolicyUpdater {
     try {
       value = await this.runOperation(request.operation, request.operationRetry);
     } catch (operationError) {
+      if (request.isOperationOutcomeUnknown?.(operationError)) {
+        throw new PolicyOperationOutcomeUnknownError(
+          request.roleName,
+          request.policyName,
+          transition.hash,
+          { cause: operationError },
+        );
+      }
       if (transitionStaged) {
         try {
           await this.writeExact(request.roleName, request.policyName, current);
@@ -541,6 +571,24 @@ function policyStringList(value: unknown, path: string): string[] {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function resourceIdentity(value: unknown): string | undefined {
+  if (!isRecord(value)) return undefined;
+  for (const key of [
+    "gatewayId",
+    "targetId",
+    "harnessId",
+    "onlineEvaluationConfigId",
+    "policyEngineId",
+  ]) {
+    if (typeof value[key] === "string") return `${key} ${value[key]}`;
+  }
+  for (const nested of ["response", "gateway", "target", "harness"]) {
+    const identity = resourceIdentity(value[nested]);
+    if (identity) return identity;
+  }
+  return undefined;
 }
 
 function delay(milliseconds: number): Promise<void> {


### PR DESCRIPTION
## Summary

- add an allow-only `PolicyContribution` compiler with permission atom ownership, deterministic rendering and hashing, exact bipartite compaction, condition canonicalization, and IAM size validation
- add execution-role naming, documented-prefix recognition, trust validation, failed-create cleanup, and customer-role opt-out decisions
- add a serialized `C -> C union D -> D/C` policy updater with aggregate quota checks, IAM propagation handling, operation retries, rollback, drift detection, incomplete-inventory preservation, and post-create desired-state resolution
- add reusable AgentCore grant helpers plus Gateway, Harness, and online-evaluation scenario coverage

## Stack

Base: `refactor` at `531d0684789511fc19f60d4aa7a93f1688eb401e`.

## Verification

- focused IAM suite: 35 pass, 0 fail
- full repository suite: 1,141 pass, 0 fail
- coverage: 94.11% lines, 98.03% functions
- `bun run typecheck`
- `bun run lint:check`
- `bun run format:check`
- `bun run build`
- npm tarball build and extracted `dist/index.js --help` smoke

Live verification in the isolated deploy account covered:

- CLI role creation, reuse, and trust validation
- initial generated policy write
- successful transition policy and exact final policy
- AgentCore-operation failure and exact current-policy restoration
- generated-child post-success finalization
- incomplete-inventory preservation of unread grants
- preservation of a separate customer inline policy
- aggregate inline-policy quota failure before the operation
- policy and role cleanup

The disposable role was independently queried after cleanup and returned `NoSuchEntity`.
