### PR TITLE
feat(dev): agent-proxy routes for the Agent Inspector

### DIFF
--- a/src/core/dev/inspector/invocations.test.ts
+++ b/src/core/dev/inspector/invocations.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import type { HttpRequestHandler } from "../../../io/httpServer";
+import { type HttpRequestHandler, startHttpServer } from "../../../io/httpServer";
+import { parseAgentEvent } from "./invocations";
 import { ServerFarm, fakeSupervisor, post, runningAgent } from "./testkit";
 import type { InspectorDeps } from "./types";
 
@@ -36,6 +37,40 @@ describe("POST /invocations routing", () => {
       success: false,
       error: "MCP agents are invoked through POST /api/mcp, not /invocations.",
     });
+  });
+});
+
+describe("upstream connection failures", () => {
+  async function deadPort(): Promise<number> {
+    const handle = await startHttpServer(() => ({ status: 200 }));
+    await handle.close();
+    return handle.port;
+  }
+
+  test.each([
+    { protocol: "HTTP", errorPrefix: "Agent server error" },
+    { protocol: "A2A", errorPrefix: "A2A agent error" },
+  ])("returns 502 when a $protocol agent is unreachable", async ({ protocol, errorPrefix }) => {
+    const supervisor = fakeSupervisor({
+      agents: [runningAgent("orders", await deadPort(), protocol)],
+    });
+    const { url } = await farm.inspector({ supervisor });
+    const response = await post(url, "/invocations", { agentName: "orders", prompt: "hi" });
+    expect(response.status).toBe(502);
+    const body = (await response.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toContain(errorPrefix);
+  });
+});
+
+describe("parseAgentEvent drops non-renderable frames", () => {
+  test.each([
+    { name: "a JSON primitive that is not text", data: JSON.stringify(42) },
+    { name: "a blank error field", data: JSON.stringify({ error: "" }) },
+    { name: "a blank text field", data: JSON.stringify({ text: "" }) },
+    { name: "an empty non-JSON token", data: "" },
+  ])("returns null for $name", ({ data }) => {
+    expect(parseAgentEvent(data)).toBeNull();
   });
 });
 
@@ -140,6 +175,50 @@ describe("A2A agent invocation", () => {
     const response = await post(url, "/invocations", { agentName: "orders", prompt: "hi" });
     expect(response.headers.get("content-type")).toContain("text/event-stream");
     expect(await response.text()).toBe(`data: ${JSON.stringify("final")}\n\n`);
+  });
+
+  test.each([
+    {
+      name: "an artifact-update with no preceding status-update",
+      frame: JSON.stringify({
+        result: { kind: "artifact-update", artifact: { parts: [{ kind: "text", text: "art" }] } },
+      }),
+      expected: "art",
+    },
+    { name: "a frame that is not JSON", frame: "not-json", expected: "not-json" },
+    {
+      name: "a task event carrying a status message",
+      frame: JSON.stringify({
+        result: {
+          kind: "task",
+          status: { message: { parts: [{ kind: "text", text: "task-text" }] } },
+        },
+      }),
+      expected: "task-text",
+    },
+  ])("streams text extracted from $name", async ({ frame, expected }) => {
+    const { url } = await inspectorFor(sseAgent([frame]), "A2A");
+    const response = await post(url, "/invocations", { agentName: "orders", prompt: "hi" });
+    expect(await response.text()).toBe(`data: ${JSON.stringify(expected)}\n\n`);
+  });
+
+  test("drops a task frame that carries no renderable parts", async () => {
+    const { url } = await inspectorFor(
+      sseAgent([JSON.stringify({ result: { kind: "task" } })]),
+      "A2A",
+    );
+    const response = await post(url, "/invocations", { agentName: "orders", prompt: "hi" });
+    expect(await response.text()).toBe("");
+  });
+
+  test("passes a non-JSON A2A response through as plain text", async () => {
+    const { url } = await inspectorFor(
+      () => ({ status: 200, headers: { "Content-Type": "text/plain" }, body: "not json" }),
+      "A2A",
+    );
+    const response = await post(url, "/invocations", { agentName: "orders", prompt: "hi" });
+    expect(response.headers.get("content-type")).toContain("text/plain");
+    expect(await response.text()).toBe("not json");
   });
 
   test("requires a prompt", async () => {

--- a/src/core/dev/inspector/invocations.test.ts
+++ b/src/core/dev/inspector/invocations.test.ts
@@ -6,7 +6,6 @@ import type { InspectorDeps } from "./types";
 const farm = new ServerFarm();
 afterEach(() => farm.close());
 
-/** A fake agent that replies with a fixed SSE stream over its own body. */
 function sseAgent(frames: string[]): HttpRequestHandler {
   return () => ({
     status: 200,
@@ -15,7 +14,6 @@ function sseAgent(frames: string[]): HttpRequestHandler {
   });
 }
 
-/** Stand up a fake agent, point a running supervisor at it, and start the inspector. */
 async function inspectorFor(handler: HttpRequestHandler, protocol = "HTTP") {
   const agent = await farm.serve(handler);
   const supervisor = fakeSupervisor({ agents: [runningAgent("orders", agent.port, protocol)] });

--- a/src/core/dev/inspector/invocations.test.ts
+++ b/src/core/dev/inspector/invocations.test.ts
@@ -167,4 +167,11 @@ describe("AGUI agent invocation", () => {
     expect(body).toMatchObject({ messages: [{ role: "user", content: "hi" }] });
     expect(await response.text()).toBe("data: passthrough\n\n");
   });
+
+  test("requires a prompt", async () => {
+    const { url } = await inspectorFor(sseAgent([]), "AGUI");
+    const response = await post(url, "/invocations", { agentName: "orders" });
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ success: false, error: "prompt is required" });
+  });
 });

--- a/src/core/dev/inspector/invocations.test.ts
+++ b/src/core/dev/inspector/invocations.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type { HttpRequestHandler } from "../../../io/httpServer";
+import { ServerFarm, fakeSupervisor, post, runningAgent } from "./testkit";
+import type { InspectorDeps } from "./types";
+
+const farm = new ServerFarm();
+afterEach(() => farm.close());
+
+/** A fake agent that replies with a fixed SSE stream over its own body. */
+function sseAgent(frames: string[]): HttpRequestHandler {
+  return () => ({
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+    body: frames.map((frame) => `data: ${frame}\n\n`).join(""),
+  });
+}
+
+/** Stand up a fake agent, point a running supervisor at it, and start the inspector. */
+async function inspectorFor(handler: HttpRequestHandler, protocol = "HTTP") {
+  const agent = await farm.serve(handler);
+  const supervisor = fakeSupervisor({ agents: [runningAgent("orders", agent.port, protocol)] });
+  return farm.inspector({ supervisor } satisfies InspectorDeps);
+}
+
+describe("POST /invocations routing", () => {
+  test("returns 409 when no agent is running", async () => {
+    const { url } = await farm.inspector({ supervisor: fakeSupervisor() });
+    const response = await post(url, "/invocations", { prompt: "hi" });
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({ success: false });
+  });
+
+  test("directs MCP agents to the dedicated proxy instead of mis-proxying them", async () => {
+    const { url } = await inspectorFor(sseAgent([]), "MCP");
+    const response = await post(url, "/invocations", { agentName: "orders", prompt: "hi" });
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      success: false,
+      error: "MCP agents are invoked through POST /api/mcp, not /invocations.",
+    });
+  });
+});
+
+describe("HTTP agent SSE normalization", () => {
+  test.each([
+    { name: "a bedrock text event", frame: JSON.stringify({ text: "hello" }), expected: "hello" },
+    { name: "a bare JSON string token", frame: JSON.stringify("world"), expected: "world" },
+    {
+      name: "a ConverseStream content delta",
+      frame: JSON.stringify({ event: { contentBlockDelta: { delta: { text: "delta" } } } }),
+      expected: "delta",
+    },
+    { name: "a non-JSON plain-text token", frame: "raw-token", expected: "raw-token" },
+  ])("normalizes $name to a data frame", async ({ frame, expected }) => {
+    const { url } = await inspectorFor(sseAgent([frame]));
+    const response = await post(url, "/invocations", { agentName: "orders", prompt: "hi" });
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+    expect(await response.text()).toBe(`data: ${JSON.stringify(expected)}\n\n`);
+  });
+
+  test("re-frames an agent error event as an error payload", async () => {
+    const { url } = await inspectorFor(sseAgent([JSON.stringify({ error: "boom" })]));
+    const response = await post(url, "/invocations", { agentName: "orders", prompt: "hi" });
+    expect(await response.text()).toBe(`data: ${JSON.stringify({ error: "boom" })}\n\n`);
+  });
+
+  test("passes a non-SSE response body through untouched", async () => {
+    const { url } = await inspectorFor(() => ({
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ answer: 42 }),
+    }));
+    const response = await post(url, "/invocations", { agentName: "orders", prompt: "hi" });
+    expect(response.headers.get("content-type")).toContain("application/json");
+    expect(await response.json()).toEqual({ answer: 42 });
+  });
+
+  test("echoes one session id and forwards it to the agent", async () => {
+    let received: string | undefined;
+    const { url } = await inspectorFor((request) => {
+      received = request.headers["x-amzn-bedrock-agentcore-runtime-session-id"] as string;
+      return { status: 200, headers: { "Content-Type": "text/event-stream" }, body: "" };
+    });
+    const response = await post(url, "/invocations", {
+      agentName: "orders",
+      prompt: "hi",
+      sessionId: "session-42",
+    });
+    expect(response.headers.get("x-session-id")).toBe("session-42");
+    expect(received).toBe("session-42");
+  });
+});
+
+describe("A2A agent invocation", () => {
+  test("translates the prompt to message/stream and reduces events to text frames", async () => {
+    let rpcMethod: string | undefined;
+    const { url } = await inspectorFor((request) => {
+      rpcMethod = (JSON.parse(request.body.toString()) as { method: string }).method;
+      const status = JSON.stringify({
+        result: {
+          kind: "status-update",
+          status: { message: { parts: [{ kind: "text", text: "streamed" }] } },
+        },
+      });
+      return {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+        body: `data: ${status}\n\n`,
+      };
+    }, "A2A");
+    const response = await post(url, "/invocations", { agentName: "orders", prompt: "hi" });
+    expect(rpcMethod).toBe("message/stream");
+    expect(await response.text()).toBe(`data: ${JSON.stringify("streamed")}\n\n`);
+  });
+
+  test("skips artifact text already streamed by a preceding status-update", async () => {
+    const status = JSON.stringify({
+      result: {
+        kind: "status-update",
+        status: { message: { parts: [{ kind: "text", text: "answer" }] } },
+      },
+    });
+    const artifact = JSON.stringify({
+      result: { kind: "artifact-update", artifact: { parts: [{ kind: "text", text: "answer" }] } },
+    });
+    const { url } = await inspectorFor(sseAgent([status, artifact]), "A2A");
+    const response = await post(url, "/invocations", { agentName: "orders", prompt: "hi" });
+    expect(await response.text()).toBe(`data: ${JSON.stringify("answer")}\n\n`);
+  });
+
+  test("falls back to extracting text from a non-streaming JSON-RPC result", async () => {
+    const { url } = await inspectorFor(
+      () => ({
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          result: { artifacts: [{ parts: [{ kind: "text", text: "final" }] }] },
+        }),
+      }),
+      "A2A",
+    );
+    const response = await post(url, "/invocations", { agentName: "orders", prompt: "hi" });
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+    expect(await response.text()).toBe(`data: ${JSON.stringify("final")}\n\n`);
+  });
+
+  test("requires a prompt", async () => {
+    const { url } = await inspectorFor(sseAgent([]), "A2A");
+    const response = await post(url, "/invocations", { agentName: "orders" });
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ success: false, error: "prompt is required" });
+  });
+});
+
+describe("AGUI agent invocation", () => {
+  test("sends a RunAgentInput body and passes the response through", async () => {
+    let body: Record<string, unknown> | undefined;
+    const { url } = await inspectorFor((request) => {
+      body = JSON.parse(request.body.toString()) as Record<string, unknown>;
+      return {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+        body: "data: passthrough\n\n",
+      };
+    }, "AGUI");
+    const response = await post(url, "/invocations", { agentName: "orders", prompt: "hi" });
+    expect(body).toMatchObject({ messages: [{ role: "user", content: "hi" }] });
+    expect(await response.text()).toBe("data: passthrough\n\n");
+  });
+});

--- a/src/core/dev/inspector/invocations.ts
+++ b/src/core/dev/inspector/invocations.ts
@@ -22,7 +22,6 @@ import type { InspectorDeps } from "./types";
 export async function handleInvocations(
   deps: InspectorDeps,
   request: HttpRequest,
-  nextA2aId: () => number,
 ): Promise<HttpResponse> {
   const parsed = parseJsonBody(request.body);
   const agentName = asString(parsed?.agentName);
@@ -44,7 +43,7 @@ export async function handleInvocations(
     return apiError(400, "MCP agents are invoked through POST /api/mcp, not /invocations.");
   }
   if (running.protocol === "A2A") {
-    return invokeA2aAgent(running.port, parsed, sessionId, nextA2aId, signal);
+    return invokeA2aAgent(running.port, parsed, sessionId, signal);
   }
   if (running.protocol === "AGUI") {
     return invokeAguiAgent(running.port, parsed, sessionId, userId, signal);
@@ -52,17 +51,22 @@ export async function handleInvocations(
   return invokeHttpAgent(running.port, request.body, sessionId, userId, signal);
 }
 
-/** Forward to the agent's /invocations route, normalizing SSE events to plain text. */
-async function invokeHttpAgent(
+/**
+ * POST to an agent's /invocations route with the shared session/user headers.
+ * `normalizeSse` re-frames an event stream through {@link parseAgentEvent}; a
+ * non-event-stream response, or a typed stream (AGUI), passes through untouched.
+ */
+async function forwardInvocation(
   port: number,
-  body: Buffer,
+  body: Buffer | string,
   sessionId: string,
   userId: string | undefined,
   signal: AbortSignal,
+  options: { accept: string; normalizeSse: boolean },
 ): Promise<HttpResponse> {
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
-    Accept: "text/event-stream, */*",
+    Accept: options.accept,
     "x-amzn-bedrock-agentcore-runtime-session-id": sessionId,
   };
   if (userId) headers["x-amzn-bedrock-agentcore-runtime-user-id"] = userId;
@@ -72,7 +76,7 @@ async function invokeHttpAgent(
     agentResponse = await fetch(`http://127.0.0.1:${port}/invocations`, {
       method: "POST",
       headers,
-      body: body.toString(),
+      body,
       signal,
     });
   } catch (error) {
@@ -84,8 +88,25 @@ async function invokeHttpAgent(
   return {
     status: agentResponse.status,
     headers: { "Content-Type": contentType, "x-session-id": sessionId },
-    body: contentType.includes("text/event-stream") ? transformAgentSse(stream) : stream,
+    body:
+      options.normalizeSse && contentType.includes("text/event-stream")
+        ? transformAgentSse(stream)
+        : stream,
   };
+}
+
+/** Forward an HTTP agent's raw body, normalizing SSE events to plain text. */
+function invokeHttpAgent(
+  port: number,
+  body: Buffer,
+  sessionId: string,
+  userId: string | undefined,
+  signal: AbortSignal,
+): Promise<HttpResponse> {
+  return forwardInvocation(port, body, sessionId, userId, signal, {
+    accept: "text/event-stream, */*",
+    normalizeSse: true,
+  });
 }
 
 /** Re-frame each agent SSE event through {@link parseAgentEvent}. */
@@ -93,38 +114,36 @@ async function* transformAgentSse(
   stream: AsyncIterable<Uint8Array>,
 ): AsyncGenerator<Uint8Array, void> {
   for await (const data of sseData(stream)) {
-    const { content, error } = parseAgentEvent(data);
-    if (error) yield sseEvent({ error });
-    else if (content) yield sseEvent(content);
+    const payload = parseAgentEvent(data);
+    if (payload !== null) yield sseEvent(payload);
   }
 }
 
 /**
- * Extract displayable text from one agent SSE `data` payload. Handles plain
- * strings, `{"text": ...}` events from the bedrock-agentcore runtime,
- * `{"error": ...}` events, and ConverseStream-shaped content deltas. A payload
- * that is not JSON is a plain-text token, forwarded unchanged.
+ * Extract the payload to emit from one agent SSE `data` frame: a plain text
+ * token, an `{ error }` object, or null when the frame carries no displayable
+ * content. Handles `{"text": ...}` events from the bedrock-agentcore runtime,
+ * `{"error": ...}` events, and ConverseStream-shaped content deltas; a frame
+ * that is not JSON is itself a plain-text token.
  */
-export function parseAgentEvent(data: string): { content: string | null; error: string | null } {
+export function parseAgentEvent(data: string): string | { error: string } | null {
   try {
     const parsed: unknown = JSON.parse(data);
-    if (typeof parsed === "string") return { content: parsed, error: null };
+    if (typeof parsed === "string") return parsed || null;
     if (parsed && typeof parsed === "object") {
       if ("error" in parsed) {
-        return { content: null, error: String((parsed as { error: unknown }).error) };
+        const error = String((parsed as { error: unknown }).error);
+        return error ? { error } : null;
       }
-      if ("text" in parsed) {
-        return { content: String((parsed as { text: unknown }).text), error: null };
-      }
+      if ("text" in parsed) return String((parsed as { text: unknown }).text) || null;
       const event = (parsed as { event?: { contentBlockDelta?: { delta?: { text?: string } } } })
         .event;
-      const text = event?.contentBlockDelta?.delta?.text;
-      if (typeof text === "string") return { content: text, error: null };
+      return event?.contentBlockDelta?.delta?.text || null;
     }
   } catch {
-    return { content: data, error: null };
+    return data || null;
   }
-  return { content: null, error: null };
+  return null;
 }
 
 /**
@@ -136,7 +155,6 @@ async function invokeA2aAgent(
   port: number,
   body: Record<string, unknown> | undefined,
   sessionId: string,
-  nextA2aId: () => number,
   signal: AbortSignal,
 ): Promise<HttpResponse> {
   const prompt = asString(body?.prompt);
@@ -144,7 +162,7 @@ async function invokeA2aAgent(
 
   const a2aBody = {
     jsonrpc: "2.0",
-    id: nextA2aId(),
+    id: randomUUID(),
     method: "message/stream",
     params: {
       message: {
@@ -275,7 +293,7 @@ function extractPartsText(parts: A2aPart[] | undefined): string | null {
  * AGUI agents expect a RunAgentInput body; translate the SPA's `{ prompt }`
  * payload and pass the typed AG-UI SSE response through untouched.
  */
-async function invokeAguiAgent(
+function invokeAguiAgent(
   port: number,
   body: Record<string, unknown> | undefined,
   sessionId: string,
@@ -283,7 +301,7 @@ async function invokeAguiAgent(
   signal: AbortSignal,
 ): Promise<HttpResponse> {
   const prompt = asString(body?.prompt);
-  if (!prompt) return apiError(400, "prompt is required");
+  if (!prompt) return Promise.resolve(apiError(400, "prompt is required"));
 
   const aguiBody = JSON.stringify({
     threadId: sessionId,
@@ -295,31 +313,8 @@ async function invokeAguiAgent(
     forwardedProps: {},
   });
 
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-    Accept: "text/event-stream",
-    "x-amzn-bedrock-agentcore-runtime-session-id": sessionId,
-  };
-  if (userId) headers["x-amzn-bedrock-agentcore-runtime-user-id"] = userId;
-
-  let agentResponse: Response;
-  try {
-    agentResponse = await fetch(`http://127.0.0.1:${port}/invocations`, {
-      method: "POST",
-      headers,
-      body: aguiBody,
-      signal,
-    });
-  } catch (error) {
-    return apiError(502, `AGUI agent error: ${errorMessage(error)}`);
-  }
-
-  return {
-    status: agentResponse.status,
-    headers: {
-      "Content-Type": agentResponse.headers.get("content-type") ?? "text/plain",
-      "x-session-id": sessionId,
-    },
-    body: iterateBody(agentResponse.body),
-  };
+  return forwardInvocation(port, aguiBody, sessionId, userId, signal, {
+    accept: "text/event-stream",
+    normalizeSse: false,
+  });
 }

--- a/src/core/dev/inspector/invocations.ts
+++ b/src/core/dev/inspector/invocations.ts
@@ -1,10 +1,4 @@
-/**
- * POST /invocations — the protocol-aware proxy to a locally running agent.
- * Ported from the reference web-ui/handlers/invocations.ts; the SSE framing
- * (`data: <json>\n\n`) is part of the SPA wire contract. Every upstream fetch
- * carries the client's abort signal so a browser disconnect tears down the
- * agent request instead of leaking it.
- */
+// Every upstream fetch carries the client abort signal, so a browser disconnect tears down the agent request.
 import { randomUUID } from "node:crypto";
 import type { HttpRequest, HttpResponse } from "../../../io/httpServer";
 import {
@@ -25,13 +19,11 @@ export async function handleInvocations(
 ): Promise<HttpResponse> {
   const parsed = parseJsonBody(request.body);
   const agentName = asString(parsed?.agentName);
-  // One session id for the whole exchange: request header, agent body, and the
-  // echoed x-session-id must agree, so it is computed once here.
+  // Request header, agent body, and echoed x-session-id must agree, so one session id is computed once.
   const sessionId = asString(parsed?.sessionId) ?? randomUUID();
   const userId = asString(parsed?.userId);
   const signal = request.signal;
 
-  // Route to the named agent, falling back to the first running one.
   let running = agentName ? deps.supervisor.running(agentName) : undefined;
   if (!running) {
     const first = deps.supervisor.snapshot().find((agent) => agent.phase === "running");
@@ -51,11 +43,6 @@ export async function handleInvocations(
   return invokeHttpAgent(running.port, request.body, sessionId, userId, signal);
 }
 
-/**
- * POST to an agent's /invocations route with the shared session/user headers.
- * `normalizeSse` re-frames an event stream through {@link parseAgentEvent}; a
- * non-event-stream response, or a typed stream (AGUI), passes through untouched.
- */
 async function forwardInvocation(
   port: number,
   body: Buffer | string,
@@ -95,7 +82,6 @@ async function forwardInvocation(
   };
 }
 
-/** Forward an HTTP agent's raw body, normalizing SSE events to plain text. */
 function invokeHttpAgent(
   port: number,
   body: Buffer,
@@ -109,7 +95,6 @@ function invokeHttpAgent(
   });
 }
 
-/** Re-frame each agent SSE event through {@link parseAgentEvent}. */
 async function* transformAgentSse(
   stream: AsyncIterable<Uint8Array>,
 ): AsyncGenerator<Uint8Array, void> {
@@ -119,13 +104,7 @@ async function* transformAgentSse(
   }
 }
 
-/**
- * Extract the payload to emit from one agent SSE `data` frame: a plain text
- * token, an `{ error }` object, or null when the frame carries no displayable
- * content. Handles `{"text": ...}` events from the bedrock-agentcore runtime,
- * `{"error": ...}` events, and ConverseStream-shaped content deltas; a frame
- * that is not JSON is itself a plain-text token.
- */
+// Handles bedrock {text}, {error}, ConverseStream contentBlockDelta, bare JSON string, and non-JSON tokens.
 export function parseAgentEvent(data: string): string | { error: string } | null {
   try {
     const parsed: unknown = JSON.parse(data);
@@ -146,11 +125,7 @@ export function parseAgentEvent(data: string): string | { error: string } | null
   return null;
 }
 
-/**
- * A2A agents speak JSON-RPC at their root path: translate the SPA's
- * `{ prompt }` payload into `message/stream` and reduce the A2A event stream
- * to the `data: "text"` frames the SPA's chat expects.
- */
+// A2A agents speak JSON-RPC at their root path, so {prompt} becomes a message/stream call reduced to text frames.
 async function invokeA2aAgent(
   port: number,
   body: Record<string, unknown> | undefined,
@@ -192,7 +167,6 @@ async function invokeA2aAgent(
     return sse(transformA2aSse(iterateBody(agentResponse.body)), sessionId);
   }
 
-  // Non-streaming fallback: extract text from the JSON-RPC result.
   const responseText = await agentResponse.text();
   try {
     const parsed = JSON.parse(responseText) as Record<string, unknown>;
@@ -233,12 +207,7 @@ function isStatusUpdateEvent(event: Record<string, unknown>): boolean {
   return target.kind === "status-update";
 }
 
-/**
- * Extract displayable text from an A2A SSE event (artifact-update or
- * status-update, optionally wrapped in a JSON-RPC result envelope). When
- * `streamedFromStatus` is set, artifact-update text is skipped because the
- * same content already streamed incrementally via status-update events.
- */
+// When streamedFromStatus is set, artifact-update text is skipped because status-update already streamed it.
 function extractSseEventText(
   event: Record<string, unknown>,
   streamedFromStatus: boolean,
@@ -261,7 +230,6 @@ function extractSseEventText(
   return extractTaskText(target);
 }
 
-/** Extract text from a full A2A Task result (artifacts array and/or status message). */
 function extractTaskText(result: Record<string, unknown>): string | null {
   const artifacts = result.artifacts as { parts?: A2aPart[] }[] | undefined;
   if (artifacts) {
@@ -289,10 +257,7 @@ function extractPartsText(parts: A2aPart[] | undefined): string | null {
   return texts.length > 0 ? texts.join("") : null;
 }
 
-/**
- * AGUI agents expect a RunAgentInput body; translate the SPA's `{ prompt }`
- * payload and pass the typed AG-UI SSE response through untouched.
- */
+// AGUI agents expect a RunAgentInput body, and the typed AG-UI SSE response passes through untouched.
 function invokeAguiAgent(
   port: number,
   body: Record<string, unknown> | undefined,

--- a/src/core/dev/inspector/invocations.ts
+++ b/src/core/dev/inspector/invocations.ts
@@ -40,7 +40,10 @@ export async function handleInvocations(
   if (running.protocol === "AGUI") {
     return invokeAguiAgent(running.port, parsed, sessionId, userId, signal);
   }
-  return invokeHttpAgent(running.port, request.body, sessionId, userId, signal);
+  return forwardInvocation(running.port, request.body, sessionId, userId, signal, {
+    accept: "text/event-stream, */*",
+    normalizeSse: true,
+  });
 }
 
 async function forwardInvocation(
@@ -80,19 +83,6 @@ async function forwardInvocation(
         ? transformAgentSse(stream)
         : stream,
   };
-}
-
-function invokeHttpAgent(
-  port: number,
-  body: Buffer,
-  sessionId: string,
-  userId: string | undefined,
-  signal: AbortSignal,
-): Promise<HttpResponse> {
-  return forwardInvocation(port, body, sessionId, userId, signal, {
-    accept: "text/event-stream, */*",
-    normalizeSse: true,
-  });
 }
 
 async function* transformAgentSse(
@@ -191,9 +181,9 @@ async function* transformA2aSse(
   for await (const data of sseData(stream)) {
     try {
       const event = JSON.parse(data) as Record<string, unknown>;
-      const text = extractSseEventText(event, streamedFromStatus);
+      const { text, kind } = extractSseEventText(event, streamedFromStatus);
       if (text) {
-        if (isStatusUpdateEvent(event)) streamedFromStatus = true;
+        if (kind === "status-update") streamedFromStatus = true;
         yield sseEvent(text);
       }
     } catch {
@@ -202,43 +192,36 @@ async function* transformA2aSse(
   }
 }
 
-function isStatusUpdateEvent(event: Record<string, unknown>): boolean {
-  const target = (event.result as Record<string, unknown>) ?? event;
-  return target.kind === "status-update";
-}
-
 // When streamedFromStatus is set, artifact-update text is skipped because status-update already streamed it.
 function extractSseEventText(
   event: Record<string, unknown>,
   streamedFromStatus: boolean,
-): string | null {
+): { text: string | null; kind: string | undefined } {
   const target = (event.result as Record<string, unknown>) ?? event;
   const kind = target.kind as string | undefined;
 
   if (kind === "artifact-update") {
-    if (streamedFromStatus) return null;
+    if (streamedFromStatus) return { text: null, kind };
     const artifact = target.artifact as { parts?: A2aPart[] } | undefined;
-    return extractPartsText(artifact?.parts);
+    return { text: extractPartsText(artifact?.parts), kind };
   }
 
   if (kind === "status-update") {
     const status = target.status as { message?: { parts?: A2aPart[] } } | undefined;
-    if (status?.message?.parts) return extractPartsText(status.message.parts);
-    return null;
+    return { text: status?.message?.parts ? extractPartsText(status.message.parts) : null, kind };
   }
 
-  return extractTaskText(target);
+  return { text: extractTaskText(target), kind };
 }
 
 function extractTaskText(result: Record<string, unknown>): string | null {
   const artifacts = result.artifacts as { parts?: A2aPart[] }[] | undefined;
   if (artifacts) {
-    const texts: string[] = [];
-    for (const artifact of artifacts) {
-      const text = extractPartsText(artifact.parts);
-      if (text) texts.push(text);
-    }
-    if (texts.length > 0) return texts.join("\n");
+    const text = artifacts
+      .map((artifact) => extractPartsText(artifact.parts))
+      .filter((part): part is string => part !== null)
+      .join("\n");
+    if (text) return text;
   }
 
   const status = result.status as { message?: { parts?: A2aPart[] } } | undefined;
@@ -249,16 +232,15 @@ function extractTaskText(result: Record<string, unknown>): string | null {
 type A2aPart = { kind?: string; type?: string; text?: string };
 
 function extractPartsText(parts: A2aPart[] | undefined): string | null {
-  if (!parts) return null;
-  const texts: string[] = [];
-  for (const part of parts) {
-    if ((part.kind === "text" || part.type === "text") && part.text) texts.push(part.text);
-  }
-  return texts.length > 0 ? texts.join("") : null;
+  const text = (parts ?? [])
+    .filter((part) => (part.kind === "text" || part.type === "text") && part.text)
+    .map((part) => part.text ?? "")
+    .join("");
+  return text || null;
 }
 
 // AGUI agents expect a RunAgentInput body, and the typed AG-UI SSE response passes through untouched.
-function invokeAguiAgent(
+async function invokeAguiAgent(
   port: number,
   body: Record<string, unknown> | undefined,
   sessionId: string,
@@ -266,7 +248,7 @@ function invokeAguiAgent(
   signal: AbortSignal,
 ): Promise<HttpResponse> {
   const prompt = asString(body?.prompt);
-  if (!prompt) return Promise.resolve(apiError(400, "prompt is required"));
+  if (!prompt) return apiError(400, "prompt is required");
 
   const aguiBody = JSON.stringify({
     threadId: sessionId,

--- a/src/core/dev/inspector/invocations.ts
+++ b/src/core/dev/inspector/invocations.ts
@@ -1,0 +1,325 @@
+/**
+ * POST /invocations — the protocol-aware proxy to a locally running agent.
+ * Ported from the reference web-ui/handlers/invocations.ts; the SSE framing
+ * (`data: <json>\n\n`) is part of the SPA wire contract. Every upstream fetch
+ * carries the client's abort signal so a browser disconnect tears down the
+ * agent request instead of leaking it.
+ */
+import { randomUUID } from "node:crypto";
+import type { HttpRequest, HttpResponse } from "../../../io/httpServer";
+import {
+  apiError,
+  asString,
+  errorMessage,
+  iterateBody,
+  parseJsonBody,
+  sse,
+  sseData,
+  sseEvent,
+} from "./respond";
+import type { InspectorDeps } from "./types";
+
+export async function handleInvocations(
+  deps: InspectorDeps,
+  request: HttpRequest,
+  nextA2aId: () => number,
+): Promise<HttpResponse> {
+  const parsed = parseJsonBody(request.body);
+  const agentName = asString(parsed?.agentName);
+  // One session id for the whole exchange: request header, agent body, and the
+  // echoed x-session-id must agree, so it is computed once here.
+  const sessionId = asString(parsed?.sessionId) ?? randomUUID();
+  const userId = asString(parsed?.userId);
+  const signal = request.signal;
+
+  // Route to the named agent, falling back to the first running one.
+  let running = agentName ? deps.supervisor.running(agentName) : undefined;
+  if (!running) {
+    const first = deps.supervisor.snapshot().find((agent) => agent.phase === "running");
+    if (first) running = deps.supervisor.running(first.name);
+  }
+  if (!running) return apiError(409, "No agent is running. Call POST /api/start first.");
+
+  if (running.protocol === "MCP") {
+    return apiError(400, "MCP agents are invoked through POST /api/mcp, not /invocations.");
+  }
+  if (running.protocol === "A2A") {
+    return invokeA2aAgent(running.port, parsed, sessionId, nextA2aId, signal);
+  }
+  if (running.protocol === "AGUI") {
+    return invokeAguiAgent(running.port, parsed, sessionId, userId, signal);
+  }
+  return invokeHttpAgent(running.port, request.body, sessionId, userId, signal);
+}
+
+/** Forward to the agent's /invocations route, normalizing SSE events to plain text. */
+async function invokeHttpAgent(
+  port: number,
+  body: Buffer,
+  sessionId: string,
+  userId: string | undefined,
+  signal: AbortSignal,
+): Promise<HttpResponse> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Accept: "text/event-stream, */*",
+    "x-amzn-bedrock-agentcore-runtime-session-id": sessionId,
+  };
+  if (userId) headers["x-amzn-bedrock-agentcore-runtime-user-id"] = userId;
+
+  let agentResponse: Response;
+  try {
+    agentResponse = await fetch(`http://127.0.0.1:${port}/invocations`, {
+      method: "POST",
+      headers,
+      body: body.toString(),
+      signal,
+    });
+  } catch (error) {
+    return apiError(502, `Agent server error: ${errorMessage(error)}`);
+  }
+
+  const contentType = agentResponse.headers.get("content-type") ?? "text/plain";
+  const stream = iterateBody(agentResponse.body);
+  return {
+    status: agentResponse.status,
+    headers: { "Content-Type": contentType, "x-session-id": sessionId },
+    body: contentType.includes("text/event-stream") ? transformAgentSse(stream) : stream,
+  };
+}
+
+/** Re-frame each agent SSE event through {@link parseAgentEvent}. */
+async function* transformAgentSse(
+  stream: AsyncIterable<Uint8Array>,
+): AsyncGenerator<Uint8Array, void> {
+  for await (const data of sseData(stream)) {
+    const { content, error } = parseAgentEvent(data);
+    if (error) yield sseEvent({ error });
+    else if (content) yield sseEvent(content);
+  }
+}
+
+/**
+ * Extract displayable text from one agent SSE `data` payload. Handles plain
+ * strings, `{"text": ...}` events from the bedrock-agentcore runtime,
+ * `{"error": ...}` events, and ConverseStream-shaped content deltas. A payload
+ * that is not JSON is a plain-text token, forwarded unchanged.
+ */
+export function parseAgentEvent(data: string): { content: string | null; error: string | null } {
+  try {
+    const parsed: unknown = JSON.parse(data);
+    if (typeof parsed === "string") return { content: parsed, error: null };
+    if (parsed && typeof parsed === "object") {
+      if ("error" in parsed) {
+        return { content: null, error: String((parsed as { error: unknown }).error) };
+      }
+      if ("text" in parsed) {
+        return { content: String((parsed as { text: unknown }).text), error: null };
+      }
+      const event = (parsed as { event?: { contentBlockDelta?: { delta?: { text?: string } } } })
+        .event;
+      const text = event?.contentBlockDelta?.delta?.text;
+      if (typeof text === "string") return { content: text, error: null };
+    }
+  } catch {
+    return { content: data, error: null };
+  }
+  return { content: null, error: null };
+}
+
+/**
+ * A2A agents speak JSON-RPC at their root path: translate the SPA's
+ * `{ prompt }` payload into `message/stream` and reduce the A2A event stream
+ * to the `data: "text"` frames the SPA's chat expects.
+ */
+async function invokeA2aAgent(
+  port: number,
+  body: Record<string, unknown> | undefined,
+  sessionId: string,
+  nextA2aId: () => number,
+  signal: AbortSignal,
+): Promise<HttpResponse> {
+  const prompt = asString(body?.prompt);
+  if (!prompt) return apiError(400, "prompt is required");
+
+  const a2aBody = {
+    jsonrpc: "2.0",
+    id: nextA2aId(),
+    method: "message/stream",
+    params: {
+      message: {
+        messageId: randomUUID(),
+        role: "user",
+        parts: [{ kind: "text", text: prompt }],
+        contextId: sessionId,
+      },
+    },
+  };
+
+  let agentResponse: Response;
+  try {
+    agentResponse = await fetch(`http://127.0.0.1:${port}/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "text/event-stream" },
+      body: JSON.stringify(a2aBody),
+      signal,
+    });
+  } catch (error) {
+    return apiError(502, `A2A agent error: ${errorMessage(error)}`);
+  }
+  if (!agentResponse.ok) return apiError(502, `A2A agent returned ${agentResponse.status}`);
+
+  const contentType = agentResponse.headers.get("content-type") ?? "";
+  if (contentType.includes("text/event-stream") && agentResponse.body) {
+    return sse(transformA2aSse(iterateBody(agentResponse.body)), sessionId);
+  }
+
+  // Non-streaming fallback: extract text from the JSON-RPC result.
+  const responseText = await agentResponse.text();
+  try {
+    const parsed = JSON.parse(responseText) as Record<string, unknown>;
+    const result = parsed.result as Record<string, unknown> | undefined;
+    const text = result
+      ? (extractTaskText(result) ?? JSON.stringify(result, null, 2))
+      : responseText;
+    return {
+      status: 200,
+      headers: { "Content-Type": "text/event-stream", "x-session-id": sessionId },
+      body: Buffer.from(sseEvent(text)),
+    };
+  } catch {
+    return { status: 200, headers: { "Content-Type": "text/plain" }, body: responseText };
+  }
+}
+
+async function* transformA2aSse(
+  stream: AsyncIterable<Uint8Array>,
+): AsyncGenerator<Uint8Array, void> {
+  let streamedFromStatus = false;
+  for await (const data of sseData(stream)) {
+    try {
+      const event = JSON.parse(data) as Record<string, unknown>;
+      const text = extractSseEventText(event, streamedFromStatus);
+      if (text) {
+        if (isStatusUpdateEvent(event)) streamedFromStatus = true;
+        yield sseEvent(text);
+      }
+    } catch {
+      yield sseEvent(data);
+    }
+  }
+}
+
+function isStatusUpdateEvent(event: Record<string, unknown>): boolean {
+  const target = (event.result as Record<string, unknown>) ?? event;
+  return target.kind === "status-update";
+}
+
+/**
+ * Extract displayable text from an A2A SSE event (artifact-update or
+ * status-update, optionally wrapped in a JSON-RPC result envelope). When
+ * `streamedFromStatus` is set, artifact-update text is skipped because the
+ * same content already streamed incrementally via status-update events.
+ */
+function extractSseEventText(
+  event: Record<string, unknown>,
+  streamedFromStatus: boolean,
+): string | null {
+  const target = (event.result as Record<string, unknown>) ?? event;
+  const kind = target.kind as string | undefined;
+
+  if (kind === "artifact-update") {
+    if (streamedFromStatus) return null;
+    const artifact = target.artifact as { parts?: A2aPart[] } | undefined;
+    return extractPartsText(artifact?.parts);
+  }
+
+  if (kind === "status-update") {
+    const status = target.status as { message?: { parts?: A2aPart[] } } | undefined;
+    if (status?.message?.parts) return extractPartsText(status.message.parts);
+    return null;
+  }
+
+  return extractTaskText(target);
+}
+
+/** Extract text from a full A2A Task result (artifacts array and/or status message). */
+function extractTaskText(result: Record<string, unknown>): string | null {
+  const artifacts = result.artifacts as { parts?: A2aPart[] }[] | undefined;
+  if (artifacts) {
+    const texts: string[] = [];
+    for (const artifact of artifacts) {
+      const text = extractPartsText(artifact.parts);
+      if (text) texts.push(text);
+    }
+    if (texts.length > 0) return texts.join("\n");
+  }
+
+  const status = result.status as { message?: { parts?: A2aPart[] } } | undefined;
+  if (status?.message?.parts) return extractPartsText(status.message.parts);
+  return null;
+}
+
+type A2aPart = { kind?: string; type?: string; text?: string };
+
+function extractPartsText(parts: A2aPart[] | undefined): string | null {
+  if (!parts) return null;
+  const texts: string[] = [];
+  for (const part of parts) {
+    if ((part.kind === "text" || part.type === "text") && part.text) texts.push(part.text);
+  }
+  return texts.length > 0 ? texts.join("") : null;
+}
+
+/**
+ * AGUI agents expect a RunAgentInput body; translate the SPA's `{ prompt }`
+ * payload and pass the typed AG-UI SSE response through untouched.
+ */
+async function invokeAguiAgent(
+  port: number,
+  body: Record<string, unknown> | undefined,
+  sessionId: string,
+  userId: string | undefined,
+  signal: AbortSignal,
+): Promise<HttpResponse> {
+  const prompt = asString(body?.prompt);
+  if (!prompt) return apiError(400, "prompt is required");
+
+  const aguiBody = JSON.stringify({
+    threadId: sessionId,
+    runId: randomUUID(),
+    messages: [{ id: randomUUID(), role: "user", content: prompt }],
+    tools: [],
+    context: [],
+    state: {},
+    forwardedProps: {},
+  });
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Accept: "text/event-stream",
+    "x-amzn-bedrock-agentcore-runtime-session-id": sessionId,
+  };
+  if (userId) headers["x-amzn-bedrock-agentcore-runtime-user-id"] = userId;
+
+  let agentResponse: Response;
+  try {
+    agentResponse = await fetch(`http://127.0.0.1:${port}/invocations`, {
+      method: "POST",
+      headers,
+      body: aguiBody,
+      signal,
+    });
+  } catch (error) {
+    return apiError(502, `AGUI agent error: ${errorMessage(error)}`);
+  }
+
+  return {
+    status: agentResponse.status,
+    headers: {
+      "Content-Type": agentResponse.headers.get("content-type") ?? "text/plain",
+      "x-session-id": sessionId,
+    },
+    body: iterateBody(agentResponse.body),
+  };
+}

--- a/src/core/dev/inspector/proxies.test.ts
+++ b/src/core/dev/inspector/proxies.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type { HttpRequestHandler } from "../../../io/httpServer";
+import { ServerFarm, fakeSupervisor, get, post, runningAgent } from "./testkit";
+
+const farm = new ServerFarm();
+afterEach(() => farm.close());
+
+async function inspectorFor(handler: HttpRequestHandler) {
+  const agent = await farm.serve(handler);
+  const supervisor = fakeSupervisor({ agents: [runningAgent("orders", agent.port, "MCP")] });
+  return farm.inspector({ supervisor });
+}
+
+describe("POST /api/mcp", () => {
+  test("forwards the JSON-RPC body and returns the parsed result with the session id", async () => {
+    const { url } = await inspectorFor((request) => {
+      expect(request.url).toBe("/mcp");
+      return {
+        status: 200,
+        headers: { "Content-Type": "application/json", "mcp-session-id": "mcp-1" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, result: { tools: [] } }),
+      };
+    });
+    const response = await post(url, "/api/mcp", {
+      agentName: "orders",
+      body: { jsonrpc: "2.0", id: 1, method: "tools/list" },
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      success: true,
+      result: { jsonrpc: "2.0", id: 1, result: { tools: [] } },
+      sessionId: "mcp-1",
+    });
+  });
+
+  test.each([
+    { name: "invalid JSON", body: "not json", expected: "Invalid JSON" },
+    { name: "a missing agentName", body: { body: {} }, expected: "agentName is required" },
+    { name: "a missing body", body: { agentName: "orders" }, expected: "body is required" },
+  ])("rejects $name with 400", async ({ body, expected }) => {
+    const { url } = await inspectorFor(() => ({ status: 200, body: "{}" }));
+    const response = await fetch(`${url}/api/mcp`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "X-Agentcore-Local": "1" },
+      body: typeof body === "string" ? body : JSON.stringify(body),
+    });
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ success: false, error: expected });
+  });
+
+  test("rejects an agent that is not running with 400", async () => {
+    const { url } = await farm.inspector({ supervisor: fakeSupervisor() });
+    const response = await post(url, "/api/mcp", { agentName: "ghost", body: {} });
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      success: false,
+      error: 'Agent "ghost" is not running',
+    });
+  });
+
+  test("returns 502 when the agent responds with an error status", async () => {
+    const { url } = await inspectorFor(() => ({ status: 500, body: "down" }));
+    const response = await post(url, "/api/mcp", { agentName: "orders", body: {} });
+    expect(response.status).toBe(502);
+    expect(await response.json()).toMatchObject({ success: false });
+  });
+
+  test("returns 502 when the response exceeds the size limit", async () => {
+    const { url } = await inspectorFor(() => ({
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+      body: "x".repeat(10 * 1024 * 1024 + 1),
+    }));
+    const response = await post(url, "/api/mcp", { agentName: "orders", body: {} });
+    expect(response.status).toBe(502);
+    expect(await response.json()).toEqual({
+      success: false,
+      error: "MCP response exceeded the size limit",
+    });
+  });
+});
+
+describe("GET /api/a2a/agent-card", () => {
+  test("returns the running agent's card", async () => {
+    const { url } = await inspectorFor((request) => {
+      expect(request.url).toBe("/.well-known/agent.json");
+      return {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "orders", version: "1.0" }),
+      };
+    });
+    const response = await get(url, "/api/a2a/agent-card?agentName=orders");
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      success: true,
+      card: { name: "orders", version: "1.0" },
+    });
+  });
+
+  test("requires the agentName query parameter", async () => {
+    const { url } = await inspectorFor(() => ({ status: 200, body: "{}" }));
+    const response = await get(url, "/api/a2a/agent-card");
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      success: false,
+      error: "agentName query parameter is required",
+    });
+  });
+
+  test("returns 502 when the card is not available", async () => {
+    const { url } = await inspectorFor(() => ({ status: 404, body: "missing" }));
+    const response = await get(url, "/api/a2a/agent-card?agentName=orders");
+    expect(response.status).toBe(502);
+    expect(await response.json()).toMatchObject({ success: false });
+  });
+});

--- a/src/core/dev/inspector/proxies.ts
+++ b/src/core/dev/inspector/proxies.ts
@@ -1,0 +1,108 @@
+/**
+ * Thin proxies to a locally running agent: POST /api/mcp (JSON-RPC forward)
+ * and GET /api/a2a/agent-card. Ported from the reference mcp-proxy.ts /
+ * a2a-proxy.ts. Both forward the client's abort signal so a disconnect cancels
+ * the upstream request.
+ */
+import type { HttpRequest, HttpResponse } from "../../../io/httpServer";
+import { apiError, asString, errorMessage, json, parseJsonBody } from "./respond";
+import type { InspectorDeps } from "./types";
+
+/** Cap the buffered MCP response so a runaway agent cannot exhaust memory. */
+const MAX_MCP_RESPONSE_BYTES = 10 * 1024 * 1024;
+
+/** POST /api/mcp — forward a JSON-RPC body to the agent's /mcp endpoint. */
+export async function handleMcpProxy(
+  deps: InspectorDeps,
+  request: HttpRequest,
+): Promise<HttpResponse> {
+  const parsed = parseJsonBody(request.body);
+  if (!parsed) return apiError(400, "Invalid JSON");
+  const agentName = asString(parsed.agentName);
+  if (!agentName) return apiError(400, "agentName is required");
+  const body = parsed.body;
+  if (!body || typeof body !== "object") return apiError(400, "body is required");
+  const sessionId = asString(parsed.sessionId);
+
+  const running = deps.supervisor.running(agentName);
+  if (!running) return apiError(400, `Agent "${agentName}" is not running`);
+
+  let mcpResponse: Response;
+  try {
+    mcpResponse = await fetch(`http://127.0.0.1:${running.port}/mcp`, {
+      method: "POST",
+      // The response is buffered and returned as JSON below, so ask for JSON
+      // only rather than advertising an event stream this proxy never streams.
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        ...(sessionId !== undefined && { "mcp-session-id": sessionId }),
+      },
+      body: JSON.stringify(body),
+      signal: request.signal,
+    });
+  } catch (error) {
+    return apiError(502, `Failed to connect to MCP agent: ${errorMessage(error)}`);
+  }
+  if (!mcpResponse.ok) return apiError(502, `MCP server returned status ${mcpResponse.status}`);
+
+  const responseText = await readCapped(mcpResponse, MAX_MCP_RESPONSE_BYTES);
+  if (responseText === undefined) return apiError(502, "MCP response exceeded the size limit");
+
+  const responseSessionId = mcpResponse.headers.get("mcp-session-id") ?? undefined;
+  let result: unknown;
+  try {
+    result = JSON.parse(responseText);
+  } catch {
+    result = responseText;
+  }
+  return json(200, { success: true, result, sessionId: responseSessionId });
+}
+
+/** GET /api/a2a/agent-card?agentName=xxx — fetch the running agent's A2A card. */
+export async function handleA2aAgentCard(
+  deps: InspectorDeps,
+  url: URL,
+  signal: AbortSignal,
+): Promise<HttpResponse> {
+  const agentName = url.searchParams.get("agentName") ?? undefined;
+  if (!agentName) return apiError(400, "agentName query parameter is required");
+
+  const running = deps.supervisor.running(agentName);
+  if (!running) return apiError(400, `Agent "${agentName}" is not running`);
+
+  try {
+    const cardResponse = await fetch(`http://127.0.0.1:${running.port}/.well-known/agent.json`, {
+      method: "GET",
+      headers: { Accept: "application/json" },
+      signal,
+    });
+    if (!cardResponse.ok) {
+      return apiError(502, `Agent card not available (${cardResponse.status})`);
+    }
+    const card: unknown = await cardResponse.json();
+    return json(200, { success: true, card });
+  } catch (error) {
+    return apiError(502, `Failed to fetch agent card: ${errorMessage(error)}`);
+  }
+}
+
+/** Read a response body as text, or undefined when it exceeds `maxBytes`. */
+async function readCapped(response: Response, maxBytes: number): Promise<string | undefined> {
+  const reader = response.body?.getReader();
+  if (!reader) return "";
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      size += value.length;
+      if (size > maxBytes) return undefined;
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}

--- a/src/core/dev/inspector/proxies.ts
+++ b/src/core/dev/inspector/proxies.ts
@@ -1,9 +1,3 @@
-/**
- * Thin proxies to a locally running agent: POST /api/mcp (JSON-RPC forward)
- * and GET /api/a2a/agent-card. Ported from the reference mcp-proxy.ts /
- * a2a-proxy.ts. Both forward the client's abort signal so a disconnect cancels
- * the upstream request.
- */
 import type { HttpRequest, HttpResponse } from "../../../io/httpServer";
 import { apiError, asString, errorMessage, iterateBody, json, parseJsonBody } from "./respond";
 import type { InspectorDeps } from "./types";
@@ -11,7 +5,6 @@ import type { InspectorDeps } from "./types";
 /** Cap the buffered MCP response so a runaway agent cannot exhaust memory. */
 const MAX_MCP_RESPONSE_BYTES = 10 * 1024 * 1024;
 
-/** POST /api/mcp — forward a JSON-RPC body to the agent's /mcp endpoint. */
 export async function handleMcpProxy(
   deps: InspectorDeps,
   request: HttpRequest,
@@ -31,8 +24,7 @@ export async function handleMcpProxy(
   try {
     mcpResponse = await fetch(`http://127.0.0.1:${running.port}/mcp`, {
       method: "POST",
-      // The response is buffered and returned as JSON below, so ask for JSON
-      // only rather than advertising an event stream this proxy never streams.
+      // Accept JSON only because this proxy buffers the full response and never streams.
       headers: {
         "Content-Type": "application/json",
         Accept: "application/json",
@@ -59,7 +51,6 @@ export async function handleMcpProxy(
   return json(200, { success: true, result, sessionId: responseSessionId });
 }
 
-/** GET /api/a2a/agent-card?agentName=xxx — fetch the running agent's A2A card. */
 export async function handleA2aAgentCard(
   deps: InspectorDeps,
   url: URL,
@@ -87,7 +78,6 @@ export async function handleA2aAgentCard(
   }
 }
 
-/** Read a response body as text, or undefined when it exceeds `maxBytes`. */
 async function readCapped(response: Response, maxBytes: number): Promise<string | undefined> {
   const chunks: Uint8Array[] = [];
   let size = 0;

--- a/src/core/dev/inspector/proxies.ts
+++ b/src/core/dev/inspector/proxies.ts
@@ -5,7 +5,7 @@
  * the upstream request.
  */
 import type { HttpRequest, HttpResponse } from "../../../io/httpServer";
-import { apiError, asString, errorMessage, json, parseJsonBody } from "./respond";
+import { apiError, asString, errorMessage, iterateBody, json, parseJsonBody } from "./respond";
 import type { InspectorDeps } from "./types";
 
 /** Cap the buffered MCP response so a runaway agent cannot exhaust memory. */
@@ -89,20 +89,12 @@ export async function handleA2aAgentCard(
 
 /** Read a response body as text, or undefined when it exceeds `maxBytes`. */
 async function readCapped(response: Response, maxBytes: number): Promise<string | undefined> {
-  const reader = response.body?.getReader();
-  if (!reader) return "";
   const chunks: Uint8Array[] = [];
   let size = 0;
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      size += value.length;
-      if (size > maxBytes) return undefined;
-      chunks.push(value);
-    }
-  } finally {
-    reader.releaseLock();
+  for await (const value of iterateBody(response.body)) {
+    size += value.length;
+    if (size > maxBytes) return undefined;
+    chunks.push(value);
   }
   return Buffer.concat(chunks).toString("utf8");
 }

--- a/src/core/dev/inspector/resources.test.ts
+++ b/src/core/dev/inspector/resources.test.ts
@@ -35,6 +35,81 @@ function project(): Project {
         },
       ],
       credentials: [{ authorizerType: "ApiKeyCredentialProvider", name: "stripe-key" }],
+      evaluators: [
+        {
+          name: "quality",
+          level: "SESSION",
+          description: "Checks quality",
+          config: {
+            llmAsAJudge: {
+              model: "anthropic.claude-v2",
+              instructions: "Judge the answer",
+              ratingScale: { numerical: [{ value: 1, label: "bad", definition: "Bad answer" }] },
+            },
+          },
+        },
+      ],
+      onlineEvalConfigs: [
+        { name: "prod_eval", agent: "orders", samplingRate: 10, evaluators: ["quality"] },
+      ],
+      agentCoreGateways: [
+        {
+          name: "gw",
+          targets: [
+            {
+              name: "orders-target",
+              targetType: "lambda",
+              toolDefinitions: [
+                {
+                  name: "lookup",
+                  description: "Look up an order",
+                  inputSchema: { type: "object" },
+                },
+              ],
+              compute: {
+                host: "Lambda",
+                implementation: { language: "Python", path: "tools", handler: "handler.main" },
+                pythonVersion: "PYTHON_3_12",
+              },
+            },
+          ],
+        },
+      ],
+      mcpRuntimeTools: [
+        {
+          name: "search-tool",
+          toolDefinition: {
+            name: "search",
+            description: "Search the catalog",
+            inputSchema: { type: "object" },
+          },
+          compute: {
+            host: "AgentCoreRuntime",
+            implementation: { language: "Python", path: "tools", handler: "handler.main" },
+          },
+          bindings: [{ runtimeName: "orders", envVarName: "SEARCH_URL" }],
+        },
+      ],
+      unassignedTargets: [
+        {
+          name: "catalog",
+          targetType: "smithyModel",
+          schemaSource: { inline: { path: "schema.smithy" } },
+        },
+      ],
+      policyEngines: [
+        {
+          name: "guardrails",
+          description: "Access policies",
+          policies: [
+            {
+              name: "allow_read",
+              description: "Allow reads",
+              statement: "permit(principal, action, resource);",
+            },
+          ],
+        },
+      ],
     }),
   };
 }
@@ -67,12 +142,29 @@ describe("GET /api/resources", () => {
         },
       ],
       credentials: [{ name: "stripe-key", type: "ApiKeyCredentialProvider" }],
-      gateways: [],
-      mcpRuntimeTools: [],
-      evaluators: [],
-      onlineEvalConfigs: [],
-      policyEngines: [],
-      unassignedTargets: [],
+      gateways: [{ name: "gw", targets: [{ name: "lookup", targetType: "lambda" }] }],
+      mcpRuntimeTools: [
+        { name: "search-tool", bindings: [{ runtimeName: "orders", envVarName: "SEARCH_URL" }] },
+      ],
+      evaluators: [
+        {
+          name: "quality",
+          level: "SESSION",
+          description: "Checks quality",
+          configType: "llm-as-a-judge",
+        },
+      ],
+      onlineEvalConfigs: [
+        { name: "prod_eval", agent: "orders", evaluators: ["quality"], samplingRate: 10 },
+      ],
+      policyEngines: [
+        {
+          name: "guardrails",
+          description: "Access policies",
+          policies: [{ name: "allow_read", description: "Allow reads" }],
+        },
+      ],
+      unassignedTargets: [{ name: "catalog", targetType: "smithyModel" }],
       deploymentTargets: [],
     });
   });

--- a/src/core/dev/inspector/resources.test.ts
+++ b/src/core/dev/inspector/resources.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import type { Project } from "../../../handlers/project/types";
+import { ProjectSpecSchema } from "../../../projectSchemas/project";
+import { handleResources } from "./resources";
+import { fakeSupervisor } from "./testkit";
+import type { InspectorDeps } from "./types";
+
+function deps(overrides: Partial<InspectorDeps> = {}): InspectorDeps {
+  return { supervisor: fakeSupervisor(), ...overrides };
+}
+
+function project(): Project {
+  return {
+    name: "Demo",
+    rootPath: "/workspace/demo",
+    spec: ProjectSpecSchema.parse({
+      name: "Demo",
+      version: 1,
+      managedBy: "CDK",
+      runtimes: [
+        {
+          name: "orders",
+          build: "Container",
+          entrypoint: "index.ts",
+          codeLocation: "src",
+          envVars: [{ name: "STAGE", value: "dev" }],
+        },
+      ],
+      harnesses: [{ name: "support", path: "harness/support" }],
+      memories: [
+        {
+          name: "chat",
+          eventExpiryDuration: 30,
+          strategies: [{ type: "SEMANTIC", namespaceTemplates: ["/users/{actorId}/facts"] }],
+        },
+      ],
+      credentials: [{ authorizerType: "ApiKeyCredentialProvider", name: "stripe-key" }],
+    }),
+  };
+}
+
+describe("GET /api/resources", () => {
+  test("flattens the project spec into the resource graph", () => {
+    const response = handleResources(deps({ project: project() }));
+    expect(response.status).toBe(200);
+    expect(JSON.parse(response.body as string)).toEqual({
+      success: true,
+      project: "Demo",
+      agents: [
+        {
+          name: "orders",
+          build: "Container",
+          entrypoint: "index.ts",
+          codeLocation: "src",
+          runtimeVersion: "",
+          networkMode: "PUBLIC",
+          protocol: "HTTP",
+          envVars: ["STAGE"],
+        },
+      ],
+      harnesses: [{ name: "support", model: "", tools: [] }],
+      memories: [
+        {
+          name: "chat",
+          strategies: [{ type: "SEMANTIC", namespaceTemplates: ["/users/{actorId}/facts"] }],
+          expiryDays: 30,
+        },
+      ],
+      credentials: [{ name: "stripe-key", type: "ApiKeyCredentialProvider" }],
+      gateways: [],
+      mcpRuntimeTools: [],
+      evaluators: [],
+      onlineEvalConfigs: [],
+      policyEngines: [],
+      unassignedTargets: [],
+      deploymentTargets: [],
+    });
+  });
+
+  test("returns 404 when there is no project", () => {
+    const response = handleResources(deps());
+    expect(response.status).toBe(404);
+    expect(JSON.parse(response.body as string)).toEqual({
+      success: false,
+      error: "No agentcore project found",
+    });
+  });
+});

--- a/src/core/dev/inspector/resources.ts
+++ b/src/core/dev/inspector/resources.ts
@@ -1,11 +1,3 @@
-/**
- * GET /api/resources — the project resource graph the SPA's resources panel
- * renders, built from the resolved project spec. Resource details the
- * reference exposed but this project schema lacks (aws-targets regions,
- * per-harness model/tool specs, deployed state) are emitted with their
- * neutral defaults so the wire shape stays intact; deployed state returns
- * with real deploy wiring.
- */
 import type { HttpResponse } from "../../../io/httpServer";
 import { apiError, json } from "./respond";
 import type { InspectorDeps } from "./types";
@@ -15,7 +7,7 @@ export function handleResources(deps: InspectorDeps): HttpResponse {
   if (!project) return apiError(404, "No agentcore project found");
 
   const spec = project.spec;
-  // The literal is the wire contract — the SPA depends on these exact field names.
+  // The literal is the wire contract. The SPA depends on these exact field names.
   const resources = {
     success: true,
     project: project.name,
@@ -29,8 +21,7 @@ export function handleResources(deps: InspectorDeps): HttpResponse {
       protocol: runtime.protocol ?? "HTTP",
       envVars: runtime.envVars?.map((envVar) => envVar.name) ?? [],
     })),
-    // Harness registry entries carry only name + path; model/tool details
-    // lived in per-harness spec files the reference read separately.
+    // Project schema has no per-harness model or tool spec yet, so neutral defaults.
     harnesses: spec.harnesses.map((harness) => ({ name: harness.name, model: "", tools: [] })),
     memories: spec.memories.map((memory) => ({
       name: memory.name,
@@ -83,7 +74,7 @@ export function handleResources(deps: InspectorDeps): HttpResponse {
       name: target.name,
       targetType: target.targetType,
     })),
-    // The project schema has no aws-targets equivalent yet.
+    // Project schema has no aws-targets or deployed-state equivalent yet, so neutral defaults.
     deploymentTargets: [],
   };
   return json(200, resources);

--- a/src/core/dev/inspector/resources.ts
+++ b/src/core/dev/inspector/resources.ts
@@ -1,0 +1,90 @@
+/**
+ * GET /api/resources — the project resource graph the SPA's resources panel
+ * renders, built from the resolved project spec. Resource details the
+ * reference exposed but this project schema lacks (aws-targets regions,
+ * per-harness model/tool specs, deployed state) are emitted with their
+ * neutral defaults so the wire shape stays intact; deployed state returns
+ * with real deploy wiring.
+ */
+import type { HttpResponse } from "../../../io/httpServer";
+import { apiError, json } from "./respond";
+import type { InspectorDeps } from "./types";
+
+export function handleResources(deps: InspectorDeps): HttpResponse {
+  const project = deps.project;
+  if (!project) return apiError(404, "No agentcore project found");
+
+  const spec = project.spec;
+  // The literal is the wire contract — the SPA depends on these exact field names.
+  const resources = {
+    success: true,
+    project: project.name,
+    agents: spec.runtimes.map((runtime) => ({
+      name: runtime.name,
+      build: runtime.build,
+      entrypoint: runtime.entrypoint,
+      codeLocation: runtime.codeLocation,
+      runtimeVersion: runtime.runtimeVersion ?? "",
+      networkMode: runtime.networkMode ?? "PUBLIC",
+      protocol: runtime.protocol ?? "HTTP",
+      envVars: runtime.envVars?.map((envVar) => envVar.name) ?? [],
+    })),
+    // Harness registry entries carry only name + path; model/tool details
+    // lived in per-harness spec files the reference read separately.
+    harnesses: spec.harnesses.map((harness) => ({ name: harness.name, model: "", tools: [] })),
+    memories: spec.memories.map((memory) => ({
+      name: memory.name,
+      strategies: memory.strategies.map((strategy) => ({
+        type: strategy.type,
+        namespaceTemplates: strategy.namespaceTemplates ?? strategy.namespaces ?? [],
+      })),
+      expiryDays: memory.eventExpiryDuration,
+    })),
+    credentials: spec.credentials.map((credential) => ({
+      name: credential.name,
+      type: credential.authorizerType,
+    })),
+    gateways: spec.agentCoreGateways.map((gateway) => ({
+      name: gateway.name,
+      targets: gateway.targets.map((target) => ({
+        name: target.toolDefinitions?.[0]?.name ?? target.name,
+        targetType: target.targetType,
+      })),
+    })),
+    mcpRuntimeTools: (spec.mcpRuntimeTools ?? []).map((tool) => ({
+      name: tool.name,
+      bindings: tool.bindings ?? [],
+    })),
+    evaluators: spec.evaluators.map((evaluator) => ({
+      name: evaluator.name,
+      level: evaluator.level,
+      description: evaluator.description,
+      configType: evaluator.config.codeBased ? "code-based" : "llm-as-a-judge",
+    })),
+    onlineEvalConfigs: spec.onlineEvalConfigs.map((config) => ({
+      name: config.name,
+      agent: config.agent,
+      evaluators: config.evaluators,
+      insights: config.insights,
+      samplingRate: config.samplingRate,
+      description: config.description,
+      logGroupNames: config.logGroupNames,
+      serviceNames: config.serviceNames,
+    })),
+    policyEngines: spec.policyEngines.map((engine) => ({
+      name: engine.name,
+      description: engine.description,
+      policies: engine.policies.map((policy) => ({
+        name: policy.name,
+        description: policy.description,
+      })),
+    })),
+    unassignedTargets: (spec.unassignedTargets ?? []).map((target) => ({
+      name: target.name,
+      targetType: target.targetType,
+    })),
+    // The project schema has no aws-targets equivalent yet.
+    deploymentTargets: [],
+  };
+  return json(200, resources);
+}

--- a/src/core/dev/inspector/respond.ts
+++ b/src/core/dev/inspector/respond.ts
@@ -51,3 +51,75 @@ export function asString(value: unknown): string | undefined {
 export function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
+
+/** An SSE response streaming `body`, optionally echoing the session id back. */
+export function sse(body: AsyncIterable<Uint8Array>, sessionId?: string): HttpResponse {
+  return {
+    status: 200,
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+      ...(sessionId !== undefined && { "x-session-id": sessionId }),
+    },
+    body,
+  };
+}
+
+/** One SSE event in the `data: <json>\n\n` framing every Inspector stream uses. */
+export function sseEvent(payload: unknown): Uint8Array {
+  return new TextEncoder().encode(`data: ${JSON.stringify(payload)}\n\n`);
+}
+
+/** Iterate a fetch response body; a null body yields nothing. */
+export async function* iterateBody(
+  stream: ReadableStream<Uint8Array> | null,
+): AsyncGenerator<Uint8Array, void> {
+  if (!stream) return;
+  const reader = stream.getReader();
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) return;
+      yield value;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+/** Split a byte stream into text lines, flushing any trailing partial line. */
+export async function* lines(stream: AsyncIterable<Uint8Array>): AsyncGenerator<string, void> {
+  const decoder = new TextDecoder();
+  let buffer = "";
+  for await (const chunk of stream) {
+    buffer += decoder.decode(chunk, { stream: true });
+    const parts = buffer.split("\n");
+    buffer = parts.pop() ?? "";
+    yield* parts;
+  }
+  buffer += decoder.decode();
+  if (buffer) yield buffer;
+}
+
+/**
+ * Parse an SSE byte stream into each event's `data` payload, per the SSE
+ * framing rules: an optional single space after `data:`, multiple `data:` lines
+ * joined with newlines, and a blank line ending the event. Non-data lines
+ * (comments, `event:`, `id:`) are ignored rather than forwarded as content.
+ */
+export async function* sseData(stream: AsyncIterable<Uint8Array>): AsyncGenerator<string, void> {
+  let data: string[] = [];
+  for await (const raw of lines(stream)) {
+    const line = raw.endsWith("\r") ? raw.slice(0, -1) : raw;
+    if (line === "") {
+      if (data.length > 0) {
+        yield data.join("\n");
+        data = [];
+      }
+    } else if (line.startsWith("data:")) {
+      data.push(line.slice(5).replace(/^ /, ""));
+    }
+  }
+  if (data.length > 0) yield data.join("\n");
+}

--- a/src/core/dev/inspector/respond.ts
+++ b/src/core/dev/inspector/respond.ts
@@ -1,4 +1,3 @@
-/** Small response and parsing helpers shared by the Inspector route modules. */
 import type { HttpResponse } from "../../../io/httpServer";
 
 const encoder = new TextEncoder();
@@ -15,21 +14,14 @@ export function apiError(status: number, error: string): HttpResponse {
   return json(status, { success: false, error });
 }
 
-/** Parse a JSON request body, or undefined when it is not valid JSON. */
 export function parseJsonBody(body: Buffer): Record<string, unknown> | undefined {
   try {
     const parsed: unknown = JSON.parse(body.toString());
     if (parsed && typeof parsed === "object") return parsed as Record<string, unknown>;
-  } catch {
-    // fall through
-  }
+  } catch {}
   return undefined;
 }
 
-/**
- * Parse an optional epoch-milliseconds query parameter. Returns the value (or
- * undefined when absent) or an error response matching the reference wording.
- */
 export function parseTimeParam(
   url: URL,
   name: string,
@@ -54,7 +46,6 @@ export function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-/** An SSE response streaming `body`, optionally echoing the session id back. */
 export function sse(body: AsyncIterable<Uint8Array>, sessionId?: string): HttpResponse {
   return {
     status: 200,
@@ -68,12 +59,10 @@ export function sse(body: AsyncIterable<Uint8Array>, sessionId?: string): HttpRe
   };
 }
 
-/** One SSE event in the `data: <json>\n\n` framing every Inspector stream uses. */
 export function sseEvent(payload: unknown): Uint8Array {
   return encoder.encode(`data: ${JSON.stringify(payload)}\n\n`);
 }
 
-/** Iterate a fetch response body; a null body yields nothing. */
 export async function* iterateBody(
   stream: ReadableStream<Uint8Array> | null,
 ): AsyncGenerator<Uint8Array, void> {
@@ -90,7 +79,6 @@ export async function* iterateBody(
   }
 }
 
-/** Split a byte stream into text lines, flushing any trailing partial line. */
 export async function* lines(stream: AsyncIterable<Uint8Array>): AsyncGenerator<string, void> {
   const decoder = new TextDecoder();
   let buffer = "";
@@ -104,12 +92,7 @@ export async function* lines(stream: AsyncIterable<Uint8Array>): AsyncGenerator<
   if (buffer) yield buffer;
 }
 
-/**
- * Parse an SSE byte stream into each event's `data` payload, per the SSE
- * framing rules: an optional single space after `data:`, multiple `data:` lines
- * joined with newlines, and a blank line ending the event. Non-data lines
- * (comments, `event:`, `id:`) are ignored rather than forwarded as content.
- */
+/** SSE framing: strip one optional space after `data:`, join multiple `data:` lines with newlines, end the event on a blank line, ignore non-data lines. */
 export async function* sseData(stream: AsyncIterable<Uint8Array>): AsyncGenerator<string, void> {
   let data: string[] = [];
   for await (const raw of lines(stream)) {

--- a/src/core/dev/inspector/respond.ts
+++ b/src/core/dev/inspector/respond.ts
@@ -1,6 +1,8 @@
 /** Small response and parsing helpers shared by the Inspector route modules. */
 import type { HttpResponse } from "../../../io/httpServer";
 
+const encoder = new TextEncoder();
+
 export function json(status: number, body: unknown): HttpResponse {
   return {
     status,
@@ -68,7 +70,7 @@ export function sse(body: AsyncIterable<Uint8Array>, sessionId?: string): HttpRe
 
 /** One SSE event in the `data: <json>\n\n` framing every Inspector stream uses. */
 export function sseEvent(payload: unknown): Uint8Array {
-  return new TextEncoder().encode(`data: ${JSON.stringify(payload)}\n\n`);
+  return encoder.encode(`data: ${JSON.stringify(payload)}\n\n`);
 }
 
 /** Iterate a fetch response body; a null body yields nothing. */

--- a/src/core/dev/inspector/server.ts
+++ b/src/core/dev/inspector/server.ts
@@ -36,10 +36,6 @@ const STATIC_CORS_HEADERS = {
 } as const;
 
 export function createInspectorHandler(deps: InspectorDeps): HttpRequestHandler {
-  // A2A message ids must be unique per JSON-RPC call across the handler's life.
-  let a2aId = 0;
-  const nextA2aId = () => ++a2aId;
-
   return async (request) => {
     // DNS rebinding protection — a custom domain resolving to 127.0.0.1 would
     // bypass origin checks, so only loopback Host headers are accepted.
@@ -63,16 +59,12 @@ export function createInspectorHandler(deps: InspectorDeps): HttpRequestHandler 
       return withHeaders(forbidden("Forbidden: missing X-Agentcore-Local header"), cors);
     }
 
-    const response = await route(deps, request, nextA2aId);
+    const response = await route(deps, request);
     return withHeaders(response, cors);
   };
 }
 
-async function route(
-  deps: InspectorDeps,
-  request: HttpRequest,
-  nextA2aId: () => number,
-): Promise<HttpResponse> {
+async function route(deps: InspectorDeps, request: HttpRequest): Promise<HttpResponse> {
   const url = new URL(request.url, "http://localhost");
   const { pathname } = url;
   const { method } = request;
@@ -81,9 +73,7 @@ async function route(
   if (method === "GET" && pathname === "/api/traces") return handleListTraces(deps, url);
   if (method === "GET" && pathname.startsWith("/api/traces/")) return handleGetTrace(deps, url);
   if (method === "POST" && pathname === "/api/start") return handleStart(deps, request);
-  if (method === "POST" && pathname === "/invocations") {
-    return handleInvocations(deps, request, nextA2aId);
-  }
+  if (method === "POST" && pathname === "/invocations") return handleInvocations(deps, request);
   if (method === "POST" && pathname === "/api/mcp") return handleMcpProxy(deps, request);
   if (method === "GET" && pathname === "/api/a2a/agent-card") {
     return handleA2aAgentCard(deps, url, request.signal);

--- a/src/core/dev/inspector/server.ts
+++ b/src/core/dev/inspector/server.ts
@@ -2,12 +2,15 @@
  * The Agent Inspector request handler: a pure request → response function the
  * dev command composes with io/startHttpServer. It ports the reference
  * WebUIServer's security model (DNS-rebinding Host check, server-side origin
- * allowlist, X-Agentcore-Local on POSTs, CORS preflight) and the routes the SPA
- * calls this layer: status, on-demand start, trace reads, and the static SPA.
- * Agent-proxy routes (invocations, MCP, A2A, resources) register in a later PR.
+ * allowlist, X-Agentcore-Local on POSTs, CORS preflight) and the SPA routes this
+ * layer answers: status, on-demand start, trace reads, agent invocation, the MCP
+ * and A2A proxies, the project resource graph, and the static SPA.
  */
 import { ResourceNotFoundError } from "../../../errors";
 import type { HttpRequest, HttpRequestHandler, HttpResponse } from "../../../io/httpServer";
+import { handleInvocations } from "./invocations";
+import { handleMcpProxy, handleA2aAgentCard } from "./proxies";
+import { handleResources } from "./resources";
 import { apiError, asString, errorMessage, json, parseJsonBody, parseTimeParam } from "./respond";
 import type { InspectorDeps } from "./types";
 
@@ -33,6 +36,10 @@ const STATIC_CORS_HEADERS = {
 } as const;
 
 export function createInspectorHandler(deps: InspectorDeps): HttpRequestHandler {
+  // A2A message ids must be unique per JSON-RPC call across the handler's life.
+  let a2aId = 0;
+  const nextA2aId = () => ++a2aId;
+
   return async (request) => {
     // DNS rebinding protection — a custom domain resolving to 127.0.0.1 would
     // bypass origin checks, so only loopback Host headers are accepted.
@@ -56,12 +63,16 @@ export function createInspectorHandler(deps: InspectorDeps): HttpRequestHandler 
       return withHeaders(forbidden("Forbidden: missing X-Agentcore-Local header"), cors);
     }
 
-    const response = await route(deps, request);
+    const response = await route(deps, request, nextA2aId);
     return withHeaders(response, cors);
   };
 }
 
-async function route(deps: InspectorDeps, request: HttpRequest): Promise<HttpResponse> {
+async function route(
+  deps: InspectorDeps,
+  request: HttpRequest,
+  nextA2aId: () => number,
+): Promise<HttpResponse> {
   const url = new URL(request.url, "http://localhost");
   const { pathname } = url;
   const { method } = request;
@@ -70,6 +81,14 @@ async function route(deps: InspectorDeps, request: HttpRequest): Promise<HttpRes
   if (method === "GET" && pathname === "/api/traces") return handleListTraces(deps, url);
   if (method === "GET" && pathname.startsWith("/api/traces/")) return handleGetTrace(deps, url);
   if (method === "POST" && pathname === "/api/start") return handleStart(deps, request);
+  if (method === "POST" && pathname === "/invocations") {
+    return handleInvocations(deps, request, nextA2aId);
+  }
+  if (method === "POST" && pathname === "/api/mcp") return handleMcpProxy(deps, request);
+  if (method === "GET" && pathname === "/api/a2a/agent-card") {
+    return handleA2aAgentCard(deps, url, request.signal);
+  }
+  if (method === "GET" && pathname === "/api/resources") return handleResources(deps);
   if (method === "GET" && !pathname.startsWith("/api/")) {
     const asset = await serveAsset(deps, pathname);
     if (asset) return asset;

--- a/src/core/dev/inspector/server.ts
+++ b/src/core/dev/inspector/server.ts
@@ -1,10 +1,7 @@
 /**
- * The Agent Inspector request handler: a pure request → response function the
- * dev command composes with io/startHttpServer. It ports the reference
- * WebUIServer's security model (DNS-rebinding Host check, server-side origin
- * allowlist, X-Agentcore-Local on POSTs, CORS preflight) and the SPA routes this
- * layer answers: status, on-demand start, trace reads, agent invocation, the MCP
- * and A2A proxies, the project resource graph, and the static SPA.
+ * The Agent Inspector request handler: a pure request to response function
+ * wrapping the security model (loopback Host check, origin allowlist,
+ * X-Agentcore-Local on POSTs) around the SPA, proxy, and trace routes.
  */
 import { ResourceNotFoundError } from "../../../errors";
 import type { HttpRequest, HttpRequestHandler, HttpResponse } from "../../../io/httpServer";
@@ -14,20 +11,17 @@ import { handleResources } from "./resources";
 import { apiError, asString, errorMessage, json, parseJsonBody, parseTimeParam } from "./respond";
 import type { InspectorDeps } from "./types";
 
-/** Origins the Vite dev server uses for the frontend HMR workflow. */
 const DEV_SERVER_ORIGINS = ["http://localhost:5173", "http://127.0.0.1:5173"];
 
-/** Loopback Host headers the DNS-rebinding guard accepts, port already stripped. */
 const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"]);
 
-/** Newest traces returned per list poll — bounds a payload that carries full spans per row. */
+/** Bounds a payload that carries full spans per row. */
 const TRACE_LIST_LIMIT = 200;
 
-/** CSP for served HTML, blocking inline-script injection from agent responses. */
+/** Blocks inline-script injection from agent responses in served HTML. */
 const CSP_HEADER =
   "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data:; font-src 'self' data:";
 
-/** CORS headers that never vary; only Access-Control-Allow-Origin is per-request. */
 const STATIC_CORS_HEADERS = {
   "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
   "Access-Control-Allow-Headers": "Content-Type, X-Agentcore-Local, Mcp-Session-Id",
@@ -37,15 +31,12 @@ const STATIC_CORS_HEADERS = {
 
 export function createInspectorHandler(deps: InspectorDeps): HttpRequestHandler {
   return async (request) => {
-    // DNS rebinding protection — a custom domain resolving to 127.0.0.1 would
-    // bypass origin checks, so only loopback Host headers are accepted.
+    // A custom domain resolving to 127.0.0.1 would bypass origin checks, so only loopback Host headers are accepted.
     const host = request.headers.host ?? "";
     const hostname = host.replace(/:\d+$/, "");
     if (!LOOPBACK_HOSTS.has(hostname)) return forbidden("Forbidden");
 
-    // Server-side origin validation — CORS headers alone only stop the browser
-    // from reading responses; the request's side effects (starting agents,
-    // invoking with AWS credentials) must be blocked before any handler runs.
+    // CORS only stops the browser reading responses, so side effects (starting agents, invoking with AWS credentials) must be blocked here before any handler runs.
     const origin = asString(request.headers.origin);
     const allowedOrigins = [`http://${host}`, ...DEV_SERVER_ORIGINS];
     if (origin && !allowedOrigins.includes(origin)) return forbidden("Forbidden");
@@ -53,8 +44,7 @@ export function createInspectorHandler(deps: InspectorDeps): HttpRequestHandler 
 
     if (request.method === "OPTIONS") return { status: 204, headers: cors };
 
-    // Require a custom header on all POSTs: it forces a CORS preflight (which
-    // the origin check blocks cross-origin), closing the simple-form-POST gap.
+    // The custom header forces a CORS preflight that the origin check blocks cross-origin, closing the simple-form-POST gap.
     if (request.method === "POST" && !request.headers["x-agentcore-local"]) {
       return withHeaders(forbidden("Forbidden: missing X-Agentcore-Local header"), cors);
     }
@@ -86,10 +76,9 @@ async function route(deps: InspectorDeps, request: HttpRequest): Promise<HttpRes
   return apiError(404, "Not Found");
 }
 
-/** GET /api/status — available agents, running ports, and per-agent errors. */
 function handleStatus(deps: InspectorDeps): HttpResponse {
   const snapshot = deps.supervisor.snapshot();
-  // The literal is the wire contract — the SPA depends on these exact field names.
+  // The literal is the wire contract. The SPA depends on these exact field names.
   const status = {
     mode: "dev",
     agents: snapshot.map(({ name, buildType, protocol }) => ({ name, buildType, protocol })),
@@ -105,7 +94,6 @@ function handleStatus(deps: InspectorDeps): HttpResponse {
   return json(200, status);
 }
 
-/** POST /api/start — start an agent on demand; concurrent starts share one attempt. */
 async function handleStart(deps: InspectorDeps, request: HttpRequest): Promise<HttpResponse> {
   const agentName = asString(parseJsonBody(request.body)?.agentName);
   if (!agentName) return apiError(400, "agentName is required");
@@ -119,7 +107,6 @@ async function handleStart(deps: InspectorDeps, request: HttpRequest): Promise<H
   }
 }
 
-/** GET /api/traces?agentName=xxx — recent local OTEL traces. */
 async function handleListTraces(deps: InspectorDeps, url: URL): Promise<HttpResponse> {
   if (!deps.traces) return apiError(404, "Traces are not available");
 
@@ -141,7 +128,6 @@ async function handleListTraces(deps: InspectorDeps, url: URL): Promise<HttpResp
   }
 }
 
-/** GET /api/traces/:traceId — full span and log data for one local trace. */
 async function handleGetTrace(deps: InspectorDeps, url: URL): Promise<HttpResponse> {
   if (!deps.traces) return apiError(404, "Traces are not available");
 
@@ -157,7 +143,6 @@ async function handleGetTrace(deps: InspectorDeps, url: URL): Promise<HttpRespon
   }
 }
 
-/** Serve a static SPA asset, falling back to index.html for client-side routes. */
 async function serveAsset(
   deps: InspectorDeps,
   pathname: string,
@@ -171,7 +156,7 @@ async function serveAsset(
       "Content-Type": asset.contentType,
       ...(asset.contentType.includes("text/html") && { "Content-Security-Policy": CSP_HEADER }),
     },
-    // A view over the cached bytes, not a copy — the server only reads it.
+    // A view over the cached bytes, not a copy, since the server only reads it.
     body: Buffer.from(asset.body.buffer, asset.body.byteOffset, asset.body.byteLength),
   };
 }
@@ -181,8 +166,7 @@ function forbidden(message: string): HttpResponse {
 }
 
 function corsHeaders(origin: string | undefined, allowedOrigins: string[]): Record<string, string> {
-  // A present origin already passed the allowlist check above, so echo it back;
-  // otherwise fall back to the primary allowed origin.
+  // A present origin already passed the allowlist check above, so it is safe to echo back.
   return { "Access-Control-Allow-Origin": origin || allowedOrigins[0]!, ...STATIC_CORS_HEADERS };
 }
 

--- a/src/io/httpServer.test.ts
+++ b/src/io/httpServer.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { type HttpServerHandle, startHttpServer } from "./httpServer";
+import type { ServerResponse } from "node:http";
+import { type HttpServerHandle, startHttpServer, stream } from "./httpServer";
 
 let handle: HttpServerHandle | undefined;
 
@@ -71,6 +72,21 @@ describe("startHttpServer", () => {
     expect((await fetch(`http://127.0.0.1:${handle.port}/`)).status).toBe(200);
   });
 
+  test("streams an async-iterable body chunk by chunk", async () => {
+    handle = await startHttpServer(() => ({
+      status: 200,
+      headers: { "Content-Type": "text/plain" },
+      body: (async function* () {
+        yield new TextEncoder().encode("one\n");
+        yield new TextEncoder().encode("two\n");
+      })(),
+    }));
+
+    const response = await fetch(`http://127.0.0.1:${handle.port}/`);
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("one\ntwo\n");
+  });
+
   test("aborting the signal closes the server", async () => {
     const controller = new AbortController();
     const server = await startHttpServer(() => ({ status: 200 }), { signal: controller.signal });
@@ -89,5 +105,47 @@ describe("startHttpServer", () => {
   test("listen failure rejects instead of hanging", async () => {
     handle = await startHttpServer(() => ({ status: 200 }));
     expect(startHttpServer(() => ({ status: 200 }), { port: handle.port })).rejects.toThrow();
+  });
+});
+
+describe("stream", () => {
+  /** A minimal ServerResponse double recording writes and whether end() ran. */
+  function fakeResponse() {
+    const written: string[] = [];
+    let ended = false;
+    const response = {
+      write: (chunk: Uint8Array) => {
+        written.push(new TextDecoder().decode(chunk));
+        return true;
+      },
+      end: () => {
+        ended = true;
+      },
+    } as unknown as ServerResponse;
+    return { response, written, ended: () => ended };
+  }
+
+  test("pumps every chunk then ends the response", async () => {
+    const { response, written, ended } = fakeResponse();
+    async function* body() {
+      yield new TextEncoder().encode("a");
+      yield new TextEncoder().encode("b");
+    }
+    await stream(body(), response, new AbortController().signal);
+    expect(written).toEqual(["a", "b"]);
+    expect(ended()).toBe(true);
+  });
+
+  test("stops writing and skips end() once the signal aborts mid-stream", async () => {
+    const controller = new AbortController();
+    const { response, written, ended } = fakeResponse();
+    async function* body() {
+      yield new TextEncoder().encode("a");
+      controller.abort();
+      yield new TextEncoder().encode("b");
+    }
+    await stream(body(), response, controller.signal);
+    expect(written).toEqual(["a"]);
+    expect(ended()).toBe(false);
   });
 });

--- a/src/io/httpServer.test.ts
+++ b/src/io/httpServer.test.ts
@@ -87,6 +87,22 @@ describe("startHttpServer", () => {
     expect(await response.text()).toBe("one\ntwo\n");
   });
 
+  test("a handler stream that throws after starting ends the response without crashing", async () => {
+    handle = await startHttpServer(() => ({
+      status: 200,
+      headers: { "Content-Type": "text/plain" },
+      body: (async function* () {
+        yield new TextEncoder().encode("partial");
+        throw new Error("mid-stream boom");
+      })(),
+    }));
+
+    const response = await fetch(`http://127.0.0.1:${handle.port}/`);
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("partial");
+    expect((await fetch(`http://127.0.0.1:${handle.port}/`)).status).toBe(200);
+  });
+
   test("aborting the signal closes the server", async () => {
     const controller = new AbortController();
     const server = await startHttpServer(() => ({ status: 200 }), { signal: controller.signal });
@@ -133,6 +149,39 @@ describe("stream", () => {
     await stream(body(), response, new AbortController().signal);
     expect(written).toEqual(["a", "b"]);
     expect(ended()).toBe(true);
+  });
+
+  test("waits for a drain event when the socket applies backpressure", async () => {
+    const written: string[] = [];
+    let drainListener: (() => void) | undefined;
+    let ended = false;
+    const response = {
+      write: (chunk: Uint8Array) => {
+        written.push(new TextDecoder().decode(chunk));
+        // First write reports a full buffer, so the pump must await drain before continuing.
+        return written.length > 1;
+      },
+      once: (event: string, listener: () => void) => {
+        if (event === "drain") drainListener = listener;
+      },
+      off: () => {},
+      end: () => {
+        ended = true;
+      },
+    } as unknown as ServerResponse;
+
+    async function* body() {
+      yield new TextEncoder().encode("a");
+      yield new TextEncoder().encode("b");
+    }
+    const pumped = stream(body(), response, new AbortController().signal);
+    await Bun.sleep(0);
+    expect(drainListener).toBeDefined();
+    drainListener?.();
+    await pumped;
+
+    expect(written).toEqual(["a", "b"]);
+    expect(ended).toBe(true);
   });
 
   test("stops writing and skips end() once the signal aborts mid-stream", async () => {

--- a/src/io/httpServer.test.ts
+++ b/src/io/httpServer.test.ts
@@ -109,7 +109,6 @@ describe("startHttpServer", () => {
 });
 
 describe("stream", () => {
-  /** A minimal ServerResponse double recording writes and whether end() ran. */
   function fakeResponse() {
     const written: string[] = [];
     let ended = false;

--- a/src/io/httpServer.ts
+++ b/src/io/httpServer.ts
@@ -1,5 +1,4 @@
-// Uses node:http rather than Bun.serve because the npm bundle targets Node,
-// where Bun APIs are absent (same constraint as exec.ts).
+// Uses node:http rather than Bun.serve because the npm bundle targets Node, where Bun APIs are absent.
 import {
   type IncomingHttpHeaders,
   type IncomingMessage,
@@ -16,39 +15,29 @@ export interface HttpRequest {
   url: string;
   headers: IncomingHttpHeaders;
   body: Buffer;
-  /** Aborts when the client disconnects, so a handler can cancel upstream work. */
   signal: AbortSignal;
 }
 
 export interface HttpResponse {
   status: number;
   headers?: Record<string, string>;
-  /** A string/Buffer sends one response; an async iterable streams chunks (SSE). */
   body?: string | Buffer | AsyncIterable<Uint8Array>;
 }
 
 export type HttpRequestHandler = (request: HttpRequest) => HttpResponse | Promise<HttpResponse>;
 
 export interface HttpServerHandle {
-  /** The port the server is listening on. */
   port: number;
-  /** Stops accepting connections and closes active ones. Idempotent. */
   close(): Promise<void>;
 }
 
-/**
- * Starts an HTTP server for local dev tooling. Binds `host` (default 127.0.0.1)
- * on the given port (0 lets the OS assign one). Handler errors become plain 500s;
- * oversized bodies become 413s. Aborting the signal closes the server. A wider
- * bind such as 0.0.0.0 is only for reaching the server from a container.
- */
+// Binds 127.0.0.1 by default. A wider bind like 0.0.0.0 is only for reaching the server from a container.
 export async function startHttpServer(
   handler: HttpRequestHandler,
   options: { port?: number; host?: string; signal?: AbortSignal } = {},
 ): Promise<HttpServerHandle> {
   const server = createServer((request, response) => {
-    // A dropped connection mid-response can reject here; swallow it so a client
-    // that disconnects can never take down the whole dev command.
+    // Swallow rejections so a client that disconnects mid-response cannot take down the dev command.
     void respond(handler, request, response).catch(() => {});
   });
 
@@ -71,11 +60,7 @@ async function respond(
   request: IncomingMessage,
   response: ServerResponse,
 ): Promise<void> {
-  // On Node (the runtime the published bundle targets) the response emits
-  // "close" when the client disconnects, aborting the signal so a proxied agent
-  // request tears down with it. Under Bun's node:http a mid-stream disconnect is
-  // not surfaced, so this teardown is a no-op there, which only leaks a local
-  // dev fetch until it finishes on its own.
+  // Under Bun's node:http a mid-stream disconnect is not surfaced, so this teardown is a no-op there and leaks a local dev fetch until it finishes.
   const controller = new AbortController();
   response.on("close", () => controller.abort());
 
@@ -83,8 +68,7 @@ async function respond(
   try {
     body = await readBody(request);
   } catch (error) {
-    // Answer before closing: destroying the socket first surfaces as a connection
-    // reset, which many clients treat as transient and silently retry.
+    // Answer before closing. Destroying the socket first surfaces as a connection reset, which many clients silently retry.
     const status = error instanceof BodyTooLargeError ? 413 : 400;
     response.writeHead(status, { Connection: "close" }).end(() => request.destroy());
     return;
@@ -105,8 +89,7 @@ async function respond(
       response.end(result.body);
     }
   } catch {
-    // Once any byte is written, writeHead throws, so only send the 500 when the
-    // response has not started; otherwise just close what is already open.
+    // Once any byte is written, writeHead throws, so only send the 500 before the response has started.
     if (response.headersSent) {
       response.end();
       return;
@@ -120,7 +103,6 @@ function isAsyncIterable(body: HttpResponse["body"]): body is AsyncIterable<Uint
   return typeof body === "object" && body !== null && Symbol.asyncIterator in body;
 }
 
-/** Pump an async iterable to the response, honoring backpressure and disconnects. */
 export async function stream(
   body: AsyncIterable<Uint8Array>,
   response: ServerResponse,
@@ -133,7 +115,6 @@ export async function stream(
   if (!signal.aborted) response.end();
 }
 
-/** Resolve when the write buffer flushes or the connection closes. */
 function drain(response: ServerResponse, signal: AbortSignal): Promise<void> {
   if (signal.aborted) return Promise.resolve();
   return new Promise((resolve) => {

--- a/src/io/httpServer.ts
+++ b/src/io/httpServer.ts
@@ -16,12 +16,15 @@ export interface HttpRequest {
   url: string;
   headers: IncomingHttpHeaders;
   body: Buffer;
+  /** Aborts when the client disconnects, so a handler can cancel upstream work. */
+  signal: AbortSignal;
 }
 
 export interface HttpResponse {
   status: number;
   headers?: Record<string, string>;
-  body?: string | Buffer;
+  /** A string/Buffer sends one response; an async iterable streams chunks (SSE). */
+  body?: string | Buffer | AsyncIterable<Uint8Array>;
 }
 
 export type HttpRequestHandler = (request: HttpRequest) => HttpResponse | Promise<HttpResponse>;
@@ -68,6 +71,14 @@ async function respond(
   request: IncomingMessage,
   response: ServerResponse,
 ): Promise<void> {
+  // On Node (the runtime the published bundle targets) the response emits
+  // "close" when the client disconnects, aborting the signal so a proxied agent
+  // request tears down with it. Under Bun's node:http a mid-stream disconnect is
+  // not surfaced, so this teardown is a no-op there, which only leaks a local
+  // dev fetch until it finishes on its own.
+  const controller = new AbortController();
+  response.on("close", () => controller.abort());
+
   let body: Buffer;
   try {
     body = await readBody(request);
@@ -85,9 +96,14 @@ async function respond(
       url: request.url ?? "/",
       headers: request.headers,
       body,
+      signal: controller.signal,
     });
     response.writeHead(result.status, result.headers);
-    response.end(result.body);
+    if (isAsyncIterable(result.body)) {
+      await stream(result.body, response, controller.signal);
+    } else {
+      response.end(result.body);
+    }
   } catch {
     // Once any byte is written, writeHead throws, so only send the 500 when the
     // response has not started; otherwise just close what is already open.
@@ -98,6 +114,37 @@ async function respond(
     response.writeHead(500, { "Content-Type": "application/json" });
     response.end(JSON.stringify({ error: "internal error" }));
   }
+}
+
+function isAsyncIterable(body: HttpResponse["body"]): body is AsyncIterable<Uint8Array> {
+  return typeof body === "object" && body !== null && Symbol.asyncIterator in body;
+}
+
+/** Pump an async iterable to the response, honoring backpressure and disconnects. */
+export async function stream(
+  body: AsyncIterable<Uint8Array>,
+  response: ServerResponse,
+  signal: AbortSignal,
+): Promise<void> {
+  for await (const chunk of body) {
+    if (signal.aborted) break;
+    if (!response.write(chunk)) await drain(response, signal);
+  }
+  if (!signal.aborted) response.end();
+}
+
+/** Resolve when the write buffer flushes or the connection closes. */
+function drain(response: ServerResponse, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return Promise.resolve();
+  return new Promise((resolve) => {
+    const done = () => {
+      response.off("drain", done);
+      signal.removeEventListener("abort", done);
+      resolve();
+    };
+    response.once("drain", done);
+    signal.addEventListener("abort", done, { once: true });
+  });
 }
 
 class BodyTooLargeError extends Error {}


### PR DESCRIPTION
## What

Adds the Agent Inspector routes that talk to a running agent or read the project spec. This layer is still a pure request-to-response handler and is not reachable from the CLI yet. The `project dev` wiring lands in #2086.


## Routes

- `POST /invocations` — protocol-aware proxy. HTTP, A2A, and AGUI agents are each normalized into the SPA's `data: <json>` SSE contract. MCP returns a clear error pointing at `/api/mcp` rather than being proxied as HTTP.
- `POST /api/mcp` — forwards a JSON-RPC body to the agent's `/mcp` endpoint, buffering the reply under a 10MB cap.
- `GET /api/a2a/agent-card` — fetches the running agent's A2A card.
- `GET /api/resources` — flattens `project.spec` into the resource graph the SPA renders.

## Tests

Every route is unit tested behind fake deps: invocation routing and SSE normalization (including A2A dedup and the non-streaming fallback), the MCP forward and its size cap, the agent-card paths, the resource graph, and `httpServer`'s streaming and abort handling.

`bun test`, `typecheck`, `lint:check`, `format:check` all green.
