### PR TITLE
fix(export): validate project before harness fetch

### DIFF
--- a/src/cli/commands/export/__tests__/tty-guard.test.ts
+++ b/src/cli/commands/export/__tests__/tty-guard.test.ts
@@ -8,9 +8,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // Ink renderer, telemetry, and post-command notices. The guard runs first in
 // renderTUI, so a non-TTY context exits before any of these are reached.
 const mockRender = vi.fn((..._args: unknown[]) => ({ waitUntilExit: () => Promise.resolve() }));
+const mockFindConfigRoot = vi.fn<() => string | undefined>(() => '/fake/project/agentcore');
+const mockHandleExportHarness = vi.fn();
 
 vi.mock('ink', () => ({
   render: (...args: unknown[]) => mockRender(...args),
+}));
+
+vi.mock('../../../../lib', async importOriginal => ({
+  ...(await importOriginal<typeof import('../../../../lib')>()),
+  findConfigRoot: () => mockFindConfigRoot(),
+}));
+
+vi.mock('../harness-action', () => ({
+  handleExportHarness: (...args: unknown[]) => mockHandleExportHarness(...args),
 }));
 
 vi.mock('../../../telemetry', () => ({
@@ -43,6 +54,7 @@ describe('export harness TTY guard', () => {
       throw new Error(`process.exit(${code})`);
     });
     errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    mockFindConfigRoot.mockReturnValue('/fake/project/agentcore');
   });
 
   afterEach(() => {
@@ -83,5 +95,30 @@ describe('export harness TTY guard', () => {
 
     expect(exitSpy).not.toHaveBeenCalled();
     expect(mockRender).toHaveBeenCalled();
+  });
+
+  it('rejects ARN export before entering the export routine when no project exists', async () => {
+    mockFindConfigRoot.mockReturnValue(undefined);
+
+    await expect(
+      program.parseAsync(
+        ['export', 'harness', '--arn', 'arn:aws:bedrock-agentcore:us-east-1:111122223333:harness/example'],
+        { from: 'user' }
+      )
+    ).rejects.toThrow('process.exit(1)');
+
+    expect(errorSpy).toHaveBeenCalledWith('No agentcore project found. Run `agentcore create` first.');
+    expect(mockHandleExportHarness).not.toHaveBeenCalled();
+  });
+
+  it('rejects interactive export before rendering the TUI when no project exists', async () => {
+    process.stdin.isTTY = true;
+    process.stdout.isTTY = true;
+    mockFindConfigRoot.mockReturnValue(undefined);
+
+    await expect(program.parseAsync(['export', 'harness'], { from: 'user' })).rejects.toThrow('process.exit(1)');
+
+    expect(errorSpy).toHaveBeenCalledWith('No agentcore project found. Run `agentcore create` first.');
+    expect(mockRender).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/commands/export/index.ts
+++ b/src/cli/commands/export/index.ts
@@ -1,3 +1,4 @@
+import { findConfigRoot } from '../../../lib';
 import { serializeResult } from '../../../lib/result';
 import { ANSI, COMMAND_DESCRIPTIONS } from '../../constants';
 import { renderTUI } from '../../tui/render';
@@ -26,6 +27,11 @@ export function registerExport(program: Command): void {
     .option('--build <type>', 'Build type: CodeZip or Container [non-interactive]')
     .option('--json', 'Output results as JSON')
     .action(async options => {
+      if (!findConfigRoot()) {
+        console.error('No agentcore project found. Run `agentcore create` first.');
+        process.exit(1);
+      }
+
       if (!options.name && !options.arn) {
         if (options.json) {
           console.log(JSON.stringify({ success: false, error: '--name or --arn is required in non-interactive mode' }));


### PR DESCRIPTION
## Description

`agentcore export harness --arn` fetched the Harness from the service before validating that the command was running inside an AgentCore project. This made the CLI report successful fetch progress before failing on a local prerequisite that was knowable up front.

This change applies the same `findConfigRoot()` guard used by sibling project commands before either launching the export TUI or entering the export routine. It also adds command-level regression coverage proving that:

- ARN export never enters the export routine without a project
- interactive export never renders the TUI without a project

## Related Issue

Closes #2090

## Documentation PR

N/A - this restores the expected prerequisite ordering without changing the command interface.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [x] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots (N/A - no asset changes)

Additional verification:

- `npm run build`
- `npm run format:check`
- `npx vitest run --project unit src/cli/commands/export` (`7` files, `167` tests passed)
- Full unit suite: `428` files, `6,150` tests passed
- Integration suite: `34` files, `342` tests passed, `1` skipped
- Built CLI from a non-project directory exits immediately with `No agentcore project found. Run \`agentcore create\` first.` for `export harness --arn`

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly (N/A - no documentation change required)
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published (N/A - no dependencies)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
