### PR TITLE
fix: route Harness invoke exec through command API

### DIFF
--- a/src/cli/commands/invoke/__tests__/action-harness-exec.test.ts
+++ b/src/cli/commands/invoke/__tests__/action-harness-exec.test.ts
@@ -1,0 +1,203 @@
+import { executeBashCommand } from '../../../aws';
+import { invokeHarness } from '../../../aws/agentcore-harness';
+import type { InvokeContext } from '../action';
+import { handleHarnessInvokeByArn, handleInvoke } from '../action';
+import type { InvokeOptions } from '../types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockResolveInvokeTarget = vi.fn();
+
+vi.mock('../resolve', () => ({
+  resolveInvokeTarget: (...args: unknown[]) => mockResolveInvokeTarget(...args),
+}));
+
+vi.mock('../../../aws', () => ({
+  DEFAULT_RUNTIME_USER_ID: 'default-user',
+  buildAguiRunInput: vi.fn(),
+  executeBashCommand: vi.fn(),
+  extractResult: vi.fn(),
+  getOrCreatePaymentSession: vi.fn(),
+  invokeA2ARuntime: vi.fn(),
+  invokeAgentRuntime: vi.fn(),
+  invokeAgentRuntimeStreaming: vi.fn(),
+  invokeAguiRuntime: vi.fn(),
+  mcpCallTool: vi.fn(),
+  mcpInitSession: vi.fn(),
+  mcpListTools: vi.fn(),
+  parseSSE: vi.fn(),
+}));
+
+vi.mock('../../../aws/agentcore-harness', () => ({
+  invokeHarness: vi.fn(),
+}));
+
+vi.mock('../../../logging', () => ({
+  InvokeLogger: class {
+    logFilePath = '/tmp/fake.log';
+    logPrompt = vi.fn();
+    logResponse = vi.fn();
+    logError = vi.fn();
+    logInfo = vi.fn();
+  },
+}));
+
+vi.mock('../../../operations/fetch-access', () => ({
+  canFetchHarnessToken: vi.fn().mockResolvedValue(false),
+  fetchHarnessToken: vi.fn(),
+}));
+
+const HARNESS_NAME = 'OrderResearchAgent';
+const HARNESS_ARN = 'arn:aws:bedrock-agentcore:us-east-1:123456789012:harness/OrderResearchAgent-abc123';
+const SESSION_ID = '11111111-2222-4333-8444-555555555555';
+
+function commandStream() {
+  return (async function* () {
+    await Promise.resolve();
+    yield { type: 'stdout' as const, data: 'report contents\n' };
+    yield { type: 'stop' as const, exitCode: 0, status: 'COMPLETED' };
+  })();
+}
+
+function harnessStream() {
+  return (async function* () {
+    await Promise.resolve();
+    yield {
+      type: 'contentBlockDelta' as const,
+      delta: { type: 'text' as const, text: 'model response' },
+    };
+  })();
+}
+
+function makeContext(): InvokeContext {
+  return {
+    project: {
+      name: 'HarnessExecTest',
+      runtimes: [],
+      harnesses: [{ name: HARNESS_NAME }],
+    } as never,
+    deployedState: {
+      targets: {
+        default: {
+          resources: {
+            harnesses: {
+              [HARNESS_NAME]: {
+                harnessArn: HARNESS_ARN,
+              },
+            },
+          },
+        },
+      },
+    } as never,
+    awsTargets: [{ name: 'default', region: 'us-east-1' }] as never,
+  };
+}
+
+function makeRuntimeContext(): InvokeContext {
+  return {
+    project: {
+      name: 'RuntimeExecTest',
+      runtimes: [{ name: 'CustomerSupport', protocol: 'HTTP' }],
+      harnesses: [],
+    } as never,
+    deployedState: { targets: { default: { resources: {} } } } as never,
+    awsTargets: [{ name: 'default', region: 'us-east-1' }] as never,
+  };
+}
+
+function makeOptions(overrides: Partial<InvokeOptions> = {}): InvokeOptions {
+  return {
+    exec: true,
+    prompt: 'cat /tmp/warranty_report.md',
+    sessionId: SESSION_ID,
+    timeout: 30,
+    headers: { 'x-test-header': 'value' },
+    bearerToken: 'test-token',
+    json: true,
+    ...overrides,
+  };
+}
+
+describe('handleInvoke — Harness exec', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResolveInvokeTarget.mockResolvedValue({
+      success: true,
+      agentSpec: { name: 'CustomerSupport', protocol: 'HTTP' },
+      targetName: 'default',
+      targetConfig: { name: 'default', region: 'us-east-1' },
+      region: 'us-east-1',
+      runtimeArn: 'arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/CustomerSupport-abc123',
+      baggage: undefined,
+    });
+    vi.mocked(executeBashCommand).mockResolvedValue({ stream: commandStream(), sessionId: SESSION_ID });
+    vi.mocked(invokeHarness).mockReturnValue(harnessStream() as never);
+  });
+
+  it('executes against a configured Harness instead of sending a model message', async () => {
+    const result = await handleInvoke(makeContext(), makeOptions({ harnessName: HARNESS_NAME }));
+
+    expect(executeBashCommand).toHaveBeenCalledWith({
+      region: 'us-east-1',
+      runtimeArn: HARNESS_ARN,
+      command: 'cat /tmp/warranty_report.md',
+      sessionId: SESSION_ID,
+      timeout: 30,
+      headers: { 'x-test-header': 'value' },
+      bearerToken: 'test-token',
+    });
+    expect(invokeHarness).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      success: true,
+      exitCode: 0,
+      agentName: HARNESS_NAME,
+      targetName: 'default',
+      response: JSON.stringify({
+        stdout: 'report contents\n',
+        stderr: '',
+        exitCode: 0,
+        status: 'COMPLETED',
+      }),
+    });
+  });
+
+  it('executes against a Harness ARN instead of sending a model message', async () => {
+    const result = await handleHarnessInvokeByArn(HARNESS_ARN, 'us-east-1', makeOptions());
+
+    expect(executeBashCommand).toHaveBeenCalledWith({
+      region: 'us-east-1',
+      runtimeArn: HARNESS_ARN,
+      command: 'cat /tmp/warranty_report.md',
+      sessionId: SESSION_ID,
+      timeout: 30,
+      headers: { 'x-test-header': 'value' },
+      bearerToken: 'test-token',
+    });
+    expect(invokeHarness).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      success: true,
+      exitCode: 0,
+      agentName: 'external-harness',
+    });
+  });
+
+  it('preserves Runtime exec behavior through the shared execution path', async () => {
+    const result = await handleInvoke(makeRuntimeContext(), makeOptions());
+
+    expect(executeBashCommand).toHaveBeenCalledWith({
+      region: 'us-east-1',
+      runtimeArn: 'arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/CustomerSupport-abc123',
+      command: 'cat /tmp/warranty_report.md',
+      sessionId: SESSION_ID,
+      timeout: 30,
+      headers: { 'x-test-header': 'value' },
+      bearerToken: 'test-token',
+    });
+    expect(invokeHarness).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      success: true,
+      exitCode: 0,
+      agentName: 'CustomerSupport',
+      targetName: 'default',
+    });
+  });
+});

--- a/src/cli/commands/invoke/action.ts
+++ b/src/cli/commands/invoke/action.ts
@@ -389,116 +389,13 @@ export async function handleInvoke(context: InvokeContext, options: InvokeOption
 
   // Exec mode: run shell command in runtime container
   if (options.exec) {
-    const logger = new InvokeLogger({
-      agentName: agentSpec.name,
-      runtimeArn: runtimeArn,
+    return handleInvokeExec({
       region: targetConfig.region,
-      sessionId: options.sessionId,
+      runtimeArn,
+      agentName: agentSpec.name,
+      targetName: selectedTargetName,
+      options,
     });
-    const command = options.prompt;
-    if (!command) {
-      return { success: false, error: new ValidationError('--exec requires a command (prompt)') };
-    }
-    logger.logPrompt(command, options.sessionId, options.userId);
-
-    try {
-      const result = await executeBashCommand({
-        region: targetConfig.region,
-        runtimeArn: runtimeArn,
-        command,
-        sessionId: options.sessionId,
-        timeout: options.timeout,
-        headers: options.headers,
-        bearerToken: options.bearerToken,
-      });
-
-      let stdout = '';
-      let stderr = '';
-      let exitCode: number | undefined;
-      let status: string | undefined;
-
-      for await (const event of result.stream) {
-        switch (event.type) {
-          case 'stdout':
-            if (event.data) {
-              stdout += event.data;
-              if (!options.json) {
-                process.stdout.write(event.data);
-              }
-            }
-            break;
-          case 'stderr':
-            if (event.data) {
-              stderr += event.data;
-              if (!options.json) {
-                process.stderr.write(event.data);
-              }
-            }
-            break;
-          case 'stop':
-            exitCode = event.exitCode;
-            status = event.status;
-            break;
-        }
-      }
-
-      logger.logResponse(stdout || stderr || `exit code: ${exitCode}`);
-
-      if (options.json) {
-        if (exitCode === 0) {
-          return {
-            success: true,
-            exitCode,
-            agentName: agentSpec.name,
-            targetName: selectedTargetName,
-            response: JSON.stringify({ stdout, stderr, exitCode, status }),
-            logFilePath: logger.logFilePath,
-          };
-        }
-        return {
-          success: false,
-          exitCode,
-          error: new Error(`Command exited with code ${exitCode}`),
-          agentName: agentSpec.name,
-          targetName: selectedTargetName,
-          response: JSON.stringify({ stdout, stderr, exitCode, status }),
-          logFilePath: logger.logFilePath,
-        };
-      }
-
-      if (exitCode === undefined) {
-        return {
-          success: false,
-          error: new Error('Command stream ended without exit code'),
-          agentName: agentSpec.name,
-          targetName: selectedTargetName,
-          logFilePath: logger.logFilePath,
-        };
-      }
-
-      if (exitCode !== 0) {
-        return {
-          success: false,
-          exitCode,
-          error: new Error(`Command exited with code ${exitCode}${status === 'TIMED_OUT' ? ' (timed out)' : ''}`),
-          agentName: agentSpec.name,
-          targetName: selectedTargetName,
-          response: JSON.stringify({ stdout, stderr, exitCode, status }),
-          logFilePath: logger.logFilePath,
-        };
-      }
-
-      return {
-        success: true,
-        exitCode,
-        agentName: agentSpec.name,
-        targetName: selectedTargetName,
-        logFilePath: logger.logFilePath,
-      };
-    } catch (err) {
-      logger.logError(err, 'exec command failed');
-      throw err;
-    }
   }
 
   // MCP protocol handling
@@ -835,6 +732,128 @@ export function buildHarnessBaseOpts(
   return baseOpts;
 }
 
+interface InvokeExecParams {
+  region: string;
+  runtimeArn: string;
+  agentName: string;
+  targetName?: string;
+  options: InvokeOptions;
+}
+
+async function handleInvokeExec(params: InvokeExecParams): Promise<InvokeResult> {
+  const { region, runtimeArn, agentName, targetName, options } = params;
+  const logger = new InvokeLogger({
+    agentName,
+    runtimeArn,
+    region,
+    sessionId: options.sessionId,
+  });
+  const command = options.prompt;
+  if (!command) {
+    return { success: false, error: new ValidationError('--exec requires a command (prompt)') };
+  }
+  logger.logPrompt(command, options.sessionId, options.userId);
+
+  try {
+    const result = await executeBashCommand({
+      region,
+      runtimeArn,
+      command,
+      sessionId: options.sessionId,
+      timeout: options.timeout,
+      headers: options.headers,
+      bearerToken: options.bearerToken,
+    });
+
+    let stdout = '';
+    let stderr = '';
+    let exitCode: number | undefined;
+    let status: string | undefined;
+
+    for await (const event of result.stream) {
+      switch (event.type) {
+        case 'stdout':
+          if (event.data) {
+            stdout += event.data;
+            if (!options.json) {
+              process.stdout.write(event.data);
+            }
+          }
+          break;
+        case 'stderr':
+          if (event.data) {
+            stderr += event.data;
+            if (!options.json) {
+              process.stderr.write(event.data);
+            }
+          }
+          break;
+        case 'stop':
+          exitCode = event.exitCode;
+          status = event.status;
+          break;
+      }
+    }
+
+    logger.logResponse(stdout || stderr || `exit code: ${exitCode}`);
+
+    if (options.json) {
+      if (exitCode === 0) {
+        return {
+          success: true,
+          exitCode,
+          agentName,
+          targetName,
+          response: JSON.stringify({ stdout, stderr, exitCode, status }),
+          logFilePath: logger.logFilePath,
+        };
+      }
+      return {
+        success: false,
+        exitCode,
+        error: new Error(`Command exited with code ${exitCode}`),
+        agentName,
+        targetName,
+        response: JSON.stringify({ stdout, stderr, exitCode, status }),
+        logFilePath: logger.logFilePath,
+      };
+    }
+
+    if (exitCode === undefined) {
+      return {
+        success: false,
+        error: new Error('Command stream ended without exit code'),
+        agentName,
+        targetName,
+        logFilePath: logger.logFilePath,
+      };
+    }
+
+    if (exitCode !== 0) {
+      return {
+        success: false,
+        exitCode,
+        error: new Error(`Command exited with code ${exitCode}${status === 'TIMED_OUT' ? ' (timed out)' : ''}`),
+        agentName,
+        targetName,
+        response: JSON.stringify({ stdout, stderr, exitCode, status }),
+        logFilePath: logger.logFilePath,
+      };
+    }
+
+    return {
+      success: true,
+      exitCode,
+      agentName,
+      targetName,
+      logFilePath: logger.logFilePath,
+    };
+  } catch (err) {
+    logger.logError(err, 'exec command failed');
+    throw err;
+  }
+}
+
 export async function handleHarnessInvokeByArn(
   harnessArn: string,
   region: string,
@@ -850,6 +869,14 @@ export async function handleHarnessInvokeByArn(
   }
 
   const sessionId = options.sessionId ?? randomUUID();
+  if (options.exec) {
+    return handleInvokeExec({
+      region,
+      runtimeArn: harnessArn,
+      agentName: 'external-harness',
+      options: { ...options, sessionId },
+    });
+  }
   const logger = new InvokeLogger({ agentName: 'external-harness', runtimeArn: harnessArn, region, sessionId });
   logger.logPrompt(options.prompt, sessionId, options.userId);
 
@@ -983,13 +1010,7 @@ async function handleHarnessInvoke(
 
   const sessionId = options.sessionId ?? randomUUID();
   const region = targetConfig.region;
-
-  const logger = new InvokeLogger({
-    agentName: harnessName,
-    runtimeArn: harnessState.harnessArn,
-    region,
-    sessionId,
-  });
+  options = { ...options, sessionId };
 
   // Read harness spec for auth config
   const configIO = new ConfigIO();
@@ -1032,6 +1053,22 @@ async function handleHarnessInvoke(
     };
   }
 
+  if (options.exec) {
+    return handleInvokeExec({
+      region,
+      runtimeArn: harnessState.harnessArn,
+      agentName: harnessName,
+      targetName: selectedTargetName,
+      options,
+    });
+  }
+
+  const logger = new InvokeLogger({
+    agentName: harnessName,
+    runtimeArn: harnessState.harnessArn,
+    region,
+    sessionId,
+  });
   logger.logPrompt(options.prompt, sessionId, options.userId);
 
   const baseOpts = buildHarnessBaseOpts(options, harnessSpec?.model);


### PR DESCRIPTION
## Description

Route the documented `agentcore invoke --exec --harness` and
`--harness-arn` paths through `InvokeAgentRuntimeCommand` instead of sending
the command as a conversational `InvokeHarness` message.

This extracts the existing Runtime exec behavior into a shared invoke helper,
preserving streaming output, JSON envelopes, exit codes, timeout status,
headers, bearer tokens, and invocation logging for Runtime and Harness targets.

## Related Issue

Closes #2096

## Documentation PR

N/A. This fixes the CLI to match the existing AgentCore Harness documentation.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [x] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

Additional verification:

- Added three focused regression tests for configured Harness, direct Harness ARN, and unchanged Runtime exec behavior.
- Focused Harness exec tests: 3 passed.
- Invoke/exec action and command tests: 165 passed; the spawned-CLI integration file fails with empty child output on this host and reproduces unchanged on an untouched `origin/main` worktree.
- Exact `npm run test:unit`: 6,048 passed; 105 sandbox/baseline failures reproduce on untouched `origin/main` (spawned CLI output, read-only home, and unavailable ports).
- Exact `npm run test:integ`: 34 passed, 251 skipped; 58 failures have the same empty spawned-CLI output signature and are unrelated to the changed invoke action.
- `npm run build`: passed.
- `npm run format:check`: passed.
- Live Harness deploy in account `603141041947`, `us-east-1`:
  `invoke --exec --harness ExecHarness "printf harness-exec-ok"` returned
  stdout `harness-exec-ok`, exit code `0`, and status `COMPLETED`.
- Live Runtime regression in the same account and Region:
  `invoke --exec --runtime RuntimeExecFix "printf runtime-exec-ok"` returned
  stdout `runtime-exec-ok`, exit code `0`, and status `COMPLETED`.
- Both disposable CloudFormation stacks and resources were deleted and absence was verified.

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
