### PR TITLE
fix(deps): consume agentcore-cdk alpha.48

### DIFF
--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -645,7 +645,7 @@ exports[`Assets Directory Snapshots > CDK assets > cdk/cdk/package.json should m
     "typescript": "~5.9.3"
   },
   "dependencies": {
-    "@aws/agentcore-cdk": "0.1.0-alpha.45",
+    "@aws/agentcore-cdk": "0.1.0-alpha.48",
     "aws-cdk-lib": "~2.261.0",
     "constructs": "~10.7.0"
   }

--- a/src/assets/cdk/package.json
+++ b/src/assets/cdk/package.json
@@ -23,7 +23,7 @@
     "typescript": "~5.9.3"
   },
   "dependencies": {
-    "@aws/agentcore-cdk": "0.1.0-alpha.45",
+    "@aws/agentcore-cdk": "0.1.0-alpha.48",
     "aws-cdk-lib": "~2.261.0",
     "constructs": "~10.7.0"
   }

--- a/src/lib/dependency-management/__tests__/plan.test.ts
+++ b/src/lib/dependency-management/__tests__/plan.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest';
 
 const VENDED: PackageManifest = {
   dependencies: {
-    '@aws/agentcore-cdk': '0.1.0-alpha.45',
+    '@aws/agentcore-cdk': '0.1.0-alpha.48',
     'aws-cdk-lib': '~2.261.0',
     constructs: '~10.7.0',
   },
@@ -42,7 +42,7 @@ describe('computeSyncPlan', () => {
     expect(plan.migratedFromCaret).toBe(true);
     expect(plan.skew).toEqual([]);
     expect(plan.changes).toEqual([
-      { name: '@aws/agentcore-cdk', section: 'dependencies', from: '^0.1.0-alpha.19', to: '0.1.0-alpha.45' },
+      { name: '@aws/agentcore-cdk', section: 'dependencies', from: '^0.1.0-alpha.19', to: '0.1.0-alpha.48' },
       { name: 'aws-cdk-lib', section: 'dependencies', from: '^2.248.0', to: '~2.261.0' },
       { name: 'constructs', section: 'dependencies', from: '^10.0.0', to: '~10.7.0' },
     ]);
@@ -83,12 +83,12 @@ describe('computeSyncPlan', () => {
     expect(plan.changes).toEqual([{ name: 'aws-cdk-lib', section: 'dependencies', from: '~2.261.5', to: '~2.261.0' }]);
   });
 
-  it('detects prerelease skew on the exact-pinned construct (alpha.50 > alpha.45)', () => {
+  it('detects prerelease skew on the exact-pinned construct (alpha.50 > alpha.48)', () => {
     const plan = computeSyncPlan(
       VENDED,
       project({ dependencies: { ...VENDED.dependencies, '@aws/agentcore-cdk': '0.1.0-alpha.50' } })
     );
-    expect(plan.skew).toEqual([{ name: '@aws/agentcore-cdk', declared: '0.1.0-alpha.50', expected: '0.1.0-alpha.45' }]);
+    expect(plan.skew).toEqual([{ name: '@aws/agentcore-cdk', declared: '0.1.0-alpha.50', expected: '0.1.0-alpha.48' }]);
   });
 
   it('upgrades an older exact-pinned prerelease', () => {
@@ -98,7 +98,7 @@ describe('computeSyncPlan', () => {
     );
     expect(plan.skew).toEqual([]);
     expect(plan.changes).toEqual([
-      { name: '@aws/agentcore-cdk', section: 'dependencies', from: '0.1.0-alpha.19', to: '0.1.0-alpha.45' },
+      { name: '@aws/agentcore-cdk', section: 'dependencies', from: '0.1.0-alpha.19', to: '0.1.0-alpha.48' },
     ]);
   });
 

--- a/src/lib/dependency-management/__tests__/sync.test.ts
+++ b/src/lib/dependency-management/__tests__/sync.test.ts
@@ -14,7 +14,7 @@ vi.mock('../../utils/subprocess', () => ({
 const VENDED = {
   name: 'agentcore-cdk-app',
   dependencies: {
-    '@aws/agentcore-cdk': '0.1.0-alpha.45',
+    '@aws/agentcore-cdk': '0.1.0-alpha.48',
     'aws-cdk-lib': '~2.261.0',
   },
   devDependencies: {
@@ -78,7 +78,7 @@ describe('syncManagedDependencies', () => {
     expect(result.notice).toContain('disableDependencyManagement');
 
     const written = readProject();
-    expect(written.dependencies['@aws/agentcore-cdk']).toBe('0.1.0-alpha.45');
+    expect(written.dependencies['@aws/agentcore-cdk']).toBe('0.1.0-alpha.48');
     expect(written.dependencies['aws-cdk-lib']).toBe('~2.261.0');
     expect(written.dependencies.lodash).toBe('^4.17.21');
 
@@ -103,7 +103,7 @@ describe('syncManagedDependencies', () => {
   it('preserves key order and unknown fields when rewriting', async () => {
     writeProject({
       zeta: 'kept',
-      dependencies: { lodash: '1.0.0', 'aws-cdk-lib': '~2.250.0', '@aws/agentcore-cdk': '0.1.0-alpha.45' },
+      dependencies: { lodash: '1.0.0', 'aws-cdk-lib': '~2.250.0', '@aws/agentcore-cdk': '0.1.0-alpha.48' },
       scripts: { build: 'tsc' },
       devDependencies: { typescript: '~5.9.3' },
     });
@@ -163,7 +163,7 @@ describe('syncManagedDependencies', () => {
     expect(result.warnings.some(w => w.includes('newer than this CLI was tested with'))).toBe(true);
     // The skewed dep is left alone; the other managed dep still syncs.
     expect(readProject().dependencies['aws-cdk-lib']).toBe('~2.300.0');
-    expect(readProject().dependencies['@aws/agentcore-cdk']).toBe('0.1.0-alpha.45');
+    expect(readProject().dependencies['@aws/agentcore-cdk']).toBe('0.1.0-alpha.48');
   });
 
   it('check mode computes the plan and a future-tense notice without writing or installing', async () => {
@@ -211,7 +211,7 @@ describe('syncManagedDependencies', () => {
 
   it('restores a deleted managed dependency', async () => {
     writeProject({
-      dependencies: { '@aws/agentcore-cdk': '0.1.0-alpha.45' },
+      dependencies: { '@aws/agentcore-cdk': '0.1.0-alpha.48' },
       devDependencies: { typescript: '~5.9.3' },
     });
     const result = await run();


### PR DESCRIPTION
## Description

Updates the CLI-managed `@aws/agentcore-cdk` dependency from `0.1.0-alpha.45` to the published
`0.1.0-alpha.48` release.

The newer construct release includes the uv wheel-diagnostic retry fix from
`aws/agentcore-l3-cdk-constructs#329`, which restores LangChain/LangGraph CodeZip synthesis with
current uv versions. It also carries the managed-memory ARN, configuration-bundle partition, and
gateway parameter preservation fixes released since `alpha.45`.

This change updates the vended CDK manifest, dependency reconciliation expectations, prerelease
skew tests, and the asset snapshot. Existing projects are upgraded to `alpha.48` by the normal
managed-dependency sync on their next deploy.

## Related Issue

Closes #2050

## Documentation PR

N/A. This consumes an already-published compatible L3 bugfix release without changing the CLI
interface.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [x] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

Additional verification:

- `npm run build`
- `npm run format:check`
- Focused dependency-management and asset snapshot tests: 158 passed
- Integration tests: 336 passed, 1 skipped

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly, or no documentation change is required
- [x] I have added an appropriate example to the documentation, or no new example is required
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
