### PR TITLE
feat: add config-bundle readonly TUI

### DIFF
--- a/src/components/ConfigBundlePicker.tsx
+++ b/src/components/ConfigBundlePicker.tsx
@@ -1,0 +1,80 @@
+import type { ConfigurationBundleSummary } from "@aws-sdk/client-bedrock-agentcore-control";
+import { useNavigate } from "react-router";
+import type { ScreenProps } from "../handlers/types";
+import { coreOptsFromCtx } from "../handlers/utils";
+import { formatTimestamp } from "./formatTimestamp";
+import { PaginatedTablePicker } from "./PaginatedTablePicker";
+import type { DataTableColumn } from "./ui/data-table";
+
+interface ConfigBundleRow extends Record<string, unknown> {
+  bundleId: string;
+  bundleName: string;
+  description: string;
+  createdAt: string;
+}
+
+export const configBundleColumns = [
+  { key: "bundleName", header: "name", flex: true },
+  { key: "description", header: "description", width: 28, minWidth: 12 },
+  {
+    key: "createdAt",
+    header: "created UTC",
+    width: 16,
+    minWidth: 11,
+    render: formatTimestamp,
+  },
+] satisfies DataTableColumn<ConfigBundleRow>[];
+
+function toRow(bundle: ConfigurationBundleSummary): ConfigBundleRow {
+  const id = bundle.bundleId ?? "";
+  return {
+    bundleId: id,
+    bundleName: bundle.bundleName ?? id,
+    description: bundle.description ?? "-",
+    createdAt: bundle.createdAt?.toISOString() ?? "-",
+  };
+}
+
+export interface ConfigBundlePickerProps extends ScreenProps {
+  breadcrumb: string[];
+  description?: string;
+  onSelect: (bundleId: string) => void;
+  onEscape?: () => void;
+}
+
+export function ConfigBundlePicker({
+  ctx,
+  core,
+  breadcrumb,
+  description,
+  onSelect,
+  onEscape,
+}: ConfigBundlePickerProps) {
+  const opts = coreOptsFromCtx(ctx);
+  const navigate = useNavigate();
+  const goBack = onEscape ?? (() => navigate("/" + breadcrumb.slice(0, -1).join("/")));
+
+  return (
+    <PaginatedTablePicker
+      breadcrumb={breadcrumb}
+      description={description}
+      queryKey={["configuration-bundles", opts.region]}
+      loadPage={async (token, pageSize) => {
+        const response = await core.eval.listConfigurationBundles(token, pageSize, opts);
+        return {
+          items: response.bundles ?? [],
+          nextToken: response.nextToken,
+        };
+      }}
+      toRow={toRow}
+      columns={configBundleColumns}
+      getValue={(row) => row.bundleId}
+      onSelect={onSelect}
+      onBack={goBack}
+      loadingMessage="Loading configuration bundles…"
+      errorMessage={(error) => `Error: ${error.message}`}
+      emptyMessage="No configuration bundles found in this Region."
+      emptyPageMessage="No configuration bundles on this page."
+    />
+  );
+}

--- a/src/components/ConfigBundleVersionPicker.tsx
+++ b/src/components/ConfigBundleVersionPicker.tsx
@@ -1,0 +1,88 @@
+import type { ConfigurationBundleVersionSummary } from "@aws-sdk/client-bedrock-agentcore-control";
+import type { ScreenProps } from "../handlers/types";
+import { coreOptsFromCtx } from "../handlers/utils";
+import { formatTimestamp } from "./formatTimestamp";
+import { PaginatedTablePicker } from "./PaginatedTablePicker";
+import type { DataTableColumn } from "./ui/data-table";
+
+interface ConfigBundleVersionRow extends Record<string, unknown> {
+  versionId: string;
+  branchName: string;
+  commitMessage: string;
+  versionCreatedAt: string;
+}
+
+export const configBundleVersionColumns = [
+  { key: "versionId", header: "version", width: 20, minWidth: 10 },
+  { key: "branchName", header: "branch", width: 12, minWidth: 8 },
+  { key: "commitMessage", header: "message", flex: true },
+  {
+    key: "versionCreatedAt",
+    header: "created UTC",
+    width: 16,
+    minWidth: 11,
+    render: formatTimestamp,
+  },
+] satisfies DataTableColumn<ConfigBundleVersionRow>[];
+
+function toRow(version: ConfigurationBundleVersionSummary): ConfigBundleVersionRow {
+  return {
+    versionId: version.versionId ?? "",
+    branchName: version.lineageMetadata?.branchName ?? "-",
+    commitMessage: version.lineageMetadata?.commitMessage ?? "-",
+    versionCreatedAt: version.versionCreatedAt?.toISOString() ?? "-",
+  };
+}
+
+export interface ConfigBundleVersionPickerProps extends ScreenProps {
+  bundleId: string;
+  breadcrumb: string[];
+  onSelect: (versionId: string) => void;
+  onBack: () => void;
+}
+
+export function ConfigBundleVersionPicker({
+  ctx,
+  core,
+  bundleId,
+  breadcrumb,
+  onSelect,
+  onBack,
+}: ConfigBundleVersionPickerProps) {
+  const opts = coreOptsFromCtx(ctx);
+
+  return (
+    <PaginatedTablePicker
+      breadcrumb={breadcrumb}
+      queryKey={["configuration-bundle-versions", opts.region, bundleId]}
+      loadPage={async (token, pageSize) => {
+        const response = await core.eval.listConfigurationBundleVersions(
+          bundleId,
+          token,
+          pageSize,
+          opts,
+        );
+        return {
+          items: response.versions ?? [],
+          nextToken: response.nextToken,
+        };
+      }}
+      toRow={toRow}
+      columns={configBundleVersionColumns}
+      sortRows={(rows) =>
+        [...rows].sort((left, right) =>
+          String(right.versionCreatedAt).localeCompare(String(left.versionCreatedAt)),
+        )
+      }
+      getValue={(row) => row.versionId}
+      onSelect={onSelect}
+      onBack={onBack}
+      loadingMessage="Loading configuration bundle versions…"
+      errorMessage={(error) =>
+        `Error loading versions for configuration bundle ${bundleId}: ${error.message}`
+      }
+      emptyMessage={`No versions found for configuration bundle ${bundleId}.`}
+      emptyPageMessage={`No versions on this page for configuration bundle ${bundleId}.`}
+    />
+  );
+}

--- a/src/components/Root.tsx
+++ b/src/components/Root.tsx
@@ -54,6 +54,11 @@ import { BatchEvaluationGetJsonScreen } from "../handlers/eval/batch-evaluation/
 import { DatasetScreen } from "../handlers/eval/dataset/screen.tsx";
 import { DatasetListScreen } from "../handlers/eval/dataset/list/screen.tsx";
 import { DatasetGetScreen, DatasetGetJsonScreen } from "../handlers/eval/dataset/get/screen.tsx";
+import { ConfigBundleScreen } from "../handlers/eval/config-bundle/screen.tsx";
+import { ConfigBundleListScreen } from "../handlers/eval/config-bundle/list/screen.tsx";
+import { ConfigBundleGetScreen } from "../handlers/eval/config-bundle/get/screen.tsx";
+import { ConfigBundleVersionScreen } from "../handlers/eval/config-bundle/version/screen.tsx";
+import { ConfigBundleVersionListScreen } from "../handlers/eval/config-bundle/version/list/screen.tsx";
 import { MemoryEventScreen } from "../handlers/memory/event/screen.tsx";
 import { MemoryEventGetScreen } from "../handlers/memory/event/get/screen.tsx";
 import { MemoryEventListScreen } from "../handlers/memory/event/list/screen.tsx";
@@ -493,6 +498,38 @@ export function Root({ path, ctx, core, queryClient }: RootProps) {
           <Route
             path="agentcore/eval/dataset/get/:datasetId/json"
             element={<DatasetGetJsonScreen ctx={ctx} core={core} />}
+          />
+          <Route
+            path="agentcore/eval/config-bundle"
+            element={<ConfigBundleScreen ctx={ctx} core={core} />}
+          />
+          <Route
+            path="agentcore/eval/config-bundle/list"
+            element={<ConfigBundleListScreen ctx={ctx} core={core} />}
+          />
+          <Route
+            path="agentcore/eval/config-bundle/get"
+            element={<Navigate to="/agentcore/eval/config-bundle/list" replace />}
+          />
+          <Route
+            path="agentcore/eval/config-bundle/get/:bundleId"
+            element={<ConfigBundleGetScreen ctx={ctx} core={core} />}
+          />
+          <Route
+            path="agentcore/eval/config-bundle/get/:bundleId/:versionId"
+            element={<ConfigBundleGetScreen ctx={ctx} core={core} />}
+          />
+          <Route
+            path="agentcore/eval/config-bundle/version"
+            element={<ConfigBundleVersionScreen ctx={ctx} core={core} />}
+          />
+          <Route
+            path="agentcore/eval/config-bundle/version/list"
+            element={<ConfigBundleVersionListScreen ctx={ctx} core={core} />}
+          />
+          <Route
+            path="agentcore/eval/config-bundle/version/list/:bundleId"
+            element={<ConfigBundleVersionListScreen ctx={ctx} core={core} />}
           />
           <Route
             path="agentcore/eval/batch-evaluation"

--- a/src/handlers/eval/config-bundle/config-bundle.screen.test.tsx
+++ b/src/handlers/eval/config-bundle/config-bundle.screen.test.tsx
@@ -1,0 +1,364 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type {
+  ConfigurationBundleSummary,
+  ConfigurationBundleVersionSummary,
+  GetConfigurationBundleResponse,
+  GetConfigurationBundleVersionResponse,
+} from "@aws-sdk/client-bedrock-agentcore-control";
+import {
+  cleanupScreens,
+  renderScreen,
+  TestCoreClient,
+  waitFor,
+  waitForText,
+} from "../../../testing";
+
+afterEach(cleanupScreens);
+
+const evalEndpointUrl = "https://eval.test";
+
+function bundleSummary(
+  overrides: Partial<ConfigurationBundleSummary> = {},
+): ConfigurationBundleSummary {
+  return {
+    bundleArn: "arn:aws:bedrock-agentcore:us-east-1:123456789012:configuration-bundle/bundle-1",
+    bundleId: "bundle-1",
+    bundleName: "orders-prompt",
+    description: "Order support agent configuration",
+    createdAt: new Date("2026-08-01T01:02:03.000Z"),
+    ...overrides,
+  };
+}
+
+function bundleVersionSummary(
+  overrides: Partial<ConfigurationBundleVersionSummary> = {},
+): ConfigurationBundleVersionSummary {
+  return {
+    bundleArn: "arn:aws:bedrock-agentcore:us-east-1:123456789012:configuration-bundle/bundle-1",
+    bundleId: "bundle-1",
+    versionId: "version-1",
+    versionCreatedAt: new Date("2026-08-02T12:34:56.000Z"),
+    lineageMetadata: {
+      branchName: "mainline",
+      commitMessage: "Initial configuration",
+      parentVersionIds: [],
+    },
+    ...overrides,
+  };
+}
+
+function latestBundleResponse(
+  overrides: Partial<GetConfigurationBundleResponse> = {},
+): GetConfigurationBundleResponse {
+  return {
+    bundleArn: "arn:aws:bedrock-agentcore:us-east-1:123456789012:configuration-bundle/bundle-1",
+    bundleId: "bundle-1",
+    bundleName: "orders-prompt",
+    description: "Order support agent configuration",
+    versionId: "version-2",
+    components: {
+      "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/orders-agent": {
+        configuration: { system_prompt: "Help customers with their orders." },
+      },
+    },
+    lineageMetadata: {
+      branchName: "mainline",
+      commitMessage: "Improve order guidance",
+      parentVersionIds: ["version-1"],
+    },
+    createdAt: new Date("2026-08-01T01:02:03.000Z"),
+    updatedAt: new Date("2026-08-03T04:05:06.000Z"),
+    ...overrides,
+  };
+}
+
+function versionBundleResponse(
+  overrides: Partial<GetConfigurationBundleVersionResponse> = {},
+): GetConfigurationBundleVersionResponse {
+  return {
+    bundleArn: "arn:aws:bedrock-agentcore:us-east-1:123456789012:configuration-bundle/bundle-1",
+    bundleId: "bundle-1",
+    bundleName: "orders-prompt",
+    description: "Order support agent configuration",
+    versionId: "version-1",
+    components: {
+      "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/orders-agent": {
+        configuration: { system_prompt: "Help with orders." },
+      },
+    },
+    lineageMetadata: {
+      branchName: "mainline",
+      commitMessage: "Initial configuration",
+      parentVersionIds: [],
+    },
+    createdAt: new Date("2026-08-01T01:02:03.000Z"),
+    versionCreatedAt: new Date("2026-08-02T12:34:56.000Z"),
+    ...overrides,
+  };
+}
+
+function coreWithBundles(bundles: ConfigurationBundleSummary[]): TestCoreClient {
+  const core = new TestCoreClient();
+  core.eval.setListConfigurationBundlesResponse({ bundles });
+  return core;
+}
+
+describe("configuration bundle menu", () => {
+  test("offers only get, list, and version", async () => {
+    const screen = renderScreen("/agentcore/eval/config-bundle");
+
+    await waitForText(
+      screen.lastFrame,
+      "get the latest or a specific configuration bundle version",
+    );
+    const frame = screen.lastFrame()!;
+    expect(frame).toContain("list");
+    expect(frame).toContain("version");
+    expect(frame).not.toContain("create");
+    expect(frame).not.toContain("update");
+    expect(frame).not.toContain("delete");
+  });
+
+  test("the version menu offers only list", async () => {
+    const screen = renderScreen("/agentcore/eval/config-bundle/version");
+
+    await waitForText(screen.lastFrame, "list immutable versions of a configuration bundle");
+    expect(screen.lastFrame()).not.toContain("create");
+    expect(screen.lastFrame()).not.toContain("delete");
+  });
+});
+
+describe("configuration bundle picker", () => {
+  test("renders name, description, and creation time", async () => {
+    const core = coreWithBundles([
+      bundleSummary({
+        bundleName: "staging-prompt",
+        description: "Staging agent settings",
+        createdAt: new Date("2026-08-03T02:03:04.000Z"),
+      }),
+    ]);
+    const screen = renderScreen("/agentcore/eval/config-bundle/list", { core });
+
+    await waitForText(screen.lastFrame, "staging-prompt");
+    const frame = screen.lastFrame()!;
+    expect(frame).toContain("Staging agent settings");
+    expect(frame).toContain("2026-08-03 02:03");
+  });
+
+  test("calls listConfigurationBundles with exact Core options", async () => {
+    const core = coreWithBundles([bundleSummary()]);
+    renderScreen("/agentcore/eval/config-bundle/list", {
+      core,
+      endpointUrl: evalEndpointUrl,
+    });
+
+    await waitFor(() => core.eval.calls.some((call) => call.method === "listConfigurationBundles"));
+    expect(core.eval.calls.filter((call) => call.method === "listConfigurationBundles")).toEqual([
+      {
+        method: "listConfigurationBundles",
+        args: [
+          undefined,
+          expect.any(Number),
+          { region: "us-east-1", endpointUrl: evalEndpointUrl },
+        ],
+      },
+    ]);
+  });
+
+  test("bare get redirects to the bundle picker", async () => {
+    const core = coreWithBundles([
+      bundleSummary({ bundleId: "redirected-bundle", bundleName: "redirected-bundle" }),
+    ]);
+    const screen = renderScreen("/agentcore/eval/config-bundle/get", { core });
+
+    await waitForText(screen.lastFrame, "redirected-bundle");
+    expect(core.eval.calls[0]?.method).toBe("listConfigurationBundles");
+  });
+
+  test("selection opens the latest mainline bundle JSON", async () => {
+    const core = coreWithBundles([bundleSummary()]);
+    core.eval.setGetConfigurationBundleResponse(latestBundleResponse());
+    const screen = renderScreen("/agentcore/eval/config-bundle/list", {
+      core,
+      endpointUrl: evalEndpointUrl,
+    });
+
+    await waitForText(screen.lastFrame, "orders-prompt");
+    await screen.press("return");
+    await waitForText(screen.lastFrame, "agentcore → eval → config-bundle → get → bundle-1");
+    await waitForText(screen.lastFrame, '"system_prompt"');
+    expect(core.eval.calls.find((call) => call.method === "getConfigurationBundle")).toEqual({
+      method: "getConfigurationBundle",
+      args: [
+        "bundle-1",
+        undefined,
+        "mainline",
+        { region: "us-east-1", endpointUrl: evalEndpointUrl },
+      ],
+    });
+  });
+
+  test("shows the empty state", async () => {
+    const screen = renderScreen("/agentcore/eval/config-bundle/list");
+    await waitForText(screen.lastFrame, "No configuration bundles found in this Region.");
+  });
+});
+
+describe("configuration bundle version list", () => {
+  test("uses the bundle picker to scope an unscoped version list", async () => {
+    const core = coreWithBundles([
+      bundleSummary({ bundleId: "bundle/blue one", bundleName: "pick-bundle" }),
+    ]);
+    core.eval.setListConfigurationBundleVersionsResponse({
+      versions: [bundleVersionSummary({ bundleId: "bundle/blue one", versionId: "version-9" })],
+    });
+    const screen = renderScreen("/agentcore/eval/config-bundle/version/list", { core });
+
+    await waitForText(screen.lastFrame, "pick-bundle");
+    await screen.press("return");
+    await waitForText(
+      screen.lastFrame,
+      "agentcore → eval → config-bundle → version → list → bundle/blue one",
+    );
+    await waitForText(screen.lastFrame, "version-9");
+    expect(
+      core.eval.calls.some(
+        (call) =>
+          call.method === "listConfigurationBundleVersions" && call.args[0] === "bundle/blue one",
+      ),
+    ).toBe(true);
+  });
+
+  test("calls listConfigurationBundleVersions with exact scope and options", async () => {
+    const core = new TestCoreClient();
+    core.eval.setListConfigurationBundleVersionsResponse({
+      versions: [bundleVersionSummary()],
+    });
+    renderScreen("/agentcore/eval/config-bundle/version/list/bundle-1", {
+      core,
+      endpointUrl: evalEndpointUrl,
+    });
+
+    await waitFor(() =>
+      core.eval.calls.some((call) => call.method === "listConfigurationBundleVersions"),
+    );
+    expect(
+      core.eval.calls.filter((call) => call.method === "listConfigurationBundleVersions"),
+    ).toEqual([
+      {
+        method: "listConfigurationBundleVersions",
+        args: [
+          "bundle-1",
+          undefined,
+          expect.any(Number),
+          { region: "us-east-1", endpointUrl: evalEndpointUrl },
+        ],
+      },
+    ]);
+    expect(core.eval.calls.some((call) => call.method === "listConfigurationBundles")).toBe(false);
+  });
+
+  test("renders newest versions first with branch, message, and creation time", async () => {
+    const core = new TestCoreClient();
+    core.eval.setListConfigurationBundleVersionsResponse({
+      versions: [
+        bundleVersionSummary({
+          versionId: "older-version",
+          versionCreatedAt: new Date("2026-08-02T00:00:00.000Z"),
+        }),
+        bundleVersionSummary({
+          versionId: "newer-version",
+          versionCreatedAt: new Date("2026-08-04T10:11:12.000Z"),
+          lineageMetadata: {
+            branchName: "review",
+            commitMessage: "Tune the review prompt",
+          },
+        }),
+      ],
+    });
+    const screen = renderScreen("/agentcore/eval/config-bundle/version/list/bundle-1", { core });
+
+    await waitForText(screen.lastFrame, "older-version");
+    const frame = screen.lastFrame()!;
+    expect(frame).toContain("review");
+    expect(frame).toContain("Tune the review prompt");
+    expect(frame).toContain("2026-08-04 10:11");
+    expect(frame.indexOf("newer-version")).toBeLessThan(frame.indexOf("older-version"));
+  });
+
+  test("selection opens the selected immutable version JSON", async () => {
+    const core = new TestCoreClient();
+    core.eval.setListConfigurationBundleVersionsResponse({
+      versions: [bundleVersionSummary({ versionId: "version-9" })],
+    });
+    core.eval.setGetConfigurationBundleVersionResponse(
+      versionBundleResponse({ versionId: "version-9" }),
+    );
+    const screen = renderScreen("/agentcore/eval/config-bundle/version/list/bundle-1", {
+      core,
+      endpointUrl: evalEndpointUrl,
+    });
+
+    await waitForText(screen.lastFrame, "version-9");
+    await screen.press("return");
+    await waitForText(
+      screen.lastFrame,
+      "agentcore → eval → config-bundle → get → bundle-1 → version-9",
+    );
+    await waitForText(screen.lastFrame, '"components"');
+    expect(core.eval.calls.find((call) => call.method === "getConfigurationBundle")).toEqual({
+      method: "getConfigurationBundle",
+      args: [
+        "bundle-1",
+        "version-9",
+        "mainline",
+        { region: "us-east-1", endpointUrl: evalEndpointUrl },
+      ],
+    });
+  });
+
+  test("returns to bundle selection from a scoped version list", async () => {
+    const core = coreWithBundles([bundleSummary()]);
+    core.eval.setListConfigurationBundleVersionsResponse({
+      versions: [bundleVersionSummary()],
+    });
+    const screen = renderScreen("/agentcore/eval/config-bundle/version/list/bundle-1", { core });
+
+    await waitForText(screen.lastFrame, "version-1");
+    await screen.press("escape");
+    await waitForText(
+      screen.lastFrame,
+      "agentcore → eval → config-bundle → version → list → choose a configuration bundle",
+    );
+    await waitForText(screen.lastFrame, "orders-prompt");
+  });
+
+  test("names the bundle in empty and error states", async () => {
+    const empty = renderScreen("/agentcore/eval/config-bundle/version/list/bundle-1");
+    await waitForText(empty.lastFrame, "No versions found for configuration bundle bundle-1.");
+    empty.unmount();
+
+    const core = new TestCoreClient();
+    core.eval.setError(new Error("version access denied"));
+    const failed = renderScreen("/agentcore/eval/config-bundle/version/list/bundle-1", { core });
+    await waitForText(failed.lastFrame, "Error loading versions for configuration bundle bundle-1");
+    expect(failed.lastFrame()).toContain("version access denied");
+    expect(failed.lastFrame()).toContain("[r] retry");
+  });
+});
+
+describe("configuration bundle detail", () => {
+  test("retries a failed query", async () => {
+    const core = new TestCoreClient();
+    core.eval.setError(new Error("configuration bundle unavailable"));
+    const screen = renderScreen("/agentcore/eval/config-bundle/get/bundle-1", { core });
+
+    await waitForText(screen.lastFrame, "configuration bundle unavailable");
+    expect(screen.lastFrame()).toContain("[r] retry");
+
+    core.eval.setError(undefined);
+    core.eval.setGetConfigurationBundleResponse(latestBundleResponse());
+    await screen.write("r");
+    await waitForText(screen.lastFrame, '"system_prompt"');
+  });
+});

--- a/src/handlers/eval/config-bundle/config-bundle.test.tsx
+++ b/src/handlers/eval/config-bundle/config-bundle.test.tsx
@@ -143,6 +143,24 @@ describe("eval config-bundle command hierarchy", () => {
     expect(stdout()).toContain("Usage: agentcore eval config-bundle");
     expect(core.eval.calls).toHaveLength(0);
   });
+
+  for (const command of [["get"], ["list"], ["version", "list"]] as const) {
+    test(`opens the TUI for a bare ${command.join(" ")} leaf`, async () => {
+      const { route } = testConfigBundleCommand();
+
+      await expect(route(["eval", "config-bundle", ...command])).rejects.toThrow(
+        "interactive mode requires a TTY on stdin and stdout",
+      );
+    });
+  }
+
+  test("runs normal validation for a bare CLI-only command", async () => {
+    const { route } = testConfigBundleCommand();
+
+    await expect(route(["eval", "config-bundle", "create"])).rejects.toThrow(
+      "required option '--name <name>' not specified",
+    );
+  });
 });
 
 describe("config-bundle create", () => {

--- a/src/handlers/eval/config-bundle/get/screen.tsx
+++ b/src/handlers/eval/config-bundle/get/screen.tsx
@@ -1,0 +1,39 @@
+import { useQuery } from "@tanstack/react-query";
+import { useParams } from "react-router";
+import { JsonDetail } from "../../../../components/JsonDetail";
+import type { ScreenProps } from "../../../types";
+import { coreOptsFromCtx } from "../../../utils";
+
+const DEFAULT_BRANCH = "mainline";
+
+export function ConfigBundleGetScreen({ ctx, core }: ScreenProps) {
+  const opts = coreOptsFromCtx(ctx);
+  const { bundleId, versionId } = useParams();
+  const detail = useQuery({
+    queryKey: ["configuration-bundle", opts.region, bundleId, versionId ?? DEFAULT_BRANCH],
+    queryFn: () => core.eval.getConfigurationBundle(bundleId!, versionId, DEFAULT_BRANCH, opts),
+    enabled: bundleId !== undefined,
+  });
+
+  return (
+    <JsonDetail
+      breadcrumb={[
+        "agentcore",
+        "eval",
+        "config-bundle",
+        "get",
+        bundleId ?? "",
+        ...(versionId ? [versionId] : []),
+      ]}
+      isPending={detail.isPending}
+      error={detail.isError ? (detail.error as Error) : null}
+      data={detail.data}
+      loadingLabel={
+        versionId
+          ? `Loading version ${versionId} for configuration bundle ${bundleId ?? ""}…`
+          : `Loading configuration bundle ${bundleId ?? ""}…`
+      }
+      onRetry={() => void detail.refetch()}
+    />
+  );
+}

--- a/src/handlers/eval/config-bundle/index.tsx
+++ b/src/handlers/eval/config-bundle/index.tsx
@@ -1,7 +1,8 @@
 import { Router } from "../../../router";
+import { renderTui } from "../../../tui";
+import { withTuiOnEmptyFlagsAndArgs } from "../../../middleware";
 import type { AppIO } from "../../../io";
 import type { Core } from "../../types";
-import { createHelpDefault } from "../../help";
 import { createCreateConfigBundleHandler } from "./create";
 import { createDeleteConfigBundleHandler } from "./delete";
 import { createGetConfigBundleHandler } from "./get";
@@ -11,7 +12,9 @@ import { createConfigBundleVersionHandler } from "./version";
 
 export function createConfigBundleHandler(core: Core, io: AppIO): Router {
   return new Router("config-bundle", "manage AgentCore configuration bundles")
-    .default(createHelpDefault(io))
+    .use(withTuiOnEmptyFlagsAndArgs(core, io))
+    .default(renderTui(core, io))
+    .supportedTuiCommands("get", "list", "version")
     .handler(createCreateConfigBundleHandler(core, io))
     .handler(createGetConfigBundleHandler(core))
     .handler(createListConfigBundlesHandler(core))
@@ -19,3 +22,5 @@ export function createConfigBundleHandler(core: Core, io: AppIO): Router {
     .handler(createDeleteConfigBundleHandler(core))
     .handler(createConfigBundleVersionHandler(core, io));
 }
+
+export { ConfigBundleScreen } from "./screen.tsx";

--- a/src/handlers/eval/config-bundle/list/screen.tsx
+++ b/src/handlers/eval/config-bundle/list/screen.tsx
@@ -1,0 +1,17 @@
+import { useNavigate } from "react-router";
+import { ConfigBundlePicker } from "../../../../components/ConfigBundlePicker";
+import type { ScreenProps } from "../../../types";
+
+export function ConfigBundleListScreen(props: ScreenProps) {
+  const navigate = useNavigate();
+
+  return (
+    <ConfigBundlePicker
+      {...props}
+      breadcrumb={["agentcore", "eval", "config-bundle", "list"]}
+      onSelect={(bundleId) =>
+        navigate(`/agentcore/eval/config-bundle/get/${encodeURIComponent(bundleId)}`)
+      }
+    />
+  );
+}

--- a/src/handlers/eval/config-bundle/screen.tsx
+++ b/src/handlers/eval/config-bundle/screen.tsx
@@ -1,0 +1,6 @@
+import { RouterScreen } from "../../../components/RouterScreen";
+import type { ScreenProps } from "../../types";
+
+export function ConfigBundleScreen(props: ScreenProps) {
+  return <RouterScreen {...props} path={["agentcore", "eval", "config-bundle"]} />;
+}

--- a/src/handlers/eval/config-bundle/version/index.tsx
+++ b/src/handlers/eval/config-bundle/version/index.tsx
@@ -1,11 +1,14 @@
 import { Router } from "../../../../router";
+import { renderTui } from "../../../../tui";
+import { withTuiOnEmptyFlagsAndArgs } from "../../../../middleware";
 import type { AppIO } from "../../../../io";
 import type { Core } from "../../../types";
-import { createHelpDefault } from "../../../help";
 import { createListConfigBundleVersionsHandler } from "./list";
 
 export function createConfigBundleVersionHandler(core: Core, io: AppIO): Router {
   return new Router("version", "inspect immutable configuration bundle versions")
-    .default(createHelpDefault(io))
+    .use(withTuiOnEmptyFlagsAndArgs(core, io))
+    .default(renderTui(core, io))
+    .supportedTuiCommands("list")
     .handler(createListConfigBundleVersionsHandler(core));
 }

--- a/src/handlers/eval/config-bundle/version/list/screen.tsx
+++ b/src/handlers/eval/config-bundle/version/list/screen.tsx
@@ -1,0 +1,36 @@
+import { useNavigate, useParams } from "react-router";
+import { ConfigBundlePicker } from "../../../../../components/ConfigBundlePicker";
+import { ConfigBundleVersionPicker } from "../../../../../components/ConfigBundleVersionPicker";
+import type { ScreenProps } from "../../../../types";
+
+export function ConfigBundleVersionListScreen(props: ScreenProps) {
+  const navigate = useNavigate();
+  const { bundleId } = useParams();
+
+  if (!bundleId) {
+    return (
+      <ConfigBundlePicker
+        {...props}
+        breadcrumb={["agentcore", "eval", "config-bundle", "version", "list"]}
+        description="choose a configuration bundle to list versions for"
+        onSelect={(id) =>
+          navigate(`/agentcore/eval/config-bundle/version/list/${encodeURIComponent(id)}`)
+        }
+      />
+    );
+  }
+
+  return (
+    <ConfigBundleVersionPicker
+      {...props}
+      bundleId={bundleId}
+      breadcrumb={["agentcore", "eval", "config-bundle", "version", "list", bundleId]}
+      onSelect={(versionId) =>
+        navigate(
+          `/agentcore/eval/config-bundle/get/${encodeURIComponent(bundleId)}/${encodeURIComponent(versionId)}`,
+        )
+      }
+      onBack={() => navigate("/agentcore/eval/config-bundle/version/list")}
+    />
+  );
+}

--- a/src/handlers/eval/config-bundle/version/screen.tsx
+++ b/src/handlers/eval/config-bundle/version/screen.tsx
@@ -1,0 +1,6 @@
+import { RouterScreen } from "../../../../components/RouterScreen";
+import type { ScreenProps } from "../../../types";
+
+export function ConfigBundleVersionScreen(props: ScreenProps) {
+  return <RouterScreen {...props} path={["agentcore", "eval", "config-bundle", "version"]} />;
+}


### PR DESCRIPTION
## Description

Adds an interactive, read-only TUI for `eval config-bundle` command tree. Bare read-only commands now open TUI flows instead of returning missing flag errors, while mutating commands remain CLI-only

## Screens

| Path | Screen |
|---|---|
| `eeval config-bundle` | `RouterScreen` menu |
| `eval config-bundle list` / `eval config-bundle get` | `ConfigBundlePicker` using `PaginatedTablePicker` |
| `eval config-bundle get/:bundleId` | `JsonDetail` |
| `eval config-bundle version` | `RouterScreen` menu |
| `eval config-bundle version list` | `ConfigBundlePicker` for bundle selection |
| `eval config-bundle version list/:bundleId` | `ConfigBundleVersionPicker` using `PaginatedTablePicker` |
| `eval config-bundle get/:bundleId/:versionId` | `version in JsonDetail` |

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- Added `config-bundle.screen.test.tsx` covering menu filtering, navigation, metadata rendering, pagination calls, latest and immutable version retrieval, sorting, retries, and empty/error states.
- Added command-dispatch coverage confirming only read-only leaves open the TUI.
- bun test src/handlers/eval (233 pass, 0 fail)

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [x] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
