### PR TITLE
feat(evaluator): surface skill evaluators (TOOL_CALL level + skill placeholders)

### DIFF
--- a/src/cli/operations/eval/__tests__/run-eval.test.ts
+++ b/src/cli/operations/eval/__tests__/run-eval.test.ts
@@ -847,6 +847,42 @@ describe('handleRunEval', () => {
     );
   });
 
+  it('resolves Builtin skill evaluators to TOOL_CALL level', async () => {
+    const ctx = makeDeployedContext();
+    mockLoadDeployedProjectConfig.mockResolvedValue(ctx);
+    mockResolveAgent.mockReturnValue({
+      success: true,
+      agent: {
+        agentName: 'my-agent',
+        targetName: 'dev',
+        region: 'us-east-1',
+        accountId: '111222333444',
+        runtimeId: 'rt-123',
+      },
+    });
+
+    const spanRows = [makeToolCallSpanRow('session-1', 'trace-1', 'span-tool-1', 'calculator')];
+    setupCloudWatchToReturn(spanRows);
+
+    mockEvaluate.mockResolvedValue({
+      evaluationResults: [{ value: 1.0, context: { spanContext: { sessionId: 'session-1', spanId: 'span-tool-1' } } }],
+    });
+
+    // Builtin.SkillSelectionAccuracy / SkillInstructionFollowing are TOOL_CALL-level — they must
+    // target spans, not default to SESSION (which would send no targetSpanIds).
+    const result = await handleRunEval({
+      evaluator: ['Builtin.SkillSelectionAccuracy', 'Builtin.SkillInstructionFollowing'],
+      days: 7,
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockEvaluate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetSpanIds: ['span-tool-1'],
+      })
+    );
+  });
+
   it('batches targetSpanIds into chunks of 10 for TOOL_CALL evaluators', async () => {
     const ctx = makeDeployedContext();
     mockLoadDeployedProjectConfig.mockResolvedValue(ctx);

--- a/src/cli/operations/eval/run-eval.ts
+++ b/src/cli/operations/eval/run-eval.ts
@@ -179,6 +179,10 @@ const BUILTIN_EVALUATOR_LEVELS: Record<string, EvaluatorLevel> = {
   'Builtin.InstructionFollowing': 'TRACE',
   'Builtin.Refusal': 'TRACE',
   'Builtin.ToolSelectionAccuracy': 'TOOL_CALL',
+  // Skill evaluators judge the span that carries a skill invocation, so they are TOOL_CALL —
+  // not the SESSION default an unmapped Builtin.* falls through to, which would score wrong spans.
+  'Builtin.SkillSelectionAccuracy': 'TOOL_CALL',
+  'Builtin.SkillInstructionFollowing': 'TOOL_CALL',
 };
 
 /**

--- a/src/cli/tui/screens/evaluator/__tests__/types.test.ts
+++ b/src/cli/tui/screens/evaluator/__tests__/types.test.ts
@@ -34,6 +34,12 @@ describe('LEVEL_PLACEHOLDERS', () => {
     expect(LEVEL_PLACEHOLDERS.TOOL_CALL).toContain('context');
     expect(LEVEL_PLACEHOLDERS.TOOL_CALL).toContain('tool_turn');
   });
+
+  it('TOOL_CALL exposes skill placeholders for skill evaluators', () => {
+    expect(LEVEL_PLACEHOLDERS.TOOL_CALL).toContain('available_skills');
+    expect(LEVEL_PLACEHOLDERS.TOOL_CALL).toContain('invoked_skill');
+    expect(LEVEL_PLACEHOLDERS.TOOL_CALL).toContain('skill_content');
+  });
 });
 
 describe('DEFAULT_INSTRUCTIONS', () => {

--- a/src/cli/tui/screens/evaluator/types.ts
+++ b/src/cli/tui/screens/evaluator/types.ts
@@ -195,7 +195,7 @@ export function getEvaluatorModelOptions(provider: EvaluatorModelProvider): Eval
 export const LEVEL_PLACEHOLDERS: Record<EvaluationLevel, string[]> = {
   SESSION: ['context', 'available_tools'],
   TRACE: ['context', 'assistant_turn'],
-  TOOL_CALL: ['available_tools', 'context', 'tool_turn'],
+  TOOL_CALL: ['available_tools', 'context', 'tool_turn', 'available_skills', 'invoked_skill', 'skill_content'],
 };
 
 /**
@@ -218,6 +218,9 @@ export const PLACEHOLDER_DESCRIPTIONS: Record<string, string> = {
   expected_tool_trajectory: 'caller-provided expected sequence of tool calls',
   actual_tool_trajectory: 'actual sequence of tool calls from the session',
   expected_response: 'caller-provided expected agent response',
+  available_skills: 'skills offered to the agent (name + description)',
+  invoked_skill: 'the skill the agent selected for this span',
+  skill_content: "the selected skill's SKILL.md instructions",
 };
 
 /**


### PR DESCRIPTION
## What

Land the skill-evaluator support from `bug_bash_aug_18th` (PR #2016) onto `main`.

- **run-eval level mapping**: `Builtin.SkillSelectionAccuracy` and `Builtin.SkillInstructionFollowing` now resolve to **TOOL_CALL**, so they target skill-invocation spans instead of falling through to the `SESSION` default (which silently scores the wrong spans).
- **Evaluator TUI placeholders**: TOOL_CALL custom LLM-judge evaluators now expose `{available_skills}`, `{invoked_skill}`, `{skill_content}`, matching the service prompt-template contract.
- Tests for both.

## Files
- `src/cli/operations/eval/run-eval.ts` — add the two skill built-ins to `BUILTIN_EVALUATOR_LEVELS`
- `src/cli/tui/screens/evaluator/types.ts` — add skill placeholders to `LEVEL_PLACEHOLDERS.TOOL_CALL` + descriptions
- `run-eval.test.ts`, `types.test.ts` — coverage

## Verification
Verified in the eval bug bash (Flows 5–7): level map resolves both skill built-ins to TOOL_CALL for run-eval and batch; validator accepts the three skill placeholders at TOOL_CALL.

## Follow-up (not in this PR)
Replace the static `BUILTIN_EVALUATOR_LEVELS` map with a cached `listEvaluators()` lookup so future built-ins self-resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
