### PR TITLE
fix(evaluator): derived --config, region fallback, base-id regex, llm-context

### DIFF
--- a/src/cli/primitives/EvaluatorPrimitive.ts
+++ b/src/cli/primitives/EvaluatorPrimitive.ts
@@ -1,4 +1,11 @@
-import { ConflictError, ResourceNotFoundError, createConfigIO, findConfigRoot, serializeResult, toError } from '../../lib';
+import {
+  ConflictError,
+  ResourceNotFoundError,
+  createConfigIO,
+  findConfigRoot,
+  serializeResult,
+  toError,
+} from '../../lib';
 import type { Result } from '../../lib/result';
 import type { EvaluationLevel, Evaluator, EvaluatorConfig } from '../../schema';
 import {
@@ -553,6 +560,12 @@ export class EvaluatorPrimitive extends BasePrimitive<AddEvaluatorOptions, Remov
               let resolvedLevel: EvaluationLevel | undefined = levelResult?.data;
 
               if (evalType === 'derived') {
+                // --config carries a full evaluator config for other types; a derived
+                // evaluator is built from --base-evaluator-id + --model, so reject
+                // --config here rather than silently ignoring it.
+                if (cliOptions.config) {
+                  fail('--config is not supported with --type derived; use --base-evaluator-id and --model');
+                }
                 if (!cliOptions.baseEvaluatorId) {
                   fail('--base-evaluator-id is required for --type derived');
                 }
@@ -796,16 +809,14 @@ export class EvaluatorPrimitive extends BasePrimitive<AddEvaluatorOptions, Remov
    * GetEvaluator instead of asking the customer to know it.
    */
   private async resolveBaseEvaluatorLevel(baseEvaluatorId: string): Promise<EvaluationLevel> {
-    // The deploy target region is preferred, but the file may not exist yet
-    // (evaluators can be added before any deploy), so fall back to the environment.
-    let savedRegion: string | undefined;
+    // A fresh project has no saved deploy targets, so resolve the region directly
+    // from the environment/profile fallback (env vars, then the AWS profile's region).
+    let region: string | undefined;
     try {
-      const targets = await createConfigIO().resolveAWSDeploymentTargets();
-      savedRegion = targets[0]?.region;
+      region = await createConfigIO().resolveRegionFallback();
     } catch {
-      savedRegion = undefined;
+      region = process.env.AWS_REGION ?? process.env.AWS_DEFAULT_REGION;
     }
-    const region = savedRegion ?? process.env.AWS_REGION ?? process.env.AWS_DEFAULT_REGION;
     if (!region) {
       throw new Error(
         `Could not resolve an AWS region to look up "${baseEvaluatorId}". Set AWS_REGION or pass --level explicitly.`

--- a/src/cli/primitives/EvaluatorPrimitive.ts
+++ b/src/cli/primitives/EvaluatorPrimitive.ts
@@ -811,12 +811,7 @@ export class EvaluatorPrimitive extends BasePrimitive<AddEvaluatorOptions, Remov
   private async resolveBaseEvaluatorLevel(baseEvaluatorId: string): Promise<EvaluationLevel> {
     // A fresh project has no saved deploy targets, so resolve the region directly
     // from the environment/profile fallback (env vars, then the AWS profile's region).
-    let region: string | undefined;
-    try {
-      region = await createConfigIO().resolveRegionFallback();
-    } catch {
-      region = process.env.AWS_REGION ?? process.env.AWS_DEFAULT_REGION;
-    }
+    const region = await createConfigIO().resolveRegionFallback();
     if (!region) {
       throw new Error(
         `Could not resolve an AWS region to look up "${baseEvaluatorId}". Set AWS_REGION or pass --level explicitly.`

--- a/src/lib/schemas/io/config-io.ts
+++ b/src/lib/schemas/io/config-io.ts
@@ -201,8 +201,10 @@ export class ConfigIO {
 
   /**
    * Resolve a fallback region from environment variables or AWS profile config.
+   * Public so callers that need a region before any deploy target is saved (e.g.
+   * resolving a derived evaluator's level) can reuse the same precedence.
    */
-  private async resolveRegionFallback(): Promise<string | undefined> {
+  async resolveRegionFallback(): Promise<string | undefined> {
     // Check env vars first
     const envRegion = process.env.AWS_REGION ?? process.env.AWS_DEFAULT_REGION;
     if (envRegion && AgentCoreRegionSchema.safeParse(envRegion).success) {

--- a/src/schema/llm-compacted/agentcore.ts
+++ b/src/schema/llm-compacted/agentcore.ts
@@ -280,9 +280,23 @@ interface Evaluator {
   name: string; // @regex ^[a-zA-Z][a-zA-Z0-9_]{0,47}$ @min 1 @max 48
   level: 'SESSION' | 'TRACE' | 'TOOL_CALL';
   description?: string;
-  config: { llmAsAJudge: LlmAsAJudgeConfig; codeBased?: never } | { llmAsAJudge?: never; codeBased: CodeBasedConfig };
+  config: EvaluatorConfig; // exactly one of llmAsAJudge | codeBased | derived
   kmsKeyArn?: string;
   tags?: Tags;
+}
+
+// Exactly one arm present.
+type EvaluatorConfig =
+  | { llmAsAJudge: LlmAsAJudgeConfig; codeBased?: never; derived?: never }
+  | { llmAsAJudge?: never; codeBased: CodeBasedConfig; derived?: never }
+  | { llmAsAJudge?: never; codeBased?: never; derived: DerivedEvaluatorConfig };
+
+// A derived evaluator reuses a managed base evaluator's logic (a Builtin.* or
+// ThirdParty.<Provider>.<Metric> metric) on the customer's own model. The base
+// owns the prompt + scoring; level must match the base's (resolved at add time).
+interface DerivedEvaluatorConfig {
+  baseEvaluatorId: string; // "Builtin.<Metric>" or "ThirdParty.<Provider>.<Metric>"
+  model: string; // Bedrock inference profile ID
 }
 
 interface LlmAsAJudgeConfig {

--- a/src/schema/schemas/primitives/evaluator.ts
+++ b/src/schema/schemas/primitives/evaluator.ts
@@ -95,7 +95,10 @@ export type LlmAsAJudgeConfig = z.infer<typeof LlmAsAJudgeConfigSchema>;
 // (Builtin.<Metric>). The base owns the prompt and scoring; the customer supplies
 // only the model. The evaluator's `level` must match the base's level (resolved at
 // add time via GetEvaluator), so it lives on the top-level Evaluator, not here.
-export const BASE_EVALUATOR_ID_PATTERN = /^(ThirdParty|Builtin)\.[A-Za-z0-9._-]+$/;
+// Builtin.<Metric> or ThirdParty.<Provider>.<Metric>. Each segment must be
+// non-empty alphanumeric — rejects malformed ids like "ThirdParty.DeepEval",
+// "ThirdParty..ToolUse", or "ThirdParty.DeepEval.".
+export const BASE_EVALUATOR_ID_PATTERN = /^(Builtin\.[A-Za-z0-9]+|ThirdParty\.[A-Za-z0-9]+\.[A-Za-z0-9]+)$/;
 
 export const DerivedEvaluatorConfigSchema = z.object({
   baseEvaluatorId: z


### PR DESCRIPTION
Follow-up fixes from the derived-evaluators bug bash (P2/P3), stacked on `Dervived_evaluators`.

## Fixes
1. **P2 — `--config` for derived** — `--type derived --config x.json` demanded `--base-evaluator-id`, and explicit derived flags + a nonexistent `--config` silently ignored the file. Cause: the derived arm ran before the config loader. Now `--config` is **rejected** for `--type derived` with a clear message (use `--base-evaluator-id` + `--model`).
2. **P2 — profile-only region** — auto-level lookup failed on a fresh project (empty `aws-targets.json`) when the region came only from the AWS profile. `resolveAWSDeploymentTargets()` maps over an empty array and drops the fallback. Now uses `ConfigIO.resolveRegionFallback()` (made public) which returns the scalar env→profile fallback.
3. **P3 — loose base-id regex** — `BASE_EVALUATOR_ID_PATTERN` accepted malformed ids (`ThirdParty.DeepEval`, `ThirdParty..ToolUse`, `ThirdParty.DeepEval.`) which `--level` then persisted. Tightened to `Builtin.<Metric>` / `ThirdParty.<Provider>.<Metric>`.
4. **P3 — stale `.llm-context`** — `llm-compacted` schema still described config as `llmAsAJudge | codeBased`; synced in the `derived` arm so generated project guidance matches runtime Zod.

## Verification
- Typecheck clean (pre-existing `agentcore-control.ts:546` SDK-model error unrelated).
- Evaluator schema + primitive unit tests pass.
- Behavioral smokes: `--type derived --config` → rejected; `ThirdParty.DeepEval` (+`--level`) → rejected; valid derived still writes correct config.
