### PR TITLE
fix(memory): use --id for memory selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,10 +152,10 @@ agentcore runtime endpoint list --id <runtimeId> --max-results 20
 agentcore memory get --id <memoryId>
 agentcore memory get --id <memoryId> --view without_decryption
 agentcore memory list --max-results 20
-agentcore memory event get --memory <memoryId> --actor-id <actorId> --session-id <sessionId> --event-id <eventId>
-agentcore memory event list --memory <memoryId> --actor-id <actorId> --session-id <sessionId> --max-results 20
-agentcore memory record get --memory <memoryId> --record-id <recordId>
-agentcore memory record list --memory <memoryId> --namespace <namespace> --max-results 20
+agentcore memory event get --id <memoryId> --actor-id <actorId> --session-id <sessionId> --event-id <eventId>
+agentcore memory event list --id <memoryId> --actor-id <actorId> --session-id <sessionId> --max-results 20
+agentcore memory record get --id <memoryId> --record-id <recordId>
+agentcore memory record list --id <memoryId> --namespace <namespace> --max-results 20
 
 # Inspect Gateway resources without project configuration or deployment
 agentcore gateway get --id <gatewayId>

--- a/src/handlers/memory/actor/list/index.tsx
+++ b/src/handlers/memory/actor/list/index.tsx
@@ -10,18 +10,18 @@ export const createListMemoryActorsHandler = (core: Core) =>
     name: "list",
     description: "list actors in an AgentCore Memory",
     flags: [
-      flag("memory", "the ID of the Memory", z.string().optional()),
+      flag("id", "the ID of the Memory", z.string().optional()),
       flag("max-results", "maximum number of actors to return", z.number().optional()),
       flag("next-token", "pagination token returned by a previous request", z.string().optional()),
     ],
     handle: async (ctx, flags) => {
-      if (!flags.memory) {
-        throw new InputValidationError("required option '--memory <memory>' not specified");
+      if (!flags.id) {
+        throw new InputValidationError("required option '--id <id>' not specified");
       }
 
       const response = await core.memory.listActors(
         {
-          memoryId: flags.memory,
+          memoryId: flags.id,
           maxResults: flags["max-results"],
           nextToken: flags["next-token"],
         },

--- a/src/handlers/memory/event/get/index.tsx
+++ b/src/handlers/memory/event/get/index.tsx
@@ -10,14 +10,14 @@ export const createGetMemoryEventHandler = (core: Core) =>
     name: "get",
     description: "get an AgentCore Memory Event",
     flags: [
-      flag("memory", "the ID of the Memory", z.string().optional()),
+      flag("id", "the ID of the Memory", z.string().optional()),
       flag("actor-id", "the ID of the actor", z.string().optional()),
       flag("event-id", "the event ID", z.string().optional()),
       flag("session-id", "the session ID", z.string().optional()),
     ],
     handle: async (ctx, flags) => {
-      if (!flags.memory) {
-        throw new InputValidationError("required option '--memory <memory>' not specified");
+      if (!flags.id) {
+        throw new InputValidationError("required option '--id <id>' not specified");
       }
       if (!flags["actor-id"]) {
         throw new InputValidationError("required option '--actor-id <actor-id>' not specified");
@@ -31,7 +31,7 @@ export const createGetMemoryEventHandler = (core: Core) =>
 
       const response = await core.memory.getEvent(
         {
-          memoryId: flags.memory,
+          memoryId: flags.id,
           actorId: flags["actor-id"],
           sessionId: flags["session-id"],
           eventId: flags["event-id"],

--- a/src/handlers/memory/event/list/index.tsx
+++ b/src/handlers/memory/event/list/index.tsx
@@ -11,7 +11,7 @@ export const createListMemoryEventsHandler = (core: Core) =>
     name: "list",
     description: "list AgentCore Memory events",
     flags: [
-      flag("memory", "the ID of the Memory", z.string().optional()),
+      flag("id", "the ID of the Memory", z.string().optional()),
       flag("actor-id", "the ID of the actor", z.string().optional()),
       flag("session-id", "the session ID", z.string().optional()),
       flag("include-payloads", "includes event payloads in the response", z.boolean().optional()),
@@ -27,8 +27,8 @@ export const createListMemoryEventsHandler = (core: Core) =>
     ],
 
     handle: async (ctx, flags) => {
-      if (!flags.memory) {
-        throw new InputValidationError("required option '--memory <memory>' not specified");
+      if (!flags.id) {
+        throw new InputValidationError("required option '--id <id>' not specified");
       }
       if (!flags["actor-id"]) {
         throw new InputValidationError("required option '--actor-id <actor-id>' not specified");
@@ -57,7 +57,7 @@ export const createListMemoryEventsHandler = (core: Core) =>
 
       const response = await core.memory.listEvents(
         {
-          memoryId: flags.memory,
+          memoryId: flags.id,
           actorId: flags["actor-id"],
           sessionId: flags["session-id"],
           includePayloads: flags["include-payloads"],

--- a/src/handlers/memory/memory.test.tsx
+++ b/src/handlers/memory/memory.test.tsx
@@ -137,6 +137,16 @@ describe("memory command hierarchy", () => {
     expect(record?.children().map((child) => child.name())).toEqual(["get", "list"]);
     expect(actor?.children().map((child) => child.name())).toEqual(["list"]);
     expect(session?.children().map((child) => child.name())).toEqual(["list"]);
+
+    const memorySelectors = [
+      memory?.children().find((child) => child.name() === "get"),
+      ...[event, record, actor, session].flatMap((group) => group?.children() ?? []),
+    ];
+    for (const command of memorySelectors) {
+      const flags = command?.flags().map((flag) => flag.name);
+      expect(flags).toContain("id");
+      expect(flags).not.toContain("memory");
+    }
   });
 
   test("keeps an omitted get view undefined for empty-flag routing", () => {
@@ -243,7 +253,7 @@ describe("memory event commands", () => {
       "memory",
       "event",
       "get",
-      "--memory",
+      "--id",
       EVENT_MEMORY_ID,
       "--actor-id",
       ACTOR_ID,
@@ -290,7 +300,7 @@ describe("memory event commands", () => {
       "memory",
       "event",
       "list",
-      "--memory",
+      "--id",
       EVENT_MEMORY_ID,
       "--actor-id",
       ACTOR_ID,
@@ -342,7 +352,7 @@ describe("memory event commands", () => {
         "memory",
         "event",
         "list",
-        "--memory",
+        "--id",
         EVENT_MEMORY_ID,
         "--actor-id",
         ACTOR_ID,
@@ -362,7 +372,7 @@ describe("memory event commands", () => {
         "memory",
         "event",
         "list",
-        "--memory",
+        "--id",
         EVENT_MEMORY_ID,
         "--actor-id",
         ACTOR_ID,
@@ -376,16 +386,16 @@ describe("memory event commands", () => {
   });
 
   test.each([
-    ["memory", ["--json"], "--memory <memory>"],
-    ["actor", ["--memory", EVENT_MEMORY_ID, "--json"], "--actor-id <actor-id>"],
+    ["memory", ["--json"], "--id <id>"],
+    ["actor", ["--id", EVENT_MEMORY_ID, "--json"], "--actor-id <actor-id>"],
     [
       "session",
-      ["--memory", EVENT_MEMORY_ID, "--actor-id", ACTOR_ID, "--json"],
+      ["--id", EVENT_MEMORY_ID, "--actor-id", ACTOR_ID, "--json"],
       "--session-id <session-id>",
     ],
     [
       "event",
-      ["--memory", EVENT_MEMORY_ID, "--actor-id", ACTOR_ID, "--session-id", SESSION_ID, "--json"],
+      ["--id", EVENT_MEMORY_ID, "--actor-id", ACTOR_ID, "--session-id", SESSION_ID, "--json"],
       "--event-id <event-id>",
     ],
   ] as const)("rejects a missing %s selector for event get", async (_name, flags, expected) => {
@@ -396,11 +406,11 @@ describe("memory event commands", () => {
   });
 
   test.each([
-    ["memory", ["--json"], "--memory <memory>"],
-    ["actor", ["--memory", EVENT_MEMORY_ID, "--json"], "--actor-id <actor-id>"],
+    ["memory", ["--json"], "--id <id>"],
+    ["actor", ["--id", EVENT_MEMORY_ID, "--json"], "--actor-id <actor-id>"],
     [
       "session",
-      ["--memory", EVENT_MEMORY_ID, "--actor-id", ACTOR_ID, "--json"],
+      ["--id", EVENT_MEMORY_ID, "--actor-id", ACTOR_ID, "--json"],
       "--session-id <session-id>",
     ],
   ] as const)("rejects a missing %s selector for event list", async (_name, flags, expected) => {
@@ -430,7 +440,7 @@ describe("memory event commands", () => {
         "memory",
         "event",
         "list",
-        "--memory",
+        "--id",
         EVENT_MEMORY_ID,
         "--actor-id",
         ACTOR_ID,
@@ -458,7 +468,7 @@ describe("memory actor commands", () => {
       "memory",
       "actor",
       "list",
-      "--memory",
+      "--id",
       EVENT_MEMORY_ID,
       "--max-results",
       "1",
@@ -485,9 +495,7 @@ describe("memory actor commands", () => {
   test("rejects a missing Memory selector for actor list", async () => {
     const command = testMemoryCommand();
 
-    await expect(command.route(["memory", "actor", "list", "--json"])).rejects.toThrow(
-      "--memory <memory>",
-    );
+    await expect(command.route(["memory", "actor", "list", "--json"])).rejects.toThrow("--id <id>");
     expect(command.core.memory.calls).toEqual([]);
   });
 });
@@ -506,7 +514,7 @@ describe("memory session commands", () => {
       "memory",
       "session",
       "list",
-      "--memory",
+      "--id",
       EVENT_MEMORY_ID,
       "--actor-id",
       ACTOR_ID,
@@ -534,8 +542,8 @@ describe("memory session commands", () => {
   });
 
   test.each([
-    ["memory", ["--json"], "--memory <memory>"],
-    ["actor", ["--memory", EVENT_MEMORY_ID, "--json"], "--actor-id <actor-id>"],
+    ["memory", ["--json"], "--id <id>"],
+    ["actor", ["--id", EVENT_MEMORY_ID, "--json"], "--actor-id <actor-id>"],
   ] as const)("rejects a missing %s selector for session list", async (_name, flags, expected) => {
     const command = testMemoryCommand();
 
@@ -555,7 +563,7 @@ describe("memory record commands", () => {
       "memory",
       "record",
       "get",
-      "--memory",
+      "--id",
       EVENT_MEMORY_ID,
       "--record-id",
       RECORD_ID,
@@ -577,8 +585,8 @@ describe("memory record commands", () => {
   });
 
   test.each([
-    ["memory", ["--json"], "--memory <memory>"],
-    ["record", ["--memory", EVENT_MEMORY_ID, "--json"], "--record-id <record-id>"],
+    ["memory", ["--json"], "--id <id>"],
+    ["record", ["--id", EVENT_MEMORY_ID, "--json"], "--record-id <record-id>"],
   ] as const)("rejects a missing %s selector for record get", async (_name, flags, expected) => {
     const command = testMemoryCommand();
 
@@ -604,7 +612,7 @@ describe("memory record commands", () => {
       "memory",
       "record",
       "list",
-      "--memory",
+      "--id",
       EVENT_MEMORY_ID,
       "--namespace",
       "/customers/acme",
@@ -650,7 +658,7 @@ describe("memory record commands", () => {
       "memory",
       "record",
       "list",
-      "--memory",
+      "--id",
       EVENT_MEMORY_ID,
       "--namespace-path",
       "/customers/acme/*",
@@ -685,7 +693,7 @@ describe("memory record commands", () => {
       "memory",
       "record",
       "list",
-      "--memory",
+      "--id",
       EVENT_MEMORY_ID,
       "--namespace",
       "/customers/acme",
@@ -729,7 +737,7 @@ describe("memory record commands", () => {
 
     await expect(
       command.route(["memory", "record", "list", "--namespace", "/customers/acme", "--json"]),
-    ).rejects.toThrow("--memory <memory>");
+    ).rejects.toThrow("--id <id>");
     expect(command.core.memory.calls).toEqual([]);
   });
 
@@ -740,7 +748,7 @@ describe("memory record commands", () => {
     const command = testMemoryCommand();
 
     await expect(
-      command.route(["memory", "record", "list", "--memory", EVENT_MEMORY_ID, ...selectors]),
+      command.route(["memory", "record", "list", "--id", EVENT_MEMORY_ID, ...selectors]),
     ).rejects.toThrow("exactly one of '--namespace' or '--namespace-path' must be specified");
     expect(command.core.memory.calls).toEqual([]);
   });
@@ -753,7 +761,7 @@ describe("memory record commands", () => {
         "memory",
         "record",
         "list",
-        "--memory",
+        "--id",
         EVENT_MEMORY_ID,
         "--namespace",
         "/customers/acme",
@@ -814,7 +822,7 @@ describe("memory record commands", () => {
         "memory",
         "record",
         "list",
-        "--memory",
+        "--id",
         EVENT_MEMORY_ID,
         "--namespace",
         "/customers/acme",

--- a/src/handlers/memory/record/get/index.tsx
+++ b/src/handlers/memory/record/get/index.tsx
@@ -10,12 +10,12 @@ export const createGetMemoryRecordHandler = (core: Core) =>
     name: "get",
     description: "get an AgentCore Memory record",
     flags: [
-      flag("memory", "the ID of the Memory", z.string().optional()),
+      flag("id", "the ID of the Memory", z.string().optional()),
       flag("record-id", "the ID of the Memory record", z.string().optional()),
     ],
     handle: async (ctx, flags) => {
-      if (!flags.memory) {
-        throw new InputValidationError("required option '--memory <memory>' not specified");
+      if (!flags.id) {
+        throw new InputValidationError("required option '--id <id>' not specified");
       }
       if (!flags["record-id"]) {
         throw new InputValidationError("required option '--record-id <record-id>' not specified");
@@ -23,7 +23,7 @@ export const createGetMemoryRecordHandler = (core: Core) =>
 
       const response = await core.memory.getMemoryRecord(
         {
-          memoryId: flags.memory,
+          memoryId: flags.id,
           memoryRecordId: flags["record-id"],
         },
         coreOptsFromCtx(ctx),

--- a/src/handlers/memory/record/list/index.tsx
+++ b/src/handlers/memory/record/list/index.tsx
@@ -11,7 +11,7 @@ export const createListMemoryRecordsHandler = (core: Core) =>
     name: "list",
     description: "list AgentCore Memory records",
     flags: [
-      flag("memory", "the ID of the Memory", z.string().optional()),
+      flag("id", "the ID of the Memory", z.string().optional()),
       flag("namespace", "filter by namespace prefix", z.string().optional()),
       flag("namespace-path", "filter by namespace hierarchy", z.string().optional()),
       flag("strategy-id", "filter by Memory strategy ID", z.string().optional()),
@@ -20,8 +20,8 @@ export const createListMemoryRecordsHandler = (core: Core) =>
       flag("next-token", "pagination token returned by a previous request", z.string().optional()),
     ],
     handle: async (ctx, flags) => {
-      if (!flags.memory) {
-        throw new InputValidationError("required option '--memory <memory>' not specified");
+      if (!flags.id) {
+        throw new InputValidationError("required option '--id <id>' not specified");
       }
 
       const hasNamespace = flags.namespace !== undefined;
@@ -35,7 +35,7 @@ export const createListMemoryRecordsHandler = (core: Core) =>
       const metadataFilters = parseMemoryMetadataFilters(flags["metadata-filters"]);
       const response = await core.memory.listMemoryRecords(
         {
-          memoryId: flags.memory,
+          memoryId: flags.id,
           namespace: flags.namespace,
           namespacePath: flags["namespace-path"],
           memoryStrategyId: flags["strategy-id"],

--- a/src/handlers/memory/session/list/index.tsx
+++ b/src/handlers/memory/session/list/index.tsx
@@ -10,14 +10,14 @@ export const createListMemorySessionsHandler = (core: Core) =>
     name: "list",
     description: "list sessions in an AgentCore Memory",
     flags: [
-      flag("memory", "the ID of the Memory", z.string().optional()),
+      flag("id", "the ID of the Memory", z.string().optional()),
       flag("actor-id", "the ID of the actor", z.string().optional()),
       flag("max-results", "maximum number of sessions to return", z.number().optional()),
       flag("next-token", "pagination token returned by a previous request", z.string().optional()),
     ],
     handle: async (ctx, flags) => {
-      if (!flags.memory) {
-        throw new InputValidationError("required option '--memory <memory>' not specified");
+      if (!flags.id) {
+        throw new InputValidationError("required option '--id <id>' not specified");
       }
       if (!flags["actor-id"]) {
         throw new InputValidationError("required option '--actor-id <actor-id>' not specified");
@@ -25,7 +25,7 @@ export const createListMemorySessionsHandler = (core: Core) =>
 
       const response = await core.memory.listSessions(
         {
-          memoryId: flags.memory,
+          memoryId: flags.id,
           actorId: flags["actor-id"],
           maxResults: flags["max-results"],
           nextToken: flags["next-token"],


### PR DESCRIPTION
This PR standardize the parent Memory selector on `--id` across event, record, actor, and session commands. We see this convention in the rest of the CLI.

I also add a regression assertion that imperative Memory selectors do not use `--memory`

bun build, typecheck, lint, format and test pass