### PR TITLE
fix: honor language defaults for BYO agents

### DIFF
--- a/src/cli/commands/add/__tests__/add-agent.test.ts
+++ b/src/cli/commands/add/__tests__/add-agent.test.ts
@@ -272,6 +272,74 @@ describe('add agent command', () => {
       const agent = projectSpec.runtimes.find((a: { name: string }) => a.name === agentName);
       expect(agent, 'Agent should be in agentcore.json').toBeTruthy();
       expect(agent.codeLocation.includes(codeDir), `codeLocation should reference ${codeDir}`).toBeTruthy();
+      expect(agent.entrypoint).toBe('main.py');
+      expect(agent.runtimeVersion).toBe('PYTHON_3_14');
+    });
+
+    it('uses TypeScript defaults for BYO agents', async () => {
+      const agentName = `ByoTypeScriptAgent${Date.now()}`;
+      const codeDir = 'existing-typescript-agent';
+
+      const result = await runCLI(
+        [
+          'add',
+          'agent',
+          '--name',
+          agentName,
+          '--type',
+          'byo',
+          '--code-location',
+          codeDir,
+          '--language',
+          'TypeScript',
+          '--framework',
+          'Strands',
+          '--model-provider',
+          'Bedrock',
+          '--json',
+        ],
+        projectDir
+      );
+
+      expect(result.exitCode, `stdout: ${result.stdout}`).toBe(0);
+
+      const projectSpec = JSON.parse(await readFile(join(projectDir, 'agentcore/agentcore.json'), 'utf-8'));
+      const agent = projectSpec.runtimes.find((a: { name: string }) => a.name === agentName);
+      expect(agent.entrypoint).toBe('main.js');
+      expect(agent.runtimeVersion).toBe('NODE_22');
+    });
+
+    it('preserves Python defaults for BYO agents with Other language', async () => {
+      const agentName = `ByoOtherAgent${Date.now()}`;
+      const codeDir = 'existing-other-agent';
+
+      const result = await runCLI(
+        [
+          'add',
+          'agent',
+          '--name',
+          agentName,
+          '--type',
+          'byo',
+          '--code-location',
+          codeDir,
+          '--language',
+          'Other',
+          '--framework',
+          'Strands',
+          '--model-provider',
+          'Bedrock',
+          '--json',
+        ],
+        projectDir
+      );
+
+      expect(result.exitCode, `stdout: ${result.stdout}`).toBe(0);
+
+      const projectSpec = JSON.parse(await readFile(join(projectDir, 'agentcore/agentcore.json'), 'utf-8'));
+      const agent = projectSpec.runtimes.find((a: { name: string }) => a.name === agentName);
+      expect(agent.entrypoint).toBe('main.py');
+      expect(agent.runtimeVersion).toBe('PYTHON_3_14');
     });
 
     it('requires code-location for BYO path', async () => {

--- a/src/cli/primitives/AgentPrimitive.tsx
+++ b/src/cli/primitives/AgentPrimitive.tsx
@@ -27,7 +27,8 @@ import type {
 import {
   AgentEnvSpecSchema,
   CREDENTIAL_PROVIDERS,
-  DEFAULT_PYTHON_VERSION,
+  DEFAULT_ENTRYPOINT_BY_LANGUAGE,
+  DEFAULT_RUNTIME_BY_LANGUAGE,
   LIFECYCLE_TIMEOUT_MAX,
   LIFECYCLE_TIMEOUT_MIN,
 } from '../../schema';
@@ -720,13 +721,14 @@ export class AgentPrimitive extends BasePrimitive<AddAgentOptions, RemovableReso
         : undefined;
 
     const lifecycleConfiguration = this.buildLifecycleConfig(options);
+    const defaultLanguage = options.language === 'TypeScript' ? 'TypeScript' : 'Python';
 
     const agent: AgentEnvSpec = {
       name: options.name,
       build: options.buildType,
-      entrypoint: (options.entrypoint ?? 'main.py') as FilePath,
+      entrypoint: (options.entrypoint ?? DEFAULT_ENTRYPOINT_BY_LANGUAGE[defaultLanguage]) as FilePath,
       codeLocation: codeLocation as DirectoryPath,
-      runtimeVersion: DEFAULT_PYTHON_VERSION,
+      runtimeVersion: DEFAULT_RUNTIME_BY_LANGUAGE[defaultLanguage],
       protocol,
       networkMode,
       ...(networkMode === 'VPC' &&


### PR DESCRIPTION
Closes #2075

`add agent --type byo --language TypeScript` currently persists the Python runtime and entrypoint, so the documented TypeScript BYO path later selects the wrong packager. This updates the BYO mapping to use the existing language default maps: TypeScript now persists `NODE_22` and `main.js` when no entrypoint is supplied. Python and `Other` retain their existing `PYTHON_3_14` / `main.py` behavior, and explicitly supplied entrypoints remain unchanged.

The focused add-agent regression coverage verifies persistence for TypeScript, Python, and `Other`. `git diff --check` passed. The local checkout did not include the npm toolchain, and `npx` could not reach the registry (`EAI_AGAIN`), so the Vitest, TypeScript, and Prettier checks could not run locally.
