### PR TITLE
feat(project): add online-insight to project add

### DIFF
--- a/src/core/project/manager.tsx
+++ b/src/core/project/manager.tsx
@@ -173,6 +173,7 @@ export class FsProjectManager implements ProjectManager {
       }
       case "config-bundle":
       case "online-eval":
+      case "online-insight":
         newResources.push(resourceConfig);
         break;
 
@@ -272,6 +273,7 @@ function toProjectSpecKey(resourceType: ProjectResource) {
     case "config-bundle":
       return "configBundles";
     case "online-eval":
+    case "online-insight":
       return "onlineEvalConfigs";
   }
 }

--- a/src/handlers/project/add/index.ts
+++ b/src/handlers/project/add/index.ts
@@ -3,6 +3,7 @@ import { Router } from "../../../router";
 import { createAddConfigBundleHandler } from "./config-bundle";
 import { createAddHarnessHandler } from "./harness";
 import { createAddOnlineEvalHandler } from "./online-eval";
+import { createAddOnlineInsightHandler } from "./online-insight";
 import type { AddProjectResourceConfig } from "./types";
 
 export function createAddProjectResourceHandler(config: AddProjectResourceConfig): Router {
@@ -11,5 +12,6 @@ export function createAddProjectResourceHandler(config: AddProjectResourceConfig
   projectAdd.handler(createAddConfigBundleHandler(config));
   projectAdd.handler(createAddHarnessHandler(config));
   projectAdd.handler(createAddOnlineEvalHandler(config));
+  projectAdd.handler(createAddOnlineInsightHandler(config));
   return projectAdd;
 }

--- a/src/handlers/project/add/online-insight/index.test.ts
+++ b/src/handlers/project/add/online-insight/index.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createRootHandler } from "../../../index";
+import {
+  createSilentLogger,
+  TestCoreClient,
+  TestGlobalConfigAccessor,
+  testIO,
+} from "../../../../testing";
+import { DeserializationError, InputValidationError } from "../../../../errors";
+
+const originalCwd = process.cwd();
+const tempDirectories: string[] = [];
+
+async function inTempDirectory(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "agentcore-online-insight-"));
+  tempDirectories.push(directory);
+  process.chdir(directory);
+  return process.cwd();
+}
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  await Promise.all(
+    tempDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+async function run(args: string[], opts?: { core?: TestCoreClient }) {
+  const io = testIO();
+  const core = opts?.core ?? new TestCoreClient();
+  const root = createRootHandler(core, {
+    io: io.io,
+    globalConfigAccessor: new TestGlobalConfigAccessor(),
+    logger: createSilentLogger(),
+  });
+  await root.route(["node", "agentcore", "project", ...args]);
+  return { io, core };
+}
+
+async function inProject(name = "TestProject"): Promise<string> {
+  const directory = await inTempDirectory();
+  await run(["create", "--name", name, "--skip-install", "--skip-git"]);
+  const projectRoot = join(directory, name);
+  process.chdir(projectRoot);
+  return projectRoot;
+}
+
+const INSIGHT = "Builtin.Insight.FailureAnalysis";
+
+describe("project add online-insight", () => {
+  test.each<[string, string[], Record<string, unknown>]>([
+    [
+      "minimal — agent source",
+      ["--name", "x", "--agent", "hello_world", "--insight", INSIGHT, "--sampling-rate", "50"],
+      { agent: "hello_world", insights: [INSIGHT], samplingRate: 50 },
+    ],
+    [
+      "custom log-group source",
+      [
+        "--name",
+        "x",
+        "--log-group-name",
+        "/aws/foo",
+        "--insight",
+        INSIGHT,
+        "--sampling-rate",
+        "50",
+      ],
+      { logGroupNames: ["/aws/foo"], insights: [INSIGHT], samplingRate: 50 },
+    ],
+    [
+      "agent source with endpoint",
+      [
+        "--name",
+        "x",
+        "--agent",
+        "hello_world",
+        "--endpoint",
+        "PROD",
+        "--insight",
+        INSIGHT,
+        "--sampling-rate",
+        "10",
+      ],
+      { agent: "hello_world", endpoint: "PROD" },
+    ],
+    [
+      "clustering frequencies",
+      [
+        "--name",
+        "x",
+        "--agent",
+        "hello_world",
+        "--insight",
+        INSIGHT,
+        "--sampling-rate",
+        "10",
+        "--clustering-frequency",
+        "DAILY",
+        "WEEKLY",
+      ],
+      { clusteringConfig: { frequencies: ["DAILY", "WEEKLY"] } },
+    ],
+    [
+      "service-name filter on a custom source",
+      [
+        "--name",
+        "x",
+        "--log-group-name",
+        "/aws/foo",
+        "--service-name",
+        "svc",
+        "--insight",
+        INSIGHT,
+        "--sampling-rate",
+        "25",
+      ],
+      { logGroupNames: ["/aws/foo"], serviceNames: ["svc"] },
+    ],
+    [
+      "description, enable-on-create false, tags",
+      [
+        "--name",
+        "x",
+        "--agent",
+        "hello_world",
+        "--insight",
+        INSIGHT,
+        "--sampling-rate",
+        "5",
+        "--description",
+        "monitor prod",
+        "--enable-on-create",
+        "false",
+        "--tags",
+        '{"team":"ml"}',
+      ],
+      { description: "monitor prod", enableOnCreate: false, tags: { team: "ml" } },
+    ],
+  ])("%s", async (_label, flags, expected) => {
+    const projectRoot = await inProject();
+    await run(["add", "online-insight", ...flags]);
+
+    const agentcoreJson = await Bun.file(join(projectRoot, "agentcore", "agentcore.json")).json();
+    const config = agentcoreJson.onlineEvalConfigs.find((c: { name: string }) => c.name === "x");
+    expect(config).toMatchObject(expected);
+  });
+
+  test("rejects a duplicate online-insight name", async () => {
+    await inProject();
+    const flags = [
+      "--name",
+      "x",
+      "--agent",
+      "hello_world",
+      "--insight",
+      INSIGHT,
+      "--sampling-rate",
+      "50",
+    ];
+    await run(["add", "online-insight", ...flags]);
+    await expect(run(["add", "online-insight", ...flags])).rejects.toBeInstanceOf(
+      InputValidationError,
+    );
+  });
+
+  test("rejects when the existing spec is invalid", async () => {
+    const projectRoot = await inProject();
+
+    const specPath = join(projectRoot, "agentcore", "agentcore.json");
+    const spec = await Bun.file(specPath).json();
+    spec.unknownField = "bad";
+    await Bun.write(specPath, JSON.stringify(spec));
+
+    await expect(
+      run([
+        "add",
+        "online-insight",
+        "--name",
+        "x",
+        "--agent",
+        "hello_world",
+        "--insight",
+        INSIGHT,
+        "--sampling-rate",
+        "5",
+      ]),
+    ).rejects.toBeInstanceOf(DeserializationError);
+  });
+
+  test.each<[string, string[]]>([
+    ["missing --name", ["--agent", "a", "--insight", INSIGHT, "--sampling-rate", "10"]],
+    ["missing --sampling-rate", ["--name", "x", "--agent", "a", "--insight", INSIGHT]],
+    ["no --insight", ["--name", "x", "--agent", "a", "--sampling-rate", "10"]],
+    [
+      "invalid insight id",
+      ["--name", "x", "--agent", "a", "--insight", "NotAnInsight", "--sampling-rate", "10"],
+    ],
+    [
+      "--agent and --log-group-name are mutually exclusive",
+      [
+        "--name",
+        "x",
+        "--agent",
+        "a",
+        "--log-group-name",
+        "/x",
+        "--insight",
+        INSIGHT,
+        "--sampling-rate",
+        "10",
+      ],
+    ],
+    [
+      "--endpoint without --agent",
+      [
+        "--name",
+        "x",
+        "--log-group-name",
+        "/x",
+        "--endpoint",
+        "PROD",
+        "--insight",
+        INSIGHT,
+        "--sampling-rate",
+        "10",
+      ],
+    ],
+    [
+      "--service-name without --log-group-name",
+      [
+        "--name",
+        "x",
+        "--agent",
+        "a",
+        "--service-name",
+        "svc",
+        "--insight",
+        INSIGHT,
+        "--sampling-rate",
+        "10",
+      ],
+    ],
+  ])("%s", async (_label, flags) => {
+    await inProject();
+    await expect(run(["add", "online-insight", ...flags])).rejects.toBeInstanceOf(
+      InputValidationError,
+    );
+  });
+});

--- a/src/handlers/project/add/online-insight/index.ts
+++ b/src/handlers/project/add/online-insight/index.ts
@@ -1,0 +1,112 @@
+import z from "zod";
+import { createHandler, flag, ProjectKey } from "../../../../router";
+import { InputValidationError } from "../../../../errors";
+import { OnlineEvalConfigSchema } from "../../../../projectSchemas/online-eval-config";
+import { parseJsonFlag } from "../../../utils";
+import type { AddProjectResourceConfig } from "../types";
+
+const BUILTIN_INSIGHT_PREFIX = "Builtin.Insight.";
+const ARN_PREFIX = "arn:";
+
+export const createAddOnlineInsightHandler = (config: AddProjectResourceConfig) =>
+  createHandler({
+    name: "online-insight",
+    description: "adds an online insight config to the current project",
+    flags: [
+      flag("name", "the name of the online insight config", z.string().optional()),
+      flag(
+        "agent",
+        "harness/runtime name whose traffic to sample (mutually exclusive with --log-group-name)",
+        z.string().optional(),
+      ),
+      flag(
+        "endpoint",
+        "the agent endpoint qualifier to scope monitoring to (requires --agent)",
+        z.string().optional(),
+      ),
+      flag(
+        "log-group-name",
+        "CloudWatch log group name(s) for custom data sources (1-5; mutually exclusive with --agent)",
+        z.array(z.string()).optional(),
+      ),
+      flag(
+        "service-name",
+        "service name(s) to filter traces for custom data sources (requires --log-group-name)",
+        z.array(z.string()).optional(),
+      ),
+      flag(
+        "insight",
+        "insight ID(s) to apply: Builtin.Insight.* identifiers or full ARNs",
+        z.array(z.string()).optional(),
+      ),
+      flag(
+        "clustering-frequency",
+        "insight clustering cadence(s): DAILY, WEEKLY, MONTHLY",
+        z.array(z.enum(["DAILY", "WEEKLY", "MONTHLY"])).optional(),
+      ),
+      flag(
+        "sampling-rate",
+        "percentage of sessions to sample (0.01-100)",
+        z.number().min(0.01).max(100).optional(),
+      ),
+      flag(
+        "description",
+        "a description of the config's monitoring purpose",
+        z.string().optional(),
+      ),
+      flag(
+        "enable-on-create",
+        "enable insights immediately after deploy (default true; pass false to add it paused)",
+        z.enum(["true", "false"]).optional(),
+      ),
+      flag("tags", "tags to apply (JSON object of key/value strings)", z.string().optional()),
+    ],
+    handle: async (ctx, flags) => {
+      if (!flags["name"])
+        throw new InputValidationError("required option '--name <name>' not specified");
+      if (flags["sampling-rate"] === undefined)
+        throw new InputValidationError(
+          "required option '--sampling-rate <sampling-rate>' not specified",
+        );
+
+      for (const id of flags["insight"] ?? []) {
+        if (!id.startsWith(BUILTIN_INSIGHT_PREFIX) && !id.startsWith(ARN_PREFIX))
+          throw new InputValidationError(
+            `invalid insight "${id}": must be a ${BUILTIN_INSIGHT_PREFIX}* identifier or a full ARN`,
+          );
+      }
+
+      const frequencies = flags["clustering-frequency"];
+      const candidate = {
+        name: flags["name"],
+        agent: flags["agent"],
+        endpoint: flags["endpoint"],
+        logGroupNames: flags["log-group-name"],
+        serviceNames: flags["service-name"],
+        insights: flags["insight"],
+        clusteringConfig: frequencies ? { frequencies } : undefined,
+        samplingRate: flags["sampling-rate"],
+        description: flags["description"],
+        enableOnCreate:
+          flags["enable-on-create"] === undefined
+            ? undefined
+            : flags["enable-on-create"] === "true",
+        tags: parseJsonFlag<Record<string, string>>("tags", flags["tags"]),
+      };
+
+      const parsed = OnlineEvalConfigSchema.safeParse(candidate);
+      if (!parsed.success) throw new InputValidationError(z.prettifyError(parsed.error));
+
+      const project = ctx.require(ProjectKey);
+      for await (const event of config.projectManager.addResource(project, {
+        resourceType: "online-insight",
+        resourceConfig: parsed.data,
+      })) {
+        config.io.stderr.write(`${event.message}\n`);
+      }
+
+      config.io.stderr.write(
+        `added online-insight config '${flags["name"]}' to '${project.name}'\n`,
+      );
+    },
+  });

--- a/src/handlers/project/add/online-insight/index.ts
+++ b/src/handlers/project/add/online-insight/index.ts
@@ -16,7 +16,7 @@ export const createAddOnlineInsightHandler = (config: AddProjectResourceConfig) 
       flag("name", "the name of the online insight config", z.string().optional()),
       flag(
         "agent",
-        "harness/runtime name whose traffic to sample (mutually exclusive with --log-group-name)",
+        "runtime name whose traffic to sample (mutually exclusive with --log-group-name)",
         z.string().optional(),
       ),
       flag(

--- a/src/handlers/project/types.ts
+++ b/src/handlers/project/types.ts
@@ -59,6 +59,10 @@ export type AddResourceInput =
   | {
       resourceType: "online-eval";
       resourceConfig: z.input<typeof OnlineEvalConfigSchema>;
+    }
+  | {
+      resourceType: "online-insight";
+      resourceConfig: z.input<typeof OnlineEvalConfigSchema>;
     };
 
 export type ProjectResource = AddResourceInput["resourceType"];


### PR DESCRIPTION
## Command structure

```
Usage: agentcore project add online-insight [options]

adds an online insight config to the current project

Options:
  --name <name>                            the name of the online insight config
  --agent <agent>                          harness/runtime name whose traffic to sample (mutually exclusive with --log-group-name)
  --endpoint <endpoint>                    the agent endpoint qualifier to scope monitoring to (requires --agent)
  --log-group-name <name...>               CloudWatch log group name(s) for custom data sources (1-5; mutually exclusive with --agent)
  --service-name <name...>                 service name(s) to filter traces for custom data sources (requires --log-group-name)
  --insight <insight...>                   insight ID(s) to apply: Builtin.Insight.* identifiers or full ARNs
  --clustering-frequency <freq...>         insight clustering cadence(s): DAILY, WEEKLY, MONTHLY
  --sampling-rate <sampling-rate>          percentage of sessions to sample (0.01-100)
  --description <description>              a description of the config's monitoring purpose
  --enable-on-create <true|false>          enable insights immediately after deploy (default true; pass false to add it paused)
  --tags <tags>                            tags to apply (JSON object of key/value strings)
```

`online-insight` is the insights counterpart of `online-eval` (#2048): same schema, same `onlineEvalConfigs` array, same spec key — it fills `insights` instead of `evaluators` and adds `--clustering-frequency`. Source options are identical (`--agent` XOR `--log-group-name`).

## agentcore.json fields written

Each invocation appends one entry to `onlineEvalConfigs[]` in `agentcore/agentcore.json`:

| Field | From flag | Notes |
|-------|-----------|-------|
| `name` | `--name` | required; 1-48 chars, letter-led alnum/underscore |
| `agent` | `--agent` | runtime to monitor; **XOR** `logGroupNames` |
| `endpoint` | `--endpoint` | endpoint qualifier; requires `agent` |
| `logGroupNames` | `--log-group-name` | custom CloudWatch source (1-5); **XOR** `agent` |
| `serviceNames` | `--service-name` | trace filter; requires `logGroupNames` |
| `insights` | `--insight` | required; each `Builtin.Insight.*` or an ARN |
| `clusteringConfig.frequencies` | `--clustering-frequency` | subset of DAILY/WEEKLY/MONTHLY; requires insights |
| `samplingRate` | `--sampling-rate` | required; 0.01-100 (percent) |
| `description` | `--description` | <=200 chars |
| `enableOnCreate` | `--enable-on-create` | `true`/`false`; `false` deploys the config paused |
| `tags` | `--tags` | JSON key/value object |

Cross-field rules are enforced by `OnlineEvalConfigSchema` (agent XOR log groups, endpoint→agent, serviceNames→log groups, clustering→insights). Insight-ID format (`Builtin.Insight.*` / ARN) is validated in the handler. `--agent` existence is checked project-wide on the post-write `ProjectSpecSchema` validation in `addResource`.

## Implementation

Mirrors the merged `online-eval` PR — 1 new handler + 1 co-located test + 3 small wirings:
- **new** `src/handlers/project/add/online-insight/index.ts`
- **new** `src/handlers/project/add/online-insight/index.test.ts`
- `add/index.ts` — register the handler
- `project/types.ts` — add `online-insight` to `AddResourceInput`
- `core/project/manager.tsx` — stack into the no-scaffold case + `toProjectSpecKey`

## Verification

- `tsc --noEmit` 0 errors; `bun test` — new suite 15/15, project+manager regression 148/148; `prettier --check .` clean.
- **Bug bash (22/22 pass):** 9 happy + 11 error flows local, plus a real deploy to a sandbox account — synthesized `AWS::BedrockAgentCore::OnlineEvaluationConfig` (Insights wired, ENABLED at sampling 50), a second config deployed paused (`--enable-on-create false` → DISABLED), both verified via the control plane and torn down.


---
**Related:** aws/agentcore-l3-cdk-constructs#335 — `OnlineEvaluationConfig` `agent` resolves runtimes only (harness targets unsupported). The `--agent` help text here says "runtime" to match.