### PR TITLE
feat(evaluator): add derived evaluators (reuse a base metric on your own model)

### DIFF
--- a/schemas/agentcore.schema.v1.json
+++ b/schemas/agentcore.schema.v1.json
@@ -1082,15 +1082,9 @@
               "llmAsAJudge": {
                 "type": "object",
                 "properties": {
-                  "modelProvider": {
-                    "type": "string",
-                    "enum": ["Bedrock", "OpenResponses"]
-                  },
                   "model": {
                     "type": "string",
-                    "minLength": 1,
-                    "maxLength": 2048,
-                    "pattern": "^[\\x21-\\x7e]+$"
+                    "minLength": 1
                   },
                   "instructions": {
                     "type": "string",
@@ -1192,6 +1186,22 @@
                     "additionalProperties": false
                   }
                 },
+                "additionalProperties": false
+              },
+              "derived": {
+                "type": "object",
+                "properties": {
+                  "baseEvaluatorId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "pattern": "^(ThirdParty|Builtin)\\.[A-Za-z0-9._-]+$"
+                  },
+                  "model": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": ["baseEvaluatorId", "model"],
                 "additionalProperties": false
               }
             },

--- a/src/cli/primitives/EvaluatorPrimitive.ts
+++ b/src/cli/primitives/EvaluatorPrimitive.ts
@@ -1,13 +1,15 @@
-import { ConflictError, ResourceNotFoundError, findConfigRoot, serializeResult, toError } from '../../lib';
+import { ConflictError, ResourceNotFoundError, createConfigIO, findConfigRoot, serializeResult, toError } from '../../lib';
 import type { Result } from '../../lib/result';
 import type { EvaluationLevel, Evaluator, EvaluatorConfig } from '../../schema';
 import {
+  BASE_EVALUATOR_ID_PATTERN,
   EvaluationLevelSchema,
   EvaluatorModelIdSchema,
   EvaluatorModelProviderSchema,
   EvaluatorSchema,
   isValidKmsKeyArn,
 } from '../../schema';
+import { getEvaluator } from '../aws/agentcore-control';
 import { getErrorMessage } from '../errors';
 import type { RemovalPreview, SchemaChange } from '../operations/remove/types';
 import { runCliCommand } from '../telemetry/cli-command-run.js';
@@ -125,7 +127,9 @@ export interface ThirdPartyLibraryOptions {
 
 export interface AddEvaluatorOptions {
   name: string;
-  level: EvaluationLevel;
+  // Required. For a derived evaluator the CLI resolves it from the base metric
+  // before calling add(); other types take it from --level.
+  level?: EvaluationLevel;
   description?: string;
   config: EvaluatorConfig;
   kmsKeyArn?: string;
@@ -341,10 +345,20 @@ export class EvaluatorPrimitive extends BasePrimitive<AddEvaluatorOptions, Remov
       .command(this.kind)
       .description('Add a custom evaluator to the project')
       .option('--name <name>', 'Evaluator name')
-      .option('--level <level>', 'Evaluation level: SESSION, TRACE, TOOL_CALL')
-      .option('--type <type>', 'Evaluator type: llm-as-a-judge (default) or code-based')
-      .option('--model <model>', '[LLM] Bedrock inference profile ID or OpenResponses model ID for LLM-as-a-Judge')
+      .option(
+        '--level <level>',
+        'Evaluation level: SESSION, TRACE, TOOL_CALL (auto-resolved from the base for --type derived)'
+      )
+      .option('--type <type>', 'Evaluator type: llm-as-a-judge (default), code-based, or derived')
+      .option(
+        '--model <model>',
+        '[LLM] Bedrock inference profile ID or OpenResponses model ID; [derived] Bedrock inference profile ID for the judge model'
+      )
       .option('--model-provider <provider>', '[LLM] Model provider: Bedrock (default) or OpenResponses')
+      .option(
+        '--base-evaluator-id <id>',
+        '[derived] Managed base metric to derive from: "ThirdParty.<Provider>.<Metric>" or "Builtin.<Metric>"'
+      )
       .option(
         '--instructions <text>',
         '[LLM] Evaluation prompt instructions (must include level-appropriate placeholders, e.g. {context})'
@@ -373,6 +387,7 @@ export class EvaluatorPrimitive extends BasePrimitive<AddEvaluatorOptions, Remov
           type?: string;
           model?: string;
           modelProvider?: string;
+          baseEvaluatorId?: string;
           instructions?: string;
           ratingScale?: string;
           lambdaArn?: string;
@@ -394,12 +409,19 @@ export class EvaluatorPrimitive extends BasePrimitive<AddEvaluatorOptions, Remov
                 throw new Error(error);
               };
 
-              if (!cliOptions.name || !cliOptions.level) {
-                fail('--name and --level are required in non-interactive mode');
+              // A derived evaluator resolves its level from the base metric, so
+              // --level is optional (an offline override); required otherwise.
+              const isDerived = cliOptions.type === 'derived' || cliOptions.baseEvaluatorId !== undefined;
+
+              if (!cliOptions.name) {
+                fail('--name is required in non-interactive mode');
+              }
+              if (!isDerived && !cliOptions.level) {
+                fail('--level is required in non-interactive mode');
               }
 
-              const levelResult = EvaluationLevelSchema.safeParse(cliOptions.level);
-              if (!levelResult.success) {
+              const levelResult = cliOptions.level ? EvaluationLevelSchema.safeParse(cliOptions.level) : undefined;
+              if (levelResult && !levelResult.success) {
                 fail(`Invalid --level "${cliOptions.level}". Must be one of: SESSION, TRACE, TOOL_CALL`);
               }
 
@@ -490,10 +512,12 @@ export class EvaluatorPrimitive extends BasePrimitive<AddEvaluatorOptions, Remov
                 }
               }
 
-              // Default --type to code-based when 3P template is provided
-              const evalType = cliOptions.type ?? (threePLibrary ? 'code-based' : 'llm-as-a-judge');
-              if (evalType !== 'llm-as-a-judge' && evalType !== 'code-based') {
-                fail(`Invalid --type "${evalType}". Must be one of: llm-as-a-judge, code-based`);
+              // Default --type: derived when a base id is given, else code-based when a
+              // 3P (code) template is provided, else llm-as-a-judge.
+              const evalType =
+                cliOptions.type ?? (isDerived ? 'derived' : threePLibrary ? 'code-based' : 'llm-as-a-judge');
+              if (evalType !== 'llm-as-a-judge' && evalType !== 'code-based' && evalType !== 'derived') {
+                fail(`Invalid --type "${evalType}". Must be one of: llm-as-a-judge, code-based, derived`);
               }
 
               // Cross-validate flags against evaluator type
@@ -502,11 +526,20 @@ export class EvaluatorPrimitive extends BasePrimitive<AddEvaluatorOptions, Remov
                 if (cliOptions.timeout) fail('--timeout requires --type code-based');
                 if (threePLibrary) fail('--3p-template-json requires --type code-based');
               }
+              if (evalType !== 'derived' && cliOptions.baseEvaluatorId) {
+                fail('--base-evaluator-id requires --type derived');
+              }
               if (evalType === 'code-based') {
                 if (cliOptions.model) fail('--model cannot be used with --type code-based');
                 if (cliOptions.modelProvider) fail('--model-provider cannot be used with --type code-based');
                 if (cliOptions.instructions) fail('--instructions cannot be used with --type code-based');
                 if (cliOptions.ratingScale) fail('--rating-scale cannot be used with --type code-based');
+              }
+              if (evalType === 'derived') {
+                // The base metric owns the prompt and scale.
+                if (cliOptions.instructions) fail('--instructions cannot be used with --type derived');
+                if (cliOptions.ratingScale) fail('--rating-scale cannot be used with --type derived');
+                if (cliOptions.modelProvider) fail('--model-provider cannot be used with --type derived');
               }
               if (cliOptions.config && cliOptions.modelProvider) {
                 fail(
@@ -516,8 +549,33 @@ export class EvaluatorPrimitive extends BasePrimitive<AddEvaluatorOptions, Remov
 
               let configJson: EvaluatorConfig;
               let thirdParty: ThirdPartyLibraryOptions | undefined;
+              // For derived, the level is resolved from the base metric (or --level override).
+              let resolvedLevel: EvaluationLevel | undefined = levelResult?.data;
 
-              if (threePLibrary) {
+              if (evalType === 'derived') {
+                if (!cliOptions.baseEvaluatorId) {
+                  fail('--base-evaluator-id is required for --type derived');
+                }
+                if (!cliOptions.model) {
+                  fail('--model is required for --type derived (you bring the judge model)');
+                }
+                if (!BASE_EVALUATOR_ID_PATTERN.test(cliOptions.baseEvaluatorId!)) {
+                  fail(
+                    `Invalid --base-evaluator-id "${cliOptions.baseEvaluatorId}". ` +
+                      'Must be "ThirdParty.<Provider>.<Metric>" or "Builtin.<Metric>"'
+                  );
+                }
+                // The service requires the derived evaluator's level to match the base
+                // metric's level. Resolve it via GetEvaluator so the customer never has
+                // to know or type it; --level stays available as an offline override.
+                resolvedLevel ??= await this.resolveBaseEvaluatorLevel(cliOptions.baseEvaluatorId!);
+                configJson = {
+                  derived: {
+                    baseEvaluatorId: cliOptions.baseEvaluatorId!,
+                    model: cliOptions.model!,
+                  },
+                };
+              } else if (threePLibrary) {
                 const libraryConfig = THIRD_PARTY_EVALUATOR_LIBRARIES[threePLibrary];
                 configJson = this.buildThirdPartyConfig(cliOptions.name!, libraryConfig, cliOptions.timeout);
                 thirdParty = {
@@ -553,7 +611,7 @@ export class EvaluatorPrimitive extends BasePrimitive<AddEvaluatorOptions, Remov
                 const modelProvider = modelProviderResult.data!;
 
                 if (!cliOptions.instructions) {
-                  const level = levelResult.data!;
+                  const level = levelResult!.data!;
                   const placeholders = LEVEL_PLACEHOLDERS[level].map(p => `{${p}}`).join(', ');
                   fail(
                     `--instructions is required in non-interactive mode (or use --config). ` +
@@ -561,7 +619,7 @@ export class EvaluatorPrimitive extends BasePrimitive<AddEvaluatorOptions, Remov
                   );
                 }
 
-                const placeholderCheck = validateInstructionPlaceholders(cliOptions.instructions!, levelResult.data!);
+                const placeholderCheck = validateInstructionPlaceholders(cliOptions.instructions!, levelResult!.data!);
                 if (placeholderCheck !== true) {
                   fail(placeholderCheck);
                 }
@@ -603,7 +661,7 @@ export class EvaluatorPrimitive extends BasePrimitive<AddEvaluatorOptions, Remov
 
               const result = await this.add({
                 name: cliOptions.name!,
-                level: levelResult.data!,
+                level: resolvedLevel,
                 config: configJson,
                 kmsKeyArn: cliOptions.kmsKeyArn,
                 thirdParty,
@@ -622,6 +680,10 @@ export class EvaluatorPrimitive extends BasePrimitive<AddEvaluatorOptions, Remov
                   console.log(`  IAM:  ${result.codePath}execution-role-policy.json`);
                   console.log(
                     `\n  Next: Edit lambda_function.py with your evaluation logic, then run \`agentcore deploy\``
+                  );
+                } else if (evalType === 'derived') {
+                  console.log(
+                    `Added evaluator '${result.evaluatorName}' (derived from ${cliOptions.baseEvaluatorId} evaluator)`
                   );
                 } else {
                   console.log(`Added evaluator '${result.evaluatorName}'`);
@@ -644,7 +706,7 @@ export class EvaluatorPrimitive extends BasePrimitive<AddEvaluatorOptions, Remov
 
               return {
                 evaluator_type: standardize(EvaluatorType, evalType),
-                evaluator_level: standardize(EvaluatorLevel, levelResult.data),
+                evaluator_level: standardize(EvaluatorLevel, resolvedLevel),
                 ...(configJson.llmAsAJudge && {
                   evaluator_model_provider: standardize(
                     EvaluatorModelProvider,
@@ -728,7 +790,43 @@ export class EvaluatorPrimitive extends BasePrimitive<AddEvaluatorOptions, Remov
     };
   }
 
+  /**
+   * Resolve a derived evaluator's level from its base metric. The service requires
+   * the derived evaluator's level to match the base's, so we read it via
+   * GetEvaluator instead of asking the customer to know it.
+   */
+  private async resolveBaseEvaluatorLevel(baseEvaluatorId: string): Promise<EvaluationLevel> {
+    // The deploy target region is preferred, but the file may not exist yet
+    // (evaluators can be added before any deploy), so fall back to the environment.
+    let savedRegion: string | undefined;
+    try {
+      const targets = await createConfigIO().resolveAWSDeploymentTargets();
+      savedRegion = targets[0]?.region;
+    } catch {
+      savedRegion = undefined;
+    }
+    const region = savedRegion ?? process.env.AWS_REGION ?? process.env.AWS_DEFAULT_REGION;
+    if (!region) {
+      throw new Error(
+        `Could not resolve an AWS region to look up "${baseEvaluatorId}". Set AWS_REGION or pass --level explicitly.`
+      );
+    }
+    try {
+      const base = await getEvaluator({ region, evaluatorId: baseEvaluatorId });
+      return base.level;
+    } catch (err) {
+      throw new Error(
+        `Could not resolve the level for base evaluator "${baseEvaluatorId}": ${getErrorMessage(err)}. ` +
+          'Pass --level explicitly to override.'
+      );
+    }
+  }
+
   private async createEvaluator(options: AddEvaluatorOptions): Promise<Evaluator> {
+    if (!options.level) {
+      throw new Error('Evaluation level is required (SESSION, TRACE, or TOOL_CALL)');
+    }
+
     const evaluator: Evaluator = {
       name: options.name,
       level: options.level,

--- a/src/cli/telemetry/schemas/common-shapes.ts
+++ b/src/cli/telemetry/schemas/common-shapes.ts
@@ -38,7 +38,7 @@ export const CredentialType = z.enum(['api-key', 'oauth']);
 // Mirrors DependencySyncOutcome in src/lib/dependency-management/types.ts.
 export const DepSyncOutcome = z.enum(['synced', 'check-only', 'opted-out', 'skipped', 'failure-suppressed', 'failed']);
 export const SkillSourceType = z.enum(['path', 's3', 'git', 'aws_skills']);
-export const EvaluatorType = z.enum(['llm-as-a-judge', 'code-based']);
+export const EvaluatorType = z.enum(['llm-as-a-judge', 'code-based', 'derived']);
 export const EvaluatorModelProvider = z.enum(['bedrock', 'openresponses']);
 export const ExitReason = z.enum(['success', 'failure']);
 export const FilterState = z.enum(['deployed', 'local-only', 'pending-removal', 'none']);

--- a/src/schema/schemas/agentcore-project.ts
+++ b/src/schema/schemas/agentcore-project.ts
@@ -67,12 +67,14 @@ export type {
   RatingScale,
 } from './primitives/evaluator';
 export {
+  BASE_EVALUATOR_ID_PATTERN,
   BedrockModelIdSchema,
   isValidBedrockModelId,
   EvaluatorNameSchema,
   KMS_KEY_ARN_PATTERN,
   isValidKmsKeyArn,
 } from './primitives/evaluator';
+export type { DerivedEvaluatorConfig } from './primitives/evaluator';
 export { ConfigBundleSchema };
 export type { ComponentConfiguration, ComponentConfigurationMap, ConfigBundle } from './primitives/config-bundle';
 export { ConfigBundleNameSchema, ComponentConfigurationMapSchema } from './primitives/config-bundle';
@@ -360,6 +362,8 @@ export type EvaluatorType = z.infer<typeof EvaluatorTypeSchema>;
 
 export const EvaluatorSchema = z.object({
   name: EvaluatorNameSchema,
+  // Required for every evaluator. For a derived evaluator it must match the base
+  // metric's level; the CLI resolves it via GetEvaluator at add time.
   level: EvaluationLevelSchema,
   description: z.string().optional(),
   config: EvaluatorConfigSchema,

--- a/src/schema/schemas/primitives/evaluator.ts
+++ b/src/schema/schemas/primitives/evaluator.ts
@@ -86,6 +86,31 @@ export const LlmAsAJudgeConfigSchema = z.object({
 export type LlmAsAJudgeConfig = z.infer<typeof LlmAsAJudgeConfigSchema>;
 
 // ============================================================================
+// Derived Evaluator Config
+// ============================================================================
+
+// A derived evaluator reuses a managed base evaluator's logic (prompt + scoring)
+// and runs it on the customer's own model. The base is a managed metric — a
+// third-party library metric (ThirdParty.<Provider>.<Metric>) or a built-in
+// (Builtin.<Metric>). The base owns the prompt and scoring; the customer supplies
+// only the model. The evaluator's `level` must match the base's level (resolved at
+// add time via GetEvaluator), so it lives on the top-level Evaluator, not here.
+export const BASE_EVALUATOR_ID_PATTERN = /^(ThirdParty|Builtin)\.[A-Za-z0-9._-]+$/;
+
+export const DerivedEvaluatorConfigSchema = z.object({
+  baseEvaluatorId: z
+    .string()
+    .min(1)
+    .regex(
+      BASE_EVALUATOR_ID_PATTERN,
+      'Must be a managed base id: "ThirdParty.<Provider>.<Metric>" or "Builtin.<Metric>"'
+    ),
+  model: BedrockModelIdSchema,
+});
+
+export type DerivedEvaluatorConfig = z.infer<typeof DerivedEvaluatorConfigSchema>;
+
+// ============================================================================
 // Code-Based Evaluator Config
 // ============================================================================
 
@@ -125,9 +150,16 @@ export const EvaluatorConfigSchema = z
   .object({
     llmAsAJudge: LlmAsAJudgeConfigSchema.optional(),
     codeBased: CodeBasedConfigSchema.optional(),
+    derived: DerivedEvaluatorConfigSchema.optional(),
   })
-  .refine(config => Boolean(config.llmAsAJudge) !== Boolean(config.codeBased), {
-    message: 'Config must have either llmAsAJudge or codeBased, not both',
+  .superRefine((config, ctx) => {
+    const arms = [config.llmAsAJudge, config.codeBased, config.derived].filter(Boolean).length;
+    if (arms !== 1) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Config must have exactly one of llmAsAJudge, codeBased, or derived',
+      });
+    }
   });
 
 export type EvaluatorConfig = z.infer<typeof EvaluatorConfigSchema>;


### PR DESCRIPTION
## What this does — 1 line

`agentcore add evaluator --type derived --base-evaluator-id <id> --model <m>` — create an evaluator that reuses a **managed base metric**'s prompt/scoring on **your own model**. The base is a 3P library metric (`ThirdParty.<Provider>.<Metric>`) or a built-in (`Builtin.<Metric>`).

## Try it

```bash
# derive from a 3P metric (level auto-resolves to SESSION)
agentcore add evaluator --name my_tool_use \
  --type derived --base-evaluator-id ThirdParty.DeepEval.ToolUse \
  --model us.anthropic.claude-sonnet-4-6

# derive from a built-in (level auto-resolves to TRACE)
agentcore add evaluator --name my_helpfulness \
  --type derived --base-evaluator-id Builtin.Helpfulness \
  --model us.anthropic.claude-sonnet-4-6
```

Output:
```
Added evaluator 'my_tool_use' (derived from ThirdParty.DeepEval.ToolUse evaluator)
```

## `add evaluator --help` (new options)

```
  --type <type>              llm-as-a-judge (default) | code-based | derived        ← now includes derived
  --base-evaluator-id <id>   [derived] "ThirdParty.<Provider>.<Metric>" or "Builtin.<Metric>"   ← new
  --level <level>            SESSION | TRACE | TOOL_CALL (auto-resolved from the base for derived)
  --model <model>            [LLM] Bedrock/OpenResponses model; [derived] your judge model
```
`--instructions` / `--rating-scale` / `--model-provider` are rejected for `--type derived` (the base owns the prompt + scale).

## Additions to `agentcore.json`

```json
{
  "name": "my_tool_use",
  "level": "SESSION",
  "config": { "derived": { "baseEvaluatorId": "ThirdParty.DeepEval.ToolUse", "model": "us.anthropic.claude-sonnet-4-6" } }
}
```

## How level is set

The API requires the derived evaluator's `level` to **match the base metric's level**. The CLI resolves it for you at add time via `GetEvaluator(baseEvaluatorId)` and bakes it into `agentcore.json` — you never type it. `--level` stays available as an offline override.

## Changes
1. **schema** — new `EvaluatorConfig.derived` arm `{ baseEvaluatorId, model }`; config is exactly-one-of `llmAsAJudge | codeBased | derived`; `level` required for every evaluator.
2. **CLI** — `--type derived` + `--base-evaluator-id`; auto-level via `GetEvaluator`; derived success message.
3. **telemetry** — `EvaluatorType` gains `derived`.

## Verification
- Schema + primitive unit tests pass; regenerated JSON schema.
- Verified end-to-end on gamma (us-west-2): both 3P (`ThirdParty.DeepEval.ToolUse` → SESSION) and built-in (`Builtin.Helpfulness` → TRACE) auto-resolve their level and write the right `config.derived`.
- The `add online-eval` TUI evaluator picker lists the managed `ThirdParty.*` evaluators alongside `Builtin.*`.

> Companion CDK change (emits `EvaluatorConfig.Derived` into the CFN Evaluator): aws/agentcore-l3-cdk-constructs#323
