### PR TITLE
fix(dev): update container test schema import

### DIFF
--- a/src/core/dev/container.test.ts
+++ b/src/core/dev/container.test.ts
@@ -11,7 +11,7 @@ import {
   type ProcessStreamer,
   type StreamProcessOptions,
 } from "../../io";
-import type { ProjectRuntime } from "../project/schema";
+import type { ProjectRuntime } from "../../projectSchemas/runtime";
 import { ContainerDevRunner } from "./container";
 
 type ProcessCall = {


### PR DESCRIPTION
## Summary
- update the container dev runner test to import `ProjectRuntime` from its new `projectSchemas` location
- fix the post-#1962 `refactor` typecheck failure

## Verification
- `bun run typecheck`
- `bun run lint:check`
- `bun run format:check`
- `bun audit`
- `bun test` (1,288 passed)
- `bun run build`