### PR TITLE
fix: validate existing IAM role trust policies

### DIFF
--- a/src/cli/aws/__tests__/iam.test.ts
+++ b/src/cli/aws/__tests__/iam.test.ts
@@ -1,0 +1,50 @@
+import { ValidationError } from '../../../lib/errors/types.js';
+import { validateIamRoleTrustPolicy } from '../iam';
+import { describe, expect, it } from 'vitest';
+
+const expectedPolicy = {
+  Version: '2012-10-17',
+  Statement: [
+    {
+      Effect: 'Allow',
+      Principal: { Service: 'bedrock-agentcore.amazonaws.com' },
+      Action: 'sts:AssumeRole',
+    },
+  ],
+};
+
+describe('validateIamRoleTrustPolicy', () => {
+  it('accepts structurally equal policies regardless of object key order', () => {
+    const reorderedPolicy = {
+      Statement: [
+        {
+          Action: 'sts:AssumeRole',
+          Principal: { Service: 'bedrock-agentcore.amazonaws.com' },
+          Effect: 'Allow',
+        },
+      ],
+      Version: '2012-10-17',
+    };
+
+    expect(() =>
+      validateIamRoleTrustPolicy(reorderedPolicy, expectedPolicy, 'TestRole', 'Delete the role.')
+    ).not.toThrow();
+  });
+
+  it('accepts a URL-encoded matching policy', () => {
+    const encodedPolicy = encodeURIComponent(JSON.stringify(expectedPolicy));
+
+    expect(() =>
+      validateIamRoleTrustPolicy(encodedPolicy, expectedPolicy, 'TestRole', 'Delete the role.')
+    ).not.toThrow();
+  });
+
+  it.each([undefined, 'not-json', { ...expectedPolicy, Statement: [] }])(
+    'rejects a missing, malformed, or mismatched policy',
+    actualPolicy => {
+      expect(() => validateIamRoleTrustPolicy(actualPolicy, expectedPolicy, 'TestRole', 'Delete the role.')).toThrow(
+        ValidationError
+      );
+    }
+  );
+});

--- a/src/cli/aws/iam.ts
+++ b/src/cli/aws/iam.ts
@@ -1,0 +1,41 @@
+import { ValidationError } from '../../lib/errors/types.js';
+import stableStringify from 'fast-json-stable-stringify';
+
+export type IamPolicyDocument = Record<string, unknown>;
+
+function parseIamPolicyDocument(policy: unknown): unknown {
+  if (typeof policy !== 'string') return policy;
+
+  try {
+    return JSON.parse(decodeURIComponent(policy));
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Reject an IAM role whose trust policy does not structurally match the expected policy.
+ *
+ * IAM may return AssumeRolePolicyDocument as an object or a URL-encoded JSON string.
+ */
+export function validateIamRoleTrustPolicy(
+  actualPolicy: unknown,
+  expectedPolicy: IamPolicyDocument,
+  roleName: string,
+  remediation: string
+): void {
+  const parsedPolicy = parseIamPolicyDocument(actualPolicy);
+  if (
+    parsedPolicy !== null &&
+    typeof parsedPolicy === 'object' &&
+    !Array.isArray(parsedPolicy) &&
+    stableStringify(parsedPolicy) === stableStringify(expectedPolicy)
+  ) {
+    return;
+  }
+
+  throw new ValidationError(
+    `Refusing to reuse existing IAM role "${roleName}" because its trust policy does not match ` +
+      `the policy required by AgentCore. ${remediation}`
+  );
+}

--- a/src/cli/operations/jobs/ab-test/__tests__/resolve.test.ts
+++ b/src/cli/operations/jobs/ab-test/__tests__/resolve.test.ts
@@ -1,6 +1,164 @@
 import type { AgentCoreProjectSpec } from '../../../../../schema';
-import { resolveRuntimeTargetNames } from '../resolve';
-import { describe, expect, it } from 'vitest';
+import { getOrCreateABTestRole, resolveRuntimeTargetNames } from '../resolve';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockIamSend } = vi.hoisted(() => ({
+  mockIamSend: vi.fn(),
+}));
+
+vi.mock('@aws-sdk/client-iam', () => ({
+  IAMClient: class {
+    send = mockIamSend;
+  },
+  CreateRoleCommand: class {
+    constructor(public input: unknown) {}
+  },
+  GetRoleCommand: class {
+    constructor(public input: unknown) {}
+  },
+  PutRolePolicyCommand: class {
+    constructor(public input: unknown) {}
+  },
+  DeleteRolePolicyCommand: class {
+    constructor(public input: unknown) {}
+  },
+  DeleteRoleCommand: class {
+    constructor(public input: unknown) {}
+  },
+}));
+
+vi.mock('../../../../aws/account', () => ({
+  getCredentialProvider: vi.fn().mockReturnValue({}),
+}));
+
+const accountId = '123456789012';
+const roleArn = `arn:aws:iam::${accountId}:role/AgentCore-Test-ABTestExperiment`;
+
+interface TestTrustPolicy {
+  Version: string;
+  Statement: {
+    Effect: string;
+    Principal: Record<string, string>;
+    Action: string;
+    Condition?: {
+      StringEquals: Record<string, string>;
+      ArnLike: Record<string, string>;
+    };
+  }[];
+}
+
+function expectedTrustPolicy(): TestTrustPolicy {
+  return {
+    Version: '2012-10-17',
+    Statement: [
+      {
+        Effect: 'Allow',
+        Principal: { Service: 'bedrock-agentcore.amazonaws.com' },
+        Action: 'sts:AssumeRole',
+        Condition: {
+          StringEquals: { 'aws:SourceAccount': accountId },
+          ArnLike: { 'aws:SourceArn': `arn:aws:bedrock-agentcore:*:${accountId}:ab-test/*` },
+        },
+      },
+    ],
+  };
+}
+
+function roleOptions() {
+  return {
+    region: 'us-east-1',
+    projectName: 'Test',
+    testName: 'Experiment',
+    gatewayArn: `arn:aws:bedrock-agentcore:us-east-1:${accountId}:gateway/test`,
+    propagationDelayMs: 0,
+  };
+}
+
+function entityAlreadyExistsError(): Error {
+  return Object.assign(new Error('Role already exists'), { name: 'EntityAlreadyExistsException' });
+}
+
+describe('getOrCreateABTestRole', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates a new role and applies its inline permissions policy', async () => {
+    mockIamSend.mockResolvedValueOnce({ Role: { Arn: roleArn } }).mockResolvedValueOnce({});
+
+    await expect(getOrCreateABTestRole(roleOptions())).resolves.toBe(roleArn);
+    expect(mockIamSend).toHaveBeenCalledTimes(2);
+  });
+
+  it('reuses an existing role when its trust policy matches', async () => {
+    mockIamSend
+      .mockRejectedValueOnce(entityAlreadyExistsError())
+      .mockResolvedValueOnce({
+        Role: { Arn: roleArn, AssumeRolePolicyDocument: expectedTrustPolicy() },
+      })
+      .mockResolvedValueOnce({});
+
+    await expect(getOrCreateABTestRole(roleOptions())).resolves.toBe(roleArn);
+    expect(mockIamSend).toHaveBeenCalledTimes(3);
+  });
+
+  it('reuses an existing role with a URL-encoded matching trust policy', async () => {
+    const encodedPolicy = encodeURIComponent(JSON.stringify(expectedTrustPolicy()));
+    mockIamSend
+      .mockRejectedValueOnce(entityAlreadyExistsError())
+      .mockResolvedValueOnce({
+        Role: { Arn: roleArn, AssumeRolePolicyDocument: encodedPolicy },
+      })
+      .mockResolvedValueOnce({});
+
+    await expect(getOrCreateABTestRole(roleOptions())).resolves.toBe(roleArn);
+    expect(mockIamSend).toHaveBeenCalledTimes(3);
+  });
+
+  it('rejects an existing role with an additional trusted principal', async () => {
+    const trustPolicy = expectedTrustPolicy();
+    trustPolicy.Statement.push({
+      Effect: 'Allow',
+      Principal: { AWS: `arn:aws:iam::${accountId}:user/attacker` },
+      Action: 'sts:AssumeRole',
+    });
+    mockIamSend.mockRejectedValueOnce(entityAlreadyExistsError()).mockResolvedValueOnce({
+      Role: { Arn: roleArn, AssumeRolePolicyDocument: trustPolicy },
+    });
+
+    await expect(getOrCreateABTestRole(roleOptions())).rejects.toThrow(/trust policy does not match/);
+    expect(mockIamSend).toHaveBeenCalledTimes(2);
+  });
+
+  const weakenedConditions: [string, (policy: TestTrustPolicy) => void][] = [
+    [
+      'SourceAccount',
+      policy => {
+        policy.Statement[0]!.Condition!.StringEquals['aws:SourceAccount'] = '*';
+      },
+    ],
+    [
+      'SourceArn',
+      policy => {
+        policy.Statement[0]!.Condition!.ArnLike['aws:SourceArn'] = '*';
+      },
+    ],
+  ];
+
+  it.each(weakenedConditions)(
+    'rejects an existing role with a weakened %s condition',
+    async (_condition, weakenPolicy) => {
+      const trustPolicy = expectedTrustPolicy();
+      weakenPolicy(trustPolicy);
+      mockIamSend.mockRejectedValueOnce(entityAlreadyExistsError()).mockResolvedValueOnce({
+        Role: { Arn: roleArn, AssumeRolePolicyDocument: trustPolicy },
+      });
+
+      await expect(getOrCreateABTestRole(roleOptions())).rejects.toThrow(/trust policy does not match/);
+      expect(mockIamSend).toHaveBeenCalledTimes(2);
+    }
+  );
+});
 
 type GatewaysOnly = Pick<AgentCoreProjectSpec, 'agentCoreGateways'>;
 

--- a/src/cli/operations/jobs/ab-test/resolve.ts
+++ b/src/cli/operations/jobs/ab-test/resolve.ts
@@ -8,6 +8,7 @@
 import type { AgentCoreProjectSpec, DeployedResourceState } from '../../../../schema';
 import { getCredentialProvider } from '../../../aws/account';
 import type { ABTestEvaluationConfig, ABTestVariant } from '../../../aws/agentcore-ab-tests';
+import { validateIamRoleTrustPolicy } from '../../../aws/iam';
 import { arnPrefix } from '../../../aws/partition';
 import {
   CreateRoleCommand,
@@ -61,7 +62,7 @@ export async function getOrCreateABTestRole(options: CreateABTestRoleOptions): P
   const accountId = gatewayArn.split(':')[4] ?? '*';
   const roleName = generateRoleName(projectName, testName);
 
-  const trustPolicy = JSON.stringify({
+  const trustPolicyDocument = {
     Version: '2012-10-17',
     Statement: [
       {
@@ -74,7 +75,8 @@ export async function getOrCreateABTestRole(options: CreateABTestRoleOptions): P
         },
       },
     ],
-  });
+  };
+  const trustPolicy = JSON.stringify(trustPolicyDocument);
 
   let roleArn: string;
   try {
@@ -102,6 +104,12 @@ export async function getOrCreateABTestRole(options: CreateABTestRoleOptions): P
       if (!roleArn) {
         throw new Error(`Role "${roleName}" already exists but ARN could not be retrieved`);
       }
+      validateIamRoleTrustPolicy(
+        existing.Role?.AssumeRolePolicyDocument,
+        trustPolicyDocument,
+        roleName,
+        'Delete the conflicting role or provide a customer-managed role with --role-arn.'
+      );
     } else {
       throw err;
     }


### PR DESCRIPTION
## Description

Adds trust-policy validation before reusing an existing managed IAM role in the imperative `agentcore run ab-test` path

- Adds a shared IAM trust-policy validator
- Validates an existing deterministic AB-test role before adopting it or updating its inline permissions
- Rejects missing, malformed, or divergent trust policies with guidance to delete the conflicting role or provide `--role-arn`
- Handling of attached or inline permission-policies remains unchanged

### Behavior Change

Existing AB tests are unaffected. New roles, matching existing roles, and explicit customer-managed roles continue to work normally.

When creating, retrying, or recreating an AB test without `--role-arn`, the CLI will now reject an existing deterministic role whose trust policy differs from the policy it would create. 

## Type of Change

<!-- Check all that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [x] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
