### PR TITLE
fix(online-eval): correct --agent help to runtime-only

### DIFF
--- a/src/handlers/project/add/online-eval/index.ts
+++ b/src/handlers/project/add/online-eval/index.ts
@@ -13,7 +13,7 @@ export const createAddOnlineEvalHandler = (config: AddProjectResourceConfig) =>
       flag("name", "the name of the online evaluation config", z.string().optional()),
       flag(
         "agent",
-        "harness/runtime name whose traffic to sample (mutually exclusive with --log-group-name)",
+        "runtime name whose traffic to sample (mutually exclusive with --log-group-name)",
         z.string().optional(),
       ),
       flag(


### PR DESCRIPTION
Follow-up to the `online-insight` PR (#2063), applying the same one-line fix to `online-eval`.

## Change
`add online-eval` `--agent` help text: `"harness/runtime name …"` → `"runtime name …"`.

## Why
Only **runtimes** are valid online-eval targets end-to-end, so the old wording promised harness support that no layer implements:
- `ProjectSpecSchema` superRefine builds `agentNames` from `spec.runtimes` only — a harness name always raises "references unknown agent".
- The CDK construct resolves `config.agent` against a runtime-only `environments` map and derives the monitored log group from a runtime id.

Adding harnesses to the validation set would be worse (it'd pass CLI validation, then fail at CDK synth). Real harness support is a construct-level feature tracked separately.

**Related:** aws/agentcore-l3-cdk-constructs#335

## Verification
`tsc --noEmit` 0 errors · `prettier --check` clean · `online-eval` suite 16/16 (help-text change is test-neutral — no test asserts the string).