### PR TITLE
feat(capacity-provider): restore Journey 1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,9 +32,9 @@ These options are available on all commands:
 
 - `create` - Create new AgentCore project
 - `add` - Add resources (agent, memory, credential, evaluator, online-eval, gateway, gateway-target, policy-engine,
-  policy, payment-manager, payment-connector)
+  policy, payment-manager, payment-connector, capacity-provider)
 - `remove` - Remove resources (agent, memory, credential, evaluator, online-eval, gateway, gateway-target,
-  policy-engine, policy, payment-manager, payment-connector, all)
+  policy-engine, policy, payment-manager, payment-connector, capacity-provider, all)
 - `deploy` - Deploy infrastructure to AWS
 - `status` - Check deployment status
 - `dev` - Local development server (CodeZip: uvicorn with hot-reload; Container: Docker build + run with volume mount)
@@ -90,6 +90,7 @@ Current primitives:
 - `PolicyPrimitive` — Cedar policy creation/removal within policy engines
 - `PaymentManagerPrimitive` — payment manager creation/removal with agent code wiring
 - `PaymentConnectorPrimitive` — payment connector creation/removal with credential management
+- `CapacityProviderPrimitive` — capacity provider creation/removal (customer-managed EC2 compute pool for runtimes)
 
 Singletons are created in `registry.ts` and wired into CLI commands via `cli.ts`. See `src/cli/AGENTS.md` for details on
 adding new primitives.

--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ agentcore invoke
 
 ### Resource Management
 
-| Command  | Description                                                                                                                                                                                                                                             |
-| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `add`    | Add harnesses, agents, memory, credentials, gateways and gateway-targets, evaluators, online evals, online insights, knowledge bases, config bundles, datasets, policy engines and policies, payment managers and payment connectors, runtime endpoints |
-| `remove` | Remove any of the above resources from the project                                                                                                                                                                                                      |
+| Command  | Description                                                                                                                                                                                                                                                                 |
+| -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `add`    | Add harnesses, agents, memory, credentials, gateways and gateway-targets, evaluators, online evals, online insights, knowledge bases, config bundles, datasets, policy engines and policies, payment managers and payment connectors, capacity providers, runtime endpoints |
+| `remove` | Remove any of the above resources from the project                                                                                                                                                                                                                          |
 
 > **Note**: Run `agentcore deploy` after `add` or `remove` to update resources in AWS.
 
@@ -264,8 +264,8 @@ my-project/
 Projects use JSON schema files in the `agentcore/` directory:
 
 - `agentcore.json` - Project resources (agents, memory, credentials, gateways, evaluators, online evals/insights,
-  knowledge bases, harnesses, policy engines and policies, payment managers and connectors, config bundles, datasets,
-  runtime endpoints)
+  knowledge bases, harnesses, policy engines and policies, payment managers and connectors, capacity providers, config
+  bundles, datasets, runtime endpoints)
 - `deployed-state.json` - Runtime state in agentcore/.cli/ (auto-managed)
 - `aws-targets.json` - Deployment targets (account, region)
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -785,6 +785,57 @@ agentcore add config-bundle \
 | `--commit-message <text>`  | Commit message for this version                                                                                               |
 | `--json`                   | JSON output                                                                                                                   |
 
+### add capacity-provider
+
+Add a capacity provider — a customer-managed pool of AWS-managed EC2 compute that agent runtimes can run on instead of
+the default managed fleet. Everything except the description and tags is immutable after creation.
+
+**Operator role.** AgentCore assumes an IAM _operator role_ to create and manage the EC2 compute on your behalf. Omit
+`--operator-role-arn` and the CLI provisions one for you at deploy time — a role that trusts
+`bedrock-agentcore.amazonaws.com` (scoped to your account and region) and carries the AWS managed policy
+`BedrockAgentCoreRuntimeInstancesOperatorRolePolicy` (EC2/Auto Scaling/fleet management plus the
+`agentcore-lifecycle-events-*` EventBridge permissions the service needs). Pass `--operator-role-arn` only when you want
+to bring your own role; it must grant those same permissions, or capacity provider creation fails asynchronously
+(surfaced by CloudFormation as `NotStabilized`).
+
+```bash
+# Minimal — operator role is created automatically
+agentcore add capacity-provider \
+  --name MyCapacityProvider \
+  --subnets subnet-0123456789abcdef0 \
+  --security-groups sg-0123456789abcdef0 \
+  --instance-types c6a.large
+
+# With a named EBS volume, lifecycle limits, and ARM64 (and a bring-your-own operator role)
+agentcore add capacity-provider \
+  --name MyCapacityProvider \
+  --operator-role-arn arn:aws:iam::123456789012:role/MyOperatorRole \
+  --subnets subnet-0123456789abcdef0,subnet-0fedcba9876543210 \
+  --security-groups sg-0123456789abcdef0 \
+  --os LINUX_ARM64 \
+  --instance-types c7g.large,c7g.xlarge \
+  --volume data:20 --volume-encrypted \
+  --idle-instance-timeout 3600 \
+  --max-lifetime 28800
+```
+
+| Flag                             | Description                                                                                                    |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `--name <name>`                  | Capacity provider name (required); immutable after creation                                                    |
+| `--operator-role-arn <arn>`      | IAM role ARN AgentCore assumes to manage the capacity provider (optional — auto-created if omitted); immutable |
+| `--description <desc>`           | Description (the only mutable field besides tags)                                                              |
+| `--subnets <subnets>`            | Comma-separated subnet IDs, 1–16 (required)                                                                    |
+| `--security-groups <groups>`     | Comma-separated security group IDs, 1–16 (required)                                                            |
+| `--os <os>`                      | `LINUX_X86_64` (default) or `LINUX_ARM64`                                                                      |
+| `--instance-types <types>`       | Comma-separated allowed EC2 instance types, 1–30 (required)                                                    |
+| `--volume <name:sizeGiB>`        | Named EBS volume as `name:sizeGiB` (repeatable, max 5)                                                         |
+| `--volume-encrypted`             | Encrypt EBS volumes                                                                                            |
+| `--volume-kms-key <arn>`         | KMS key ARN for EBS volume encryption                                                                          |
+| `--instance-profile-arn <arn>`   | IAM instance profile ARN for launched instances                                                                |
+| `--idle-instance-timeout <secs>` | Idle instance timeout in seconds (60–1209600)                                                                  |
+| `--max-lifetime <secs>`          | Maximum instance lifetime in seconds (60–1209600)                                                              |
+| `--json`                         | JSON output                                                                                                    |
+
 ### remove
 
 Remove resources from project.
@@ -804,6 +855,7 @@ agentcore remove dataset --name MyDataset
 agentcore remove config-bundle --name MyBundle
 agentcore remove payment-manager --name MyManager -y
 agentcore remove payment-connector --name MyCDPConnector --manager MyManager -y
+agentcore remove capacity-provider --name MyCapacityProvider -y
 
 # Reset everything
 agentcore remove all -y

--- a/integ-tests/add-remove-capacity-provider.test.ts
+++ b/integ-tests/add-remove-capacity-provider.test.ts
@@ -1,0 +1,210 @@
+import { createTestProject, readProjectConfig, runCLI } from '../src/test-utils/index.js';
+import type { TestProject } from '../src/test-utils/index.js';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const OPERATOR_ROLE_ARN = 'arn:aws:iam::123456789012:role/MyOperatorRole';
+
+describe('integration: add and remove capacity providers', () => {
+  let project: TestProject;
+
+  beforeAll(async () => {
+    project = await createTestProject({ noAgent: true });
+  });
+
+  afterAll(async () => {
+    await project.cleanup();
+  });
+
+  describe('capacity provider lifecycle', () => {
+    const cpName = `IntegCp${Date.now().toString().slice(-6)}`;
+
+    it('adds a capacity provider', async () => {
+      const result = await runCLI(
+        [
+          'add',
+          'capacity-provider',
+          '--name',
+          cpName,
+          '--operator-role-arn',
+          OPERATOR_ROLE_ARN,
+          '--subnets',
+          'subnet-0123456789abcdef0',
+          '--security-groups',
+          'sg-0123456789abcdef0',
+          '--os',
+          'LINUX_X86_64',
+          '--instance-types',
+          'c6a.large',
+          '--json',
+        ],
+        project.projectPath
+      );
+
+      expect(result.exitCode, `stdout: ${result.stdout}, stderr: ${result.stderr}`).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(true);
+      expect(json.capacityProviderName).toBe(cpName);
+
+      const config = await readProjectConfig(project.projectPath);
+      const cp = config.capacityProviders?.find((c: Record<string, unknown>) => c.name === cpName);
+      expect(cp, `Capacity provider "${cpName}" should be in config`).toBeTruthy();
+      expect(cp!.operatorRoleArn).toBe(OPERATOR_ROLE_ARN);
+      const ec2 = (cp as any).computeConfiguration.ec2Configuration;
+      expect(ec2.launchTemplateSource.launchParameters.operatingSystem).toBe('LINUX_X86_64');
+      expect(ec2.launchTemplateSource.launchParameters.instanceRequirements.allowedInstanceTypes).toEqual([
+        'c6a.large',
+      ]);
+      expect(ec2.vpcConfiguration.subnets).toEqual(['subnet-0123456789abcdef0']);
+      expect(ec2.vpcConfiguration.securityGroups).toEqual(['sg-0123456789abcdef0']);
+    });
+
+    it('adds a capacity provider with volumes, lifecycle, and description', async () => {
+      const richName = `${cpName}Rich`;
+      const result = await runCLI(
+        [
+          'add',
+          'capacity-provider',
+          '--name',
+          richName,
+          '--operator-role-arn',
+          OPERATOR_ROLE_ARN,
+          '--description',
+          'my rich capacity provider',
+          '--subnets',
+          'subnet-0123456789abcdef0,subnet-0fedcba9876543210',
+          '--security-groups',
+          'sg-0123456789abcdef0',
+          '--os',
+          'LINUX_ARM64',
+          '--instance-types',
+          'c7g.large,c7g.xlarge',
+          '--volume',
+          'data:20',
+          '--volume-encrypted',
+          '--idle-instance-timeout',
+          '3600',
+          '--max-lifetime',
+          '28800',
+          '--json',
+        ],
+        project.projectPath
+      );
+
+      expect(result.exitCode, `stdout: ${result.stdout}, stderr: ${result.stderr}`).toBe(0);
+      expect(JSON.parse(result.stdout).success).toBe(true);
+
+      const config = await readProjectConfig(project.projectPath);
+      const cp = config.capacityProviders?.find((c: Record<string, unknown>) => c.name === richName);
+      expect(cp).toBeTruthy();
+      expect(cp!.description).toBe('my rich capacity provider');
+      const ec2 = (cp as any).computeConfiguration.ec2Configuration;
+      expect(ec2.launchTemplateSource.launchParameters.operatingSystem).toBe('LINUX_ARM64');
+      expect(ec2.vpcConfiguration.subnets).toHaveLength(2);
+      expect(ec2.volumes).toEqual([{ ebsConfiguration: { name: 'data', sizeGiB: 20, encrypted: true } }]);
+      expect(ec2.lifecycleConfiguration).toEqual({ idleInstanceTimeout: 3600, maxLifetime: 28800 });
+
+      await runCLI(['remove', 'capacity-provider', '--name', richName, '--yes'], project.projectPath);
+    });
+
+    it('rejects a duplicate capacity provider name', async () => {
+      const result = await runCLI(
+        [
+          'add',
+          'capacity-provider',
+          '--name',
+          cpName,
+          '--operator-role-arn',
+          OPERATOR_ROLE_ARN,
+          '--subnets',
+          'subnet-0123456789abcdef0',
+          '--security-groups',
+          'sg-0123456789abcdef0',
+          '--instance-types',
+          'c6a.large',
+          '--json',
+        ],
+        project.projectPath
+      );
+
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(json.error).toContain('already exists');
+    });
+
+    it('removes the capacity provider', async () => {
+      const result = await runCLI(
+        ['remove', 'capacity-provider', '--name', cpName, '--yes', '--json'],
+        project.projectPath
+      );
+
+      expect(result.exitCode, `stdout: ${result.stdout}, stderr: ${result.stderr}`).toBe(0);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(true);
+
+      const config = await readProjectConfig(project.projectPath);
+      const found = config.capacityProviders?.some((c: Record<string, unknown>) => c.name === cpName);
+      expect(found, `Capacity provider "${cpName}" should be removed`).toBeFalsy();
+    });
+  });
+
+  describe('validation', () => {
+    it('rejects a missing required option', async () => {
+      const result = await runCLI(['add', 'capacity-provider', '--name', 'noRole', '--json'], project.projectPath);
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+    });
+
+    it('rejects an unsupported operating system', async () => {
+      const result = await runCLI(
+        [
+          'add',
+          'capacity-provider',
+          '--name',
+          'badOs',
+          '--operator-role-arn',
+          OPERATOR_ROLE_ARN,
+          '--subnets',
+          'subnet-0123456789abcdef0',
+          '--security-groups',
+          'sg-0123456789abcdef0',
+          '--os',
+          'WINDOWS_X86_64',
+          '--instance-types',
+          'c6a.large',
+          '--json',
+        ],
+        project.projectPath
+      );
+      expect(result.exitCode).toBe(1);
+    });
+
+    it('rejects a malformed operator role ARN', async () => {
+      const result = await runCLI(
+        [
+          'add',
+          'capacity-provider',
+          '--name',
+          'badArn',
+          '--operator-role-arn',
+          'not-an-arn',
+          '--subnets',
+          'subnet-0123456789abcdef0',
+          '--security-groups',
+          'sg-0123456789abcdef0',
+          '--instance-types',
+          'c6a.large',
+          '--json',
+        ],
+        project.projectPath
+      );
+      expect(result.exitCode).toBe(1);
+    });
+
+    it('passes agentcore validate after add/remove lifecycle', async () => {
+      const result = await runCLI(['validate'], project.projectPath);
+      expect(result.exitCode).toBe(0);
+    });
+  });
+});

--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -7577,7 +7577,7 @@ file maps to a JSON config file and includes validation constraints as comments 
 
 ### Key Types
 
-- **AgentCoreProjectSpec**: Root config with runtimes, memories, knowledge bases, credentials, evaluators, online evals and insights, gateways, policy engines, config bundles, A/B tests, harness registrations, datasets, and payment managers
+- **AgentCoreProjectSpec**: Root config with runtimes, memories, knowledge bases, credentials, evaluators, online evals and insights, gateways, policy engines, config bundles, A/B tests, harness registrations, datasets, payment managers, and capacity providers
 - **AgentEnvSpec**: Agent configuration (build type, entrypoint, code location, runtime version, network mode)
 - **Memory**: Memory resource with strategies (SEMANTIC, SUMMARIZATION, USER_PREFERENCE, EPISODIC) and expiry
 - **Credential**: API key or OAuth credential provider
@@ -7688,7 +7688,7 @@ Run \`agentcore --help\` or \`agentcore <command> --help\` for full flags. Commo
 
 | Command | Description |
 | --- | --- |
-| \`agentcore add <resource>\` | Add agent, memory, credential, gateway, gateway-target, evaluator, online-eval, online-insights, knowledge-base, harness, policy-engine, policy, payment-manager, payment-connector, config-bundle, dataset, runtime-endpoint |
+| \`agentcore add <resource>\` | Add agent, memory, credential, gateway, gateway-target, evaluator, online-eval, online-insights, knowledge-base, harness, policy-engine, policy, payment-manager, payment-connector, capacity-provider, config-bundle, dataset, runtime-endpoint |
 | \`agentcore remove <resource>\` | Remove any resource |
 | \`agentcore export harness\` | Export a harness to a Strands runtime agent under \`app/<agentName>/\` |
 

--- a/src/assets/agents/AGENTS.md
+++ b/src/assets/agents/AGENTS.md
@@ -56,7 +56,7 @@ file maps to a JSON config file and includes validation constraints as comments 
 
 ### Key Types
 
-- **AgentCoreProjectSpec**: Root config with runtimes, memories, knowledge bases, credentials, evaluators, online evals and insights, gateways, policy engines, config bundles, A/B tests, harness registrations, datasets, and payment managers
+- **AgentCoreProjectSpec**: Root config with runtimes, memories, knowledge bases, credentials, evaluators, online evals and insights, gateways, policy engines, config bundles, A/B tests, harness registrations, datasets, payment managers, and capacity providers
 - **AgentEnvSpec**: Agent configuration (build type, entrypoint, code location, runtime version, network mode)
 - **Memory**: Memory resource with strategies (SEMANTIC, SUMMARIZATION, USER_PREFERENCE, EPISODIC) and expiry
 - **Credential**: API key or OAuth credential provider
@@ -167,7 +167,7 @@ Run `agentcore --help` or `agentcore <command> --help` for full flags. Commonly 
 
 | Command | Description |
 | --- | --- |
-| `agentcore add <resource>` | Add agent, memory, credential, gateway, gateway-target, evaluator, online-eval, online-insights, knowledge-base, harness, policy-engine, policy, payment-manager, payment-connector, config-bundle, dataset, runtime-endpoint |
+| `agentcore add <resource>` | Add agent, memory, credential, gateway, gateway-target, evaluator, online-eval, online-insights, knowledge-base, harness, policy-engine, policy, payment-manager, payment-connector, capacity-provider, config-bundle, dataset, runtime-endpoint |
 | `agentcore remove <resource>` | Remove any resource |
 | `agentcore export harness` | Export a harness to a Strands runtime agent under `app/<agentName>/` |
 

--- a/src/cli/cloudformation/__tests__/outputs-capacity-provider.test.ts
+++ b/src/cli/cloudformation/__tests__/outputs-capacity-provider.test.ts
@@ -1,0 +1,51 @@
+import { parseCapacityProviderOutputs } from '../outputs';
+import { describe, expect, it } from 'vitest';
+
+describe('parseCapacityProviderOutputs', () => {
+  it('parses Id and Arn from stack outputs', () => {
+    const outputs = {
+      ApplicationCapacityProviderMyCpIdOutputABC123: 'MyCp-abc1234567',
+      ApplicationCapacityProviderMyCpArnOutputDEF456:
+        'arn:aws:bedrock-agentcore:us-west-2:123456789012:capacity-provider/MyCp-abc1234567',
+    };
+
+    const result = parseCapacityProviderOutputs(outputs, ['MyCp']);
+
+    expect(result).toEqual({
+      MyCp: {
+        capacityProviderId: 'MyCp-abc1234567',
+        capacityProviderArn: 'arn:aws:bedrock-agentcore:us-west-2:123456789012:capacity-provider/MyCp-abc1234567',
+      },
+    });
+  });
+
+  it('parses multiple capacity providers', () => {
+    const outputs = {
+      ApplicationCapacityProviderFirstIdOutputAAA: 'first-id',
+      ApplicationCapacityProviderFirstArnOutputBBB: 'arn:first',
+      ApplicationCapacityProviderSecondIdOutputCCC: 'second-id',
+      ApplicationCapacityProviderSecondArnOutputDDD: 'arn:second',
+    };
+
+    const result = parseCapacityProviderOutputs(outputs, ['First', 'Second']);
+
+    expect(Object.keys(result)).toHaveLength(2);
+    expect(result.First!.capacityProviderId).toBe('first-id');
+    expect(result.Second!.capacityProviderArn).toBe('arn:second');
+  });
+
+  it('skips a capacity provider when the Id output is missing', () => {
+    const outputs = {
+      ApplicationCapacityProviderMyCpArnOutputDEF: 'arn:test',
+    };
+
+    const result = parseCapacityProviderOutputs(outputs, ['MyCp']);
+
+    expect(result).toEqual({});
+  });
+
+  it('returns empty for no names', () => {
+    const result = parseCapacityProviderOutputs({ ApplicationCapacityProviderMyCpIdOutputX: 'x' }, []);
+    expect(result).toEqual({});
+  });
+});

--- a/src/cli/cloudformation/outputs.ts
+++ b/src/cli/cloudformation/outputs.ts
@@ -1,5 +1,6 @@
 import type {
   AgentCoreDeployedState,
+  CapacityProviderDeployedState,
   ConfigBundleDeployedState,
   DatasetDeployedState,
   DeployedState,
@@ -545,6 +546,37 @@ export function parseDatasetOutputs(
 }
 
 /**
+ * Parse stack outputs into deployed state for capacity providers.
+ *
+ * Output key pattern: ApplicationCapacityProvider{PascalName}(Id|Arn)Output{Hash}
+ */
+export function parseCapacityProviderOutputs(
+  outputs: StackOutputs,
+  capacityProviderNames: string[]
+): Record<string, CapacityProviderDeployedState> {
+  const capacityProviders: Record<string, CapacityProviderDeployedState> = {};
+  const outputKeys = Object.keys(outputs);
+
+  for (const capacityProviderName of capacityProviderNames) {
+    const pascal = toPascalId('CapacityProvider', capacityProviderName);
+    const idPrefix = `Application${pascal}IdOutput`;
+    const arnPrefix = `Application${pascal}ArnOutput`;
+
+    const idKey = outputKeys.find(k => k.startsWith(idPrefix));
+    const arnKey = outputKeys.find(k => k.startsWith(arnPrefix));
+
+    if (idKey && arnKey) {
+      capacityProviders[capacityProviderName] = {
+        capacityProviderId: outputs[idKey]!,
+        capacityProviderArn: outputs[arnKey]!,
+      };
+    }
+  }
+
+  return capacityProviders;
+}
+
+/**
  * Parse CDK stack outputs for CFN-deployed harnesses into deployed-state records.
  *
  * The L3 AgentCoreApplication emits, per harness `${name}` (pascal = toPascalId('Harness', name)):
@@ -742,6 +774,7 @@ export interface BuildDeployedStateOptions {
   configBundles?: Record<string, ConfigBundleDeployedState>;
   knowledgeBases?: Record<string, KnowledgeBaseDeployedState>;
   payments?: Record<string, PaymentDeployedState>;
+  capacityProviders?: Record<string, CapacityProviderDeployedState>;
   /**
    * Names of A/B tests currently declared in the project spec. AB test state is managed
    * post-deploy (not via CFN outputs) and carried forward across deploys; passing the
@@ -776,6 +809,7 @@ export function buildDeployedState(opts: BuildDeployedStateOptions): DeployedSta
     configBundles,
     knowledgeBases,
     payments,
+    capacityProviders,
     abTestNames,
   } = opts;
   const targetState: TargetDeployedState = {
@@ -876,6 +910,11 @@ export function buildDeployedState(opts: BuildDeployedStateOptions): DeployedSta
   // Add payment state from CFN outputs (or preserve credential provider state)
   if (payments && Object.keys(payments).length > 0) {
     targetState.resources!.payments = payments;
+  }
+
+  // Add capacity provider state from CFN outputs
+  if (capacityProviders && Object.keys(capacityProviders).length > 0) {
+    targetState.resources!.capacityProviders = capacityProviders;
   }
 
   return {

--- a/src/cli/commands/deploy/actions.ts
+++ b/src/cli/commands/deploy/actions.ts
@@ -18,6 +18,7 @@ import {
   getStackOutputs,
   omitPaymentAuthorizationOutputs,
   parseAgentOutputs,
+  parseCapacityProviderOutputs,
   parseConfigBundleOutputs,
   parseDatasetOutputs,
   parseEvaluatorOutputs,
@@ -710,6 +711,10 @@ export async function handleDeploy(options: ValidatedDeployOptions): Promise<Dep
     const datasetNames = (context.projectSpec.datasets ?? []).map(d => d.name);
     const datasets = parseDatasetOutputs(outputs, datasetNames);
 
+    // Parse capacity provider outputs
+    const capacityProviderNames = (context.projectSpec.capacityProviders ?? []).map(cp => cp.name);
+    const capacityProviders = parseCapacityProviderOutputs(outputs, capacityProviderNames);
+
     // Parse config bundle outputs
     const configBundleNames = (context.projectSpec.configBundles ?? []).map(b => b.name);
     const configBundles = parseConfigBundleOutputs(outputs, configBundleNames);
@@ -799,6 +804,7 @@ export async function handleDeploy(options: ValidatedDeployOptions): Promise<Dep
       configBundles,
       knowledgeBases,
       payments,
+      capacityProviders,
       abTestNames: (context.projectSpec.abTests ?? []).map(t => t.name),
     });
 

--- a/src/cli/commands/remove/command.tsx
+++ b/src/cli/commands/remove/command.tsx
@@ -27,6 +27,7 @@ async function handleRemoveAll(options: RemoveAllOptions): Promise<RemoveResult>
       for (const e of current.evaluators ?? []) items.push(`evaluator: ${e.name}`);
       for (const g of current.agentCoreGateways ?? []) items.push(`gateway: ${g.name}`);
       for (const pe of current.policyEngines ?? []) items.push(`policy-engine: ${pe.name}`);
+      for (const cp of current.capacityProviders ?? []) items.push(`capacity-provider: ${cp.name}`);
       return {
         success: true,
         message: items.length > 0 ? `Would remove: ${items.join(', ')}` : 'Nothing to remove',
@@ -85,6 +86,7 @@ async function handleRemoveAll(options: RemoveAllOptions): Promise<RemoveResult>
       harnesses: [],
       datasets: [],
       payments: [],
+      capacityProviders: [],
     });
 
     // Preserve aws-targets.json and deployed-state.json so that

--- a/src/cli/commands/remove/types.ts
+++ b/src/cli/commands/remove/types.ts
@@ -17,7 +17,8 @@ export type ResourceType =
   | 'dataset'
   | 'knowledge-base'
   | 'payment-manager'
-  | 'payment-connector';
+  | 'payment-connector'
+  | 'capacity-provider';
 
 export interface RemoveOptions {
   resourceType: ResourceType;

--- a/src/cli/commands/status/__tests__/action.test.ts
+++ b/src/cli/commands/status/__tests__/action.test.ts
@@ -1441,4 +1441,58 @@ describe('handleProjectStatus — invocation URL enrichment', () => {
     expect(agentEntry!.deploymentState).toBe('pending-removal');
     expect(agentEntry!.invocationUrl).toBeUndefined();
   });
+
+  it('marks capacity provider deployed / local-only / pending-removal correctly', () => {
+    const project = {
+      ...baseProject,
+      capacityProviders: [
+        {
+          name: 'my-cp',
+          operatorRoleArn: 'arn:aws:iam::123456789012:role/Op',
+          computeConfiguration: {
+            ec2Configuration: {
+              launchTemplateSource: {
+                launchParameters: {
+                  operatingSystem: 'LINUX_X86_64',
+                  instanceRequirements: { allowedInstanceTypes: ['c6a.large'] },
+                },
+              },
+              vpcConfiguration: { subnets: ['subnet-0123456789abcdef0'], securityGroups: ['sg-0123456789abcdef0'] },
+            },
+          },
+        },
+      ],
+    } as unknown as AgentCoreProjectSpec;
+
+    // Deployed
+    const deployed = computeResourceStatuses(project, {
+      capacityProviders: {
+        'my-cp': {
+          capacityProviderId: 'my-cp-abc1234567',
+          capacityProviderArn: 'arn:aws:bedrock-agentcore:us-east-1:123456789012:capacity-provider/my-cp-abc1234567',
+        },
+      },
+    });
+    const deployedEntry = deployed.find(r => r.resourceType === 'capacity-provider' && r.name === 'my-cp');
+    expect(deployedEntry).toBeDefined();
+    expect(deployedEntry!.deploymentState).toBe('deployed');
+    expect(deployedEntry!.identifier).toContain('capacity-provider/my-cp-abc1234567');
+
+    // Local-only
+    const local = computeResourceStatuses(project, undefined);
+    const localEntry = local.find(r => r.resourceType === 'capacity-provider' && r.name === 'my-cp');
+    expect(localEntry!.deploymentState).toBe('local-only');
+
+    // Pending removal: deployed but not in local spec
+    const pending = computeResourceStatuses(baseProject, {
+      capacityProviders: {
+        'gone-cp': {
+          capacityProviderId: 'gone-cp-abc1234567',
+          capacityProviderArn: 'arn:aws:bedrock-agentcore:us-east-1:123456789012:capacity-provider/gone-cp-abc1234567',
+        },
+      },
+    });
+    const pendingEntry = pending.find(r => r.resourceType === 'capacity-provider' && r.name === 'gone-cp');
+    expect(pendingEntry!.deploymentState).toBe('pending-removal');
+  });
 });

--- a/src/cli/commands/status/action.ts
+++ b/src/cli/commands/status/action.ts
@@ -42,7 +42,8 @@ export interface ResourceStatusEntry {
     | 'harness'
     | 'runtime-endpoint'
     | 'knowledge-base'
-    | 'payment';
+    | 'payment'
+    | 'capacity-provider';
   name: string;
   deploymentState: ResourceDeploymentState;
   identifier?: string;
@@ -362,6 +363,15 @@ export function computeResourceStatuses(
       `${item.authorizerType} — auto-pay ${item.autoPayment ? 'on' : 'off'} (${item.connectors.length} connector(s))`,
   });
 
+  const capacityProviders = diffResourceSet({
+    resourceType: 'capacity-provider',
+    localItems: project.capacityProviders ?? [],
+    deployedRecord: resources?.capacityProviders ?? {},
+    getIdentifier: deployed => deployed.capacityProviderArn,
+    getLocalDetail: item =>
+      item.computeConfiguration.ec2Configuration.launchTemplateSource.launchParameters.operatingSystem,
+  });
+
   return [
     ...agents,
     ...runtimeEndpoints,
@@ -377,6 +387,7 @@ export function computeResourceStatuses(
     ...configBundles,
     ...harnesses,
     ...payments,
+    ...capacityProviders,
   ];
 }
 

--- a/src/cli/commands/status/command.tsx
+++ b/src/cli/commands/status/command.tsx
@@ -27,6 +27,7 @@ const VALID_RESOURCE_TYPES = [
   'dataset',
   'knowledge-base',
   'harness',
+  'capacity-provider',
 ] as const;
 const VALID_STATES = ['deployed', 'local-only', 'pending-removal'] as const;
 

--- a/src/cli/logging/remove-logger.ts
+++ b/src/cli/logging/remove-logger.ts
@@ -24,7 +24,8 @@ export interface RemoveLoggerOptions {
     | 'dataset'
     | 'knowledge-base'
     | 'payment-manager'
-    | 'payment-connector';
+    | 'payment-connector'
+    | 'capacity-provider';
   /** Name of the resource being removed */
   resourceName: string;
 }

--- a/src/cli/operations/agent/generate/write-agent-to-project.ts
+++ b/src/cli/operations/agent/generate/write-agent-to-project.ts
@@ -77,6 +77,7 @@ export async function writeAgentToProject(config: GenerateConfig, options?: Writ
       harnesses: [],
       datasets: [],
       payments: [],
+      capacityProviders: [],
     };
 
     await configIO.writeProjectSpec(project);

--- a/src/cli/operations/deploy/__tests__/preflight.test.ts
+++ b/src/cli/operations/deploy/__tests__/preflight.test.ts
@@ -162,6 +162,76 @@ describe('validateProject', () => {
     expect(result.isTeardownDeploy).toBe(false);
   });
 
+  it('allows deploy when only config bundles are defined (regression: previously misclassified as empty)', async () => {
+    mockRequireConfigRoot.mockReturnValue('/project/agentcore');
+    mockValidate.mockReturnValue(undefined);
+    mockReadProjectSpec.mockResolvedValue({
+      name: 'test-project',
+      runtimes: [],
+      agentCoreGateways: [],
+      configBundles: [{ name: 'bundle1' }],
+    });
+    mockReadAWSDeploymentTargets.mockResolvedValue([]);
+    mockValidateAwsCredentials.mockResolvedValue(undefined);
+
+    const result = await validateProject();
+
+    expect(result.projectSpec.name).toBe('test-project');
+    expect(result.isTeardownDeploy).toBe(false);
+  });
+
+  it('allows deploy when only online eval configs are defined (regression: previously misclassified as empty)', async () => {
+    mockRequireConfigRoot.mockReturnValue('/project/agentcore');
+    mockValidate.mockReturnValue(undefined);
+    mockReadProjectSpec.mockResolvedValue({
+      name: 'test-project',
+      runtimes: [],
+      agentCoreGateways: [],
+      onlineEvalConfigs: [{ name: 'oec1' }],
+    });
+    mockReadAWSDeploymentTargets.mockResolvedValue([]);
+    mockValidateAwsCredentials.mockResolvedValue(undefined);
+
+    const result = await validateProject();
+
+    expect(result.projectSpec.name).toBe('test-project');
+    expect(result.isTeardownDeploy).toBe(false);
+  });
+
+  it('allows deploy when only capacity providers are defined', async () => {
+    mockRequireConfigRoot.mockReturnValue('/project/agentcore');
+    mockValidate.mockReturnValue(undefined);
+    mockReadProjectSpec.mockResolvedValue({
+      name: 'test-project',
+      runtimes: [],
+      agentCoreGateways: [],
+      capacityProviders: [{ name: 'cp1' }],
+    });
+    mockReadAWSDeploymentTargets.mockResolvedValue([]);
+    mockValidateAwsCredentials.mockResolvedValue(undefined);
+
+    const result = await validateProject();
+
+    expect(result.projectSpec.name).toBe('test-project');
+    expect(result.isTeardownDeploy).toBe(false);
+  });
+
+  it('treats an empty project as teardown when a deployed stack exists', async () => {
+    mockRequireConfigRoot.mockReturnValue('/project/agentcore');
+    mockValidate.mockReturnValue(undefined);
+    mockReadProjectSpec.mockResolvedValue({
+      name: 'test-project',
+      runtimes: [],
+      agentCoreGateways: [],
+    });
+    mockReadAWSDeploymentTargets.mockResolvedValue([]);
+    mockReadDeployedState.mockResolvedValue({ targets: { default: {} } });
+
+    const result = await validateProject();
+
+    expect(result.isTeardownDeploy).toBe(true);
+  });
+
   it('allows deploy when both agents and gateways exist', async () => {
     mockRequireConfigRoot.mockReturnValue('/project/agentcore');
     mockValidate.mockReturnValue(undefined);

--- a/src/cli/operations/deploy/preflight.ts
+++ b/src/cli/operations/deploy/preflight.ts
@@ -68,6 +68,43 @@ export function formatError(err: unknown): string {
 }
 
 /**
+ * Spec arrays whose presence means the project has something to deploy to CloudFormation.
+ * Keep in sync with the resource types that emit CFN outputs (see cloudformation/outputs.ts
+ * parse*Outputs). A project with none of these is empty: deploy either errors ("No resources
+ * defined") or, when a stack already exists, tears it down.
+ *
+ * This is the single source of truth for "is the project deployable" — a new deployable primitive
+ * adds its key here and every consumer stays correct. Previously this was a hand-maintained boolean
+ * chain that silently drifted (configBundles and onlineEvalConfigs were both missing from it, so a
+ * project containing only those was misclassified as empty). The `satisfies` clause makes a typo'd
+ * or renamed key a compile error.
+ */
+export const DEPLOYABLE_RESOURCE_KEYS = [
+  'runtimes',
+  'agentCoreGateways',
+  'memories',
+  'knowledgeBases',
+  'evaluators',
+  'onlineEvalConfigs',
+  'policyEngines',
+  'configBundles',
+  'datasets',
+  'capacityProviders',
+  'harnesses',
+  'payments',
+] as const satisfies readonly (keyof AgentCoreProjectSpec)[];
+
+/**
+ * True when the project defines at least one resource that deploys to CloudFormation.
+ */
+export function hasDeployableResources(spec: AgentCoreProjectSpec): boolean {
+  return DEPLOYABLE_RESOURCE_KEYS.some(key => {
+    const value = spec[key];
+    return Array.isArray(value) && value.length > 0;
+  });
+}
+
+/**
  * Validates the CDK project and loads configuration.
  * Also validates AWS credentials are configured before proceeding.
  * Returns the project context needed for subsequent steps.
@@ -98,32 +135,11 @@ export async function validateProject(selectedTarget?: AwsDeploymentTarget): Pro
     // No deployed state file — no existing stack
   }
 
-  // Teardown detection: when agents is empty but deployed-state.json records existing
-  // targets, the user has run `remove all` and wants to tear down AWS resources via deploy.
+  // Teardown detection: when no deployable resources remain but deployed-state.json records
+  // existing targets, the user has run `remove all` and wants to tear down AWS resources via deploy.
   let isTeardownDeploy = false;
-  const hasAgents = projectSpec.runtimes && projectSpec.runtimes.length > 0;
-  const hasMemories = projectSpec.memories && projectSpec.memories.length > 0;
-  const hasKnowledgeBases = projectSpec.knowledgeBases && projectSpec.knowledgeBases.length > 0;
-  const hasEvaluators = projectSpec.evaluators && projectSpec.evaluators.length > 0;
-  const hasPolicyEngines = projectSpec.policyEngines && projectSpec.policyEngines.length > 0;
-  const hasHarnesses = projectSpec.harnesses && projectSpec.harnesses.length > 0;
-  const hasDatasets = projectSpec.datasets && projectSpec.datasets.length > 0;
 
-  // Check for gateways in agentcore.json
-  const hasGateways = projectSpec.agentCoreGateways && projectSpec.agentCoreGateways.length > 0;
-  const hasPayments = projectSpec.payments && projectSpec.payments.length > 0;
-
-  if (
-    !hasAgents &&
-    !hasGateways &&
-    !hasMemories &&
-    !hasKnowledgeBases &&
-    !hasEvaluators &&
-    !hasPolicyEngines &&
-    !hasHarnesses &&
-    !hasDatasets &&
-    !hasPayments
-  ) {
+  if (!hasDeployableResources(projectSpec)) {
     if (!hasExistingStack) {
       throw new ValidationError(
         'No resources defined in project. Add at least one resource (agent, memory, knowledge base, evaluator, or gateway) before deploying.'

--- a/src/cli/primitives/CapacityProviderPrimitive.ts
+++ b/src/cli/primitives/CapacityProviderPrimitive.ts
@@ -1,0 +1,274 @@
+import { ResourceNotFoundError, ValidationError, findConfigRoot, serializeResult, toError } from '../../lib';
+import type { Result } from '../../lib/result';
+import type { CapacityProvider } from '../../schema';
+import { CapacityProviderSchema } from '../../schema';
+import type { RemovalPreview, SchemaChange } from '../operations/remove/types';
+import { runCliCommand } from '../telemetry/cli-command-run.js';
+import { OperatingSystem, standardize } from '../telemetry/schemas/common-shapes.js';
+import { BasePrimitive } from './BasePrimitive';
+import type { AddResult, AddScreenComponent, RemovableResource } from './types';
+import type { Command } from '@commander-js/extra-typings';
+
+/**
+ * Options for adding a capacity provider resource (CLI-level).
+ */
+export interface AddCapacityProviderOptions {
+  name: string;
+  operatorRoleArn?: string;
+  description?: string;
+  subnets: string;
+  securityGroups: string;
+  os?: string;
+  instanceTypes: string;
+  volume?: string[];
+  volumeEncrypted?: boolean;
+  volumeKmsKey?: string;
+  instanceProfileArn?: string;
+  idleInstanceTimeout?: string;
+  maxLifetime?: string;
+}
+
+/** Split a comma-separated CLI value into a trimmed, non-empty string array. */
+function splitList(value: string): string[] {
+  return value
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean);
+}
+
+/**
+ * CapacityProviderPrimitive handles capacity provider add/remove operations.
+ *
+ * A capacity provider is a declarative resource stored in agentcore.json and
+ * synthesized to an `AWS::BedrockAgentCore::CapacityProvider` CFN resource by
+ * the vended CDK project. Everything except Description/Tags is immutable after
+ * creation.
+ */
+export class CapacityProviderPrimitive extends BasePrimitive<AddCapacityProviderOptions, RemovableResource> {
+  readonly kind = 'capacity-provider';
+  readonly label = 'Capacity Provider';
+  readonly primitiveSchema = CapacityProviderSchema;
+
+  async add(options: AddCapacityProviderOptions): Promise<AddResult<{ capacityProviderName: string }>> {
+    try {
+      const capacityProvider = this.buildCapacityProvider(options);
+
+      const project = await this.readProjectSpec();
+      this.checkDuplicate(project.capacityProviders ?? [], capacityProvider.name);
+
+      project.capacityProviders = [...(project.capacityProviders ?? []), capacityProvider];
+      await this.writeProjectSpec(project);
+
+      return { success: true, capacityProviderName: capacityProvider.name };
+    } catch (err) {
+      return { success: false, error: toError(err) };
+    }
+  }
+
+  async remove(name: string): Promise<Result> {
+    try {
+      const project = await this.readProjectSpec();
+      const existing = project.capacityProviders ?? [];
+
+      if (!existing.some(cp => cp.name === name)) {
+        return { success: false, error: new ResourceNotFoundError(`Capacity provider "${name}" not found.`) };
+      }
+
+      const remaining = existing.filter(cp => cp.name !== name);
+      await this.writeProjectSpec({
+        ...project,
+        capacityProviders: remaining.length > 0 ? remaining : undefined,
+      });
+
+      return { success: true };
+    } catch (err) {
+      return { success: false, error: toError(err) };
+    }
+  }
+
+  async previewRemove(name: string): Promise<RemovalPreview> {
+    const project = await this.readProjectSpec();
+    const existing = project.capacityProviders ?? [];
+
+    if (!existing.some(cp => cp.name === name)) {
+      throw new Error(`Capacity provider "${name}" not found.`);
+    }
+
+    const remaining = existing.filter(cp => cp.name !== name);
+    const schemaChanges: SchemaChange[] = [
+      {
+        file: 'agentcore/agentcore.json',
+        before: project,
+        after: { ...project, capacityProviders: remaining.length > 0 ? remaining : undefined },
+      },
+    ];
+
+    return {
+      summary: [`Removing capacity provider: ${name}`],
+      directoriesToDelete: [],
+      schemaChanges,
+    };
+  }
+
+  async getRemovable(): Promise<RemovableResource[]> {
+    try {
+      const project = await this.readProjectSpec();
+      return (project.capacityProviders ?? []).map(cp => ({ name: cp.name }));
+    } catch {
+      return [];
+    }
+  }
+
+  /** Names of all capacity providers in the project (for duplicate checks in the TUI). */
+  async getAllNames(): Promise<string[]> {
+    try {
+      const project = await this.readProjectSpec();
+      return (project.capacityProviders ?? []).map(cp => cp.name);
+    } catch {
+      return [];
+    }
+  }
+
+  registerCommands(addCmd: Command, removeCmd: Command): void {
+    addCmd
+      .command('capacity-provider')
+      .description('Add a capacity provider (customer-managed EC2 compute pool for agent runtimes)')
+      .option('--name <name>', 'Capacity provider name [non-interactive]')
+      .option(
+        '--operator-role-arn <arn>',
+        'IAM role ARN AgentCore assumes to manage the capacity provider. Optional — omit to have one created automatically [non-interactive]'
+      )
+      .option('--description <desc>', 'Capacity provider description [non-interactive]')
+      .option('--subnets <subnets>', 'Comma-separated subnet IDs (1-16) [non-interactive]')
+      .option('--security-groups <groups>', 'Comma-separated security group IDs (1-16) [non-interactive]')
+      .option('--os <os>', 'Operating system: LINUX_X86_64 or LINUX_ARM64 (default: LINUX_X86_64) [non-interactive]')
+      .option('--instance-types <types>', 'Comma-separated allowed EC2 instance types (1-30) [non-interactive]')
+      .option(
+        '--volume <name:sizeGiB>',
+        'Named EBS volume as name:sizeGiB (repeatable, max 5) [non-interactive]',
+        (val: string, prev: string[] = []) => [...prev, val]
+      )
+      .option('--volume-encrypted', 'Encrypt EBS volumes [non-interactive]')
+      .option('--volume-kms-key <arn>', 'KMS key ARN for EBS volume encryption [non-interactive]')
+      .option('--instance-profile-arn <arn>', 'IAM instance profile ARN for launched instances [non-interactive]')
+      .option('--idle-instance-timeout <seconds>', 'Idle instance timeout in seconds (60-1209600) [non-interactive]')
+      .option('--max-lifetime <seconds>', 'Maximum instance lifetime in seconds (60-1209600) [non-interactive]')
+      .option('--json', 'Output as JSON [non-interactive]')
+      .action(async (rawOptions: Record<string, string | string[] | boolean | undefined>) => {
+        const cliOptions = rawOptions as unknown as AddCapacityProviderOptions & { json?: boolean };
+        if (!findConfigRoot()) {
+          console.error('No agentcore project found. Run `agentcore create` first.');
+          process.exit(1);
+        }
+        await runCliCommand('add.capacity-provider', !!cliOptions.json, async () => {
+          this.validateRequiredOptions(cliOptions);
+
+          const result = await this.add(cliOptions);
+          if (!result.success) {
+            throw result.error;
+          }
+
+          if (cliOptions.json) {
+            console.log(JSON.stringify(serializeResult(result)));
+          } else {
+            console.log(`Added capacity provider '${result.capacityProviderName}'`);
+          }
+
+          const built = this.buildCapacityProvider(cliOptions);
+          const ec2 = built.computeConfiguration.ec2Configuration;
+          return {
+            operating_system: standardize(OperatingSystem, ec2.launchTemplateSource.launchParameters.operatingSystem),
+            instance_type_count:
+              ec2.launchTemplateSource.launchParameters.instanceRequirements.allowedInstanceTypes.length,
+            subnet_count: ec2.vpcConfiguration.subnets.length,
+            security_group_count: ec2.vpcConfiguration.securityGroups.length,
+            volume_count: ec2.volumes?.length ?? 0,
+            has_description: !!built.description,
+          };
+        });
+      });
+
+    this.registerRemoveSubcommand(removeCmd);
+  }
+
+  addScreen(): AddScreenComponent {
+    return null;
+  }
+
+  /**
+   * Validate that all required CLI flags are present, throwing ValidationError
+   * with an actionable message when they are not.
+   */
+  private validateRequiredOptions(options: AddCapacityProviderOptions): void {
+    const missing: string[] = [];
+    if (!options.name) missing.push('--name');
+    if (!options.subnets) missing.push('--subnets');
+    if (!options.securityGroups) missing.push('--security-groups');
+    if (!options.instanceTypes) missing.push('--instance-types');
+    if (missing.length > 0) {
+      throw new ValidationError(`Missing required option(s): ${missing.join(', ')}`);
+    }
+  }
+
+  /**
+   * Build a validated CapacityProvider config from CLI options.
+   * Zod validation (via CapacityProviderSchema.parse) rejects bad input here,
+   * at `add` time, rather than late at deploy/CFN time.
+   */
+  private buildCapacityProvider(options: AddCapacityProviderOptions): CapacityProvider {
+    const volumes = (options.volume ?? []).map(entry => {
+      // Require exactly `name:sizeGiB`. Splitting without a segment count lets `data:20:gp3`
+      // silently drop the trailing segment, and Number() accepts hex/exponent (`0x14`, `2e1`)
+      // as 20 — so validate the size as literal digits instead of trusting Number().
+      const segments = entry.split(':');
+      const [volName, sizeRaw] = segments;
+      if (segments.length !== 2 || !volName || !sizeRaw || !/^[0-9]+$/.test(sizeRaw)) {
+        throw new ValidationError(`Invalid --volume "${entry}". Expected format name:sizeGiB (e.g. data:20).`);
+      }
+      const sizeGiB = Number(sizeRaw);
+      return {
+        ebsConfiguration: {
+          name: volName,
+          sizeGiB,
+          ...(options.volumeEncrypted !== undefined && { encrypted: options.volumeEncrypted }),
+          ...(options.volumeKmsKey && { kmsKeyId: options.volumeKmsKey }),
+        },
+      };
+    });
+
+    const lifecycle: { idleInstanceTimeout?: number; maxLifetime?: number } = {};
+    if (options.idleInstanceTimeout !== undefined) {
+      lifecycle.idleInstanceTimeout = Number(options.idleInstanceTimeout);
+    }
+    if (options.maxLifetime !== undefined) {
+      lifecycle.maxLifetime = Number(options.maxLifetime);
+    }
+
+    const candidate = {
+      name: options.name,
+      ...(options.description && { description: options.description }),
+      ...(options.operatorRoleArn && { operatorRoleArn: options.operatorRoleArn }),
+      computeConfiguration: {
+        ec2Configuration: {
+          launchTemplateSource: {
+            launchParameters: {
+              operatingSystem: options.os ?? 'LINUX_X86_64',
+              instanceRequirements: {
+                allowedInstanceTypes: splitList(options.instanceTypes),
+              },
+              ...(options.instanceProfileArn && { instanceProfileArn: options.instanceProfileArn }),
+            },
+          },
+          vpcConfiguration: {
+            subnets: splitList(options.subnets),
+            securityGroups: splitList(options.securityGroups),
+          },
+          ...(volumes.length > 0 && { volumes }),
+          ...(Object.keys(lifecycle).length > 0 && { lifecycleConfiguration: lifecycle }),
+        },
+      },
+    };
+
+    return CapacityProviderSchema.parse(candidate);
+  }
+}

--- a/src/cli/primitives/__tests__/CapacityProviderPrimitive.test.ts
+++ b/src/cli/primitives/__tests__/CapacityProviderPrimitive.test.ts
@@ -1,0 +1,296 @@
+import type { AgentCoreProjectSpec, CapacityProvider } from '../../../schema';
+import type { AddCapacityProviderOptions } from '../CapacityProviderPrimitive';
+import { CapacityProviderPrimitive } from '../CapacityProviderPrimitive';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockReadProjectSpec = vi.fn();
+const mockWriteProjectSpec = vi.fn();
+
+vi.mock('../../../lib', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../../lib')>();
+  return {
+    ...actual,
+    ConfigIO: class {
+      readProjectSpec = mockReadProjectSpec;
+      writeProjectSpec = mockWriteProjectSpec;
+    },
+    findConfigRoot: vi.fn().mockReturnValue(null),
+  };
+});
+
+function makeProject(overrides: Partial<AgentCoreProjectSpec> = {}): AgentCoreProjectSpec {
+  return {
+    name: 'TestProject',
+    version: 1,
+    managedBy: 'CDK' as const,
+    runtimes: [],
+    memories: [],
+    knowledgeBases: [],
+    credentials: [],
+    evaluators: [],
+    onlineEvalConfigs: [],
+    agentCoreGateways: [],
+    policyEngines: [],
+    configBundles: [],
+    abTests: [],
+    httpGateways: [],
+    harnesses: [],
+    datasets: [],
+    payments: [],
+    ...overrides,
+  };
+}
+
+const OPERATOR_ROLE_ARN = 'arn:aws:iam::123456789012:role/MyOperatorRole';
+
+function baseOptions(overrides: Partial<AddCapacityProviderOptions> = {}): AddCapacityProviderOptions {
+  return {
+    name: 'myCp',
+    operatorRoleArn: OPERATOR_ROLE_ARN,
+    subnets: 'subnet-0123456789abcdef0',
+    securityGroups: 'sg-0123456789abcdef0',
+    instanceTypes: 'c6a.large',
+    ...overrides,
+  };
+}
+
+function makeCapacityProvider(name: string): CapacityProvider {
+  return {
+    name,
+    operatorRoleArn: OPERATOR_ROLE_ARN,
+    computeConfiguration: {
+      ec2Configuration: {
+        launchTemplateSource: {
+          launchParameters: {
+            operatingSystem: 'LINUX_X86_64',
+            instanceRequirements: { allowedInstanceTypes: ['c6a.large'] },
+          },
+        },
+        vpcConfiguration: { subnets: ['subnet-0123456789abcdef0'], securityGroups: ['sg-0123456789abcdef0'] },
+      },
+    },
+  };
+}
+
+const primitive = new CapacityProviderPrimitive();
+
+describe('CapacityProviderPrimitive', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  describe('add()', () => {
+    it('happy path — adds a capacity provider to spec and returns success', async () => {
+      mockReadProjectSpec.mockResolvedValue(makeProject());
+      mockWriteProjectSpec.mockResolvedValue(undefined);
+
+      const result = await primitive.add(baseOptions());
+
+      expect(result.success).toBe(true);
+      expect(result).toHaveProperty('capacityProviderName', 'myCp');
+
+      const written = mockWriteProjectSpec.mock.calls[0]![0] as AgentCoreProjectSpec;
+      expect(written.capacityProviders).toHaveLength(1);
+      const cp = written.capacityProviders![0]!;
+      expect(cp.name).toBe('myCp');
+      expect(cp.operatorRoleArn).toBe(OPERATOR_ROLE_ARN);
+      const ec2 = cp.computeConfiguration.ec2Configuration;
+      expect(ec2.launchTemplateSource.launchParameters.operatingSystem).toBe('LINUX_X86_64');
+      expect(ec2.launchTemplateSource.launchParameters.instanceRequirements.allowedInstanceTypes).toEqual([
+        'c6a.large',
+      ]);
+      expect(ec2.vpcConfiguration.subnets).toEqual(['subnet-0123456789abcdef0']);
+      expect(ec2.vpcConfiguration.securityGroups).toEqual(['sg-0123456789abcdef0']);
+    });
+
+    it('omitting the operator role ARN succeeds — the role is created at deploy time', async () => {
+      mockReadProjectSpec.mockResolvedValue(makeProject());
+      mockWriteProjectSpec.mockResolvedValue(undefined);
+
+      const result = await primitive.add(baseOptions({ operatorRoleArn: undefined }));
+
+      expect(result.success).toBe(true);
+      const written = mockWriteProjectSpec.mock.calls[0]![0] as AgentCoreProjectSpec;
+      const cp = written.capacityProviders![0]!;
+      // The field is omitted entirely (not written as undefined) so the construct auto-creates the role.
+      expect(cp).not.toHaveProperty('operatorRoleArn');
+    });
+
+    it('parses multi-value flags, volumes, and lifecycle', async () => {
+      mockReadProjectSpec.mockResolvedValue(makeProject());
+      mockWriteProjectSpec.mockResolvedValue(undefined);
+
+      await primitive.add(
+        baseOptions({
+          os: 'LINUX_ARM64',
+          description: 'my cp',
+          instanceTypes: 'c7g.large, c7g.xlarge',
+          subnets: 'subnet-0123456789abcdef0,subnet-0fedcba9876543210',
+          securityGroups: 'sg-0123456789abcdef0',
+          volume: ['data:20'],
+          volumeEncrypted: true,
+          idleInstanceTimeout: '3600',
+          maxLifetime: '28800',
+        })
+      );
+
+      const written = mockWriteProjectSpec.mock.calls[0]![0] as AgentCoreProjectSpec;
+      const ec2 = written.capacityProviders![0]!.computeConfiguration.ec2Configuration;
+      expect(ec2.launchTemplateSource.launchParameters.operatingSystem).toBe('LINUX_ARM64');
+      expect(ec2.launchTemplateSource.launchParameters.instanceRequirements.allowedInstanceTypes).toEqual([
+        'c7g.large',
+        'c7g.xlarge',
+      ]);
+      expect(ec2.vpcConfiguration.subnets).toHaveLength(2);
+      expect(ec2.volumes).toEqual([{ ebsConfiguration: { name: 'data', sizeGiB: 20, encrypted: true } }]);
+      expect(ec2.lifecycleConfiguration).toEqual({ idleInstanceTimeout: 3600, maxLifetime: 28800 });
+      expect(written.capacityProviders![0]!.description).toBe('my cp');
+    });
+
+    it('duplicate name — returns error without writing', async () => {
+      mockReadProjectSpec.mockResolvedValue(makeProject({ capacityProviders: [makeCapacityProvider('myCp')] }));
+
+      const result = await primitive.add(baseOptions());
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.message).toContain('myCp');
+        expect(result.error.message).toContain('already exists');
+      }
+      expect(mockWriteProjectSpec).not.toHaveBeenCalled();
+    });
+
+    it('rejects an operator role ARN with a malformed shape', async () => {
+      mockReadProjectSpec.mockResolvedValue(makeProject());
+
+      const result = await primitive.add(baseOptions({ operatorRoleArn: 'not-an-arn' }));
+
+      expect(result.success).toBe(false);
+      expect(mockWriteProjectSpec).not.toHaveBeenCalled();
+    });
+
+    it('accepts an operator role ARN without an account id (account segment optional)', async () => {
+      mockReadProjectSpec.mockResolvedValue(makeProject());
+      mockWriteProjectSpec.mockResolvedValue(undefined);
+
+      const result = await primitive.add(baseOptions({ operatorRoleArn: 'arn:aws:iam:::role/MyRole' }));
+
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects an unsupported operating system value', async () => {
+      mockReadProjectSpec.mockResolvedValue(makeProject());
+
+      const result = await primitive.add(baseOptions({ os: 'WINDOWS_X86_64' }));
+
+      expect(result.success).toBe(false);
+      expect(mockWriteProjectSpec).not.toHaveBeenCalled();
+    });
+
+    it('rejects a malformed --volume value', async () => {
+      mockReadProjectSpec.mockResolvedValue(makeProject());
+
+      const result = await primitive.add(baseOptions({ volume: ['data-no-size'] }));
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.message).toContain('name:sizeGiB');
+      }
+      expect(mockWriteProjectSpec).not.toHaveBeenCalled();
+    });
+
+    // A plain split(':') + Number() silently accepted all of these before the fix:
+    // extra segments were dropped, and hex/exponent notation coerced to a number.
+    it.each([
+      ['extra segment', 'data:20:gp3'],
+      ['hex size', 'data:0x14'],
+      ['exponent size', 'data:2e1'],
+      ['decimal size', 'data:20.5'],
+      ['empty size', 'data:'],
+    ])('rejects a --volume with %s (%s)', async (_label, value) => {
+      mockReadProjectSpec.mockResolvedValue(makeProject());
+
+      const result = await primitive.add(baseOptions({ volume: [value] }));
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.message).toContain('name:sizeGiB');
+      }
+      expect(mockWriteProjectSpec).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('remove()', () => {
+    it('removes a capacity provider from spec', async () => {
+      const project = makeProject({
+        capacityProviders: [makeCapacityProvider('cpA'), makeCapacityProvider('cpB')],
+      });
+      mockReadProjectSpec.mockResolvedValue(project);
+      mockWriteProjectSpec.mockResolvedValue(undefined);
+
+      const result = await primitive.remove('cpA');
+
+      expect(result.success).toBe(true);
+      const written = mockWriteProjectSpec.mock.calls[0]![0] as AgentCoreProjectSpec;
+      expect(written.capacityProviders).toHaveLength(1);
+      expect(written.capacityProviders![0]!.name).toBe('cpB');
+    });
+
+    it('drops the array to undefined when removing the last capacity provider', async () => {
+      const project = makeProject({ capacityProviders: [makeCapacityProvider('only')] });
+      mockReadProjectSpec.mockResolvedValue(project);
+      mockWriteProjectSpec.mockResolvedValue(undefined);
+
+      await primitive.remove('only');
+
+      const written = mockWriteProjectSpec.mock.calls[0]![0] as AgentCoreProjectSpec;
+      expect(written.capacityProviders).toBeUndefined();
+    });
+
+    it('non-existent name — returns error without writing', async () => {
+      mockReadProjectSpec.mockResolvedValue(makeProject());
+
+      const result = await primitive.remove('missing');
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.message).toContain('missing');
+        expect(result.error.message).toContain('not found');
+      }
+      expect(mockWriteProjectSpec).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getRemovable()', () => {
+    it('returns capacity provider names from spec', async () => {
+      mockReadProjectSpec.mockResolvedValue(
+        makeProject({ capacityProviders: [makeCapacityProvider('alpha'), makeCapacityProvider('beta')] })
+      );
+
+      expect(await primitive.getRemovable()).toEqual([{ name: 'alpha' }, { name: 'beta' }]);
+    });
+
+    it('returns empty array when none exist', async () => {
+      mockReadProjectSpec.mockResolvedValue(makeProject());
+      expect(await primitive.getRemovable()).toEqual([]);
+    });
+  });
+
+  describe('previewRemove()', () => {
+    it('returns summary and schema changes', async () => {
+      const project = makeProject({ capacityProviders: [makeCapacityProvider('previewCp')] });
+      mockReadProjectSpec.mockResolvedValue(project);
+
+      const preview = await primitive.previewRemove('previewCp');
+
+      expect(preview.summary[0]).toContain('previewCp');
+      expect(preview.schemaChanges).toHaveLength(1);
+      expect(preview.schemaChanges[0]!.file).toBe('agentcore/agentcore.json');
+      const after = preview.schemaChanges[0]!.after as AgentCoreProjectSpec;
+      expect(after.capacityProviders).toBeUndefined();
+    });
+
+    it('throws when not found', async () => {
+      mockReadProjectSpec.mockResolvedValue(makeProject());
+      await expect(primitive.previewRemove('missing')).rejects.toThrow('not found');
+    });
+  });
+});

--- a/src/cli/primitives/index.ts
+++ b/src/cli/primitives/index.ts
@@ -10,6 +10,8 @@ export { EvaluatorPrimitive } from './EvaluatorPrimitive';
 export { OnlineEvalConfigPrimitive } from './OnlineEvalConfigPrimitive';
 export { GatewayPrimitive } from './GatewayPrimitive';
 export { GatewayTargetPrimitive } from './GatewayTargetPrimitive';
+export { CapacityProviderPrimitive } from './CapacityProviderPrimitive';
+export type { AddCapacityProviderOptions } from './CapacityProviderPrimitive';
 export { RuntimeEndpointPrimitive } from './RuntimeEndpointPrimitive';
 export type { AddRuntimeEndpointOptions, RemovableRuntimeEndpoint } from './RuntimeEndpointPrimitive';
 export {
@@ -23,6 +25,7 @@ export {
   onlineEvalConfigPrimitive,
   gatewayPrimitive,
   gatewayTargetPrimitive,
+  capacityProviderPrimitive,
   configBundlePrimitive,
   runtimeEndpointPrimitive,
   getPrimitive,

--- a/src/cli/primitives/registry.ts
+++ b/src/cli/primitives/registry.ts
@@ -1,5 +1,6 @@
 import { AgentPrimitive } from './AgentPrimitive';
 import type { BasePrimitive } from './BasePrimitive';
+import { CapacityProviderPrimitive } from './CapacityProviderPrimitive';
 import { ConfigBundlePrimitive } from './ConfigBundlePrimitive';
 import { CredentialPrimitive } from './CredentialPrimitive';
 import { DatasetPrimitive } from './DatasetPrimitive';
@@ -38,6 +39,7 @@ export const configBundlePrimitive = new ConfigBundlePrimitive();
 export const runtimeEndpointPrimitive = new RuntimeEndpointPrimitive();
 export const paymentManagerPrimitive = new PaymentManagerPrimitive();
 export const paymentConnectorPrimitive = new PaymentConnectorPrimitive();
+export const capacityProviderPrimitive = new CapacityProviderPrimitive();
 
 /**
  * All primitives in display order.
@@ -60,6 +62,7 @@ export const ALL_PRIMITIVES: BasePrimitive<unknown, RemovableResource>[] = [
   runtimeEndpointPrimitive,
   paymentManagerPrimitive,
   paymentConnectorPrimitive,
+  capacityProviderPrimitive,
 ];
 
 /**

--- a/src/cli/project.ts
+++ b/src/cli/project.ts
@@ -24,6 +24,7 @@ export function createDefaultProjectSpec(projectName: string): AgentCoreProjectS
     abTests: [],
     datasets: [],
     payments: [],
+    capacityProviders: [],
     tags: {
       'agentcore:created-by': 'agentcore-cli',
       'agentcore:project-name': projectName,

--- a/src/cli/telemetry/schemas/command-run.ts
+++ b/src/cli/telemetry/schemas/command-run.ts
@@ -25,6 +25,7 @@ import {
   Mode,
   ModelProvider,
   NetworkMode,
+  OperatingSystem,
   OutboundAuthType,
   PolicyAttrSourceType,
   PolicyEngineMode,
@@ -112,6 +113,15 @@ const AddPolicyAttrs = safeSchema({
 });
 
 const AddSkillAttrs = safeSchema({ skill_source_type: SkillSourceType });
+
+const AddCapacityProviderAttrs = safeSchema({
+  operating_system: OperatingSystem,
+  instance_type_count: Count,
+  subnet_count: Count,
+  security_group_count: Count,
+  volume_count: Count,
+  has_description: z.boolean(),
+});
 
 const DeployAttrs = safeSchema({
   runtime_count: Count,
@@ -244,6 +254,7 @@ export const COMMAND_SCHEMAS = {
   'add.knowledge-base': AddKnowledgeBaseAttrs,
   'add.payment-manager': NoAttrs,
   'add.payment-connector': NoAttrs,
+  'add.capacity-provider': AddCapacityProviderAttrs,
   'add.skill': AddSkillAttrs,
   deploy: DeployAttrs,
 
@@ -307,6 +318,7 @@ export const COMMAND_SCHEMAS = {
   'dataset.remove-version': NoAttrs,
   'remove.payment-manager': NoAttrs,
   'remove.payment-connector': NoAttrs,
+  'remove.capacity-provider': NoAttrs,
   'remove.skill': NoAttrs,
   'telemetry.disable': NoAttrs,
   'telemetry.enable': NoAttrs,

--- a/src/cli/telemetry/schemas/common-shapes.ts
+++ b/src/cli/telemetry/schemas/common-shapes.ts
@@ -55,6 +55,7 @@ export const FilterType = z.enum([
   'config-bundle',
   'dataset',
   'harness',
+  'capacity-provider',
   'none',
 ]);
 export const AgentEnvironment = z.enum(['harness', 'runtime']);
@@ -89,6 +90,7 @@ export const MemoryType = z.enum(['none', 'shortterm', 'longandshortterm']);
 export const Mode = z.enum(['cli', 'tui']);
 export const ModelProvider = z.enum(['bedrock', 'anthropic', 'openai', 'gemini', 'lite_llm']);
 export const NetworkMode = z.enum(['public', 'vpc']);
+export const OperatingSystem = z.enum(['linux_x86_64', 'linux_arm64']);
 export const OutboundAuthType = z.enum(['oauth', 'api-key', 'none']);
 export const PolicyEngineMode = z.enum(['log_only', 'enforce']);
 export const AgentProtocol = z.enum(['http', 'mcp', 'a2a', 'agui']);

--- a/src/cli/tui/components/ResourceGraph.tsx
+++ b/src/cli/tui/components/ResourceGraph.tsx
@@ -26,6 +26,7 @@ const ICONS = {
   'runtime-endpoint': '◉',
   'knowledge-base': '✚',
   payment: '₿',
+  'capacity-provider': '▦',
 } as const;
 
 interface ResourceGraphProps {
@@ -138,6 +139,7 @@ export function ResourceGraph({ project, mcp, agentName, resourceStatuses }: Res
   const configBundles = project.configBundles ?? [];
   const datasets = project.datasets ?? [];
   const payments = project.payments ?? [];
+  const capacityProviders = project.capacityProviders ?? [];
   const harnesses = project.harnesses ?? [];
 
   // Build lookup map and collect pending-removal resources in a single pass
@@ -432,6 +434,29 @@ export function ResourceGraph({ project, mcp, agentName, resourceStatuses }: Res
                   </Text>
                 ))}
               </Box>
+            );
+          })}
+        </Box>
+      )}
+
+      {/* Capacity Providers */}
+      {capacityProviders.length > 0 && (
+        <Box flexDirection="column">
+          <SectionHeader>Capacity Providers</SectionHeader>
+          {capacityProviders.map(cp => {
+            const rsEntry = statusMap.get(`capacity-provider:${cp.name}`);
+            const localDetail =
+              cp.computeConfiguration.ec2Configuration.launchTemplateSource.launchParameters.operatingSystem;
+            return (
+              <ResourceRow
+                key={cp.name}
+                icon={ICONS['capacity-provider']}
+                color="cyan"
+                name={cp.name}
+                detail={rsEntry?.detail ?? localDetail}
+                deploymentState={rsEntry?.deploymentState}
+                identifier={rsEntry?.identifier}
+              />
             );
           })}
         </Box>

--- a/src/cli/tui/hooks/useRemove.ts
+++ b/src/cli/tui/hooks/useRemove.ts
@@ -9,6 +9,7 @@ import type { RemovablePolicyResource } from '../../primitives/PolicyPrimitive';
 import type { RemovableRuntimeEndpoint } from '../../primitives/RuntimeEndpointPrimitive';
 import {
   agentPrimitive,
+  capacityProviderPrimitive,
   configBundlePrimitive,
   credentialPrimitive,
   datasetPrimitive,
@@ -162,6 +163,11 @@ export function useRemovableDatasets() {
   return { datasets, ...rest };
 }
 
+export function useRemovableCapacityProviders() {
+  const { items: capacityProviders, ...rest } = useRemovableResources(() => capacityProviderPrimitive.getRemovable());
+  return { capacityProviders, ...rest };
+}
+
 export function useRemovableKnowledgeBases() {
   const { items: knowledgeBases, ...rest } = useRemovableResources(() => knowledgeBasePrimitive.getRemovable());
   return { knowledgeBases, ...rest };
@@ -297,6 +303,11 @@ export function useRemovalPreview() {
     [loadPreview]
   );
 
+  const loadCapacityProviderPreview = useCallback(
+    (name: string) => loadPreview(n => capacityProviderPrimitive.previewRemove(n), name),
+    [loadPreview]
+  );
+
   const reset = useCallback(() => {
     setState({ isLoading: false, preview: null, error: null });
   }, []);
@@ -317,6 +328,7 @@ export function useRemovalPreview() {
     loadPolicyPreview,
     loadConfigBundlePreview,
     loadRuntimeEndpointPreview,
+    loadCapacityProviderPreview,
     reset,
   };
 }
@@ -392,6 +404,14 @@ export function useRemoveDataset() {
   return useRemoveResource(
     (name: string) => datasetPrimitive.remove(name),
     'dataset',
+    name => name
+  );
+}
+
+export function useRemoveCapacityProvider() {
+  return useRemoveResource(
+    (name: string) => capacityProviderPrimitive.remove(name),
+    'capacity-provider',
     name => name
   );
 }

--- a/src/cli/tui/screens/add/AddFlow.tsx
+++ b/src/cli/tui/screens/add/AddFlow.tsx
@@ -7,6 +7,7 @@ import { AddAgentFlow } from '../agent/AddAgentFlow';
 import type { AddAgentConfig } from '../agent/types';
 import { FRAMEWORK_OPTIONS } from '../agent/types';
 import { useAddAgent } from '../agent/useAddAgent';
+import { AddCapacityProviderFlow } from '../capacity-provider';
 import { AddConfigBundleFlow } from '../config-bundle';
 import { AddDatasetFlow } from '../dataset';
 import { AddEvaluatorFlow } from '../evaluator';
@@ -45,6 +46,7 @@ type FlowState =
   | { name: 'runtime-endpoint-wizard' }
   | { name: 'payment-manager-wizard' }
   | { name: 'payment-connector-wizard' }
+  | { name: 'capacity-provider-wizard' }
   | {
       name: 'agent-create-success';
       agentName: string;
@@ -220,6 +222,8 @@ function getInitialFlowState(resource?: AddResourceType): FlowState {
       return { name: 'payment-manager-wizard' };
     case 'payment-connector':
       return { name: 'payment-connector-wizard' };
+    case 'capacity-provider':
+      return { name: 'capacity-provider-wizard' };
     default:
       return { name: 'select' };
   }
@@ -295,6 +299,9 @@ export function AddFlow(props: AddFlowProps) {
         break;
       case 'payment-connector':
         setFlow({ name: 'payment-connector-wizard' });
+        break;
+      case 'capacity-provider':
+        setFlow({ name: 'capacity-provider-wizard' });
         break;
     }
   }, []);
@@ -632,6 +639,19 @@ export function AddFlow(props: AddFlowProps) {
       <AddPaymentFlow
         isInteractive={props.isInteractive}
         initialAction="connector"
+        onExit={props.onExit}
+        onBack={() => setFlow({ name: 'select' })}
+        onDev={props.onDev}
+        onDeploy={props.onDeploy}
+      />
+    );
+  }
+
+  // Capacity provider wizard
+  if (flow.name === 'capacity-provider-wizard') {
+    return (
+      <AddCapacityProviderFlow
+        isInteractive={props.isInteractive}
         onExit={props.onExit}
         onBack={() => setFlow({ name: 'select' })}
         onDev={props.onDev}

--- a/src/cli/tui/screens/add/AddScreen.tsx
+++ b/src/cli/tui/screens/add/AddScreen.tsx
@@ -17,7 +17,8 @@ export type AddResourceType =
   | 'config-bundle'
   | 'dataset'
   | 'payment-manager'
-  | 'payment-connector';
+  | 'payment-connector'
+  | 'capacity-provider';
 
 const BASE_ADD_RESOURCES: { id: AddResourceType; title: string; description: string }[] = [
   { id: 'agent', title: 'Agent', description: 'Deploy an HTTP, MCP, A2A, or AG-UI agent' },
@@ -38,6 +39,11 @@ const BASE_ADD_RESOURCES: { id: AddResourceType; title: string; description: str
     id: 'payment-connector',
     title: 'Payment Connector',
     description: 'Link payment provider credentials to a manager',
+  },
+  {
+    id: 'capacity-provider',
+    title: 'Capacity Provider [preview]',
+    description: 'Customer-managed EC2 compute pool for runtimes',
   },
 ];
 

--- a/src/cli/tui/screens/add/__tests__/AddScreen.test.tsx
+++ b/src/cli/tui/screens/add/__tests__/AddScreen.test.tsx
@@ -23,4 +23,10 @@ describe('AddScreen', () => {
     expect(lastFrame()).toContain('Payment Manager');
     expect(lastFrame()).toContain('Payment Connector');
   });
+
+  it('capacity provider is a top-level option', () => {
+    const { lastFrame } = render(<AddScreen onSelect={vi.fn()} onExit={vi.fn()} />);
+
+    expect(lastFrame()).toContain('Capacity Provider');
+  });
 });

--- a/src/cli/tui/screens/capacity-provider/AddCapacityProviderFlow.tsx
+++ b/src/cli/tui/screens/capacity-provider/AddCapacityProviderFlow.tsx
@@ -1,0 +1,106 @@
+import { capacityProviderPrimitive } from '../../../primitives/registry';
+import { ErrorPrompt } from '../../components';
+import { AddSuccessScreen } from '../add/AddSuccessScreen';
+import type { AddCapacityProviderConfig } from './AddCapacityProviderScreen';
+import { AddCapacityProviderScreen } from './AddCapacityProviderScreen';
+import { Box, Text } from 'ink';
+import React, { useCallback, useEffect, useState } from 'react';
+
+type FlowState =
+  | { name: 'create-wizard' }
+  | { name: 'create-success'; capacityProviderName: string; os: string; instanceTypes: string; description?: string }
+  | { name: 'error'; message: string };
+
+interface AddCapacityProviderFlowProps {
+  isInteractive?: boolean;
+  onExit: () => void;
+  onBack: () => void;
+  onDev?: () => void;
+  onDeploy?: () => void;
+}
+
+export function AddCapacityProviderFlow({
+  isInteractive = true,
+  onExit,
+  onBack,
+  onDev,
+  onDeploy,
+}: AddCapacityProviderFlowProps) {
+  const [flow, setFlow] = useState<FlowState>({ name: 'create-wizard' });
+  const [existingNames, setExistingNames] = useState<string[]>([]);
+
+  useEffect(() => {
+    void capacityProviderPrimitive.getAllNames().then(setExistingNames);
+  }, []);
+
+  // In non-interactive mode, exit after success
+  useEffect(() => {
+    if (!isInteractive && flow.name === 'create-success') {
+      onExit();
+    }
+  }, [isInteractive, flow.name, onExit]);
+
+  const handleCreateComplete = useCallback((config: AddCapacityProviderConfig) => {
+    void capacityProviderPrimitive
+      .add({
+        name: config.name,
+        operatorRoleArn: config.operatorRoleArn,
+        description: config.description,
+        subnets: config.subnets,
+        securityGroups: config.securityGroups,
+        os: config.os,
+        instanceTypes: config.instanceTypes,
+      })
+      .then(result => {
+        if (result.success) {
+          setFlow({
+            name: 'create-success',
+            capacityProviderName: result.capacityProviderName,
+            os: config.os,
+            instanceTypes: config.instanceTypes,
+            description: config.description,
+          });
+          return;
+        }
+        setFlow({ name: 'error', message: result.error.message });
+      });
+  }, []);
+
+  if (flow.name === 'create-wizard') {
+    return (
+      <AddCapacityProviderScreen existingNames={existingNames} onComplete={handleCreateComplete} onExit={onBack} />
+    );
+  }
+
+  if (flow.name === 'create-success') {
+    return (
+      <AddSuccessScreen
+        isInteractive={isInteractive}
+        message={`Added capacity provider: ${flow.capacityProviderName}`}
+        detail="Deploy with `agentcore deploy`."
+        summary={
+          <Box flexDirection="column" marginTop={1}>
+            <Text dimColor> OS: {flow.os}</Text>
+            <Text dimColor> Instance types: {flow.instanceTypes}</Text>
+            {flow.description && <Text dimColor> Desc: {flow.description}</Text>}
+          </Box>
+        }
+        onAddAnother={onBack}
+        onDev={onDev}
+        onDeploy={onDeploy}
+        onExit={onExit}
+      />
+    );
+  }
+
+  return (
+    <ErrorPrompt
+      message="Failed to add capacity provider"
+      detail={flow.message}
+      onBack={() => {
+        setFlow({ name: 'create-wizard' });
+      }}
+      onExit={onExit}
+    />
+  );
+}

--- a/src/cli/tui/screens/capacity-provider/AddCapacityProviderScreen.tsx
+++ b/src/cli/tui/screens/capacity-provider/AddCapacityProviderScreen.tsx
@@ -1,0 +1,262 @@
+import type { OperatingSystem } from '../../../../schema';
+import { CapacityProviderNameSchema, isValidOperatorRoleArn } from '../../../../schema';
+import { ConfirmReview, Panel, Screen, StepIndicator, TextInput, WizardSelect } from '../../components';
+import type { SelectableItem } from '../../components';
+import { HELP_TEXT } from '../../constants';
+import { useListNavigation } from '../../hooks';
+import { generateUniqueName } from '../../utils';
+import React, { useMemo, useState } from 'react';
+
+const OS_OPTIONS: SelectableItem[] = [
+  { id: 'LINUX_X86_64', title: 'Linux x86_64', description: 'Intel/AMD 64-bit Linux instances' },
+  { id: 'LINUX_ARM64', title: 'Linux ARM64', description: 'Graviton/ARM 64-bit Linux instances' },
+];
+
+export interface AddCapacityProviderConfig {
+  name: string;
+  operatorRoleArn?: string;
+  description?: string;
+  subnets: string;
+  securityGroups: string;
+  os: OperatingSystem;
+  instanceTypes: string;
+}
+
+type Step =
+  | 'name'
+  | 'operator-role'
+  | 'subnets'
+  | 'security-groups'
+  | 'os'
+  | 'instance-types'
+  | 'description'
+  | 'confirm';
+
+const STEP_LABELS: Record<Step, string> = {
+  name: 'Name',
+  'operator-role': 'Operator Role',
+  subnets: 'Subnets',
+  'security-groups': 'Security Groups',
+  os: 'OS',
+  'instance-types': 'Instance Types',
+  description: 'Description',
+  confirm: 'Confirm',
+};
+
+const STEPS: Step[] = [
+  'name',
+  'operator-role',
+  'subnets',
+  'security-groups',
+  'os',
+  'instance-types',
+  'description',
+  'confirm',
+];
+
+const SUBNET_PATTERN = /^subnet-[0-9a-zA-Z]{8,17}$/;
+const SECURITY_GROUP_PATTERN = /^sg-[0-9a-zA-Z]{8,17}$/;
+
+function splitList(value: string): string[] {
+  return value
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean);
+}
+
+interface AddCapacityProviderScreenProps {
+  onComplete: (config: AddCapacityProviderConfig) => void;
+  onExit: () => void;
+  existingNames: string[];
+}
+
+export function AddCapacityProviderScreen({ onComplete, onExit, existingNames }: AddCapacityProviderScreenProps) {
+  const [step, setStep] = useState<Step>('name');
+  const [name, setName] = useState('');
+  const [operatorRoleArn, setOperatorRoleArn] = useState('');
+  const [subnets, setSubnets] = useState('');
+  const [securityGroups, setSecurityGroups] = useState('');
+  const [os, setOs] = useState<OperatingSystem>('LINUX_X86_64');
+  const [instanceTypes, setInstanceTypes] = useState('');
+  const [description, setDescription] = useState('');
+
+  const isNameStep = step === 'name';
+  const isOperatorRoleStep = step === 'operator-role';
+  const isSubnetsStep = step === 'subnets';
+  const isSecurityGroupsStep = step === 'security-groups';
+  const isOsStep = step === 'os';
+  const isInstanceTypesStep = step === 'instance-types';
+  const isDescriptionStep = step === 'description';
+  const isConfirmStep = step === 'confirm';
+
+  const osNav = useListNavigation({
+    items: OS_OPTIONS,
+    isActive: isOsStep,
+    onSelect: (item: SelectableItem) => {
+      setOs(item.id as OperatingSystem);
+      setStep('instance-types');
+    },
+    onExit: () => setStep('security-groups'),
+  });
+
+  useListNavigation({
+    items: [{ id: 'confirm', title: 'Confirm' }],
+    onSelect: () =>
+      onComplete({
+        name,
+        operatorRoleArn: operatorRoleArn || undefined,
+        subnets,
+        securityGroups,
+        os,
+        instanceTypes,
+        description: description || undefined,
+      }),
+    onExit: () => setStep('description'),
+    isActive: isConfirmStep,
+  });
+
+  const helpText = isOsStep
+    ? HELP_TEXT.NAVIGATE_SELECT
+    : isConfirmStep
+      ? HELP_TEXT.CONFIRM_CANCEL
+      : HELP_TEXT.TEXT_INPUT;
+
+  const headerContent = <StepIndicator steps={STEPS} currentStep={step} labels={STEP_LABELS} />;
+
+  const confirmFields = useMemo(
+    () => [
+      { label: 'Name', value: name },
+      { label: 'Operator Role ARN', value: operatorRoleArn || '(auto-created)' },
+      { label: 'Subnets', value: splitList(subnets).join(', ') },
+      { label: 'Security Groups', value: splitList(securityGroups).join(', ') },
+      { label: 'OS', value: os },
+      { label: 'Instance Types', value: splitList(instanceTypes).join(', ') },
+      ...(description ? [{ label: 'Description', value: description }] : []),
+    ],
+    [name, operatorRoleArn, subnets, securityGroups, os, instanceTypes, description]
+  );
+
+  return (
+    <Screen
+      title="Add Capacity Provider"
+      onExit={onExit}
+      helpText={helpText}
+      headerContent={headerContent}
+      exitEnabled={isNameStep}
+    >
+      <Panel>
+        {isNameStep && (
+          <TextInput
+            key="name"
+            prompt="Capacity provider name"
+            initialValue={name || generateUniqueName('MyCapacityProvider', existingNames)}
+            onSubmit={(value: string) => {
+              setName(value);
+              setStep('operator-role');
+            }}
+            onCancel={onExit}
+            schema={CapacityProviderNameSchema}
+            customValidation={value => !existingNames.includes(value) || 'Capacity provider name already exists'}
+          />
+        )}
+
+        {isOperatorRoleStep && (
+          <TextInput
+            key="operator-role"
+            prompt="Operator role ARN (optional, press Enter to auto-create)"
+            initialValue={operatorRoleArn}
+            onSubmit={(value: string) => {
+              setOperatorRoleArn(value);
+              setStep('subnets');
+            }}
+            onCancel={() => setStep('name')}
+            allowEmpty
+            customValidation={value =>
+              value.trim() === '' || isValidOperatorRoleArn(value) || 'Must be a valid IAM role ARN'
+            }
+          />
+        )}
+
+        {isSubnetsStep && (
+          <TextInput
+            key="subnets"
+            prompt="Subnet IDs (comma-separated, 1-16)"
+            initialValue={subnets}
+            onSubmit={(value: string) => {
+              setSubnets(value);
+              setStep('security-groups');
+            }}
+            onCancel={() => setStep('operator-role')}
+            customValidation={value => {
+              const ids = splitList(value);
+              if (ids.length < 1 || ids.length > 16) return 'Provide 1-16 subnet IDs';
+              return ids.every(id => SUBNET_PATTERN.test(id)) || 'Each must be a valid subnet ID (subnet-...)';
+            }}
+          />
+        )}
+
+        {isSecurityGroupsStep && (
+          <TextInput
+            key="security-groups"
+            prompt="Security group IDs (comma-separated, 1-16)"
+            initialValue={securityGroups}
+            onSubmit={(value: string) => {
+              setSecurityGroups(value);
+              setStep('os');
+            }}
+            onCancel={() => setStep('subnets')}
+            customValidation={value => {
+              const ids = splitList(value);
+              if (ids.length < 1 || ids.length > 16) return 'Provide 1-16 security group IDs';
+              return (
+                ids.every(id => SECURITY_GROUP_PATTERN.test(id)) || 'Each must be a valid security group ID (sg-...)'
+              );
+            }}
+          />
+        )}
+
+        {isOsStep && (
+          <WizardSelect
+            title="Operating system"
+            description="CPU architecture for the capacity provider instances"
+            items={OS_OPTIONS}
+            selectedIndex={osNav.selectedIndex}
+          />
+        )}
+
+        {isInstanceTypesStep && (
+          <TextInput
+            key="instance-types"
+            prompt="Allowed EC2 instance types (comma-separated, 1-30)"
+            initialValue={instanceTypes}
+            onSubmit={(value: string) => {
+              setInstanceTypes(value);
+              setStep('description');
+            }}
+            onCancel={() => setStep('os')}
+            customValidation={value => {
+              const types = splitList(value);
+              return (types.length >= 1 && types.length <= 30) || 'Provide 1-30 instance types';
+            }}
+          />
+        )}
+
+        {isDescriptionStep && (
+          <TextInput
+            key="description"
+            prompt="Description (optional, press Enter to skip)"
+            initialValue={description}
+            onSubmit={(value: string) => {
+              setDescription(value);
+              setStep('confirm');
+            }}
+            onCancel={() => setStep('instance-types')}
+            allowEmpty
+          />
+        )}
+
+        {isConfirmStep && <ConfirmReview fields={confirmFields} />}
+      </Panel>
+    </Screen>
+  );
+}

--- a/src/cli/tui/screens/capacity-provider/index.ts
+++ b/src/cli/tui/screens/capacity-provider/index.ts
@@ -1,0 +1,3 @@
+export { AddCapacityProviderFlow } from './AddCapacityProviderFlow';
+export { AddCapacityProviderScreen } from './AddCapacityProviderScreen';
+export type { AddCapacityProviderConfig } from './AddCapacityProviderScreen';

--- a/src/cli/tui/screens/remove/RemoveCapacityProviderScreen.tsx
+++ b/src/cli/tui/screens/remove/RemoveCapacityProviderScreen.tsx
@@ -1,0 +1,30 @@
+import type { RemovableResource } from '../../../primitives/types';
+import { SelectScreen } from '../../components';
+import React from 'react';
+
+interface RemoveCapacityProviderScreenProps {
+  capacityProviders: RemovableResource[];
+  onSelect: (capacityProviderName: string) => void;
+  onExit: () => void;
+}
+
+export function RemoveCapacityProviderScreen({
+  capacityProviders,
+  onSelect,
+  onExit,
+}: RemoveCapacityProviderScreenProps) {
+  const items = capacityProviders.map(cp => ({
+    id: cp.name,
+    title: cp.name,
+    description: 'Capacity Provider',
+  }));
+
+  return (
+    <SelectScreen
+      title="Select Capacity Provider to Remove"
+      items={items}
+      onSelect={item => onSelect(item.id)}
+      onExit={onExit}
+    />
+  );
+}

--- a/src/cli/tui/screens/remove/RemoveFlow.tsx
+++ b/src/cli/tui/screens/remove/RemoveFlow.tsx
@@ -4,6 +4,7 @@ import { harnessPrimitive, paymentManagerPrimitive } from '../../../primitives/r
 import { ErrorPrompt, Panel, Screen, SelectScreen } from '../../components';
 import {
   useRemovableAgents,
+  useRemovableCapacityProviders,
   useRemovableConfigBundles,
   useRemovableDatasets,
   useRemovableEvaluators,
@@ -20,6 +21,7 @@ import {
   useRemovableRuntimeEndpoints,
   useRemovalPreview,
   useRemoveAgent,
+  useRemoveCapacityProvider,
   useRemoveConfigBundle,
   useRemoveDataset,
   useRemoveEvaluator,
@@ -36,6 +38,7 @@ import {
 } from '../../hooks/useRemove';
 import { RemoveAgentScreen } from './RemoveAgentScreen';
 import { RemoveAllScreen } from './RemoveAllScreen';
+import { RemoveCapacityProviderScreen } from './RemoveCapacityProviderScreen';
 import { RemoveConfigBundleScreen } from './RemoveConfigBundleScreen';
 import { RemoveConfirmScreen } from './RemoveConfirmScreen';
 import { RemoveDatasetScreen } from './RemoveDatasetScreen';
@@ -75,6 +78,7 @@ type FlowState =
   | { name: 'select-config-bundle' }
   | { name: 'select-runtime-endpoint' }
   | { name: 'select-payment' }
+  | { name: 'select-capacity-provider' }
   | { name: 'confirm-agent'; agentName: string; preview: RemovalPreview }
   | { name: 'confirm-gateway'; gatewayName: string; preview: RemovalPreview }
   | { name: 'confirm-gateway-target'; tool: RemovableGatewayTarget; preview: RemovalPreview }
@@ -89,6 +93,7 @@ type FlowState =
   | { name: 'confirm-config-bundle'; bundleName: string; preview: RemovalPreview }
   | { name: 'confirm-runtime-endpoint'; endpointName: string; preview: RemovalPreview }
   | { name: 'confirm-payment'; managerName: string; preview: RemovalPreview }
+  | { name: 'confirm-capacity-provider'; capacityProviderName: string; preview: RemovalPreview }
   | { name: 'loading'; message: string }
   | { name: 'harness-success'; harnessName: string; logFilePath?: string }
   | { name: 'agent-success'; agentName: string; logFilePath?: string }
@@ -105,6 +110,7 @@ type FlowState =
   | { name: 'config-bundle-success'; bundleName: string; logFilePath?: string }
   | { name: 'runtime-endpoint-success'; endpointName: string; logFilePath?: string }
   | { name: 'payment-success'; managerName: string }
+  | { name: 'capacity-provider-success'; capacityProviderName: string; logFilePath?: string }
   | { name: 'remove-all' }
   | { name: 'error'; message: string };
 
@@ -136,6 +142,7 @@ interface RemoveFlowProps {
     | 'payment'
     | 'payment-manager'
     | 'payment-connector'
+    | 'capacity-provider'
     | 'all';
   /** Initial resource name to auto-select (for CLI --name flag) */
   initialResourceName?: string;
@@ -186,6 +193,8 @@ export function RemoveFlow({
       case 'payment-manager':
       case 'payment-connector':
         return { name: 'select-payment' };
+      case 'capacity-provider':
+        return { name: 'select-capacity-provider' };
       case 'all':
         return { name: 'remove-all' };
       default:
@@ -230,6 +239,11 @@ export function RemoveFlow({
     refresh: refreshRuntimeEndpoints,
   } = useRemovableRuntimeEndpoints();
   const { paymentManagers, isLoading: isLoadingPayments, refresh: refreshPayments } = useRemovablePaymentManagers();
+  const {
+    capacityProviders,
+    isLoading: isLoadingCapacityProviders,
+    refresh: refreshCapacityProviders,
+  } = useRemovableCapacityProviders();
 
   // Check if any data is still loading
   const isLoading =
@@ -247,7 +261,8 @@ export function RemoveFlow({
     isLoadingPolicies ||
     isLoadingConfigBundles ||
     isLoadingRuntimeEndpoints ||
-    isLoadingPayments;
+    isLoadingPayments ||
+    isLoadingCapacityProviders;
 
   // Preview hook
   const {
@@ -265,6 +280,7 @@ export function RemoveFlow({
     loadPolicyPreview,
     loadConfigBundlePreview,
     loadRuntimeEndpointPreview,
+    loadCapacityProviderPreview,
     reset: resetPreview,
   } = useRemovalPreview();
 
@@ -283,6 +299,7 @@ export function RemoveFlow({
   const { remove: removePolicyOp, reset: resetRemovePolicy } = useRemovePolicy();
   const { remove: removeConfigBundleOp, reset: resetRemoveConfigBundle } = useRemoveConfigBundle();
   const { remove: removeRuntimeEndpointOp, reset: resetRemoveRuntimeEndpoint } = useRemoveRuntimeEndpoint();
+  const { remove: removeCapacityProviderOp, reset: resetRemoveCapacityProvider } = useRemoveCapacityProvider();
 
   // Track pending result state
   const pendingResultRef = useRef<FlowState | null>(null);
@@ -319,6 +336,7 @@ export function RemoveFlow({
         'config-bundle-success',
         'runtime-endpoint-success',
         'payment-success',
+        'capacity-provider-success',
       ];
       if (successStates.includes(flow.name)) {
         onExit();
@@ -375,6 +393,9 @@ export function RemoveFlow({
         break;
       case 'payment':
         setFlow({ name: 'select-payment' });
+        break;
+      case 'capacity-provider':
+        setFlow({ name: 'select-capacity-provider' });
         break;
       case 'all':
         setFlow({ name: 'remove-all' });
@@ -576,6 +597,28 @@ export function RemoveFlow({
       }
     },
     [loadDatasetPreview, force, removeDatasetOp]
+  );
+
+  const handleSelectCapacityProvider = useCallback(
+    async (capacityProviderName: string) => {
+      const result = await loadCapacityProviderPreview(capacityProviderName);
+      if (result.ok) {
+        if (force) {
+          setFlow({ name: 'loading', message: `Removing capacity provider ${capacityProviderName}...` });
+          const removeResult = await removeCapacityProviderOp(capacityProviderName, result.preview);
+          if (removeResult.success) {
+            setFlow({ name: 'capacity-provider-success', capacityProviderName });
+          } else {
+            setFlow({ name: 'error', message: removeResult.error.message });
+          }
+        } else {
+          setFlow({ name: 'confirm-capacity-provider', capacityProviderName, preview: result.preview });
+        }
+      } else {
+        setFlow({ name: 'error', message: result.error });
+      }
+    },
+    [loadCapacityProviderPreview, force, removeCapacityProviderOp]
   );
 
   const handleSelectKnowledgeBase = useCallback(
@@ -790,6 +833,9 @@ export function RemoveFlow({
         case 'payment-manager':
           void handleSelectPaymentManager(initialResourceName);
           break;
+        case 'capacity-provider':
+          void handleSelectCapacityProvider(initialResourceName);
+          break;
       }
     }, 0);
   }, [
@@ -809,6 +855,7 @@ export function RemoveFlow({
     handleSelectConfigBundle,
     handleSelectRuntimeEndpoint,
     handleSelectPaymentManager,
+    handleSelectCapacityProvider,
   ]);
 
   // Confirm handlers - pass preview for logging
@@ -940,6 +987,26 @@ export function RemoveFlow({
     [removeDatasetOp]
   );
 
+  const handleConfirmCapacityProvider = useCallback(
+    async (capacityProviderName: string, preview: RemovalPreview) => {
+      pendingResultRef.current = null;
+      setResultReady(false);
+      setFlow({ name: 'loading', message: `Removing capacity provider ${capacityProviderName}...` });
+      const result = await removeCapacityProviderOp(capacityProviderName, preview);
+      if (result.success) {
+        pendingResultRef.current = {
+          name: 'capacity-provider-success',
+          capacityProviderName,
+          logFilePath: result.logFilePath,
+        };
+      } else {
+        pendingResultRef.current = { name: 'error', message: result.error.message };
+      }
+      setResultReady(true);
+    },
+    [removeCapacityProviderOp]
+  );
+
   const handleConfirmKnowledgeBase = useCallback(
     async (knowledgeBaseName: string, preview: RemovalPreview) => {
       pendingResultRef.current = null;
@@ -1056,6 +1123,7 @@ export function RemoveFlow({
     resetRemovePolicy();
     resetRemoveConfigBundle();
     resetRemoveRuntimeEndpoint();
+    resetRemoveCapacityProvider();
   }, [
     resetPreview,
     resetRemoveAgent,
@@ -1072,6 +1140,7 @@ export function RemoveFlow({
     resetRemovePolicy,
     resetRemoveConfigBundle,
     resetRemoveRuntimeEndpoint,
+    resetRemoveCapacityProvider,
   ]);
 
   const refreshAll = useCallback(async () => {
@@ -1091,6 +1160,7 @@ export function RemoveFlow({
       refreshConfigBundles(),
       refreshRuntimeEndpoints(),
       refreshPayments(),
+      refreshCapacityProviders(),
     ]);
   }, [
     refreshAgents,
@@ -1108,6 +1178,7 @@ export function RemoveFlow({
     refreshConfigBundles,
     refreshRuntimeEndpoints,
     refreshPayments,
+    refreshCapacityProviders,
   ]);
 
   // Select screen - wait for data to load to avoid arrow position issues
@@ -1134,6 +1205,7 @@ export function RemoveFlow({
         datasetCount={datasets.length}
         knowledgeBaseCount={knowledgeBases.length}
         paymentCount={paymentManagers.length}
+        capacityProviderCount={capacityProviders.length}
       />
     );
   }
@@ -1250,6 +1322,19 @@ export function RemoveFlow({
       <RemoveDatasetScreen
         datasets={datasets}
         onSelect={(name: string) => void handleSelectDataset(name)}
+        onExit={() => setFlow({ name: 'select' })}
+      />
+    );
+  }
+
+  if (flow.name === 'select-capacity-provider') {
+    if (initialResourceName && isLoading) {
+      return null;
+    }
+    return (
+      <RemoveCapacityProviderScreen
+        capacityProviders={capacityProviders}
+        onSelect={(name: string) => void handleSelectCapacityProvider(name)}
         onExit={() => setFlow({ name: 'select' })}
       />
     );
@@ -1480,6 +1565,17 @@ export function RemoveFlow({
     );
   }
 
+  if (flow.name === 'confirm-capacity-provider') {
+    return (
+      <RemoveConfirmScreen
+        title={`Remove Capacity Provider: ${flow.capacityProviderName}`}
+        preview={flow.preview}
+        onConfirm={() => void handleConfirmCapacityProvider(flow.capacityProviderName, flow.preview)}
+        onCancel={() => setFlow({ name: 'select-capacity-provider' })}
+      />
+    );
+  }
+
   if (flow.name === 'confirm-knowledge-base') {
     return (
       <RemoveConfirmScreen
@@ -1686,6 +1782,22 @@ export function RemoveFlow({
         isInteractive={isInteractive}
         message={`Removed dataset: ${flow.datasetName}`}
         detail="Dataset removed from agentcore.json. Deploy with `agentcore deploy` to apply changes. (Local JSONL is left on disk.)"
+        logFilePath={flow.logFilePath}
+        onRemoveAnother={() => {
+          resetAll();
+          void refreshAll().then(() => setFlow({ name: 'select' }));
+        }}
+        onExit={onExit}
+      />
+    );
+  }
+
+  if (flow.name === 'capacity-provider-success') {
+    return (
+      <RemoveSuccessScreen
+        isInteractive={isInteractive}
+        message={`Removed capacity provider: ${flow.capacityProviderName}`}
+        detail="Capacity provider removed from agentcore.json. Deploy with `agentcore deploy` to apply changes."
         logFilePath={flow.logFilePath}
         onRemoveAnother={() => {
           resetAll();

--- a/src/cli/tui/screens/remove/RemoveScreen.tsx
+++ b/src/cli/tui/screens/remove/RemoveScreen.tsx
@@ -19,6 +19,7 @@ export type RemoveResourceType =
   | 'runtime-endpoint'
   | 'dataset'
   | 'payment'
+  | 'capacity-provider'
   | 'all';
 
 const REMOVE_RESOURCES: { id: RemoveResourceType; title: string; description: string }[] = [
@@ -41,6 +42,7 @@ const REMOVE_RESOURCES: { id: RemoveResourceType; title: string; description: st
   { id: 'config-bundle', title: 'Configuration Bundle', description: 'Remove a configuration bundle' },
   { id: 'runtime-endpoint', title: 'Runtime Endpoint', description: 'Remove a runtime endpoint' },
   { id: 'dataset', title: 'Dataset', description: 'Remove a dataset' },
+  { id: 'capacity-provider', title: 'Capacity Provider [preview]', description: 'Remove a capacity provider' },
   { id: 'all', title: 'All', description: 'Reset entire agentcore project' },
 ];
 
@@ -77,6 +79,8 @@ interface RemoveScreenProps {
   knowledgeBaseCount: number;
   /** Number of payment managers available for removal */
   paymentCount: number;
+  /** Number of capacity providers available for removal */
+  capacityProviderCount: number;
 }
 
 export function RemoveScreen({
@@ -97,6 +101,7 @@ export function RemoveScreen({
   datasetCount,
   knowledgeBaseCount,
   paymentCount,
+  capacityProviderCount,
 }: RemoveScreenProps) {
   const items: SelectableItem[] = useMemo(() => {
     return REMOVE_RESOURCES.map(r => {
@@ -194,6 +199,12 @@ export function RemoveScreen({
             description = 'No payment managers to remove';
           }
           break;
+        case 'capacity-provider':
+          if (capacityProviderCount === 0) {
+            disabled = true;
+            description = 'No capacity providers to remove';
+          }
+          break;
         case 'all':
           // 'all' is always available
           break;
@@ -217,6 +228,7 @@ export function RemoveScreen({
     datasetCount,
     knowledgeBaseCount,
     paymentCount,
+    capacityProviderCount,
   ]);
 
   const isDisabled = (item: SelectableItem) => item.disabled ?? false;

--- a/src/cli/tui/screens/remove/__tests__/RemoveScreen.test.tsx
+++ b/src/cli/tui/screens/remove/__tests__/RemoveScreen.test.tsx
@@ -27,6 +27,7 @@ describe('RemoveScreen', () => {
         datasetCount={0}
         knowledgeBaseCount={0}
         paymentCount={1}
+        capacityProviderCount={0}
       />
     );
 
@@ -63,6 +64,7 @@ describe('RemoveScreen', () => {
         datasetCount={0}
         knowledgeBaseCount={0}
         paymentCount={0}
+        capacityProviderCount={0}
       />
     );
 
@@ -95,6 +97,7 @@ describe('RemoveScreen', () => {
         datasetCount={0}
         knowledgeBaseCount={3}
         paymentCount={0}
+        capacityProviderCount={0}
       />
     );
 
@@ -125,9 +128,65 @@ describe('RemoveScreen', () => {
         datasetCount={0}
         knowledgeBaseCount={0}
         paymentCount={0}
+        capacityProviderCount={0}
       />
     );
 
     expect(lastFrame()).toContain('No knowledge bases to remove');
+  });
+
+  it('Capacity Provider option enabled when capacityProviderCount > 0', () => {
+    const { lastFrame } = render(
+      <RemoveScreen
+        onSelect={vi.fn()}
+        onExit={vi.fn()}
+        agentCount={0}
+        harnessCount={0}
+        gatewayCount={0}
+        mcpToolCount={0}
+        memoryCount={0}
+        credentialCount={0}
+        evaluatorCount={0}
+        onlineEvalCount={0}
+        policyEngineCount={0}
+        policyCount={0}
+        configBundleCount={0}
+        runtimeEndpointCount={0}
+        datasetCount={0}
+        knowledgeBaseCount={0}
+        paymentCount={0}
+        capacityProviderCount={2}
+      />
+    );
+
+    expect(lastFrame()).toContain('Capacity Provider');
+    expect(lastFrame()).not.toContain('No capacity providers to remove');
+  });
+
+  it('Capacity Provider option disabled when capacityProviderCount = 0', () => {
+    const { lastFrame } = render(
+      <RemoveScreen
+        onSelect={vi.fn()}
+        onExit={vi.fn()}
+        agentCount={0}
+        harnessCount={0}
+        gatewayCount={0}
+        mcpToolCount={0}
+        memoryCount={0}
+        credentialCount={0}
+        evaluatorCount={0}
+        onlineEvalCount={0}
+        policyEngineCount={0}
+        policyCount={0}
+        configBundleCount={0}
+        runtimeEndpointCount={0}
+        datasetCount={0}
+        knowledgeBaseCount={0}
+        paymentCount={0}
+        capacityProviderCount={0}
+      />
+    );
+
+    expect(lastFrame()).toContain('No capacity providers to remove');
   });
 });

--- a/src/cli/tui/screens/remove/useRemoveFlow.ts
+++ b/src/cli/tui/screens/remove/useRemoveFlow.ts
@@ -96,6 +96,11 @@ export function useRemoveFlow({ force, dryRun }: RemoveFlowOptions): RemoveFlowS
             items.push(`${totalConnectors} payment connector${totalConnectors > 1 ? 's' : ''}`);
           }
         }
+        if (projectSpec.capacityProviders && projectSpec.capacityProviders.length > 0) {
+          items.push(
+            `${projectSpec.capacityProviders.length} capacity provider${projectSpec.capacityProviders.length > 1 ? 's' : ''}`
+          );
+        }
       } catch {
         // Project exists but has issues - still allow reset
         items.push('AgentCore project (corrupted or incomplete)');

--- a/src/schema/llm-compacted/agentcore.ts
+++ b/src/schema/llm-compacted/agentcore.ts
@@ -26,6 +26,7 @@ interface AgentCoreProjectSpec {
   abTests: ABTest[]; // default [], unique by name
   harnesses: HarnessRegistryEntry[]; // default [], unique by name
   datasets?: Dataset[]; // unique by name
+  capacityProviders?: CapacityProvider[]; // unique by name
   payments?: PaymentManager[]; // unique by name
 }
 
@@ -579,6 +580,57 @@ interface Dataset {
   description?: string; // @max 200
   config: { managed: { location: string } };
   kmsKeyArn?: string;
+}
+
+// CAPACITY PROVIDER
+
+interface CapacityProvider {
+  name: string; // @regex ^[a-zA-Z][a-zA-Z0-9_]{0,47}$ @min 1 @max 48; immutable after creation
+  description?: string; // @min 1 @max 4096; mutable (the only mutable field besides tags)
+  operatorRoleArn: string; // IAM role ARN @regex ^arn:aws(-[^:]+)?:iam::([0-9]{12})?:role/.+$ @max 2048; immutable
+  computeConfiguration: ComputeConfiguration; // immutable after creation
+  tags?: Tags;
+}
+
+interface ComputeConfiguration {
+  ec2Configuration: Ec2Configuration;
+}
+
+interface Ec2Configuration {
+  launchTemplateSource: { launchParameters: LaunchParameters };
+  vpcConfiguration: CapacityProviderVpcConfiguration;
+  volumes?: VolumeConfiguration[]; // @max 5
+  lifecycleConfiguration?: InstanceLifecycleConfiguration;
+  // long tail (rootVolume, etc.) accepted via passthrough and validated by CFN
+}
+
+interface LaunchParameters {
+  operatingSystem: 'LINUX_X86_64' | 'LINUX_ARM64';
+  instanceRequirements: { allowedInstanceTypes: string[] }; // @min 1 @max 30; each @min 1 @max 255
+  instanceProfileArn?: string; // @regex ^arn:aws(-[^:]+)?:iam::[0-9]{12}:instance-profile/.+$
+  // long tail (sshKeyName, monitoring, licenseSpecifications, capacityReservationSpecification,
+  // ephemeralVolumes, propagatedTags) accepted via passthrough and validated by CFN
+}
+
+interface CapacityProviderVpcConfiguration {
+  subnets: string[]; // @min 1 @max 16; each @regex ^subnet-[0-9a-zA-Z]{8,17}$
+  securityGroups: string[]; // @min 1 @max 16; each @regex ^sg-[0-9a-zA-Z]{8,17}$
+}
+
+interface VolumeConfiguration {
+  ebsConfiguration: {
+    name: string; // @regex ^[a-zA-Z][a-zA-Z0-9_-]{0,47}$ @min 1 @max 48
+    sizeGiB: number; // integer @min 1 @max 65536
+    volumeType?: 'standard' | 'io1' | 'io2' | 'gp2' | 'sc1' | 'st1' | 'gp3';
+    encrypted?: boolean;
+    kmsKeyId?: string; // KMS key ARN
+    // long tail (iops, throughput, snapshotId) accepted via passthrough
+  };
+}
+
+interface InstanceLifecycleConfiguration {
+  idleInstanceTimeout?: number; // integer seconds @min 60 @max 1209600
+  maxLifetime?: number; // integer seconds @min 60 @max 1209600
 }
 
 // PAYMENTS

--- a/src/schema/schemas/agentcore-project.ts
+++ b/src/schema/schemas/agentcore-project.ts
@@ -10,6 +10,7 @@ import { isReservedProjectName } from '../constants';
 import { AgentEnvSpecSchema } from './agent-env';
 import { AgentCoreGatewaySchema, AgentCoreGatewayTargetSchema, AgentCoreMcpRuntimeToolSchema } from './mcp';
 import { ABTestSchema } from './primitives/ab-test';
+import { CapacityProviderSchema } from './primitives/capacity-provider';
 import { ConfigBundleSchema } from './primitives/config-bundle';
 import { DatasetSchema } from './primitives/dataset';
 import {
@@ -92,6 +93,15 @@ export type { Tags } from './primitives/tags';
 export { DatasetSchema };
 export { DatasetNameSchema, DatasetSchemaTypeSchema } from './primitives/dataset';
 export type { Dataset, DatasetSchemaType } from './primitives/dataset';
+export { CapacityProviderSchema };
+export {
+  CapacityProviderNameSchema,
+  CAPACITY_PROVIDER_OPERATOR_ROLE_ARN_PATTERN,
+  isValidOperatorRoleArn,
+  OperatingSystemSchema,
+  OperatorRoleArnSchema,
+} from './primitives/capacity-provider';
+export type { CapacityProvider, OperatingSystem } from './primitives/capacity-provider';
 export type { ABTestMode, TargetRef, GatewayFilter, PerVariantOnlineEvaluationConfig } from './primitives/ab-test';
 export { ABTestModeSchema, TargetRefSchema, GatewayFilterSchema } from './primitives/ab-test';
 export type {
@@ -548,6 +558,17 @@ export const AgentCoreProjectSpecSchema = z
           }
           seen.add(dataset.name);
         }
+      }),
+
+    capacityProviders: z
+      .array(CapacityProviderSchema)
+      .optional()
+      .superRefine((items, ctx) => {
+        if (!items) return;
+        uniqueBy(
+          (cp: { name: string }) => cp.name,
+          (name: string) => `Duplicate capacity provider name: ${name}`
+        )(items, ctx);
       }),
 
     httpGateways: z

--- a/src/schema/schemas/deployed-state.ts
+++ b/src/schema/schemas/deployed-state.ts
@@ -325,6 +325,17 @@ export const PaymentDeployedStateSchema = z.object({
 export type PaymentDeployedState = z.infer<typeof PaymentDeployedStateSchema>;
 
 // ============================================================================
+// Capacity Provider Deployed State
+// ============================================================================
+
+export const CapacityProviderDeployedStateSchema = z.object({
+  capacityProviderId: z.string().min(1),
+  capacityProviderArn: z.string().min(1),
+});
+
+export type CapacityProviderDeployedState = z.infer<typeof CapacityProviderDeployedStateSchema>;
+
+// ============================================================================
 // Deployed Resource State
 // ============================================================================
 
@@ -346,6 +357,7 @@ export const DeployedResourceStateSchema = z.object({
   harnesses: z.record(z.string(), HarnessDeployedStateSchema).optional(),
   runtimeEndpoints: z.record(z.string(), RuntimeEndpointDeployedStateSchema).optional(),
   payments: z.record(z.string(), PaymentDeployedStateSchema).optional(),
+  capacityProviders: z.record(z.string(), CapacityProviderDeployedStateSchema).optional(),
   stackName: z.string().optional(),
   identityKmsKeyArn: z.string().optional(),
   deployHash: z.string().optional(),

--- a/src/schema/schemas/primitives/__tests__/capacity-provider.test.ts
+++ b/src/schema/schemas/primitives/__tests__/capacity-provider.test.ts
@@ -1,0 +1,98 @@
+import { CapacityProviderSchema, isValidOperatorRoleArn } from '../capacity-provider';
+import { describe, expect, it } from 'vitest';
+
+const validCp = {
+  name: 'myCp',
+  operatorRoleArn: 'arn:aws:iam::123456789012:role/MyOperatorRole',
+  computeConfiguration: {
+    ec2Configuration: {
+      launchTemplateSource: {
+        launchParameters: {
+          operatingSystem: 'LINUX_X86_64',
+          instanceRequirements: { allowedInstanceTypes: ['c6a.large'] },
+        },
+      },
+      vpcConfiguration: { subnets: ['subnet-0123456789abcdef0'], securityGroups: ['sg-0123456789abcdef0'] },
+    },
+  },
+};
+
+describe('CapacityProviderSchema', () => {
+  it('accepts a minimal valid capacity provider', () => {
+    expect(CapacityProviderSchema.safeParse(validCp).success).toBe(true);
+  });
+
+  it('rejects a name that does not start with a letter', () => {
+    const result = CapacityProviderSchema.safeParse({ ...validCp, name: '1bad' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a description over 4096 characters', () => {
+    const result = CapacityProviderSchema.safeParse({ ...validCp, description: 'x'.repeat(4097) });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts a 4096-character description', () => {
+    const result = CapacityProviderSchema.safeParse({ ...validCp, description: 'x'.repeat(4096) });
+    expect(result.success).toBe(true);
+  });
+
+  it('only accepts the two Linux operating systems', () => {
+    for (const os of ['LINUX_X86_64', 'LINUX_ARM64']) {
+      const cp = structuredClone(validCp);
+      cp.computeConfiguration.ec2Configuration.launchTemplateSource.launchParameters.operatingSystem = os;
+      expect(CapacityProviderSchema.safeParse(cp).success).toBe(true);
+    }
+    for (const os of ['MAC_ARM64', 'WINDOWS_X86_64']) {
+      const cp = structuredClone(validCp);
+      cp.computeConfiguration.ec2Configuration.launchTemplateSource.launchParameters.operatingSystem = os;
+      expect(CapacityProviderSchema.safeParse(cp).success).toBe(false);
+    }
+  });
+
+  it('requires 1-30 instance types', () => {
+    const empty = structuredClone(validCp);
+    empty.computeConfiguration.ec2Configuration.launchTemplateSource.launchParameters.instanceRequirements.allowedInstanceTypes =
+      [];
+    expect(CapacityProviderSchema.safeParse(empty).success).toBe(false);
+  });
+
+  it('rejects malformed subnet and security group IDs', () => {
+    const badSubnet = structuredClone(validCp);
+    badSubnet.computeConfiguration.ec2Configuration.vpcConfiguration.subnets = ['not-a-subnet'];
+    expect(CapacityProviderSchema.safeParse(badSubnet).success).toBe(false);
+  });
+
+  it('accepts up to 5 volumes but rejects 6', () => {
+    const mkVol = (i: number) => ({ ebsConfiguration: { name: `vol${i}`, sizeGiB: 10 } });
+    const five = structuredClone(validCp) as Record<string, unknown> & typeof validCp;
+    (five.computeConfiguration.ec2Configuration as Record<string, unknown>).volumes = [0, 1, 2, 3, 4].map(mkVol);
+    expect(CapacityProviderSchema.safeParse(five).success).toBe(true);
+
+    const six = structuredClone(validCp) as Record<string, unknown> & typeof validCp;
+    (six.computeConfiguration.ec2Configuration as Record<string, unknown>).volumes = [0, 1, 2, 3, 4, 5].map(mkVol);
+    expect(CapacityProviderSchema.safeParse(six).success).toBe(false);
+  });
+
+  it('passes through unknown launch parameters (long tail)', () => {
+    const cp = structuredClone(validCp) as Record<string, unknown> & typeof validCp;
+    (
+      cp.computeConfiguration.ec2Configuration.launchTemplateSource.launchParameters as Record<string, unknown>
+    ).sshKeyName = 'my-key';
+    const result = CapacityProviderSchema.safeParse(cp);
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('isValidOperatorRoleArn', () => {
+  it('accepts standard and account-less role ARNs', () => {
+    expect(isValidOperatorRoleArn('arn:aws:iam::123456789012:role/MyRole')).toBe(true);
+    expect(isValidOperatorRoleArn('arn:aws:iam:::role/MyRole')).toBe(true);
+    expect(isValidOperatorRoleArn('arn:aws-us-gov:iam::123456789012:role/MyRole')).toBe(true);
+  });
+
+  it('rejects non-role and malformed ARNs', () => {
+    expect(isValidOperatorRoleArn('arn:aws:iam::123456789012:user/Bob')).toBe(false);
+    expect(isValidOperatorRoleArn('not-an-arn')).toBe(false);
+  });
+});

--- a/src/schema/schemas/primitives/capacity-provider.ts
+++ b/src/schema/schemas/primitives/capacity-provider.ts
@@ -1,0 +1,213 @@
+import { TagsSchema } from './tags';
+import { z } from 'zod';
+
+// ============================================================================
+// Capacity Provider Types
+//
+// Models the AWS::BedrockAgentCore::CapacityProvider CFN resource. Known fields
+// are typed and validated here so bad input is rejected at `add` time instead
+// of failing late at deploy/CFN time; the long tail of launch parameters is
+// accepted via `.passthrough()` and validated by CFN on deploy.
+//
+// NOTE: This schema is duplicated in @aws/agentcore-cdk
+// (src/schema/schemas/primitives/capacity-provider.ts). Keep the two in sync.
+// ============================================================================
+
+/**
+ * Capacity provider name validation.
+ * Pattern: ^[a-zA-Z][a-zA-Z0-9_]{0,47}$ (matches the CFN Name property).
+ */
+export const CapacityProviderNameSchema = z
+  .string()
+  .min(1, 'Capacity provider name is required')
+  .max(48)
+  .regex(
+    /^[a-zA-Z][a-zA-Z0-9_]{0,47}$/,
+    'Must begin with a letter and contain only alphanumeric characters and underscores (max 48 chars)'
+  );
+
+// ============================================================================
+// Operator Role ARN Validation
+// ============================================================================
+
+/**
+ * Pattern for the capacity provider operator role ARN, matching the CFN
+ * resource contract exactly. The account segment is OPTIONAL — the service
+ * accepts role ARNs without an account id, so we must not force 12 digits.
+ */
+// eslint-disable-next-line security/detect-unsafe-regex -- anchored ARN pattern, no backtracking risk
+export const CAPACITY_PROVIDER_OPERATOR_ROLE_ARN_PATTERN = /^arn:[^:]+:iam::([0-9]{12})?:role\/.+$/;
+
+export const OperatorRoleArnSchema = z
+  .string()
+  .min(1, 'Operator role ARN is required')
+  .max(2048)
+  .regex(
+    CAPACITY_PROVIDER_OPERATOR_ROLE_ARN_PATTERN,
+    'Must be a valid IAM role ARN (e.g. arn:<partition>:iam::123456789012:role/MyOperatorRole)'
+  );
+
+export function isValidOperatorRoleArn(value: string): boolean {
+  return CAPACITY_PROVIDER_OPERATOR_ROLE_ARN_PATTERN.test(value);
+}
+
+// ============================================================================
+// Operating System
+//
+// The CFN resource enum lists four values (LINUX_X86_64, LINUX_ARM64,
+// MAC_ARM64, WINDOWS_X86_64), but the service API contract only supports the
+// two Linux values today; the extra two leaked into the CFN autogen ahead of
+// real support. The CLI follows the API and exposes only the Linux values.
+// ============================================================================
+
+export const OperatingSystemSchema = z.enum(['LINUX_X86_64', 'LINUX_ARM64']);
+export type OperatingSystem = z.infer<typeof OperatingSystemSchema>;
+
+// ============================================================================
+// VPC Configuration
+// ============================================================================
+
+export const VpcConfigurationSchema = z.object({
+  subnets: z
+    .array(z.string().regex(/^subnet-[0-9a-zA-Z]{8,17}$/, 'Must be a valid subnet ID'))
+    .min(1, 'At least one subnet is required')
+    .max(16),
+  securityGroups: z
+    .array(z.string().regex(/^sg-[0-9a-zA-Z]{8,17}$/, 'Must be a valid security group ID'))
+    .min(1, 'At least one security group is required')
+    .max(16),
+});
+
+export type VpcConfiguration = z.infer<typeof VpcConfigurationSchema>;
+
+// ============================================================================
+// Instance Requirements
+// ============================================================================
+
+export const InstanceRequirementsSchema = z.object({
+  allowedInstanceTypes: z.array(z.string().min(1).max(255)).min(1, 'At least one instance type is required').max(30),
+});
+
+export type InstanceRequirements = z.infer<typeof InstanceRequirementsSchema>;
+
+// ============================================================================
+// Launch Parameters
+//
+// Known fields are typed; the long tail (sshKeyName, monitoring,
+// licenseSpecifications, capacityReservationSpecification, ephemeralVolumes,
+// propagatedTags) is accepted via `.passthrough()` and validated by CFN.
+// ============================================================================
+
+export const LaunchParametersSchema = z
+  .object({
+    operatingSystem: OperatingSystemSchema,
+    instanceRequirements: InstanceRequirementsSchema,
+    instanceProfileArn: z
+      .string()
+      .regex(/^arn:[^:]+:iam::[0-9]{12}:instance-profile\/.+$/, 'Must be a valid IAM instance profile ARN')
+      .optional(),
+  })
+  .passthrough();
+
+export type LaunchParameters = z.infer<typeof LaunchParametersSchema>;
+
+// ============================================================================
+// EBS Volume Configuration
+//
+// Known fields typed; EBS long-tail tuning (iops, throughput, snapshotId) is
+// accepted via `.passthrough()`.
+// ============================================================================
+
+export const EbsVolumeConfigurationSchema = z
+  .object({
+    name: z
+      .string()
+      .min(1)
+      .max(48)
+      .regex(
+        /^[a-zA-Z][a-zA-Z0-9_-]{0,47}$/,
+        'Volume name must begin with a letter and contain only alphanumerics, underscores, and hyphens (max 48 chars)'
+      ),
+    sizeGiB: z.number().int().min(1).max(65536),
+    volumeType: z.enum(['standard', 'io1', 'io2', 'gp2', 'sc1', 'st1', 'gp3']).optional(),
+    encrypted: z.boolean().optional(),
+    kmsKeyId: z
+      .string()
+      .regex(
+        /^arn:[^:]+:kms:[a-z0-9-]+:[0-9]{12}:key\/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/,
+        'Must be a valid KMS key ARN'
+      )
+      .optional(),
+  })
+  .passthrough();
+
+export type EbsVolumeConfiguration = z.infer<typeof EbsVolumeConfigurationSchema>;
+
+export const VolumeConfigurationSchema = z.object({
+  ebsConfiguration: EbsVolumeConfigurationSchema,
+});
+
+export type VolumeConfiguration = z.infer<typeof VolumeConfigurationSchema>;
+
+// ============================================================================
+// Instance Lifecycle Configuration
+// ============================================================================
+
+const LIFECYCLE_SECONDS_MIN = 60;
+const LIFECYCLE_SECONDS_MAX = 1209600;
+
+export const InstanceLifecycleConfigurationSchema = z.object({
+  idleInstanceTimeout: z.number().int().min(LIFECYCLE_SECONDS_MIN).max(LIFECYCLE_SECONDS_MAX).optional(),
+  maxLifetime: z.number().int().min(LIFECYCLE_SECONDS_MIN).max(LIFECYCLE_SECONDS_MAX).optional(),
+});
+
+export type InstanceLifecycleConfiguration = z.infer<typeof InstanceLifecycleConfigurationSchema>;
+
+// ============================================================================
+// Compute Configuration
+//
+// `rootVolume` is accepted via `.passthrough()` on ec2Configuration (long-tail,
+// service-managed).
+// ============================================================================
+
+export const Ec2ConfigurationSchema = z
+  .object({
+    launchTemplateSource: z.object({
+      launchParameters: LaunchParametersSchema,
+    }),
+    vpcConfiguration: VpcConfigurationSchema,
+    volumes: z.array(VolumeConfigurationSchema).max(5).optional(),
+    lifecycleConfiguration: InstanceLifecycleConfigurationSchema.optional(),
+  })
+  .passthrough();
+
+export type Ec2Configuration = z.infer<typeof Ec2ConfigurationSchema>;
+
+export const ComputeConfigurationSchema = z.object({
+  ec2Configuration: Ec2ConfigurationSchema,
+});
+
+export type ComputeConfiguration = z.infer<typeof ComputeConfigurationSchema>;
+
+// ============================================================================
+// Capacity Provider Schema
+// ============================================================================
+
+export const CapacityProviderSchema = z.object({
+  /** Capacity provider name (immutable after creation). */
+  name: CapacityProviderNameSchema,
+  /** Optional description (max 4096 chars). The only mutable field besides tags. */
+  description: z.string().min(1).max(4096).optional(),
+  /**
+   * ARN of the IAM role AgentCore assumes to manage the capacity provider (immutable). Optional:
+   * when omitted, an operator role with the required trust policy and managed permissions is
+   * created automatically at deploy time.
+   */
+  operatorRoleArn: OperatorRoleArnSchema.optional(),
+  /** Compute resources for the capacity provider (immutable after creation). */
+  computeConfiguration: ComputeConfigurationSchema,
+  /** Optional resource tags. */
+  tags: TagsSchema.optional(),
+});
+
+export type CapacityProvider = z.infer<typeof CapacityProviderSchema>;

--- a/src/schema/schemas/primitives/index.ts
+++ b/src/schema/schemas/primitives/index.ts
@@ -9,6 +9,35 @@ export type {
 
 export type { Dataset, DatasetSchemaType } from './dataset';
 export { DatasetNameSchema, DatasetSchema, DatasetSchemaTypeSchema } from './dataset';
+
+export type {
+  CapacityProvider,
+  ComputeConfiguration,
+  Ec2Configuration,
+  EbsVolumeConfiguration,
+  InstanceLifecycleConfiguration,
+  InstanceRequirements,
+  LaunchParameters,
+  OperatingSystem,
+  VolumeConfiguration,
+  VpcConfiguration,
+} from './capacity-provider';
+export {
+  CAPACITY_PROVIDER_OPERATOR_ROLE_ARN_PATTERN,
+  CapacityProviderNameSchema,
+  CapacityProviderSchema,
+  ComputeConfigurationSchema,
+  Ec2ConfigurationSchema,
+  EbsVolumeConfigurationSchema,
+  InstanceLifecycleConfigurationSchema,
+  InstanceRequirementsSchema,
+  isValidOperatorRoleArn,
+  LaunchParametersSchema,
+  OperatingSystemSchema,
+  OperatorRoleArnSchema,
+  VolumeConfigurationSchema,
+  VpcConfigurationSchema,
+} from './capacity-provider';
 export {
   ABTestNameSchema,
   ABTestDescriptionSchema,


### PR DESCRIPTION
## Description

Restores capacity provider Journey 1 after #2045.

This is the exact inverse of revert commit `0cd32ba1f9d8a52f4309c1418baafa1b2b4ee0d9`, applied to current `main`. It restores the capacity provider schema, CLI and TUI add/remove flows, deploy/status/output handling, telemetry, documentation, and tests from #2030.

Companion CDK PR: https://github.com/aws/agentcore-l3-cdk-constructs/pull/340

## Related Issue

Restores #2030 after #2045.

## Documentation PR

N/A. User-facing documentation is restored in this PR.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Other (please describe):

## Testing

- `npm run test:unit` (431 files, 6,193 tests passed)
- `npm run test:integ` (35 files, 350 tests passed, 1 skipped)
- `npm run test:update-snapshots` (6,193 tests passed, no snapshot drift)
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm run test:tui` reproduced the exact current-`main` result: 15 passed and 19 pre-existing failures, with no capacity-provider failures
- Verified the complete branch diff is byte-for-byte equivalent to the inverse of `0cd32ba1f9d8a52f4309c1418baafa1b2b4ee0d9`

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [x] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
