### PR TITLE
fix(evaluator): include user_message placeholder for TOOL_CALL evaluators

### DIFF
--- a/src/cli/tui/screens/evaluator/__tests__/types.test.ts
+++ b/src/cli/tui/screens/evaluator/__tests__/types.test.ts
@@ -39,6 +39,7 @@ describe('LEVEL_PLACEHOLDERS', () => {
     expect(LEVEL_PLACEHOLDERS.TOOL_CALL).toContain('available_skills');
     expect(LEVEL_PLACEHOLDERS.TOOL_CALL).toContain('invoked_skill');
     expect(LEVEL_PLACEHOLDERS.TOOL_CALL).toContain('skill_content');
+    expect(LEVEL_PLACEHOLDERS.TOOL_CALL).toContain('user_message');
   });
 });
 

--- a/src/cli/tui/screens/evaluator/types.ts
+++ b/src/cli/tui/screens/evaluator/types.ts
@@ -195,7 +195,15 @@ export function getEvaluatorModelOptions(provider: EvaluatorModelProvider): Eval
 export const LEVEL_PLACEHOLDERS: Record<EvaluationLevel, string[]> = {
   SESSION: ['context', 'available_tools'],
   TRACE: ['context', 'assistant_turn'],
-  TOOL_CALL: ['available_tools', 'context', 'tool_turn', 'available_skills', 'invoked_skill', 'skill_content'],
+  TOOL_CALL: [
+    'available_tools',
+    'context',
+    'tool_turn',
+    'available_skills',
+    'invoked_skill',
+    'skill_content',
+    'user_message',
+  ],
 };
 
 /**
@@ -221,6 +229,7 @@ export const PLACEHOLDER_DESCRIPTIONS: Record<string, string> = {
   available_skills: 'skills offered to the agent (name + description)',
   invoked_skill: 'the skill the agent selected for this span',
   skill_content: "the selected skill's SKILL.md instructions",
+  user_message: 'the user request in the turn that triggered the skill invocation',
 };
 
 /**


### PR DESCRIPTION
## What
Add the `user_message` skill placeholder to the Tool-level (`TOOL_CALL`) prompt-template allowlist so the `agentcore add` evaluator wizard and the instruction-validation hint surface it.

## Why
AgentCore Evaluations supports `user_message` as a Tool-level skill placeholder — "the user request in the turn that triggered the skill invocation" (see [prompt templates docs](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/prompt-templates-builtin.html)). `LEVEL_PLACEHOLDERS.TOOL_CALL` omitted it, so it never appeared in the wizard's "Available placeholders" list or the validation error text.

Note: this is a discoverability fix, not a functional unblock — `validateInstructionPlaceholders` only requires *one* recognized placeholder and passes instructions through verbatim, so users could already type `{user_message}` manually alongside e.g. `{tool_turn}`.

## Changes
- `LEVEL_PLACEHOLDERS.TOOL_CALL`: add `user_message`
- `PLACEHOLDER_DESCRIPTIONS`: add its description
- Test: assert `TOOL_CALL` exposes `user_message`

## Testing
- `vitest run` on the evaluator types test — 27/27 pass
- Verified live in the TUI: `agentcore add` → Evaluator → LLM-as-a-Judge → Tool Call → Prompt now lists `{user_message}`