### PR TITLE
feat(release): auto-bump the vended CDK pin during release prep

### DIFF
--- a/.github/workflows/release-main-and-preview.yml
+++ b/.github/workflows/release-main-and-preview.yml
@@ -40,6 +40,11 @@ on:
         required: false
         type: boolean
         default: false
+      cdk_dist_tag:
+        description: '@aws/agentcore-cdk npm dist-tag to pin the vended CDK template to (default: latest)'
+        required: false
+        type: string
+        default: 'latest'
 
 permissions:
   contents: write
@@ -134,6 +139,13 @@ jobs:
 
           echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "📦 Preview version: $NEW_VERSION"
+
+      - name: Sync vended CDK version
+        env:
+          CDK_DIST_TAG: ${{ github.event.inputs.cdk_dist_tag }}
+        run: |
+          npx tsx scripts/sync-vended-cdk.ts --tag "${CDK_DIST_TAG:-latest}"
+          npx prettier --write src/assets/cdk/package.json
 
       - name: Regenerate JSON schema
         run: |

--- a/scripts/sync-vended-cdk.ts
+++ b/scripts/sync-vended-cdk.ts
@@ -1,0 +1,49 @@
+#!/usr/bin/env npx tsx
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import * as path from 'node:path';
+
+const CDK_PACKAGE = '@aws/agentcore-cdk';
+const TEMPLATE_PATH = path.resolve(__dirname, '../src/assets/cdk/package.json');
+
+function getFlagValue(flag: string): string | undefined {
+  const index = process.argv.indexOf(flag);
+  return index !== -1 ? process.argv[index + 1] : undefined;
+}
+
+function resolveTargetVersion(): string {
+  const explicit = getFlagValue('--to');
+  if (explicit) {
+    return explicit;
+  }
+  const tag = getFlagValue('--tag') ?? 'latest';
+  const version = execFileSync('npm', ['view', `${CDK_PACKAGE}@${tag}`, 'version'], { encoding: 'utf-8' }).trim();
+  if (!version) {
+    throw new Error(`could not resolve ${CDK_PACKAGE}@${tag} from npm`);
+  }
+  return version;
+}
+
+function main(): void {
+  const dryRun = process.argv.includes('--dry-run');
+  const target = resolveTargetVersion();
+
+  const pkg = JSON.parse(readFileSync(TEMPLATE_PATH, 'utf-8')) as { dependencies: Record<string, string> };
+  const current = pkg.dependencies[CDK_PACKAGE];
+
+  if (current === target) {
+    console.log(`${CDK_PACKAGE} already pinned to ${target} — no change`);
+    return;
+  }
+  if (dryRun) {
+    console.log(`[dry-run] ${CDK_PACKAGE}: ${current} -> ${target}`);
+    return;
+  }
+
+  pkg.dependencies[CDK_PACKAGE] = target;
+  writeFileSync(TEMPLATE_PATH, JSON.stringify(pkg, null, 2) + '\n');
+  console.log(`${CDK_PACKAGE}: ${current} -> ${target}`);
+}
+
+main();


### PR DESCRIPTION

Stop hand-editing the `@aws/agentcore-cdk` pin every prerelease (ddb32a2 / #2087).

> **Stacked on #2117 — review that first.** This branch targets `tj/dedupe-vended-cdk-pin`; retarget to `main` after #2117 merges.


## What changed (2 files)
1. **New** `scripts/sync-vended-cdk.ts` — resolves the target from `npm view @aws/agentcore-cdk@<tag>` (or explicit `--to <version>`), rewrites the template pin, no-op if already current. `--dry-run` supported.
2. `.github/workflows/release-main-and-preview.yml`:
   - New `cdk_dist_tag` input (default `latest` — the only dist-tag `@aws/agentcore-cdk` publishes).
   - New **"Sync vended CDK version"** step in Prepare Release, right before the existing **"Update snapshots"** step. The step runs the script + `prettier --write`; the existing snapshot step refreshes the `.snap`. The bump rides the release PR the workflow already opens.

Targets the workflow you actually dispatch (`release-main-and-preview.yml`), **not** the unused `release.yml`.

## Verified end-to-end
Ran the real workflow in a private mirror of this repo (GitHub-hosted runners, `npm publish` stubbed). With the template baselined at `alpha.48`, the release run auto-produced a PR whose diff is exactly:

```
src/assets/cdk/package.json                 -alpha.48  →  +alpha.49
…/__snapshots__/assets.snapshot.test.ts.snap -alpha.48  →  +alpha.49
```

Sync step + snapshot refresh: green. No test edits needed (tests derive the pin from #2117).

## Why safe
The bump lands in the auto-created release PR, which already requires human review **and** a manual npm-publish approval gate. Nothing auto-publishes. The step is idempotent — a no-op when the pin is already current.