### PR TITLE
test(deps): derive vended agentcore-cdk pin from the template

### DIFF
--- a/src/lib/dependency-management/__tests__/fixtures.ts
+++ b/src/lib/dependency-management/__tests__/fixtures.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import * as path from 'node:path';
+
+function resolveCdkPin(): string {
+  const raw = readFileSync(path.resolve(__dirname, '../../../assets/cdk/package.json'), 'utf-8');
+  const pin = (JSON.parse(raw) as { dependencies?: Record<string, string> }).dependencies?.['@aws/agentcore-cdk'];
+  if (!pin) {
+    throw new Error('vended CDK template is missing its @aws/agentcore-cdk pin');
+  }
+  return pin;
+}
+
+export const CDK_PIN = resolveCdkPin();
+
+export function newerPrerelease(pin: string, by = 2): string {
+  const match = /^(.*-[A-Za-z]+\.)(\d+)$/.exec(pin);
+  if (!match) {
+    throw new Error(`cannot derive a newer prerelease from non-prerelease pin: ${pin}`);
+  }
+  return `${match[1]}${Number(match[2]) + by}`;
+}

--- a/src/lib/dependency-management/__tests__/plan.test.ts
+++ b/src/lib/dependency-management/__tests__/plan.test.ts
@@ -1,10 +1,13 @@
 import { computeSyncPlan } from '../plan';
 import type { PackageManifest } from '../types';
+import { CDK_PIN, newerPrerelease } from './fixtures';
 import { describe, expect, it } from 'vitest';
+
+const CDK_PIN_NEWER = newerPrerelease(CDK_PIN);
 
 const VENDED: PackageManifest = {
   dependencies: {
-    '@aws/agentcore-cdk': '0.1.0-alpha.49',
+    '@aws/agentcore-cdk': CDK_PIN,
     'aws-cdk-lib': '~2.261.0',
     constructs: '~10.7.0',
   },
@@ -42,7 +45,7 @@ describe('computeSyncPlan', () => {
     expect(plan.migratedFromCaret).toBe(true);
     expect(plan.skew).toEqual([]);
     expect(plan.changes).toEqual([
-      { name: '@aws/agentcore-cdk', section: 'dependencies', from: '^0.1.0-alpha.19', to: '0.1.0-alpha.49' },
+      { name: '@aws/agentcore-cdk', section: 'dependencies', from: '^0.1.0-alpha.19', to: CDK_PIN },
       { name: 'aws-cdk-lib', section: 'dependencies', from: '^2.248.0', to: '~2.261.0' },
       { name: 'constructs', section: 'dependencies', from: '^10.0.0', to: '~10.7.0' },
     ]);
@@ -83,12 +86,12 @@ describe('computeSyncPlan', () => {
     expect(plan.changes).toEqual([{ name: 'aws-cdk-lib', section: 'dependencies', from: '~2.261.5', to: '~2.261.0' }]);
   });
 
-  it('detects prerelease skew on the exact-pinned construct (alpha.51 > alpha.49)', () => {
+  it('detects prerelease skew on the exact-pinned construct (a newer prerelease than the pin)', () => {
     const plan = computeSyncPlan(
       VENDED,
-      project({ dependencies: { ...VENDED.dependencies, '@aws/agentcore-cdk': '0.1.0-alpha.51' } })
+      project({ dependencies: { ...VENDED.dependencies, '@aws/agentcore-cdk': CDK_PIN_NEWER } })
     );
-    expect(plan.skew).toEqual([{ name: '@aws/agentcore-cdk', declared: '0.1.0-alpha.51', expected: '0.1.0-alpha.49' }]);
+    expect(plan.skew).toEqual([{ name: '@aws/agentcore-cdk', declared: CDK_PIN_NEWER, expected: CDK_PIN }]);
   });
 
   it('upgrades an older exact-pinned prerelease', () => {
@@ -98,7 +101,7 @@ describe('computeSyncPlan', () => {
     );
     expect(plan.skew).toEqual([]);
     expect(plan.changes).toEqual([
-      { name: '@aws/agentcore-cdk', section: 'dependencies', from: '0.1.0-alpha.19', to: '0.1.0-alpha.49' },
+      { name: '@aws/agentcore-cdk', section: 'dependencies', from: '0.1.0-alpha.19', to: CDK_PIN },
     ]);
   });
 

--- a/src/lib/dependency-management/__tests__/sync.test.ts
+++ b/src/lib/dependency-management/__tests__/sync.test.ts
@@ -1,6 +1,7 @@
 import { CliVersionTooOldError, DependencySyncError } from '../../errors/types';
 import { syncManagedDependencies } from '../sync';
 import type { SyncManagedDependenciesOptions } from '../types';
+import { CDK_PIN } from './fixtures';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
@@ -14,7 +15,7 @@ vi.mock('../../utils/subprocess', () => ({
 const VENDED = {
   name: 'agentcore-cdk-app',
   dependencies: {
-    '@aws/agentcore-cdk': '0.1.0-alpha.49',
+    '@aws/agentcore-cdk': CDK_PIN,
     'aws-cdk-lib': '~2.261.0',
   },
   devDependencies: {
@@ -78,7 +79,7 @@ describe('syncManagedDependencies', () => {
     expect(result.notice).toContain('disableDependencyManagement');
 
     const written = readProject();
-    expect(written.dependencies['@aws/agentcore-cdk']).toBe('0.1.0-alpha.49');
+    expect(written.dependencies['@aws/agentcore-cdk']).toBe(CDK_PIN);
     expect(written.dependencies['aws-cdk-lib']).toBe('~2.261.0');
     expect(written.dependencies.lodash).toBe('^4.17.21');
 
@@ -103,7 +104,7 @@ describe('syncManagedDependencies', () => {
   it('preserves key order and unknown fields when rewriting', async () => {
     writeProject({
       zeta: 'kept',
-      dependencies: { lodash: '1.0.0', 'aws-cdk-lib': '~2.250.0', '@aws/agentcore-cdk': '0.1.0-alpha.49' },
+      dependencies: { lodash: '1.0.0', 'aws-cdk-lib': '~2.250.0', '@aws/agentcore-cdk': CDK_PIN },
       scripts: { build: 'tsc' },
       devDependencies: { typescript: '~5.9.3' },
     });
@@ -163,7 +164,7 @@ describe('syncManagedDependencies', () => {
     expect(result.warnings.some(w => w.includes('newer than this CLI was tested with'))).toBe(true);
     // The skewed dep is left alone; the other managed dep still syncs.
     expect(readProject().dependencies['aws-cdk-lib']).toBe('~2.300.0');
-    expect(readProject().dependencies['@aws/agentcore-cdk']).toBe('0.1.0-alpha.49');
+    expect(readProject().dependencies['@aws/agentcore-cdk']).toBe(CDK_PIN);
   });
 
   it('check mode computes the plan and a future-tense notice without writing or installing', async () => {
@@ -211,7 +212,7 @@ describe('syncManagedDependencies', () => {
 
   it('restores a deleted managed dependency', async () => {
     writeProject({
-      dependencies: { '@aws/agentcore-cdk': '0.1.0-alpha.49' },
+      dependencies: { '@aws/agentcore-cdk': CDK_PIN },
       devDependencies: { typescript: '~5.9.3' },
     });
     const result = await run();


### PR DESCRIPTION
## TL;DR
The `@aws/agentcore-cdk` pin was hand-typed in 3 places. This makes the tests **read it from the one file that ships it**, so a version bump stops being a find-and-replace chore.

**Review time:** ~5 min. **Risk:** low — tests only, no runtime `src/` change. **Motivating commit:** ddb32a2 (#2087).

## The problem
`0.1.0-alpha.49` was duplicated in:
- `src/assets/cdk/package.json` — the real pin (`sync.ts` treats it as source of truth)
- `plan.test.ts` + `sync.test.ts` — hand-typed copies

Every prerelease bump had to edit all of them in lockstep. Miss one → red build, or a stale assertion that passes when it shouldn't.

## What changed (3 files)
1. **New** `__tests__/fixtures.ts` — exposes `CDK_PIN` read from the vended template, plus `newerPrerelease()` for skew tests. Reads via `fs` (not `import`) because `src/assets` is excluded from the TS program — same pattern the snapshot test and `sync.ts` already use.
2. `plan.test.ts` — uses `CDK_PIN` / derived `CDK_PIN_NEWER` instead of the literals.
3. `sync.test.ts` — uses `CDK_PIN` for its 5 pin literals.

Older-version fixtures (`alpha.19`) stay literal on purpose — they mean "much older", never bumped.

## Why no new guardrail literal
The asset **snapshot** already stores the pin as a literal, so any *unintended* template change still trips a red snapshot test until someone regenerates it. No point duplicating that.

## Verified
- `vitest run --project unit src/lib/dependency-management` → **40 passed**
- `npm run typecheck` · `eslint` · `prettier --check` → clean

## Next
Unblocks **#2118** (auto-bump in the release flow). The pair was dry-run tested end-to-end in a private mirror: a release run auto-produced a PR bumping the pin `alpha.48 → 49` with the snapshot refreshed and **zero** test edits.