### PR TITLE
fix(policy): support generated policy definitions

### DIFF
--- a/src/cli/aws/__tests__/policy-generation.test.ts
+++ b/src/cli/aws/__tests__/policy-generation.test.ts
@@ -1,0 +1,103 @@
+import { getPolicyGeneration } from '../policy-generation';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockSend, mockWaitUntilPolicyGenerationCompleted } = vi.hoisted(() => ({
+  mockSend: vi.fn(),
+  mockWaitUntilPolicyGenerationCompleted: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-bedrock-agentcore-control', () => ({
+  BedrockAgentCoreControlClient: class {
+    send = mockSend;
+  },
+  GetPolicyGenerationCommand: class {
+    constructor(public input: unknown) {}
+  },
+  ListPolicyGenerationAssetsCommand: class {
+    constructor(public input: unknown) {}
+  },
+  StartPolicyGenerationCommand: class {
+    constructor(public input: unknown) {}
+  },
+  waitUntilPolicyGenerationCompleted: mockWaitUntilPolicyGenerationCompleted,
+}));
+
+vi.mock('../account', () => ({
+  getCredentialProvider: vi.fn().mockReturnValue({}),
+}));
+
+describe('getPolicyGeneration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWaitUntilPolicyGenerationCompleted.mockResolvedValue({ state: 'SUCCESS' });
+  });
+
+  it('returns a generated Cedar definition statement', async () => {
+    mockSend.mockResolvedValueOnce({ status: 'GENERATED' }).mockResolvedValueOnce({
+      policyGenerationAssets: [
+        {
+          definition: {
+            cedar: { statement: 'permit(principal, action, resource);' },
+          },
+        },
+      ],
+    });
+
+    await expect(
+      getPolicyGeneration({
+        generationId: 'generation-1',
+        policyEngineId: 'engine-1',
+        region: 'us-east-1',
+      })
+    ).resolves.toEqual({
+      status: 'GENERATED',
+      statement: 'permit(principal, action, resource);',
+    });
+  });
+
+  it('returns a generated Policy definition statement', async () => {
+    mockSend.mockResolvedValueOnce({ status: 'GENERATED' }).mockResolvedValueOnce({
+      policyGenerationAssets: [
+        {
+          definition: {
+            policy: { statement: 'forbid(principal, action, resource);' },
+          },
+        },
+      ],
+    });
+
+    await expect(
+      getPolicyGeneration({
+        generationId: 'generation-1',
+        policyEngineId: 'engine-1',
+        region: 'us-west-2',
+      })
+    ).resolves.toEqual({
+      status: 'GENERATED',
+      statement: 'forbid(principal, action, resource);',
+    });
+  });
+
+  it('surfaces findings when generation produces no statement', async () => {
+    mockSend.mockResolvedValueOnce({ status: 'GENERATED' }).mockResolvedValueOnce({
+      policyGenerationAssets: [
+        {
+          findings: [
+            {
+              type: 'INVALID',
+              description: 'Non-translatable: cannot be expressed in Dogwood',
+            },
+          ],
+        },
+      ],
+    });
+
+    await expect(
+      getPolicyGeneration({
+        generationId: 'generation-1',
+        policyEngineId: 'engine-1',
+        region: 'us-west-2',
+      })
+    ).rejects.toThrow('Non-translatable: cannot be expressed in Dogwood');
+  });
+});

--- a/src/cli/aws/policy-generation.ts
+++ b/src/cli/aws/policy-generation.ts
@@ -102,16 +102,22 @@ export async function getPolicyGeneration(options: GetPolicyGenerationOptions): 
     throw new Error('Policy generation completed but no assets were returned');
   }
 
-  // Get the Cedar statement from the first asset
   const firstAsset = assets[0]!;
-  const cedarStatement = firstAsset.definition?.cedar?.statement;
+  const statement = firstAsset.definition?.cedar?.statement ?? firstAsset.definition?.policy?.statement;
 
-  if (!cedarStatement) {
-    throw new Error('Policy generation completed but no Cedar policy statement was found in the assets');
+  if (!statement) {
+    const findingDetails =
+      firstAsset.findings
+        ?.map(finding => finding.description ?? finding.type)
+        .filter((finding): finding is string => !!finding)
+        .join(', ') ?? '';
+    throw new Error(
+      `Policy generation completed but no policy statement was found in the assets${findingDetails ? `: ${findingDetails}` : ''}`
+    );
   }
 
   return {
     status: statusResponse.status ?? 'GENERATED',
-    statement: cedarStatement,
+    statement,
   };
 }


### PR DESCRIPTION
## Description

`agentcore add policy --generate` assumed generated statements always used
`definition.cedar.statement`. After the Policy service's Dogwood rollout, valid generated
statements can instead use `definition.policy.statement`, causing the CLI to report that no Cedar
statement was found even though generation succeeded.

This change:

- accepts generated statements from either supported `PolicyDefinition` member
- surfaces service findings when an asset contains no statement
- adds SDK-boundary regression tests for Cedar, Policy, and invalid generation assets

## Related Issue

Closes #2020

## Documentation PR

N/A - this restores the documented policy generation behavior.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [ ] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [x] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots (N/A - no asset changes)

Focused unit tests:

```text
npx vitest run --project unit \
  src/cli/aws/__tests__/policy-generation.test.ts \
  src/cli/primitives/__tests__/PolicyPrimitive.test.ts

Test Files  2 passed (2)
Tests      10 passed (10)
```

Also verified the changed files with Prettier and `git diff --check`.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly (N/A - no documentation change required)
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
