### PR TITLE
fix(exec): derive region from the ARN so --runtime needs no project

### DIFF
--- a/src/cli/aws/arn.ts
+++ b/src/cli/aws/arn.ts
@@ -1,0 +1,17 @@
+/**
+ * ARN parsing helpers.
+ *
+ * Kept separate from region.ts: that module *detects* the ambient region from the environment and
+ * shared config files, while these are pure string functions over an ARN the caller already holds.
+ */
+
+/**
+ * Parse the region out of a service ARN.
+ * ARN format: arn:{partition}:{service}:{region}:{account}:{resource} → field index 3 is the region.
+ * Splitting on ':' rather than matching a partition keeps this correct for GovCloud and China ARNs.
+ * Returns undefined for a malformed or region-less ARN so callers can fall back.
+ */
+export function regionFromArn(arn: string): string | undefined {
+  const region = arn.split(':')[3];
+  return region && region.length > 0 ? region : undefined;
+}

--- a/src/cli/commands/exec/__tests__/action.test.ts
+++ b/src/cli/commands/exec/__tests__/action.test.ts
@@ -767,13 +767,55 @@ describe('loadExecContext --runtime as ARN or name', () => {
     ).not.toHaveBeenCalled();
   });
 
-  it('resolves region from config when --runtime is a full ARN but --region is omitted', async () => {
+  // A full ARN already carries its region, so exec must not need a project to recover it. Reading
+  // config here used to fail outright with "AWS Targets config file not found" for anyone deploying
+  // runtimes outside this CLI (CDK, pipelines, personal stacks) — the ARN was enough all along.
+  it('takes the region from the ARN when --region is omitted, without reading config', async () => {
+    // Config reads throw, standing in for "no project / no aws-targets.json in cwd".
+    const noProject = {
+      readAWSDeploymentTargets: vi.fn().mockRejectedValue(new Error('AWS Targets config file not found')),
+      readDeployedState: vi.fn().mockRejectedValue(new Error('State config file not found')),
+    } as unknown as ConfigIO;
+
+    const ctx = await loadExecContext({ runtimeArn: 'arn:aws:bedrock-agentcore:eu-west-2:123:runtime/X' }, noProject);
+
+    expect(ctx.region).toBe('eu-west-2'); // from the ARN, not config
+    expect(ctx.runtimeArn).toBe('arn:aws:bedrock-agentcore:eu-west-2:123:runtime/X');
+    expect(
+      (noProject as unknown as { readAWSDeploymentTargets: ReturnType<typeof vi.fn> }).readAWSDeploymentTargets
+    ).not.toHaveBeenCalled();
+    expect(
+      (noProject as unknown as { readDeployedState: ReturnType<typeof vi.fn> }).readDeployedState
+    ).not.toHaveBeenCalled();
+  });
+
+  it('lets an explicit --region override the region in the ARN', async () => {
     const ctx = await loadExecContext(
-      { runtimeArn: 'arn:aws:bedrock-agentcore:us-east-1:123:runtime/X' },
+      { runtimeArn: 'arn:aws:bedrock-agentcore:us-east-1:123:runtime/X', region: 'us-west-2' },
       TWO_AGENT_CONFIG
     );
+    expect(ctx.region).toBe('us-west-2');
+  });
+
+  // Region is field 3 regardless of partition, so GovCloud and China ARNs resolve the same way.
+  it.each([
+    ['arn:aws-us-gov:bedrock-agentcore:us-gov-west-1:123:runtime/X', 'us-gov-west-1'],
+    ['arn:aws-cn:bedrock-agentcore:cn-north-1:123:runtime/X', 'cn-north-1'],
+  ])('parses the region out of a non-commercial partition ARN (%s)', async (arn, expected) => {
+    const throwing = {
+      readAWSDeploymentTargets: vi.fn().mockRejectedValue(new Error('should not be read')),
+      readDeployedState: vi.fn().mockRejectedValue(new Error('should not be read')),
+    } as unknown as ConfigIO;
+
+    const ctx = await loadExecContext({ runtimeArn: arn }, throwing);
+    expect(ctx.region).toBe(expected);
+  });
+
+  // An ARN with an empty region field carries no region to use, so config remains the fallback.
+  it('falls back to config when the ARN has no region field', async () => {
+    const ctx = await loadExecContext({ runtimeArn: 'arn:aws:bedrock-agentcore::123:runtime/X' }, TWO_AGENT_CONFIG);
     expect(ctx.region).toBe('us-east-1'); // from config
-    expect(ctx.runtimeArn).toBe('arn:aws:bedrock-agentcore:us-east-1:123:runtime/X');
+    expect(ctx.runtimeArn).toBe('arn:aws:bedrock-agentcore::123:runtime/X');
   });
 
   it('resolves runtimeArn when --runtime is an agent name', async () => {
@@ -858,10 +900,22 @@ describe('loadExecContext with harnesses', () => {
     ).not.toHaveBeenCalled();
   });
 
-  it('resolves region from config for --harness <arn> when --region is omitted', async () => {
-    const ctx = await loadExecContext({ harnessName: HARNESS_ARN }, HARNESS_ONLY_CONFIG);
-    expect(ctx.runtimeArn).toBe(HARNESS_ARN);
-    expect(ctx.region).toBe('us-east-1'); // from config target
+  it('takes the region from a --harness <arn> when --region is omitted, without reading config', async () => {
+    const noProject = {
+      readAWSDeploymentTargets: vi.fn().mockRejectedValue(new Error('AWS Targets config file not found')),
+      readDeployedState: vi.fn().mockRejectedValue(new Error('State config file not found')),
+    } as unknown as ConfigIO;
+
+    const ctx = await loadExecContext(
+      { harnessName: 'arn:aws:bedrock-agentcore:eu-west-2:123:harness/h1-abc' },
+      noProject
+    );
+
+    expect(ctx.runtimeArn).toBe('arn:aws:bedrock-agentcore:eu-west-2:123:harness/h1-abc');
+    expect(ctx.region).toBe('eu-west-2'); // from the ARN, not config
+    expect(
+      (noProject as unknown as { readAWSDeploymentTargets: ReturnType<typeof vi.fn> }).readAWSDeploymentTargets
+    ).not.toHaveBeenCalled();
   });
 
   it('rejects a runtime ARN passed to --harness (with --region)', async () => {

--- a/src/cli/commands/exec/action.ts
+++ b/src/cli/commands/exec/action.ts
@@ -1,5 +1,6 @@
 import { ConfigIO } from '../../../lib';
 import { executeBashCommand } from '../../aws/agentcore';
+import { regionFromArn } from '../../aws/arn';
 import { connectShell, startKeepalive } from '../../aws/connect-shell';
 import { ShellChannel, ShellFramer, parseStatusFrame } from '../../aws/shell-framer';
 import { withCommandRunTelemetry } from '../../telemetry/cli-command-run.js';
@@ -38,6 +39,7 @@ function assertInteractiveHarnessUnsupported(options: ExecOptions, ctx: ExecCont
 
 /** Resolve region + runtimeArn from options and/or agentcore.json deployed state.
  *  --runtime accepts either a full ARN (arn:...) or an agent name from deployed state.
+ *  A full ARN resolves with no project and no config on disk; only a *name* needs deployed state.
  */
 export async function loadExecContext(options: ExecOptions, configIO: ConfigIO = new ConfigIO()): Promise<ExecContext> {
   // Mutual exclusion: --runtime and --harness cannot both be set. Checked first so it applies to
@@ -46,19 +48,29 @@ export async function loadExecContext(options: ExecOptions, configIO: ConfigIO =
     throw new Error('Cannot specify both --runtime and --harness.');
   }
 
-  // Short-circuit: explicit ARN + region — no need to read deployed state
-  if (options.runtimeArn?.startsWith('arn:') && options.region) {
-    return assertInteractiveHarnessUnsupported(options, { region: options.region, runtimeArn: options.runtimeArn });
+  // Short-circuit: an explicit ARN already carries its region in field 3, so --region is optional.
+  // Reading config here would demand a project, an aws-targets.json and a completed deploy purely to
+  // recover a value the caller already supplied — which blocks `exec` for anyone who deploys their
+  // runtimes outside this CLI (CDK, pipelines, personal stacks).
+  // A region-less/malformed ARN still falls through so config can supply the region.
+  if (options.runtimeArn?.startsWith('arn:')) {
+    const region = options.region ?? regionFromArn(options.runtimeArn);
+    if (region) {
+      return assertInteractiveHarnessUnsupported(options, { region, runtimeArn: options.runtimeArn });
+    }
   }
 
-  // Same short-circuit for --harness <arn> + region. Validate it's a harness ARN (not a runtime ARN).
-  if (options.harnessName?.startsWith('arn:') && options.region) {
+  // Same short-circuit for --harness <arn>. Validate it's a harness ARN (not a runtime ARN).
+  if (options.harnessName?.startsWith('arn:')) {
     if (!isHarnessArn(options.harnessName)) {
       throw new Error(
         `--harness expects a harness ARN (…:harness/…), got '${options.harnessName}'. Use --runtime for a runtime ARN.`
       );
     }
-    return assertInteractiveHarnessUnsupported(options, { region: options.region, runtimeArn: options.harnessName });
+    const region = options.region ?? regionFromArn(options.harnessName);
+    if (region) {
+      return assertInteractiveHarnessUnsupported(options, { region, runtimeArn: options.harnessName });
+    }
   }
 
   const awsTargets = await configIO.readAWSDeploymentTargets();
@@ -85,7 +97,8 @@ export async function loadExecContext(options: ExecOptions, configIO: ConfigIO =
   const runtimeKeys = Object.keys(targetState?.resources?.runtimes ?? {});
   const harnessKeys = Object.keys(targetState?.resources?.harnesses ?? {});
 
-  // --runtime <arn> with no --region: ARN provided but region must come from config
+  // --runtime <arn> whose region field is empty or malformed: only reachable when the short-circuit
+  // above could not derive a region, so config is the last resort.
   if (options.runtimeArn?.startsWith('arn:')) {
     return assertInteractiveHarnessUnsupported(options, {
       region: options.region ?? targetConfig.region,

--- a/src/cli/operations/jobs/shared/region.ts
+++ b/src/cli/operations/jobs/shared/region.ts
@@ -3,7 +3,12 @@
  * no regression to either legacy path) and baked into the stored ARN; refresh/stop/archive
  * parse it back out of the ARN rather than storing a separate field.
  */
+import { regionFromArn } from '../../../aws/arn';
 import { detectRegion } from '../../../aws/region';
+
+// regionFromArn is shared with exec's target resolution, so it lives in cli/aws/arn.
+// Re-exported here to keep the jobs-facing import path stable.
+export { regionFromArn };
 
 /** AWS targets carry a per-target region; we only need that field here. */
 interface RegionTarget {
@@ -23,14 +28,4 @@ export async function resolveJobRegion(optsRegion: string | undefined, awsTarget
   }
   const { region } = await detectRegion();
   return region;
-}
-
-/**
- * Parse the region out of a service ARN.
- * ARN format: arn:{partition}:{service}:{region}:{account}:{resource} → field index 3 is the region.
- * Engine-created ARNs are always well-formed; returns undefined for a malformed/region-less ARN.
- */
-export function regionFromArn(arn: string): string | undefined {
-  const region = arn.split(':')[3];
-  return region && region.length > 0 ? region : undefined;
 }


### PR DESCRIPTION
## Description

`agentcore exec --runtime <full-arn>` fails outside an AgentCore project unless `--region` is also passed:

```
$ agentcore exec --it --runtime arn:aws:bedrock-agentcore:us-east-1:111122223333:runtime/MyRuntime-abc123 --session-id <id>
AWS Targets config file not found at: /path/to/cwd/agentcore/aws-targets.json
```

`loadExecContext` gated its "explicit ARN, skip deployed state" short-circuit on **both** flags (`options.runtimeArn?.startsWith('arn:') && options.region`), so an ARN alone fell through to `readAWSDeploymentTargets()` / `readDeployedState()`, which throw first. The branch further down labelled "`--runtime <arn>` with no `--region`" sat *after* those reads and used config only for `options.region ?? targetConfig.region` — a value already present as field 3 of the ARN that was just supplied. So the CLI demanded a project, a hand-written `aws-targets.json`, and a completed deploy purely to recover something the caller had handed it, which rules out `exec` for anyone whose runtimes are deployed by CDK, a pipeline, or a personal stack.

This derives the region from the ARN so `--region` is optional, and the short-circuit fires on the ARN alone. Config is now read only when a *name* has to be resolved. A region-less or malformed ARN still falls through to config as a last resort, so nothing that worked before stops working. `--harness <arn>` had the identical gate and gets the identical treatment.

`regionFromArn` already existed in `src/cli/operations/jobs/shared/region.ts`, so it is reused rather than rewritten. It moves to a new `src/cli/aws/arn.ts` and is re-exported from its old location to keep the jobs-facing import path stable. Two test files factory-mock the whole `aws/region` module, so it could not live there — and the split is cleaner regardless: `aws/region.ts` detects the ambient region from env and shared config files, while this is a pure string function over an ARN the caller already holds. Splitting on `:` rather than matching a partition keeps it correct for GovCloud and China ARNs.

## Related Issue

Closes #1995

## Documentation PR

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

Unit: 423/423 files, 6095/6095 tests. Typecheck, lint, prettier and secretlint clean. `test:integ` did not run to completion — I stopped it rather than block this PR, so it never printed a summary. Every integ test that did run passed and no failures appeared in the output, but I am not claiming a green integ run. No integ test touches `exec`, `cli/aws`, or the jobs region path; please let CI be the authority there.

Also verified end-to-end against a built CLI rather than by unit test alone, in an empty directory with no project:

- installed 0.25.0 → `AWS Targets config file not found at: /private/tmp/exec-fix-check/agentcore/aws-targets.json`
- this branch → reaches the real `InvokeAgentRuntime` call in `us-east-1` and fails only on cross-account authorization for a runtime in an account I have no access to

That is the correct terminal state: region resolved from the ARN, config wall gone, no project and no `aws-targets.json` on disk.

New unit tests cover region-from-ARN with config readers mocked to reject and asserted `not.toHaveBeenCalled()` (standing in for "no project at all"), an explicit `--region` overriding the ARN, `aws-us-gov` and `aws-cn` partitions, and the malformed-ARN fall-back to config.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
