### PR TITLE
fix: fix the build command to build a project that has no deployment targets

### DIFF
--- a/src/assets/cdk/bin/cdk.ts
+++ b/src/assets/cdk/bin/cdk.ts
@@ -110,9 +110,12 @@ async function main() {
 
   const spec = await configIO.readProjectSpec();
   const targets = await configIO.readAWSDeploymentTargets();
-  if (targets.length === 0) {
-    throw new Error('No deployment targets configured. Please define targets in agentcore/aws-targets.json');
-  }
+
+  // `project build` runs before a project has anywhere to deploy, so an empty target
+  // list is not an error: it synthesizes a single environment-agnostic stack, which is
+  // enough to typecheck the app and produce a template. Only a stack synthesized for a
+  // real target is a deploy candidate; the target tag below is what marks one.
+  const stackTargets: (AwsDeploymentTarget | undefined)[] = targets.length > 0 ? targets : [undefined];
 
   const specAny: SpecWithLatestFields = spec;
   const projectRoot = path.resolve(configRoot, '..');
@@ -131,15 +134,19 @@ async function main() {
 
   const app = new App();
 
-  for (const target of targets) {
-    const env = toEnvironment(target);
-    const stackName = toStackName(spec.name, target.name);
+  for (const target of stackTargets) {
+    // An environment-agnostic stack resolves its account and region from CloudFormation
+    // pseudo-parameters at deploy time instead of pinning them at synth time.
+    const env = target ? toEnvironment(target) : undefined;
+    const stackName = target ? toStackName(spec.name, target.name) : `AgentCore-${sanitize(spec.name)}`;
 
     // Extract credentials from deployed state for this target
     const targetState = (deployedState as Record<string, unknown>)?.targets as
       | Record<string, Record<string, unknown>>
       | undefined;
-    const targetResources = targetState?.[target.name]?.resources as Record<string, unknown> | undefined;
+    const targetResources = target
+      ? (targetState?.[target.name]?.resources as Record<string, unknown> | undefined)
+      : undefined;
     const credentials = targetResources?.credentials as
       | Record<string, { credentialProviderArn: string; clientSecretArn?: string }>
       | undefined;
@@ -191,10 +198,14 @@ async function main() {
       harnesses: harnessConfigs.length > 0 ? harnessConfigs : undefined,
       paymentSpec,
       env,
-      description: `AgentCore stack for ${spec.name} deployed to ${target.name} (${target.region})`,
+      description: target
+        ? `AgentCore stack for ${spec.name} deployed to ${target.name} (${target.region})`
+        : `AgentCore stack for ${spec.name} (no deployment target configured)`,
+      // Only a stack synthesized for a real target carries the target tag, which is
+      // how deploy selects the stack to ship.
       tags: {
         'agentcore:project-name': spec.name,
-        'agentcore:target-name': target.name,
+        ...(target ? { 'agentcore:target-name': target.name } : {}),
       },
     });
   }

--- a/src/core/project/manager.tsx
+++ b/src/core/project/manager.tsx
@@ -262,6 +262,11 @@ export class FsProjectManager implements ProjectManager {
     // The generated package.json defines `cdk` as "npm run build && cdk", so this
     // single command compiles the app and then synthesizes it. Synthesis needs no
     // AWS credentials: each stack's environment comes from aws-targets.json.
+    //
+    // Build deliberately does not require a deployment target. A freshly created
+    // project has none, and building is how the user first typechecks their agent, so
+    // the generated app synthesizes one environment-agnostic stack when the list is
+    // empty. Only deploying somewhere needs a real target.
     yield { message: "Synthesizing CloudFormation templates" };
     await this.run(["npm", "run", "cdk", "--", "synth", "--quiet"], cdkDir);
   }


### PR DESCRIPTION
Error:

`project build` failed on every freshly created project:

```
AgentCore CDK synthesis failed: No deployment targets configured.
Please define targets in agentcore/aws-targets.json
```

`project create` scaffolds `agentcore/aws-targets.json` as an empty list, but the generated CDK app threw on an empty list and synthesized one stack per target — so a new project had nothing to synthesize.

Fix:

Build does not need to know where a project deploys. An empty target list now synthesizes a single environment-agnostic stack, resolving account and region from CloudFormation pseudo-parameters instead of pinning them at synth time.

That stack is named `AgentCore-<project>` and carries no `agentcore:target-name` tag, so it is not a deploy candidate. A project that does configure targets is unaffected.