### PR TITLE
feat: read project stack state live from CloudFormation

### DIFF
--- a/src/core/project/backends/cdk/environment.test.ts
+++ b/src/core/project/backends/cdk/environment.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { Stack } from "@aws-sdk/client-cloudformation";
-import { isBootstrapStackNotFound, probeBootstrap, readBootstrapState } from "./environment";
+import { isStackNotFound, probeBootstrap, readBootstrapState } from "./environment";
 import type { CdkCredentialProvider } from "./toolkit";
 
 const credentials: CdkCredentialProvider = async () => ({
@@ -69,7 +69,7 @@ describe("probeBootstrap", () => {
       name: "ValidationError",
     });
 
-    expect(isBootstrapStackNotFound(notFound)).toBe(true);
+    expect(isStackNotFound(notFound)).toBe(true);
     expect(
       await probeBootstrap("us-east-1", credentials, async () => {
         throw notFound;

--- a/src/core/project/backends/cdk/environment.ts
+++ b/src/core/project/backends/cdk/environment.ts
@@ -60,7 +60,8 @@ export function readBootstrapState(stacks?: Stack[]): Exclude<BootstrapState, { 
     : { kind: "outdated", version };
 }
 
-export function isBootstrapStackNotFound(error: unknown): boolean {
+/** True when CloudFormation reports the stack does not exist (its "not found" signal is a thrown ValidationError, not an empty result). */
+export function isStackNotFound(error: unknown): boolean {
   if (!error || typeof error !== "object") return false;
   const candidate = error as { name?: unknown; message?: unknown };
   return (
@@ -92,7 +93,7 @@ export async function probeBootstrap(
   try {
     return readBootstrapState(await read(region, credentials));
   } catch (error) {
-    if (isBootstrapStackNotFound(error)) return { kind: "absent" };
+    if (isStackNotFound(error)) return { kind: "absent" };
     throw error;
   }
 }

--- a/src/core/project/backends/cdk/stackReader.test.ts
+++ b/src/core/project/backends/cdk/stackReader.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { Stack } from "@aws-sdk/client-cloudformation";
-import { classifyStack, readStackState, type StackReader } from "./stackReader";
+import { describeStack, type DescribeStacks } from "./stackReader";
 import type { CdkCredentialProvider } from "./toolkit";
 
 const credentials: CdkCredentialProvider = async () => ({
@@ -8,121 +8,53 @@ const credentials: CdkCredentialProvider = async () => ({
   secretAccessKey: "secret-key",
 });
 
-function stack(status: Stack["StackStatus"], outputs?: Stack["Outputs"]): Stack {
-  return {
-    StackName: "AgentCore-example-default",
-    CreationTime: new Date(0),
-    StackStatus: status,
-    ...(outputs && { Outputs: outputs }),
-  };
+function stack(name: string): Stack {
+  return { StackName: name, CreationTime: new Date(0), StackStatus: "CREATE_COMPLETE" };
 }
 
-describe("classifyStack", () => {
-  test("treats an absent stack as not deployed", () => {
-    expect(classifyStack(undefined)).toEqual({ kind: "not-deployed" });
-  });
-
-  test("treats a deleted stack (described by ARN) as not deployed", () => {
-    expect(classifyStack(stack("DELETE_COMPLETE"))).toEqual({ kind: "not-deployed" });
-  });
-
-  test.each([
-    "CREATE_IN_PROGRESS",
-    "UPDATE_IN_PROGRESS",
-    "DELETE_IN_PROGRESS",
-    "REVIEW_IN_PROGRESS",
-    "UPDATE_ROLLBACK_IN_PROGRESS",
-  ] as const)("reports %s as in-progress", (status) => {
-    expect(classifyStack(stack(status))).toEqual({ kind: "in-progress", status });
-  });
-
-  test.each([
-    "ROLLBACK_COMPLETE",
-    "CREATE_FAILED",
-    "ROLLBACK_FAILED",
-    "UPDATE_FAILED",
-    "UPDATE_ROLLBACK_FAILED",
-    "DELETE_FAILED",
-  ] as const)("reports %s as failed", (status) => {
-    expect(classifyStack(stack(status))).toEqual({ kind: "failed", status });
-  });
-
-  test.each(["CREATE_COMPLETE", "UPDATE_COMPLETE", "UPDATE_ROLLBACK_COMPLETE"] as const)(
-    "reports %s as ready with its outputs",
-    (status) => {
-      const result = classifyStack(
-        stack(status, [
-          { OutputKey: "RuntimeArn", OutputValue: "arn:runtime" },
-          { OutputKey: "MemoryId", OutputValue: "mem-123" },
-        ]),
-      );
-      expect(result).toEqual({
-        kind: "ready",
-        status,
-        outputs: { RuntimeArn: "arn:runtime", MemoryId: "mem-123" },
-      });
-    },
-  );
-
-  test("returns empty outputs when a ready stack declares none", () => {
-    expect(classifyStack(stack("CREATE_COMPLETE"))).toEqual({
-      kind: "ready",
-      status: "CREATE_COMPLETE",
-      outputs: {},
-    });
-  });
-
-  test("skips partial output entries", () => {
-    const result = classifyStack(
-      stack("CREATE_COMPLETE", [
-        { OutputKey: "RuntimeArn", OutputValue: "arn:runtime" },
-        { OutputKey: "NoValue" },
-        { OutputValue: "no-key" },
-      ]),
-    );
-    expect(result).toEqual({
-      kind: "ready",
-      status: "CREATE_COMPLETE",
-      outputs: { RuntimeArn: "arn:runtime" },
-    });
-  });
-});
-
-describe("readStackState", () => {
-  test("classifies the stack the reader returns, passing region + credentials + name through", async () => {
-    const calls: { region: string; credentials: CdkCredentialProvider; stackName: string }[] = [];
-    const read: StackReader = async (region, creds, stackName) => {
-      calls.push({ region, credentials: creds, stackName });
-      return stack("CREATE_COMPLETE", [{ OutputKey: "RuntimeArn", OutputValue: "arn:runtime" }]);
+describe("describeStack", () => {
+  test("returns the described stack, passing the stack name to the describer", async () => {
+    const names: string[] = [];
+    const describe: DescribeStacks = async (stackName) => {
+      names.push(stackName);
+      return [stack("AgentCore-example-prod")];
     };
 
-    const result = await readStackState("eu-west-1", credentials, "AgentCore-example-prod", read);
+    const result = await describeStack(
+      "eu-west-1",
+      credentials,
+      "AgentCore-example-prod",
+      describe,
+    );
 
-    expect(result).toEqual({
-      kind: "ready",
-      status: "CREATE_COMPLETE",
-      outputs: { RuntimeArn: "arn:runtime" },
-    });
-    expect(calls).toEqual([
-      { region: "eu-west-1", credentials, stackName: "AgentCore-example-prod" },
-    ]);
+    expect(result).toEqual(stack("AgentCore-example-prod"));
+    expect(names).toEqual(["AgentCore-example-prod"]);
   });
 
-  test("maps a missing stack to not-deployed", async () => {
-    const read: StackReader = async () => undefined;
-    expect(await readStackState("us-east-1", credentials, "missing", read)).toEqual({
-      kind: "not-deployed",
+  test("returns undefined when CloudFormation reports the stack does not exist", async () => {
+    const notFound = Object.assign(new Error("Stack with id missing does not exist"), {
+      name: "ValidationError",
     });
+    const describe: DescribeStacks = async () => {
+      throw notFound;
+    };
+
+    expect(await describeStack("us-east-1", credentials, "missing", describe)).toBeUndefined();
   });
 
-  test("propagates non-not-found errors from the reader", async () => {
+  test("returns undefined when the describer yields no stacks", async () => {
+    const describe: DescribeStacks = async () => [];
+    expect(await describeStack("us-east-1", credentials, "empty", describe)).toBeUndefined();
+  });
+
+  test("propagates errors other than not-found", async () => {
     const failure = Object.assign(new Error("User is not authorized"), {
       name: "AccessDeniedException",
     });
-    const read: StackReader = async () => {
+    const describe: DescribeStacks = async () => {
       throw failure;
     };
 
-    await expect(readStackState("us-east-1", credentials, "denied", read)).rejects.toBe(failure);
+    await expect(describeStack("us-east-1", credentials, "denied", describe)).rejects.toBe(failure);
   });
 });

--- a/src/core/project/backends/cdk/stackReader.test.ts
+++ b/src/core/project/backends/cdk/stackReader.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "bun:test";
+import type { Stack } from "@aws-sdk/client-cloudformation";
+import { classifyStack, readStackState, type StackReader } from "./stackReader";
+import type { CdkCredentialProvider } from "./toolkit";
+
+const credentials: CdkCredentialProvider = async () => ({
+  accessKeyId: "access-key",
+  secretAccessKey: "secret-key",
+});
+
+function stack(status: Stack["StackStatus"], outputs?: Stack["Outputs"]): Stack {
+  return {
+    StackName: "AgentCore-example-default",
+    CreationTime: new Date(0),
+    StackStatus: status,
+    ...(outputs && { Outputs: outputs }),
+  };
+}
+
+describe("classifyStack", () => {
+  test("treats an absent stack as not deployed", () => {
+    expect(classifyStack(undefined)).toEqual({ kind: "not-deployed" });
+  });
+
+  test("treats a deleted stack (described by ARN) as not deployed", () => {
+    expect(classifyStack(stack("DELETE_COMPLETE"))).toEqual({ kind: "not-deployed" });
+  });
+
+  test.each([
+    "CREATE_IN_PROGRESS",
+    "UPDATE_IN_PROGRESS",
+    "DELETE_IN_PROGRESS",
+    "REVIEW_IN_PROGRESS",
+    "UPDATE_ROLLBACK_IN_PROGRESS",
+  ] as const)("reports %s as in-progress", (status) => {
+    expect(classifyStack(stack(status))).toEqual({ kind: "in-progress", status });
+  });
+
+  test.each([
+    "ROLLBACK_COMPLETE",
+    "CREATE_FAILED",
+    "ROLLBACK_FAILED",
+    "UPDATE_FAILED",
+    "UPDATE_ROLLBACK_FAILED",
+    "DELETE_FAILED",
+  ] as const)("reports %s as failed", (status) => {
+    expect(classifyStack(stack(status))).toEqual({ kind: "failed", status });
+  });
+
+  test.each(["CREATE_COMPLETE", "UPDATE_COMPLETE", "UPDATE_ROLLBACK_COMPLETE"] as const)(
+    "reports %s as ready with its outputs",
+    (status) => {
+      const result = classifyStack(
+        stack(status, [
+          { OutputKey: "RuntimeArn", OutputValue: "arn:runtime" },
+          { OutputKey: "MemoryId", OutputValue: "mem-123" },
+        ]),
+      );
+      expect(result).toEqual({
+        kind: "ready",
+        status,
+        outputs: { RuntimeArn: "arn:runtime", MemoryId: "mem-123" },
+      });
+    },
+  );
+
+  test("returns empty outputs when a ready stack declares none", () => {
+    expect(classifyStack(stack("CREATE_COMPLETE"))).toEqual({
+      kind: "ready",
+      status: "CREATE_COMPLETE",
+      outputs: {},
+    });
+  });
+
+  test("skips partial output entries", () => {
+    const result = classifyStack(
+      stack("CREATE_COMPLETE", [
+        { OutputKey: "RuntimeArn", OutputValue: "arn:runtime" },
+        { OutputKey: "NoValue" },
+        { OutputValue: "no-key" },
+      ]),
+    );
+    expect(result).toEqual({
+      kind: "ready",
+      status: "CREATE_COMPLETE",
+      outputs: { RuntimeArn: "arn:runtime" },
+    });
+  });
+});
+
+describe("readStackState", () => {
+  test("classifies the stack the reader returns, passing region + credentials + name through", async () => {
+    const calls: { region: string; credentials: CdkCredentialProvider; stackName: string }[] = [];
+    const read: StackReader = async (region, creds, stackName) => {
+      calls.push({ region, credentials: creds, stackName });
+      return stack("CREATE_COMPLETE", [{ OutputKey: "RuntimeArn", OutputValue: "arn:runtime" }]);
+    };
+
+    const result = await readStackState("eu-west-1", credentials, "AgentCore-example-prod", read);
+
+    expect(result).toEqual({
+      kind: "ready",
+      status: "CREATE_COMPLETE",
+      outputs: { RuntimeArn: "arn:runtime" },
+    });
+    expect(calls).toEqual([
+      { region: "eu-west-1", credentials, stackName: "AgentCore-example-prod" },
+    ]);
+  });
+
+  test("maps a missing stack to not-deployed", async () => {
+    const read: StackReader = async () => undefined;
+    expect(await readStackState("us-east-1", credentials, "missing", read)).toEqual({
+      kind: "not-deployed",
+    });
+  });
+
+  test("propagates non-not-found errors from the reader", async () => {
+    const failure = Object.assign(new Error("User is not authorized"), {
+      name: "AccessDeniedException",
+    });
+    const read: StackReader = async () => {
+      throw failure;
+    };
+
+    await expect(readStackState("us-east-1", credentials, "denied", read)).rejects.toBe(failure);
+  });
+});

--- a/src/core/project/backends/cdk/stackReader.test.ts
+++ b/src/core/project/backends/cdk/stackReader.test.ts
@@ -42,9 +42,11 @@ describe("describeStack", () => {
     expect(await describeStack("us-east-1", credentials, "missing", describe)).toBeUndefined();
   });
 
-  test("returns undefined when the describer yields no stacks", async () => {
+  test("throws on an empty successful response — distinct from not-found", async () => {
     const describe: DescribeStacks = async () => [];
-    expect(await describeStack("us-east-1", credentials, "empty", describe)).toBeUndefined();
+    await expect(describeStack("us-east-1", credentials, "empty", describe)).rejects.toThrow(
+      /returned no stack/,
+    );
   });
 
   test("propagates errors other than not-found", async () => {

--- a/src/core/project/backends/cdk/stackReader.ts
+++ b/src/core/project/backends/cdk/stackReader.ts
@@ -3,95 +3,50 @@ import { isStackNotFound } from "./environment";
 import type { CdkCredentialProvider } from "./toolkit";
 
 /**
- * Live state of a project's CloudFormation stack.
- *
- * Deployed state now stores only the stack ARN; the resource ARNs/IDs are read
- * back from CloudFormation on demand so they can never go stale. This is the
- * shape callers (e.g. `project status`) consume.
+ * Runs a `DescribeStacks` for one stack, returning the matched stacks (or
+ * undefined). Injectable so callers/tests can supply the AWS call.
  */
-export type StackState =
-  | { kind: "not-deployed" }
-  | { kind: "in-progress"; status: string }
-  | { kind: "failed"; status: string }
-  | { kind: "ready"; status: string; outputs: Record<string, string> };
+export type DescribeStacks = (stackName: string) => Promise<Stack[] | undefined>;
 
-// Terminal statuses where the stack's resources exist and its outputs are
-// meaningful. UPDATE_ROLLBACK_COMPLETE is included: an update failed but rolled
-// back to the previous working state, so the outputs still describe live
-// resources. ROLLBACK_COMPLETE (a failed *create*) is not — it leaves no usable
-// resources — so it falls through to "failed".
-const READY_STATUSES = new Set([
-  "CREATE_COMPLETE",
-  "UPDATE_COMPLETE",
-  "UPDATE_ROLLBACK_COMPLETE",
-  "IMPORT_COMPLETE",
-  "IMPORT_ROLLBACK_COMPLETE",
-]);
-
-/** Reads a single stack by name, returning undefined when it does not exist. */
-export type StackReader = (
+// Real describer: lazily imports the SDK (kept off the CLI startup path, like
+// environment.ts) and scopes a client to the target region + credentials.
+function cloudFormationDescriber(
   region: string,
   credentials: CdkCredentialProvider,
-  stackName: string,
-) => Promise<Stack | undefined>;
-
-function outputsToRecord(outputs: Stack["Outputs"]): Record<string, string> {
-  const record: Record<string, string> = {};
-  for (const { OutputKey, OutputValue } of outputs ?? []) {
-    if (OutputKey !== undefined && OutputValue !== undefined) record[OutputKey] = OutputValue;
-  }
-  return record;
+): DescribeStacks {
+  return async (stackName) => {
+    const { CloudFormationClient, DescribeStacksCommand } =
+      await import("@aws-sdk/client-cloudformation");
+    const client = new CloudFormationClient({ credentials, region });
+    try {
+      const response = await client.send(new DescribeStacksCommand({ StackName: stackName }));
+      return response.Stacks;
+    } finally {
+      client.destroy();
+    }
+  };
 }
 
 /**
- * Maps a described stack (or its absence) onto {@link StackState}.
+ * Describes a project's CloudFormation stack, returning it or undefined when it
+ * does not exist. Accepts a stack name or ARN.
  *
- * CloudFormation's lifecycle is the substance here: an in-flight operation has
- * no settled outputs, a rolled-back create is broken, and a deleted stack is
- * effectively not deployed. Only a settled, successful status yields outputs.
+ * This is only the read: interpreting the stack's status and outputs (deployed
+ * vs. in-progress vs. failed, which outputs to surface) is left to the caller —
+ * e.g. `project status` — which owns that shape.
  */
-export function classifyStack(stack: Stack | undefined): StackState {
-  if (!stack) return { kind: "not-deployed" };
-
-  const status = stack.StackStatus;
-  // A stack described by ARN after deletion comes back as DELETE_COMPLETE;
-  // treat it the same as never-deployed.
-  if (!status || status === "DELETE_COMPLETE") return { kind: "not-deployed" };
-  if (status.endsWith("_IN_PROGRESS")) return { kind: "in-progress", status };
-  if (READY_STATUSES.has(status)) {
-    return { kind: "ready", status, outputs: outputsToRecord(stack.Outputs) };
-  }
-  return { kind: "failed", status };
-}
-
-const describeStack: StackReader = async (region, credentials, stackName) => {
-  const { CloudFormationClient, DescribeStacksCommand } =
-    await import("@aws-sdk/client-cloudformation");
-  const client = new CloudFormationClient({ credentials, region });
+export async function describeStack(
+  region: string,
+  credentials: CdkCredentialProvider,
+  stackName: string,
+  describe: DescribeStacks = cloudFormationDescriber(region, credentials),
+): Promise<Stack | undefined> {
   try {
-    const response = await client.send(new DescribeStacksCommand({ StackName: stackName }));
-    return response.Stacks?.[0];
-  } catch (error) {
-    // Not-found is a thrown ValidationError, not an empty result. Every other
+    // Not-found is a thrown ValidationError, not an empty result; every other
     // error (auth, throttling, malformed request) is real and propagates.
+    return (await describe(stackName))?.[0];
+  } catch (error) {
     if (isStackNotFound(error)) return undefined;
     throw error;
-  } finally {
-    client.destroy();
   }
-};
-
-/**
- * Reads a project's stack live from CloudFormation and classifies it.
- *
- * `read` is injectable for tests; production uses a real {@link DescribeStacksCommand}.
- * Accepts either a stack name or a stack ARN as `stackName`.
- */
-export async function readStackState(
-  region: string,
-  credentials: CdkCredentialProvider,
-  stackName: string,
-  read: StackReader = describeStack,
-): Promise<StackState> {
-  return classifyStack(await read(region, credentials, stackName));
 }

--- a/src/core/project/backends/cdk/stackReader.ts
+++ b/src/core/project/backends/cdk/stackReader.ts
@@ -1,4 +1,5 @@
 import type { Stack } from "@aws-sdk/client-cloudformation";
+import { MalformedServiceResponseError } from "../../../../errors/errors";
 import { isStackNotFound } from "./environment";
 import type { CdkCredentialProvider } from "./toolkit";
 
@@ -41,12 +42,24 @@ export async function describeStack(
   stackName: string,
   describe: DescribeStacks = cloudFormationDescriber(region, credentials),
 ): Promise<Stack | undefined> {
+  let stacks: Stack[] | undefined;
   try {
-    // Not-found is a thrown ValidationError, not an empty result; every other
-    // error (auth, throttling, malformed request) is real and propagates.
-    return (await describe(stackName))?.[0];
+    stacks = await describe(stackName);
   } catch (error) {
+    // A missing stack is reported by a thrown ValidationError, not an empty
+    // result, so this is the only "not deployed" signal. Every other error
+    // (auth, throttling, malformed request) is real and propagates.
     if (isStackNotFound(error)) return undefined;
     throw error;
   }
+
+  const stack = stacks?.[0];
+  if (!stack) {
+    // A *successful* DescribeStacks with no stack is malformed, not not-found;
+    // returning undefined would misreport a service problem as "not deployed".
+    throw new MalformedServiceResponseError(
+      `CloudFormation returned no stack after describing '${stackName}'`,
+    );
+  }
+  return stack;
 }

--- a/src/core/project/backends/cdk/stackReader.ts
+++ b/src/core/project/backends/cdk/stackReader.ts
@@ -1,0 +1,97 @@
+import type { Stack } from "@aws-sdk/client-cloudformation";
+import { isStackNotFound } from "./environment";
+import type { CdkCredentialProvider } from "./toolkit";
+
+/**
+ * Live state of a project's CloudFormation stack.
+ *
+ * Deployed state now stores only the stack ARN; the resource ARNs/IDs are read
+ * back from CloudFormation on demand so they can never go stale. This is the
+ * shape callers (e.g. `project status`) consume.
+ */
+export type StackState =
+  | { kind: "not-deployed" }
+  | { kind: "in-progress"; status: string }
+  | { kind: "failed"; status: string }
+  | { kind: "ready"; status: string; outputs: Record<string, string> };
+
+// Terminal statuses where the stack's resources exist and its outputs are
+// meaningful. UPDATE_ROLLBACK_COMPLETE is included: an update failed but rolled
+// back to the previous working state, so the outputs still describe live
+// resources. ROLLBACK_COMPLETE (a failed *create*) is not — it leaves no usable
+// resources — so it falls through to "failed".
+const READY_STATUSES = new Set([
+  "CREATE_COMPLETE",
+  "UPDATE_COMPLETE",
+  "UPDATE_ROLLBACK_COMPLETE",
+  "IMPORT_COMPLETE",
+  "IMPORT_ROLLBACK_COMPLETE",
+]);
+
+/** Reads a single stack by name, returning undefined when it does not exist. */
+export type StackReader = (
+  region: string,
+  credentials: CdkCredentialProvider,
+  stackName: string,
+) => Promise<Stack | undefined>;
+
+function outputsToRecord(outputs: Stack["Outputs"]): Record<string, string> {
+  const record: Record<string, string> = {};
+  for (const { OutputKey, OutputValue } of outputs ?? []) {
+    if (OutputKey !== undefined && OutputValue !== undefined) record[OutputKey] = OutputValue;
+  }
+  return record;
+}
+
+/**
+ * Maps a described stack (or its absence) onto {@link StackState}.
+ *
+ * CloudFormation's lifecycle is the substance here: an in-flight operation has
+ * no settled outputs, a rolled-back create is broken, and a deleted stack is
+ * effectively not deployed. Only a settled, successful status yields outputs.
+ */
+export function classifyStack(stack: Stack | undefined): StackState {
+  if (!stack) return { kind: "not-deployed" };
+
+  const status = stack.StackStatus;
+  // A stack described by ARN after deletion comes back as DELETE_COMPLETE;
+  // treat it the same as never-deployed.
+  if (!status || status === "DELETE_COMPLETE") return { kind: "not-deployed" };
+  if (status.endsWith("_IN_PROGRESS")) return { kind: "in-progress", status };
+  if (READY_STATUSES.has(status)) {
+    return { kind: "ready", status, outputs: outputsToRecord(stack.Outputs) };
+  }
+  return { kind: "failed", status };
+}
+
+const describeStack: StackReader = async (region, credentials, stackName) => {
+  const { CloudFormationClient, DescribeStacksCommand } =
+    await import("@aws-sdk/client-cloudformation");
+  const client = new CloudFormationClient({ credentials, region });
+  try {
+    const response = await client.send(new DescribeStacksCommand({ StackName: stackName }));
+    return response.Stacks?.[0];
+  } catch (error) {
+    // Not-found is a thrown ValidationError, not an empty result. Every other
+    // error (auth, throttling, malformed request) is real and propagates.
+    if (isStackNotFound(error)) return undefined;
+    throw error;
+  } finally {
+    client.destroy();
+  }
+};
+
+/**
+ * Reads a project's stack live from CloudFormation and classifies it.
+ *
+ * `read` is injectable for tests; production uses a real {@link DescribeStacksCommand}.
+ * Accepts either a stack name or a stack ARN as `stackName`.
+ */
+export async function readStackState(
+  region: string,
+  credentials: CdkCredentialProvider,
+  stackName: string,
+  read: StackReader = describeStack,
+): Promise<StackState> {
+  return classifyStack(await read(region, credentials, stackName));
+}


### PR DESCRIPTION
Adds the read-side of the deploy-state refactor: a small helper to describe a project's CloudFormation stack, so resource details can be read live instead of from a local snapshot that goes stale.

## What's here
- `describeStack(region, credentials, stackName)` — a `DescribeStacks` call that returns the stack, or `undefined` when it doesn't exist. Accepts a stack name or ARN. The AWS call is injectable (and lazy-loaded like `environment.ts`), so it's unit-tested without a real client.
- Generalized the existing bootstrap `isBootstrapStackNotFound` → `isStackNotFound` and reused it.

## Not here (by design)
Interpreting the stack — status classification (deployed / in-progress / failed) and which outputs to surface — is a `project status` decision and is left to whoever builds it, rather than baked in ahead of the consumer.