### PR TITLE
fix(project): simplify agentcore spec serialization errors

### DIFF
--- a/src/core/project/manager.test.ts
+++ b/src/core/project/manager.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdir, mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
 import { join, relative } from "node:path";
 import { tmpdir } from "node:os";
-import { InputValidationError, ProjectStateError } from "../../errors/errors";
+import { DeserializationError, ProjectStateError } from "../../errors/errors";
 import { FsProjectManager } from "./manager";
 import {
   PROJECT_TEMPLATES,
@@ -324,13 +324,13 @@ describe("FsProjectManager.resolve", () => {
     expect(await manager().manager.resolve({ filePath: root })).toBeUndefined();
   });
 
-  test("throws InputValidationError on a malformed agentcore.json", async () => {
+  test("throws on a malformed agentcore.json", async () => {
     const root = await inTempDirectory();
     await mkdir(join(root, "agentcore"), { recursive: true });
     await writeFile(join(root, "agentcore", "agentcore.json"), "{ not valid json");
 
     await expect(manager().manager.resolve({ filePath: root })).rejects.toBeInstanceOf(
-      InputValidationError,
+      DeserializationError,
     );
   });
 });

--- a/src/core/project/manager.tsx
+++ b/src/core/project/manager.tsx
@@ -24,7 +24,6 @@ import { ProjectSpecSchema } from "../../projectSchemas/project";
 import { enclosingProjectRoot } from "./fsUtils";
 import {
   AgentCoreCLIError,
-  DeserializationError,
   InputValidationError,
   NotImplementedError,
   ProjectStateError,
@@ -63,22 +62,12 @@ export class FsProjectManager implements ProjectManager {
     if (!rootPath) return undefined;
 
     const configPath = join(rootPath, "agentcore", "agentcore.json");
-    try {
-      const spec = await this.json.read(configPath, ProjectSpecSchema);
-      return {
-        name: spec.name,
-        rootPath,
-        spec,
-      };
-    } catch (error) {
-      // A malformed agentcore.json is a user-correctable problem, not a crash.
-      if (error instanceof DeserializationError) {
-        throw new InputValidationError(`invalid project configuration at ${configPath}`, {
-          cause: error,
-        });
-      }
-      throw error;
-    }
+    const spec = await this.json.read(configPath, ProjectSpecSchema);
+    return {
+      name: spec.name,
+      rootPath,
+      spec,
+    };
   }
 
   public async *create(input: CreateProjectInput): AsyncGenerator<ProjectEvent, Project> {

--- a/src/core/project/manager.tsx
+++ b/src/core/project/manager.tsx
@@ -30,7 +30,7 @@ import {
   ProjectStateError,
 } from "../../errors/errors";
 import type { HarnessSpecSchema } from "../../projectSchemas/harness";
-import type z from "zod";
+import z from "zod";
 
 type ProjectManagerConfig = {
   logger: Logger;
@@ -176,12 +176,17 @@ export class FsProjectManager implements ProjectManager {
 
     yield { message: `Updating project spec file at '${agentCoreSpecPath}'` };
 
+    const newSpec = { ...existingProjectSpec, [projectSpecKey]: newResources };
+    const newSpecParseResult = ProjectSpecSchema.safeParse(newSpec);
+
+    if (!newSpecParseResult.success)
+      throw new InputValidationError(z.prettifyError(newSpecParseResult.error), {
+        cause: newSpecParseResult.error,
+      });
+
     // rollback scaffolding changes on failed config writes to prevent bad state.
     try {
-      const newProjectSpec = await this.json.write(agentCoreSpecPath, {
-        ...existingProjectSpec,
-        [projectSpecKey]: newResources,
-      });
+      const newProjectSpec = await this.json.write(agentCoreSpecPath, newSpecParseResult.data);
 
       return {
         ...project,

--- a/src/errors/errors.tsx
+++ b/src/errors/errors.tsx
@@ -93,10 +93,9 @@ export class SourceResolutionError extends InputValidationError {
   }
 }
 
-// TODO: attach telemetry metadata to this error class.
-export class DeserializationError extends Error {
-  constructor(path: string, options?: { cause?: unknown }) {
-    super(`Failed to deserialize JSON at "${path}"`, options);
+export class DeserializationError extends AgentCoreCLIError {
+  constructor(path: string, options?: Omit<AgentCoreCLIErrorOptions, "source">) {
+    super(`Failed to deserialize file at "${path}"`, { ...options, source: ERROR_SOURCE.USER });
     this.name = "DeserializationError";
   }
 }

--- a/src/handlers/project/project.test.ts
+++ b/src/handlers/project/project.test.ts
@@ -11,7 +11,6 @@ import {
   testIO,
 } from "../../testing";
 import { InputValidationError } from "../../errors";
-import { FsReadWriteJson, type ReadWriteJson } from "../../io";
 
 async function run(args: string[], opts?: { core?: TestCoreClient }) {
   const io = testIO();
@@ -586,33 +585,28 @@ describe("project add harness", () => {
     ).rejects.toBeInstanceOf(InputValidationError);
   });
 
-  test("cleans up scaffolded files when the spec write fails", async () => {
-    const projectRoot = await inProject();
-    const logger = createSilentLogger();
-    const realJson = new FsReadWriteJson({ logger });
-
-    // A json adapter that delegates reads but always fails on write.
-    const failingJson: ReadWriteJson = {
-      read: (path, schema) => realJson.read(path, schema),
-      write: () => {
-        throw new Error("simulated write failure");
-      },
-    };
-
-    const core = new TestCoreClient({ json: failingJson });
-
-    await expect(run(["add", "harness", "--name", "x"], { core })).rejects.toThrow();
-
-    // The scaffolded harness directory should have been cleaned up.
-    expect(existsSync(join(projectRoot, "app", "x"))).toBe(false);
-  });
-
   test("rejects a duplicate harness name", async () => {
     await inProject();
     await run(["add", "harness", "--name", "x"]);
     await expect(run(["add", "harness", "--name", "x"])).rejects.toBeInstanceOf(
       InputValidationError,
     );
+  });
+
+  test("rejects when the resulting spec would be invalid and rolls back scaffolding", async () => {
+    const projectRoot = await inProject();
+
+    // create a corrupted agentcore.json
+    const specPath = join(projectRoot, "agentcore", "agentcore.json");
+    const spec = await Bun.file(specPath).json();
+    spec.unknownField = "bad";
+    await Bun.write(specPath, JSON.stringify(spec));
+
+    await expect(run(["add", "harness", "--name", "x"])).rejects.toBeInstanceOf(
+      InputValidationError,
+    );
+
+    expect(existsSync(join(projectRoot, "app", "x"))).toBe(false);
   });
 
   test.each([

--- a/src/handlers/project/project.test.ts
+++ b/src/handlers/project/project.test.ts
@@ -10,7 +10,8 @@ import {
   TestGlobalConfigAccessor,
   testIO,
 } from "../../testing";
-import { InputValidationError } from "../../errors";
+import { DeserializationError, InputValidationError } from "../../errors";
+import { FsReadWriteJson, type ReadWriteJson } from "../../io";
 
 async function run(args: string[], opts?: { core?: TestCoreClient }) {
   const io = testIO();
@@ -593,7 +594,28 @@ describe("project add harness", () => {
     );
   });
 
-  test("rejects when the resulting spec would be invalid and rolls back scaffolding", async () => {
+  test("cleans up scaffolded files when the spec write fails", async () => {
+    const projectRoot = await inProject();
+    const logger = createSilentLogger();
+    const realJson = new FsReadWriteJson({ logger });
+
+    // A json adapter that delegates reads but always fails on write.
+    const failingJson: ReadWriteJson = {
+      read: (path, schema) => realJson.read(path, schema),
+      write: () => {
+        throw new Error("simulated write failure");
+      },
+    };
+
+    const core = new TestCoreClient({ json: failingJson });
+
+    await expect(run(["add", "harness", "--name", "x"], { core })).rejects.toThrow();
+
+    // The scaffolded harness directory should have been cleaned up.
+    expect(existsSync(join(projectRoot, "app", "x"))).toBe(false);
+  });
+
+  test("rejects when the existing spec is invalid", async () => {
     const projectRoot = await inProject();
 
     // create a corrupted agentcore.json
@@ -603,10 +625,8 @@ describe("project add harness", () => {
     await Bun.write(specPath, JSON.stringify(spec));
 
     await expect(run(["add", "harness", "--name", "x"])).rejects.toBeInstanceOf(
-      InputValidationError,
+      DeserializationError,
     );
-
-    expect(existsSync(join(projectRoot, "app", "x"))).toBe(false);
   });
 
   test.each([


### PR DESCRIPTION
## Problem 
This PR solves two related problems with project spec serialization. 
- the agentcore spec is not validated before writing out. The harness piece is already validated as a side-effect of scaffolding, but we should validate the whole config. 
- `DeserializationError` does not extend the base error. (think it preceded it)

## Solution
- validate entire agentcore spec before writing out. 
- make deserialization error a user error to avoid rewrapping. 

## Testing 
added a unit test to verify the case by corrupting the agentcore.json and validating we fail early. 