### PR TITLE
ci: use dedicated release runners

### DIFF
--- a/.github/workflows/release-main-and-preview.yml
+++ b/.github/workflows/release-main-and-preview.yml
@@ -54,7 +54,7 @@ jobs:
   # ═══════════════════════════════════════════════════════════════════
   prepare-release:
     name: Prepare Release
-    runs-on: ubuntu-latest
+    runs-on: aws-release-4-core
     outputs:
       main_version: ${{ steps.bump-main.outputs.version || steps.current-main.outputs.version }}
       preview_version: ${{ steps.bump-preview.outputs.version }}
@@ -216,7 +216,7 @@ jobs:
   release-approval:
     name: Release Approval
     needs: [prepare-release]
-    runs-on: ubuntu-latest
+    runs-on: aws-release-4-core
     environment:
       name: npm-publish-approval
     steps:
@@ -242,7 +242,7 @@ jobs:
     name: Verify PR Merged
     needs: [prepare-release, release-approval]
     if: ${{ !inputs.dry_run }}
-    runs-on: ubuntu-latest
+    runs-on: aws-release-4-core
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -284,7 +284,7 @@ jobs:
     name: Publish Main (@latest)
     needs: [prepare-release, verify-merge]
     if: inputs.release_target != 'preview-only'
-    runs-on: ubuntu-latest
+    runs-on: aws-release-4-core
     environment:
       name: npm-publish
       url: https://www.npmjs.com/package/@aws/agentcore
@@ -341,7 +341,7 @@ jobs:
     name: Publish Preview (@preview)
     needs: [prepare-release, verify-merge]
     if: inputs.release_target != 'main-only'
-    runs-on: ubuntu-latest
+    runs-on: aws-release-4-core
     environment:
       name: npm-publish
       url: https://www.npmjs.com/package/@aws/agentcore
@@ -412,7 +412,7 @@ jobs:
     name: Release Summary
     needs: [prepare-release, publish-main, publish-preview]
     if: always() && !cancelled()
-    runs-on: ubuntu-latest
+    runs-on: aws-release-4-core
     steps:
       - name: Summary
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ permissions:
 jobs:
   prepare-release:
     name: Prepare Release
-    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: aws-release-4-core
     outputs:
       version: ${{ steps.bump.outputs.version }}
       branch: ${{ steps.bump.outputs.branch }}
@@ -211,7 +211,7 @@ jobs:
   test-and-build:
     name: Test and Build
     needs: prepare-release
-    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: aws-release-4-core
 
     steps:
       - uses: actions/checkout@v7
@@ -276,7 +276,7 @@ jobs:
   release-approval:
     name: Release Approval
     needs: test-and-build
-    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: aws-release-4-core
     environment:
       name: npm-publish-approval
 
@@ -298,7 +298,7 @@ jobs:
   publish-npm:
     name: Publish to npm
     needs: [prepare-release, release-approval]
-    runs-on: codebuild-agentcore-e2e-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: aws-release-4-core
     environment:
       name: npm-publish
       url: https://www.npmjs.com/package/@aws/agentcore


### PR DESCRIPTION
## Description

Moves both release workflows to the dedicated `aws-release-4-core` GitHub-hosted runner group. This keeps release publishing and provenance on GitHub Actions without competing with the shared `ubuntu-latest` pool.

Both workflows remain manually triggered with `workflow_dispatch`; no pull-request-triggered workflow can target the release runner.

## Related Issue

N/A - operational CI capacity change.

## Documentation PR

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other: CI configuration

## Testing

How have you tested the change?

- [ ] I ran `npm run test:unit` and `npm run test:integ`
- [ ] I ran `npm run typecheck`
- [ ] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots
- [x] Parsed both modified workflows as YAML
- [x] Verified every release job uses `aws-release-4-core`
- [x] Verified neither workflow has a `pull_request` trigger

Source tests were not run because this change only updates workflow runner labels.

## Checklist

- [ ] I have read the CONTRIBUTING document
- [x] No source tests are needed for this workflow-only change
- [x] No documentation changes are needed
- [x] My changes generate no new warnings
- [x] No dependent changes are required

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
