### PR TITLE
fix(status): show 'No target configured' instead of empty target label (#985)

### DIFF
--- a/src/cli/commands/status/__tests__/action.test.ts
+++ b/src/cli/commands/status/__tests__/action.test.ts
@@ -941,6 +941,36 @@ describe('handleProjectStatus — live enrichment', () => {
   });
 });
 
+describe('handleProjectStatus — target resolution', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('returns undefined targetName when no targets are configured', async () => {
+    const ctx = {
+      project: baseProject,
+      awsTargets: [],
+      deployedState: { targets: {} },
+    } as unknown as StatusContext;
+
+    const result = await handleProjectStatus(ctx);
+
+    assert(result.success);
+    expect(result.targetName).toBeUndefined();
+  });
+
+  it('returns the configured target name when a target exists', async () => {
+    const ctx = {
+      project: baseProject,
+      awsTargets: [{ name: 'dev', region: 'us-east-1', account: '123456789' }],
+      deployedState: { targets: {} },
+    } as unknown as StatusContext;
+
+    const result = await handleProjectStatus(ctx);
+
+    assert(result.success);
+    expect(result.targetName).toBe('dev');
+  });
+});
+
 describe('handleProjectStatus — knowledge base enrichment', () => {
   beforeEach(() => {
     mockGetKnowledgeBase.mockReset();

--- a/src/cli/commands/status/action.ts
+++ b/src/cli/commands/status/action.ts
@@ -726,7 +726,7 @@ export async function handleProjectStatus(
   return {
     success: true,
     projectName: project.name,
-    targetName: selectedTargetName ?? '',
+    targetName: selectedTargetName,
     targetRegion: targetConfig?.region,
     resources,
     deployedState,


### PR DESCRIPTION
## Description

`agentcore status` printed an empty target label: `AgentCore Status (target: )` on projects with no deployment target configured (any fresh `agentcore create` project, since it writes an empty `aws-targets.json`).

Root cause: the status action always returned a `targetName` string, substituting an empty string when no target was configured. The render layer only shows its "No target configured" fallback when `targetName` is missing entirely: an empty string counts as present, so the header printed a blank label. The fix is to leave `targetName` unset when there is no target, letting the existing fallback take over.

Verified with the built CLI: header now renders `AgentCore Status (target: No target configured)`.
Note: `status --json` now omits `targetName` instead of emitting `"targetName": ""`.


## Related Issue

 #985

Closes #

 #985

## Documentation PR

N/A

<!-- Link to related associated PR in the agent-docs repo -->

## Type of Change

<!-- Check all that apply -->

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [X] I ran `npm run test:unit` and `npm run test:integ`
- [X] I ran `npm run typecheck`
- [X] I ran `npm run lint`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [X] I have read the CONTRIBUTING document
- [X] I have added any necessary tests that prove my fix is effective or my feature works
- [ ] I have updated the documentation accordingly
- [X] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
