### PR TITLE
feat(evaluator): surface skill evaluators (TOOL_CALL level + skill placeholders)

### DIFF
--- a/src/cli/operations/eval/__tests__/run-eval.test.ts
+++ b/src/cli/operations/eval/__tests__/run-eval.test.ts
@@ -847,6 +847,42 @@ describe('handleRunEval', () => {
     );
   });
 
+  it('resolves Builtin skill evaluators to TOOL_CALL level', async () => {
+    const ctx = makeDeployedContext();
+    mockLoadDeployedProjectConfig.mockResolvedValue(ctx);
+    mockResolveAgent.mockReturnValue({
+      success: true,
+      agent: {
+        agentName: 'my-agent',
+        targetName: 'dev',
+        region: 'us-east-1',
+        accountId: '111222333444',
+        runtimeId: 'rt-123',
+      },
+    });
+
+    const spanRows = [makeToolCallSpanRow('session-1', 'trace-1', 'span-tool-1', 'calculator')];
+    setupCloudWatchToReturn(spanRows);
+
+    mockEvaluate.mockResolvedValue({
+      evaluationResults: [{ value: 1.0, context: { spanContext: { sessionId: 'session-1', spanId: 'span-tool-1' } } }],
+    });
+
+    // Builtin.SkillSelectionAccuracy / SkillInstructionFollowing are TOOL_CALL-level — they must
+    // target spans, not default to SESSION (which would send no targetSpanIds).
+    const result = await handleRunEval({
+      evaluator: ['Builtin.SkillSelectionAccuracy', 'Builtin.SkillInstructionFollowing'],
+      days: 7,
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockEvaluate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetSpanIds: ['span-tool-1'],
+      })
+    );
+  });
+
   it('batches targetSpanIds into chunks of 10 for TOOL_CALL evaluators', async () => {
     const ctx = makeDeployedContext();
     mockLoadDeployedProjectConfig.mockResolvedValue(ctx);

--- a/src/cli/operations/eval/run-eval.ts
+++ b/src/cli/operations/eval/run-eval.ts
@@ -179,6 +179,10 @@ const BUILTIN_EVALUATOR_LEVELS: Record<string, EvaluatorLevel> = {
   'Builtin.InstructionFollowing': 'TRACE',
   'Builtin.Refusal': 'TRACE',
   'Builtin.ToolSelectionAccuracy': 'TOOL_CALL',
+  // Skill evaluators judge the span that carries a skill invocation, so they are TOOL_CALL —
+  // not the SESSION default an unmapped Builtin.* falls through to, which would score wrong spans.
+  'Builtin.SkillSelectionAccuracy': 'TOOL_CALL',
+  'Builtin.SkillInstructionFollowing': 'TOOL_CALL',
 };
 
 /**

--- a/src/cli/tui/screens/evaluator/__tests__/types.test.ts
+++ b/src/cli/tui/screens/evaluator/__tests__/types.test.ts
@@ -34,6 +34,12 @@ describe('LEVEL_PLACEHOLDERS', () => {
     expect(LEVEL_PLACEHOLDERS.TOOL_CALL).toContain('context');
     expect(LEVEL_PLACEHOLDERS.TOOL_CALL).toContain('tool_turn');
   });
+
+  it('TOOL_CALL exposes skill placeholders for skill evaluators', () => {
+    expect(LEVEL_PLACEHOLDERS.TOOL_CALL).toContain('available_skills');
+    expect(LEVEL_PLACEHOLDERS.TOOL_CALL).toContain('invoked_skill');
+    expect(LEVEL_PLACEHOLDERS.TOOL_CALL).toContain('skill_content');
+  });
 });
 
 describe('DEFAULT_INSTRUCTIONS', () => {

--- a/src/cli/tui/screens/evaluator/types.ts
+++ b/src/cli/tui/screens/evaluator/types.ts
@@ -195,7 +195,7 @@ export function getEvaluatorModelOptions(provider: EvaluatorModelProvider): Eval
 export const LEVEL_PLACEHOLDERS: Record<EvaluationLevel, string[]> = {
   SESSION: ['context', 'available_tools'],
   TRACE: ['context', 'assistant_turn'],
-  TOOL_CALL: ['available_tools', 'context', 'tool_turn'],
+  TOOL_CALL: ['available_tools', 'context', 'tool_turn', 'available_skills', 'invoked_skill', 'skill_content'],
 };
 
 /**
@@ -218,6 +218,9 @@ export const PLACEHOLDER_DESCRIPTIONS: Record<string, string> = {
   expected_tool_trajectory: 'caller-provided expected sequence of tool calls',
   actual_tool_trajectory: 'actual sequence of tool calls from the session',
   expected_response: 'caller-provided expected agent response',
+  available_skills: 'skills offered to the agent (name + description)',
+  invoked_skill: 'the skill the agent selected for this span',
+  skill_content: "the selected skill's SKILL.md instructions",
 };
 
 /**


### PR DESCRIPTION
Stacked on `bug_bash_aug_18th` (PR #2012). Surfaces the P0 **skill evaluators** in the CLI. Scope: only the pieces that work today — the two built-in skill evaluators are already `ACTIVE` service-side (verified). Ground-truth `expectedSkills` is intentionally **excluded** (no service field exists yet — it would no-op).

## Changes
1. **Built-in level resolution** (`src/cli/operations/eval/run-eval.ts`): map `Builtin.SkillSelectionAccuracy` and `Builtin.SkillInstructionFollowing` to `TOOL_CALL`. Without this they fall through to the `SESSION` default and get scored against the wrong spans — silently. Fixes `run eval` / `run batch-evaluation` targeting for skill evaluators.
2. **Custom-evaluator TUI placeholders** (`src/cli/tui/screens/evaluator/types.ts`): expose `{available_skills}`, `{invoked_skill}`, `{skill_content}` for `TOOL_CALL` LLM-judge evaluators, matching the service prompt-template contract. Shown in the wizard's instructions step and accepted by `validateInstructionPlaceholders`.
3. Tests for both.

## Verification
- `npm run typecheck` — clean
- affected unit tests — 67 passed (incl. new `resolves Builtin skill evaluators to TOOL_CALL level`)
- eslint + prettier + secretlint (pre-commit) — clean

## Explicitly out of scope
- `expectedSkills` ground-truth (batch + on-demand): net-new across the AgentCore Evaluation model, not merged / not in review. Ship behind a flag once the service adds the field + a GT skill-selection evaluator.

## Follow-up (not here)
Replace the static `BUILTIN_EVALUATOR_LEVELS` map with a cached `listEvaluators()` lookup so future built-ins self-resolve (the map already omits Harmfulness/Stereotyping/ToolParameterAccuracy/trajectory matchers).
