### PR TITLE
fix(dev): support Node tool shims on Windows

### DIFF
--- a/src/cli/operations/dev/__tests__/codezip-dev-server.test.ts
+++ b/src/cli/operations/dev/__tests__/codezip-dev-server.test.ts
@@ -7,9 +7,14 @@ import { existsSync } from 'fs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockSpawn = vi.fn();
+const mockRunSubprocessCapture = vi.fn();
+const platformState = vi.hoisted(() => ({ isWindows: false }));
 vi.mock('child_process', () => ({
   spawn: (...args: unknown[]) => mockSpawn(...args),
   spawnSync: vi.fn(() => ({ status: 0, stdout: Buffer.from(''), stderr: Buffer.from('') })),
+}));
+vi.mock('../../../../lib/utils/subprocess', () => ({
+  runSubprocessCapture: (...args: unknown[]) => mockRunSubprocessCapture(...args),
 }));
 
 vi.mock('fs', () => ({
@@ -21,7 +26,11 @@ const mockExistsSync = vi.mocked(existsSync);
 
 vi.mock('../../../../lib/utils/platform', () => ({
   getVenvExecutable: (venvPath: string, executable: string) => `${venvPath}/bin/${executable}`,
-  isWindows: false,
+  getShellCommand: () => 'cmd',
+  getShellArgs: (command: string) => ['/c', command],
+  get isWindows() {
+    return platformState.isWindows;
+  },
 }));
 
 function createMockChildProcess() {
@@ -38,8 +47,13 @@ const defaultOptions: DevServerOptions = { port: 8080, envVars: { MY_KEY: 'secre
 
 describe('CodeZipDevServer spawn config', () => {
   beforeEach(() => {
+    platformState.isWindows = false;
     mockSpawn.mockClear();
     mockSpawn.mockReturnValue(createMockChildProcess());
+    mockRunSubprocessCapture.mockReset();
+    mockRunSubprocessCapture.mockResolvedValue({ code: 0, stdout: '', stderr: '', signal: null });
+    vi.mocked(mockCallbacks.onLog).mockClear();
+    vi.mocked(mockCallbacks.onExit).mockClear();
   });
 
   afterEach(() => vi.restoreAllMocks());
@@ -155,6 +169,28 @@ describe('CodeZipDevServer spawn config', () => {
     expect(env.LOCAL_DEV).toBe('1');
   });
 
+  it('TypeScript HTTP: runs npx through cmd on Windows', async () => {
+    platformState.isWindows = true;
+    const config: DevConfig = {
+      agentName: 'TsAgent',
+      module: 'src/main.ts',
+      directory: 'C:\\project\\app',
+      hasConfig: true,
+      isPython: false,
+      buildType: 'CodeZip',
+      protocol: 'HTTP',
+    };
+
+    const server = new CodeZipDevServer(config, defaultOptions);
+    await server.start();
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'cmd',
+      ['/c', 'npx tsx watch src/main.ts'],
+      expect.objectContaining({ cwd: 'C:\\project\\app', detached: false })
+    );
+  });
+
   it('TypeScript: installs node dependencies when node_modules missing', async () => {
     mockExistsSync.mockImplementation((p: unknown) => {
       const s = String(p);
@@ -163,13 +199,6 @@ describe('CodeZipDevServer spawn config', () => {
       if (s.endsWith('yarn.lock')) return false;
       return true;
     });
-    mockSpawnSync.mockClear();
-    mockSpawnSync.mockReturnValue({
-      status: 0,
-      stdout: Buffer.from(''),
-      stderr: Buffer.from(''),
-    } as any);
-
     const config: DevConfig = {
       agentName: 'TsAgent',
       module: 'main.ts',
@@ -183,8 +212,35 @@ describe('CodeZipDevServer spawn config', () => {
     const server = new CodeZipDevServer(config, defaultOptions);
     await server.start();
 
-    expect(mockSpawnSync).toHaveBeenCalledWith('npm', ['install'], expect.objectContaining({ cwd: '/project/app' }));
+    expect(mockRunSubprocessCapture).toHaveBeenCalledWith('npm', ['install'], { cwd: '/project/app' });
     mockExistsSync.mockImplementation(() => true);
+  });
+
+  it('TypeScript: reports the process creation error when dependency installation cannot start', async () => {
+    mockExistsSync.mockImplementation((p: unknown) => !String(p).endsWith('node_modules'));
+    mockRunSubprocessCapture.mockResolvedValue({
+      status: null,
+      code: -1,
+      stdout: '',
+      stderr: 'spawn npm ENOENT',
+      signal: null,
+    });
+    const config: DevConfig = {
+      agentName: 'TsAgent',
+      module: 'main.ts',
+      directory: '/project/app',
+      hasConfig: true,
+      isPython: false,
+      buildType: 'CodeZip',
+      protocol: 'HTTP',
+    };
+
+    const server = new CodeZipDevServer(config, defaultOptions);
+    const child = await server.start();
+
+    expect(child).toBeNull();
+    expect(mockCallbacks.onLog).toHaveBeenCalledWith('error', 'Failed to install Node dependencies: spawn npm ENOENT');
+    expect(mockSpawn).not.toHaveBeenCalled();
   });
 
   it('TypeScript: skips install when node_modules exists', async () => {
@@ -204,7 +260,7 @@ describe('CodeZipDevServer spawn config', () => {
     const server = new CodeZipDevServer(config, defaultOptions);
     await server.start();
 
-    expect(mockSpawnSync).not.toHaveBeenCalledWith('npm', ['install'], expect.anything());
+    expect(mockRunSubprocessCapture).not.toHaveBeenCalled();
   });
 
   it('MCP: extracts file from module:function entrypoint', async () => {

--- a/src/cli/operations/dev/codezip-dev-server.ts
+++ b/src/cli/operations/dev/codezip-dev-server.ts
@@ -1,4 +1,5 @@
-import { getVenvExecutable } from '../../../lib/utils/platform';
+import { getShellArgs, getShellCommand, getVenvExecutable, isWindows } from '../../../lib/utils/platform';
+import { runSubprocessCapture } from '../../../lib/utils/subprocess';
 import type { ProtocolMode } from '../../../schema';
 import { A2A_PORT_ENV } from './constants';
 import { DevServer, type LogLevel, type SpawnConfig } from './dev-server';
@@ -72,7 +73,7 @@ function ensurePythonVenv(
  * Ensures Node dependencies are installed. Runs the appropriate package manager
  * install if `node_modules` is missing. Detects pnpm/yarn via lockfile, else npm.
  */
-function ensureNodeDeps(cwd: string, onLog: (level: LogLevel, message: string) => void): boolean {
+async function ensureNodeDeps(cwd: string, onLog: (level: LogLevel, message: string) => void): Promise<boolean> {
   if (existsSync(join(cwd, 'node_modules'))) {
     return true;
   }
@@ -88,9 +89,10 @@ function ensureNodeDeps(cwd: string, onLog: (level: LogLevel, message: string) =
   }
 
   onLog('system', 'Installing Node dependencies...');
-  const result = spawnSync(cmd, args, { cwd, stdio: 'pipe' });
-  if (result.status !== 0) {
-    onLog('error', `Failed to install Node dependencies: ${result.stderr?.toString() || 'unknown error'}`);
+  const result = await runSubprocessCapture(cmd, args, { cwd });
+  if (result.code !== 0) {
+    const detail = result.stderr || result.stdout || `${cmd} exited with code ${String(result.code)}`;
+    onLog('error', `Failed to install Node dependencies: ${detail}`);
     return false;
   }
   onLog('system', 'Node dependencies ready');
@@ -125,12 +127,11 @@ function findOtelSitecustomizeDir(venvPath: string): string | undefined {
 
 /** Dev server for CodeZip agents. Runs uvicorn (Python) or npx tsx (Node.js) locally. */
 export class CodeZipDevServer extends DevServer {
-  protected prepare(): Promise<boolean> {
-    return Promise.resolve(
-      this.config.isPython
-        ? ensurePythonVenv(this.config.directory, this.options.callbacks.onLog, this.config.protocol)
-        : ensureNodeDeps(this.config.directory, this.options.callbacks.onLog)
-    );
+  protected async prepare(): Promise<boolean> {
+    if (this.config.isPython) {
+      return ensurePythonVenv(this.config.directory, this.options.callbacks.onLog, this.config.protocol);
+    }
+    return ensureNodeDeps(this.config.directory, this.options.callbacks.onLog);
   }
 
   protected getSpawnConfig(): SpawnConfig {
@@ -155,6 +156,14 @@ export class CodeZipDevServer extends DevServer {
     if (!isPython) {
       // TS entrypoint is already a file path like "main.ts" — pass it straight to tsx.
       const entryFile = module.split(':')[0] ?? module;
+      if (isWindows) {
+        return {
+          cmd: getShellCommand(),
+          args: getShellArgs(`npx tsx watch ${entryFile}`),
+          cwd: directory,
+          env,
+        };
+      }
       return {
         cmd: 'npx',
         args: ['tsx', 'watch', entryFile],

--- a/src/cli/operations/dev/web-ui/__tests__/run-web-ui.test.ts
+++ b/src/cli/operations/dev/web-ui/__tests__/run-web-ui.test.ts
@@ -1,0 +1,67 @@
+import { runWebUI } from '../run-web-ui';
+import type { WebUIOptions } from '../web-server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const state = vi.hoisted(() => ({
+  loggerLog: vi.fn(),
+  loggerFinalize: vi.fn(),
+  consumerLog: vi.fn(),
+  serverOptions: undefined as WebUIOptions | undefined,
+}));
+
+vi.mock('../../../../logging', () => ({
+  ExecLogger: class {
+    log = state.loggerLog;
+    finalize = state.loggerFinalize;
+
+    getRelativeLogPath() {
+      return '.cli/logs/dev/test.log';
+    }
+  },
+}));
+
+vi.mock('../../server', () => ({
+  findAvailablePort: vi.fn().mockResolvedValue(8081),
+}));
+
+vi.mock('../../utils', () => ({
+  onShutdownSignal: vi.fn(),
+  openBrowser: vi.fn(),
+}));
+
+vi.mock('../web-server', () => ({
+  WebUIServer: class {
+    constructor(options: WebUIOptions) {
+      state.serverOptions = options;
+    }
+
+    start = vi.fn();
+    stop = vi.fn();
+  },
+}));
+
+describe('runWebUI logging', () => {
+  beforeEach(() => {
+    state.loggerLog.mockClear();
+    state.loggerFinalize.mockClear();
+    state.consumerLog.mockClear();
+    state.serverOptions = undefined;
+  });
+
+  it('writes web UI messages to the advertised log and the display handler', async () => {
+    void runWebUI({
+      logLabel: 'dev',
+      onLog: state.consumerLog,
+      serverOptions: {
+        mode: 'dev',
+        agents: [],
+      },
+    });
+
+    await vi.waitFor(() => expect(state.serverOptions).toBeDefined());
+    state.serverOptions!.onLog!('error', 'Failed to install Node dependencies: spawn npm ENOENT');
+
+    expect(state.loggerLog).toHaveBeenCalledWith('Failed to install Node dependencies: spawn npm ENOENT', 'error');
+    expect(state.consumerLog).toHaveBeenCalledWith('error', 'Failed to install Node dependencies: spawn npm ENOENT');
+  });
+});

--- a/src/cli/operations/dev/web-ui/run-web-ui.ts
+++ b/src/cli/operations/dev/web-ui/run-web-ui.ts
@@ -29,11 +29,15 @@ export async function runWebUI(opts: RunWebUIOptions): Promise<void> {
   console.log(`Starting web UI...`);
   console.log(`Log: ${logger.getRelativeLogPath()}`);
 
-  const onLog =
+  const displayLog =
     opts.onLog ??
     ((level: 'info' | 'warn' | 'error', msg: string) => {
       if (level === 'error') console.error(`Web UI: ${msg}`);
     });
+  const onLog = (level: 'info' | 'warn' | 'error', msg: string) => {
+    logger.log(msg, level);
+    displayLog(level, msg);
+  };
 
   const webUI = new WebUIServer({
     ...serverOptions,
@@ -52,6 +56,7 @@ export async function runWebUI(opts: RunWebUIOptions): Promise<void> {
   onShutdownSignal(() => {
     console.log('\nStopping servers...');
     webUI.stop();
+    logger.finalize(true);
   });
 
   // Keep process alive

--- a/src/lib/utils/__tests__/subprocess.test.ts
+++ b/src/lib/utils/__tests__/subprocess.test.ts
@@ -55,6 +55,7 @@ describe('runSubprocessCapture', () => {
   it('returns code -1 for unknown command', async () => {
     const result = await runSubprocessCapture('__nonexistent_command_xyz__', []);
     expect(result.code).toBe(-1);
+    expect(result.stderr).toContain('__nonexistent_command_xyz__');
   });
 
   it('respects cwd option', async () => {

--- a/src/lib/utils/subprocess.ts
+++ b/src/lib/utils/subprocess.ts
@@ -113,8 +113,8 @@ export async function runSubprocessCapture(
       resolve({ stdout, stderr, code, signal });
     });
 
-    child.on('error', () => {
-      resolve({ stdout, stderr, code: -1, signal: null });
+    child.on('error', error => {
+      resolve({ stdout, stderr: stderr || error.message, code: -1, signal: null });
     });
   });
 }


### PR DESCRIPTION
## Description

Fixes the two consecutive Windows failures that prevent TypeScript CodeZip agents from starting
under `agentcore dev`.

On Windows, npm package commands are commonly `.cmd` shims and cannot be launched directly through
Node's `spawn` APIs. The dev server previously raw-spawned both `npm install` and
`npx tsx watch ...`. The install failure also discarded the process creation error and displayed
`unknown error`; manually installing dependencies only advanced the flow to the same
`spawn npx ENOENT` failure.

This change:

- runs npm, pnpm, and yarn installation through the existing Windows-aware subprocess helper
- launches `npx tsx watch` through the platform shell on Windows while preserving direct spawning
  on POSIX
- retains process creation errors in captured stderr instead of reporting `unknown error`
- writes browser-mode agent messages to the advertised dev log as well as the display callback
- adds regression coverage for Windows command routing, install failures, subprocess diagnostics,
  and web-UI log persistence

## Related Issue

Closes #1849
Closes #2036

## Documentation PR

N/A. This restores the documented TypeScript development workflow on Windows.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [x] N/A - no `src/assets/` files were modified

Additional verification:

- `npm run build`
- `npm run format:check`
- Focused dev/subprocess tests: 56 passed
- Full unit suite: 6,115 passed
- Integration tests: 336 passed, 1 skipped
- Windows behavior is covered through platform-mode unit tests; no Windows host was available for
  local end-to-end execution

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added necessary tests that prove the fix is effective
- [x] No documentation change is required
- [x] No new example is required
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
