### PR TITLE
fix(dev): cancel readiness retries on abort

### DIFF
--- a/src/core/dev/supervisor.test.ts
+++ b/src/core/dev/supervisor.test.ts
@@ -292,11 +292,13 @@ describe("DevSupervisor", () => {
       "produced no output and did not accept connections on port 1 within 0.1s",
     );
 
-    const server = createServer();
+    const server = createServer((socket) => socket.destroy());
     await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
     const port = (server.address() as { port: number }).port;
     await waitForPort(port, signal, undefined, 10, 1000); // resolves against a live listener
-    server.close();
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
   });
 
   test("recent activity keeps a silent port from timing out", async () => {

--- a/src/io/port.ts
+++ b/src/io/port.ts
@@ -57,10 +57,17 @@ export function waitForPort(
         );
         return;
       }
-      const socket = connect({ port, host: "127.0.0.1", signal }, () => {
+      const socket = connect({ port, host: "127.0.0.1" }, () => {
         socket.destroy();
         resolve();
       });
+      const onAbort = () => {
+        socket.destroy();
+        reject(new Error("Aborted while waiting for the agent to become ready."));
+      };
+      signal.addEventListener("abort", onAbort, { once: true });
+      socket.once("close", () => signal.removeEventListener("abort", onAbort));
+      if (signal.aborted) onAbort();
       socket.on("error", () => {
         socket.destroy();
         setTimeout(attempt, intervalMs);

--- a/src/io/port.ts
+++ b/src/io/port.ts
@@ -44,12 +44,25 @@ export function waitForPort(
   const startedAt = Date.now();
   const since = lastActivityAt ?? (() => startedAt);
   return new Promise((resolve, reject) => {
+    let socket: ReturnType<typeof connect> | undefined;
+    let retry: ReturnType<typeof setTimeout> | undefined;
+
+    const cleanup = () => {
+      socket?.destroy();
+      if (retry) clearTimeout(retry);
+      signal.removeEventListener("abort", onAbort);
+    };
+    const onAbort = () => {
+      cleanup();
+      reject(new Error("Aborted while waiting for the agent to become ready."));
+    };
     const attempt = () => {
       if (signal.aborted) {
-        reject(new Error("Aborted while waiting for the agent to become ready."));
+        onAbort();
         return;
       }
       if (Date.now() - since() > idleMs) {
+        cleanup();
         reject(
           new Error(
             `Agent produced no output and did not accept connections on port ${port} within ${idleMs / 1000}s.`,
@@ -57,22 +70,22 @@ export function waitForPort(
         );
         return;
       }
-      const socket = connect({ port, host: "127.0.0.1" }, () => {
-        socket.destroy();
+      socket = connect({ port, host: "127.0.0.1" }, () => {
+        cleanup();
         resolve();
       });
-      const onAbort = () => {
-        socket.destroy();
-        reject(new Error("Aborted while waiting for the agent to become ready."));
-      };
-      signal.addEventListener("abort", onAbort, { once: true });
-      socket.once("close", () => signal.removeEventListener("abort", onAbort));
-      if (signal.aborted) onAbort();
       socket.on("error", () => {
-        socket.destroy();
-        setTimeout(attempt, intervalMs);
+        socket?.destroy();
+        socket = undefined;
+        if (signal.aborted) {
+          onAbort();
+          return;
+        }
+        retry = setTimeout(attempt, intervalMs);
       });
     };
+
+    signal.addEventListener("abort", onAbort, { once: true });
     attempt();
   });
 }

--- a/src/io/port.ts
+++ b/src/io/port.ts
@@ -57,7 +57,7 @@ export function waitForPort(
         );
         return;
       }
-      const socket = connect({ port, host: "127.0.0.1" }, () => {
+      const socket = connect({ port, host: "127.0.0.1", signal }, () => {
         socket.destroy();
         resolve();
       });


### PR DESCRIPTION
## Problem

`waitForPort` left active sockets and scheduled retries alive after abort. In CI, the supervisor's 60ms abort test instead ran for about 60 seconds and timed out; the original #2041 Windows run eventually lost its runner.

## Solution

Abort now destroys the active socket, clears the pending retry, removes its listener, and rejects immediately. The TCP test also closes accepted sockets and awaits listener shutdown.

## Testing

- Windows unit CI passed in 3m24s.
- Supervisor suite passed 25 consecutive runs; the abort test completes in about 60ms.
- Supervisor, project dev, and port tests passed: 31/31.
- Prettier and `tsc --noEmit` passed.
