### PR TITLE
feat(project): add payment resources

### DIFF
--- a/src/assets/cdk/bin/cdk.ts
+++ b/src/assets/cdk/bin/cdk.ts
@@ -153,76 +153,12 @@ async function main() {
     const credentials = targetResources?.credentials as
       Record<string, { credentialProviderArn: string; clientSecretArn?: string }> | undefined;
 
-    // Payment credential provider ARNs live in the same credentials map as identity credentials
-    const paymentCredentials = credentials;
-
-    const paymentSpec = specAny.payments?.length
-      ? specAny.payments.map(
-          (p: {
-            name: string;
-            description?: string;
-            authorizerType: 'AWS_IAM' | 'CUSTOM_JWT';
-            authorizerConfiguration?: unknown;
-            autoPayment?: boolean;
-            paymentToolAllowlist?: string[];
-            networkPreferences?: string[];
-            connectors: {
-              name: string;
-              provider?: 'CoinbaseCDP' | 'StripePrivy';
-              provisionMode?: 'MANUAL' | 'QUICK_CREATE';
-              credentialName?: string;
-            }[];
-          }) => ({
-            name: p.name,
-            description: p.description,
-            authorizerType: p.authorizerType,
-            authorizerConfiguration: p.authorizerConfiguration,
-            autoPayment: p.autoPayment,
-            paymentToolAllowlist: p.paymentToolAllowlist,
-            networkPreferences: p.networkPreferences,
-            connectors: p.connectors.map(c => {
-              if (c.provisionMode === 'QUICK_CREATE') {
-                return {
-                  name: c.name,
-                  provider: 'CoinbaseCDP' as const,
-                  provisionMode: 'QUICK_CREATE' as const,
-                };
-              }
-
-              if (!c.credentialName) {
-                throw new Error(
-                  `Manual payment connector "${c.name}" on manager "${p.name}" is missing its credential name.`
-                );
-              }
-              const credentialProviderArn = paymentCredentials?.[c.credentialName]?.credentialProviderArn;
-              if (!credentialProviderArn) {
-                // Fail fast with an actionable message rather than passing an empty
-                // ARN that fails opaquely server-side at CreatePaymentConnector.
-                throw new Error(
-                  `Payment connector "${c.name}" on manager "${p.name}" references credential ` +
-                    `"${c.credentialName}", but no deployed credential provider was found for it. ` +
-                    `Run \`agentcore deploy\` so the credential provider is created first.`
-                );
-              }
-              return {
-                name: c.name,
-                provider: c.provider ?? ('CoinbaseCDP' as const),
-                ...(c.provisionMode && { provisionMode: c.provisionMode }),
-                credentialName: c.credentialName,
-                credentialProviderArn,
-              };
-            }),
-          })
-        )
-      : undefined;
-
     new AgentCoreStack(app, stackName, {
       spec,
       mcpSpec,
       credentials,
       connectorParametersByFile,
       harnesses: harnessConfigs.length > 0 ? harnessConfigs : undefined,
-      paymentSpec,
       env,
       description: target
         ? `AgentCore stack for ${spec.name} deployed to ${target.name} (${target.region})`

--- a/src/assets/cdk/bin/cdk.ts
+++ b/src/assets/cdk/bin/cdk.ts
@@ -146,14 +146,12 @@ async function main() {
 
     // Extract credentials from deployed state for this target
     const targetState = (deployedState as Record<string, unknown>)?.targets as
-      | Record<string, Record<string, unknown>>
-      | undefined;
+      Record<string, Record<string, unknown>> | undefined;
     const targetResources = target
       ? (targetState?.[target.name]?.resources as Record<string, unknown> | undefined)
       : undefined;
     const credentials = targetResources?.credentials as
-      | Record<string, { credentialProviderArn: string; clientSecretArn?: string }>
-      | undefined;
+      Record<string, { credentialProviderArn: string; clientSecretArn?: string }> | undefined;
 
     // Payment credential provider ARNs live in the same credentials map as identity credentials
     const paymentCredentials = credentials;
@@ -168,7 +166,12 @@ async function main() {
             autoPayment?: boolean;
             paymentToolAllowlist?: string[];
             networkPreferences?: string[];
-            connectors: { name: string; provider?: string; credentialName: string }[];
+            connectors: {
+              name: string;
+              provider?: 'CoinbaseCDP' | 'StripePrivy';
+              provisionMode?: 'MANUAL' | 'QUICK_CREATE';
+              credentialName?: string;
+            }[];
           }) => ({
             name: p.name,
             description: p.description,
@@ -178,6 +181,19 @@ async function main() {
             paymentToolAllowlist: p.paymentToolAllowlist,
             networkPreferences: p.networkPreferences,
             connectors: p.connectors.map(c => {
+              if (c.provisionMode === 'QUICK_CREATE') {
+                return {
+                  name: c.name,
+                  provider: 'CoinbaseCDP' as const,
+                  provisionMode: 'QUICK_CREATE' as const,
+                };
+              }
+
+              if (!c.credentialName) {
+                throw new Error(
+                  `Manual payment connector "${c.name}" on manager "${p.name}" is missing its credential name.`
+                );
+              }
               const credentialProviderArn = paymentCredentials?.[c.credentialName]?.credentialProviderArn;
               if (!credentialProviderArn) {
                 // Fail fast with an actionable message rather than passing an empty
@@ -188,7 +204,13 @@ async function main() {
                     `Run \`agentcore deploy\` so the credential provider is created first.`
                 );
               }
-              return { name: c.name, provider: c.provider, credentialProviderArn };
+              return {
+                name: c.name,
+                provider: c.provider ?? ('CoinbaseCDP' as const),
+                ...(c.provisionMode && { provisionMode: c.provisionMode }),
+                credentialName: c.credentialName,
+                credentialProviderArn,
+              };
             }),
           })
         )

--- a/src/assets/cdk/lib/cdk-stack.ts
+++ b/src/assets/cdk/lib/cdk-stack.ts
@@ -1,15 +1,12 @@
 import {
   AgentCoreApplication,
   AgentCoreMcp,
-  AgentCorePaymentManager,
-  AgentCorePaymentConnector,
+  AgentCorePayments,
   type AgentCoreProjectSpec,
   type AgentCoreMcpSpec,
-  type CustomJWTAuthorizerConfig,
   type HarnessDeploymentConfig,
 } from '@aws/agentcore-cdk';
 import { CfnOutput, Stack, type StackProps } from 'aws-cdk-lib';
-import * as iam from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
 
 /**
@@ -18,35 +15,6 @@ import { Construct } from 'constructs';
  * synthesize the AWS::BedrockAgentCore::Harness resource.
  */
 export type HarnessConfig = HarnessDeploymentConfig;
-
-export type ManualPaymentConnectorSpec = {
-  name: string;
-  provider: 'CoinbaseCDP' | 'StripePrivy';
-  provisionMode?: 'MANUAL';
-  credentialName: string;
-  credentialProviderArn: string;
-};
-
-export type QuickCreatePaymentConnectorSpec = {
-  name: string;
-  provider: 'CoinbaseCDP';
-  provisionMode: 'QUICK_CREATE';
-  credentialName?: never;
-  credentialProviderArn?: never;
-};
-
-export type PaymentConnectorSpec = ManualPaymentConnectorSpec | QuickCreatePaymentConnectorSpec;
-
-export interface PaymentSpec {
-  name: string;
-  description?: string;
-  authorizerType: 'AWS_IAM' | 'CUSTOM_JWT';
-  authorizerConfiguration?: { customJWTAuthorizer: CustomJWTAuthorizerConfig };
-  autoPayment?: boolean;
-  paymentToolAllowlist?: string[];
-  networkPreferences?: string[];
-  connectors: PaymentConnectorSpec[];
-}
 
 export interface AgentCoreStackProps extends StackProps {
   /**
@@ -70,34 +38,6 @@ export interface AgentCoreStackProps extends StackProps {
    * connectorConfigFile path. Forwarded to AgentCoreApplication.
    */
   connectorParametersByFile?: Record<string, Record<string, unknown>>;
-  /**
-   * Payment specifications with resolved credential provider ARNs.
-   */
-  paymentSpec?: PaymentSpec[];
-}
-
-function paymentManagerCdkId(managerName: string): string {
-  return `PaymentManagerM${managerName.length}${managerName}`;
-}
-
-function paymentConnectorCdkId(managerName: string, connectorName: string): string {
-  return `PaymentConnectorM${managerName.length}${managerName}C${connectorName.length}${connectorName}`;
-}
-
-/**
- * Decide whether a deployed runtime should receive payment env vars + IAM grants.
- * Payments today only ships a runtime shim for Python HTTP runtimes; injecting
- * AGENTCORE_PAYMENT_* env vars into TypeScript / MCP / A2A / AGUI runtimes
- * would surface env vars they cannot consume and would dilute least-privilege
- * IAM grants for runtimes that never call ProcessPayment.
- */
-function isPaymentEligibleAgent(agent: { entrypoint?: string; protocol?: string }): boolean {
-  if (agent.protocol && agent.protocol !== 'HTTP') {
-    return false;
-  }
-  const entrypoint = typeof agent.entrypoint === 'string' ? agent.entrypoint : '';
-  const entrypointFile = entrypoint.split(':')[0] ?? '';
-  return entrypointFile.endsWith('.py');
 }
 
 /**
@@ -113,7 +53,7 @@ export class AgentCoreStack extends Stack {
   constructor(scope: Construct, id: string, props: AgentCoreStackProps) {
     super(scope, id, props);
 
-    const { spec, mcpSpec, credentials, harnesses, connectorParametersByFile, paymentSpec } = props;
+    const { spec, mcpSpec, credentials, harnesses, connectorParametersByFile } = props;
 
     // Create AgentCoreApplication with all agents and harness roles
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -128,6 +68,11 @@ export class AgentCoreStack extends Stack {
       appProps.credentials = credentials;
     }
     this.application = new AgentCoreApplication(this, 'Application', appProps as any);
+    new AgentCorePayments(this, 'Payments', {
+      spec,
+      credentials,
+      agentCoreApplication: this.application,
+    });
 
     // Create AgentCoreMcp if there are gateways configured
     if (mcpSpec?.agentCoreGateways && mcpSpec.agentCoreGateways.length > 0) {
@@ -138,143 +83,6 @@ export class AgentCoreStack extends Stack {
         credentials,
         projectTags: spec.tags,
       });
-    }
-
-    // Create payment infrastructure via CFN constructs
-    if (paymentSpec && paymentSpec.length > 0) {
-      for (const payment of paymentSpec) {
-        const managerCdkId = paymentManagerCdkId(payment.name);
-        const manager = new AgentCorePaymentManager(this, managerCdkId, {
-          projectName: spec.name,
-          name: payment.name,
-          authorizerType: payment.authorizerType,
-          description: payment.description,
-          authorizerConfiguration: payment.authorizerConfiguration,
-          tags: spec.tags,
-        });
-
-        const prefix = `AGENTCORE_PAYMENT_${payment.name.toUpperCase().replace(/-/g, '_')}`;
-
-        // Wire env vars from construct output tokens into eligible agent environments only.
-        // See isPaymentEligibleAgent — non-Python or non-HTTP runtimes have no shim that
-        // can consume these env vars, and giving them sts:AssumeRole on the
-        // ProcessPaymentRole would broaden the privilege surface unnecessarily.
-        for (const env of this.application.environments.values()) {
-          if (!isPaymentEligibleAgent(env.agent)) {
-            continue;
-          }
-          env.runtime.addEnvironmentVariable(`${prefix}_MANAGER_ARN`, manager.paymentManagerArn);
-          env.runtime.addEnvironmentVariable(`${prefix}_PROCESS_PAYMENT_ROLE_ARN`, manager.processPaymentRoleArn);
-
-          // Grant runtime execution role permission to assume the ProcessPaymentRole.
-          // The ProcessPaymentRole's trust policy allows AccountRootPrincipal, but the
-          // caller still needs sts:AssumeRole on its own role to perform the assumption.
-          env.runtime.role.addToPrincipalPolicy(
-            new iam.PolicyStatement({
-              actions: ['sts:AssumeRole'],
-              resources: [manager.processPaymentRoleArn],
-            })
-          );
-
-          // Grant payment data-plane actions directly to the runtime role.
-          //
-          // NOTE: This deviates from the canonical role model in the AgentCore Payments
-          // beta guide, which assigns Get/List/Create instrument+session actions to a
-          // separate ManagementRole and limits the agent's role to ProcessPayment only.
-          // The current SDK plugin (AgentCorePaymentsPlugin.generate_payment_header)
-          // calls GetPaymentInstrument internally during the 402 auto-pay path, so the
-          // runtime role needs read access. CreatePaymentSession is included so
-          // `agentcore invoke --auto-session` works without a separate ManagementRole
-          // call. Tighten this if the SDK is updated to accept pre-fetched instrument
-          // details and split create-session into a backend-only flow.
-          env.runtime.role.addToPrincipalPolicy(
-            new iam.PolicyStatement({
-              actions: [
-                'bedrock-agentcore:GetPaymentInstrument',
-                'bedrock-agentcore:ListPaymentInstruments',
-                'bedrock-agentcore:GetPaymentInstrumentBalance',
-                'bedrock-agentcore:GetPaymentSession',
-                'bedrock-agentcore:ListPaymentSessions',
-                'bedrock-agentcore:CreatePaymentSession',
-                'bedrock-agentcore:ProcessPayment',
-              ],
-              resources: [manager.paymentManagerArn, `${manager.paymentManagerArn}/*`],
-            })
-          );
-
-          if (payment.autoPayment !== undefined) {
-            env.runtime.addEnvironmentVariable(`${prefix}_AUTO_PAYMENT`, String(payment.autoPayment));
-          }
-          if (payment.paymentToolAllowlist) {
-            env.runtime.addEnvironmentVariable(`${prefix}_TOOL_ALLOWLIST`, payment.paymentToolAllowlist.join(','));
-          }
-          if (payment.networkPreferences) {
-            env.runtime.addEnvironmentVariable(`${prefix}_NETWORK_PREFERENCES`, payment.networkPreferences.join(','));
-          }
-          if (payment.authorizerType === 'CUSTOM_JWT') {
-            env.runtime.addEnvironmentVariable(`${prefix}_AUTH_MODE`, 'bearer');
-          }
-        }
-
-        // Create connectors for this manager
-        for (const connector of payment.connectors) {
-          const connectorCdkId = paymentConnectorCdkId(payment.name, connector.name);
-          let conn: AgentCorePaymentConnector;
-          if (connector.provisionMode === 'QUICK_CREATE') {
-            conn = new AgentCorePaymentConnector(this, connectorCdkId, {
-              projectName: spec.name,
-              paymentManager: manager,
-              connector,
-            });
-          } else {
-            conn = new AgentCorePaymentConnector(this, connectorCdkId, {
-              projectName: spec.name,
-              paymentManager: manager,
-              connector: {
-                name: connector.name,
-                provider: connector.provider,
-                provisionMode: connector.provisionMode,
-                credentialName: connector.credentialName,
-              },
-              credentialProviderArn: connector.credentialProviderArn,
-            });
-          }
-
-          // Wire first connector's ID as env var (eligible agents only)
-          if (connector === payment.connectors[0]) {
-            for (const env of this.application.environments.values()) {
-              if (!isPaymentEligibleAgent(env.agent)) continue;
-              env.runtime.addEnvironmentVariable(`${prefix}_CONNECTOR_ID`, conn.paymentConnectorId);
-            }
-          }
-
-          new CfnOutput(this, `${connectorCdkId}ConnectorId`, {
-            value: conn.paymentConnectorId,
-          });
-          if (connector.provisionMode === 'QUICK_CREATE') {
-            new CfnOutput(this, `${connectorCdkId}ConnectorStatus`, {
-              value: conn.paymentConnectorStatus,
-            });
-            new CfnOutput(this, `${connectorCdkId}AuthorizationUrl`, {
-              value: conn.authorizationUrl,
-            });
-          }
-        }
-
-        // CFN Outputs for post-deploy state parsing
-        new CfnOutput(this, `${managerCdkId}Arn`, {
-          value: manager.paymentManagerArn,
-        });
-        new CfnOutput(this, `${managerCdkId}Id`, {
-          value: manager.paymentManagerId,
-        });
-        new CfnOutput(this, `${managerCdkId}ProcessPaymentRoleArn`, {
-          value: manager.processPaymentRoleArn,
-        });
-        new CfnOutput(this, `${managerCdkId}ResourceRetrievalRoleArn`, {
-          value: manager.resourceRetrievalRoleArn,
-        });
-      }
     }
 
     // Stack-level output

--- a/src/assets/cdk/lib/cdk-stack.ts
+++ b/src/assets/cdk/lib/cdk-stack.ts
@@ -19,11 +19,23 @@ import { Construct } from 'constructs';
  */
 export type HarnessConfig = HarnessDeploymentConfig;
 
-export interface PaymentConnectorSpec {
+export interface ManualPaymentConnectorSpec {
   name: string;
   provider: 'CoinbaseCDP' | 'StripePrivy';
+  provisionMode?: 'MANUAL';
+  credentialName: string;
   credentialProviderArn: string;
 }
+
+export interface QuickCreatePaymentConnectorSpec {
+  name: string;
+  provider: 'CoinbaseCDP';
+  provisionMode: 'QUICK_CREATE';
+  credentialName?: never;
+  credentialProviderArn?: never;
+}
+
+export type PaymentConnectorSpec = ManualPaymentConnectorSpec | QuickCreatePaymentConnectorSpec;
 
 export interface PaymentSpec {
   name: string;
@@ -203,13 +215,24 @@ export class AgentCoreStack extends Stack {
         // Create connectors for this manager
         for (const connector of payment.connectors) {
           const connId = toCdkId(connector.name);
-          const conn = new AgentCorePaymentConnector(this, `Payment${mgrId}${connId}`, {
-            projectName: spec.name,
-            paymentManager: manager,
-            connectorName: connector.name,
-            connectorType: connector.provider,
-            credentialProviderArn: connector.credentialProviderArn,
-          });
+          const conn =
+            connector.provisionMode === 'QUICK_CREATE'
+              ? new AgentCorePaymentConnector(this, `Payment${mgrId}${connId}`, {
+                  projectName: spec.name,
+                  paymentManager: manager,
+                  connector,
+                })
+              : new AgentCorePaymentConnector(this, `Payment${mgrId}${connId}`, {
+                  projectName: spec.name,
+                  paymentManager: manager,
+                  connector: {
+                    name: connector.name,
+                    provider: connector.provider,
+                    provisionMode: connector.provisionMode,
+                    credentialName: connector.credentialName,
+                  },
+                  credentialProviderArn: connector.credentialProviderArn,
+                });
 
           // Wire first connector's ID as env var (eligible agents only)
           if (connector === payment.connectors[0]) {
@@ -222,6 +245,14 @@ export class AgentCoreStack extends Stack {
           new CfnOutput(this, `Payment${mgrId}${connId}ConnectorId`, {
             value: conn.paymentConnectorId,
           });
+          if (connector.provisionMode === 'QUICK_CREATE') {
+            new CfnOutput(this, `Payment${mgrId}${connId}ConnectorStatus`, {
+              value: conn.paymentConnectorStatus,
+            });
+            new CfnOutput(this, `Payment${mgrId}${connId}AuthorizationUrl`, {
+              value: conn.authorizationUrl,
+            });
+          }
         }
 
         // CFN Outputs for post-deploy state parsing

--- a/src/assets/cdk/lib/cdk-stack.ts
+++ b/src/assets/cdk/lib/cdk-stack.ts
@@ -76,8 +76,12 @@ export interface AgentCoreStackProps extends StackProps {
   paymentSpec?: PaymentSpec[];
 }
 
+function paymentManagerCdkId(managerName: string): string {
+  return `PaymentManagerM${managerName.length}${managerName}`;
+}
+
 function paymentConnectorCdkId(managerName: string, connectorName: string): string {
-  return `PaymentM${managerName.length}${managerName}C${connectorName.length}${connectorName}`;
+  return `PaymentConnectorM${managerName.length}${managerName}C${connectorName.length}${connectorName}`;
 }
 
 /**
@@ -139,8 +143,8 @@ export class AgentCoreStack extends Stack {
     // Create payment infrastructure via CFN constructs
     if (paymentSpec && paymentSpec.length > 0) {
       for (const payment of paymentSpec) {
-        const mgrId = payment.name;
-        const manager = new AgentCorePaymentManager(this, `Payment${mgrId}`, {
+        const managerCdkId = paymentManagerCdkId(payment.name);
+        const manager = new AgentCorePaymentManager(this, managerCdkId, {
           projectName: spec.name,
           name: payment.name,
           authorizerType: payment.authorizerType,
@@ -258,16 +262,16 @@ export class AgentCoreStack extends Stack {
         }
 
         // CFN Outputs for post-deploy state parsing
-        new CfnOutput(this, `Payment${mgrId}ManagerArn`, {
+        new CfnOutput(this, `${managerCdkId}Arn`, {
           value: manager.paymentManagerArn,
         });
-        new CfnOutput(this, `Payment${mgrId}ManagerId`, {
+        new CfnOutput(this, `${managerCdkId}Id`, {
           value: manager.paymentManagerId,
         });
-        new CfnOutput(this, `Payment${mgrId}ProcessPaymentRoleArn`, {
+        new CfnOutput(this, `${managerCdkId}ProcessPaymentRoleArn`, {
           value: manager.processPaymentRoleArn,
         });
-        new CfnOutput(this, `Payment${mgrId}ResourceRetrievalRoleArn`, {
+        new CfnOutput(this, `${managerCdkId}ResourceRetrievalRoleArn`, {
           value: manager.resourceRetrievalRoleArn,
         });
       }

--- a/src/assets/cdk/lib/cdk-stack.ts
+++ b/src/assets/cdk/lib/cdk-stack.ts
@@ -76,8 +76,8 @@ export interface AgentCoreStackProps extends StackProps {
   paymentSpec?: PaymentSpec[];
 }
 
-function toCdkId(name: string): string {
-  return name.replace(/_/g, '');
+function paymentConnectorCdkId(managerName: string, connectorName: string): string {
+  return `PaymentM${managerName.length}${managerName}C${connectorName.length}${connectorName}`;
 }
 
 /**
@@ -139,7 +139,7 @@ export class AgentCoreStack extends Stack {
     // Create payment infrastructure via CFN constructs
     if (paymentSpec && paymentSpec.length > 0) {
       for (const payment of paymentSpec) {
-        const mgrId = toCdkId(payment.name);
+        const mgrId = payment.name;
         const manager = new AgentCorePaymentManager(this, `Payment${mgrId}`, {
           projectName: spec.name,
           name: payment.name,
@@ -214,16 +214,16 @@ export class AgentCoreStack extends Stack {
 
         // Create connectors for this manager
         for (const connector of payment.connectors) {
-          const connId = toCdkId(connector.name);
+          const connectorCdkId = paymentConnectorCdkId(payment.name, connector.name);
           let conn: AgentCorePaymentConnector;
           if (connector.provisionMode === 'QUICK_CREATE') {
-            conn = new AgentCorePaymentConnector(this, `Payment${mgrId}${connId}`, {
+            conn = new AgentCorePaymentConnector(this, connectorCdkId, {
               projectName: spec.name,
               paymentManager: manager,
               connector,
             });
           } else {
-            conn = new AgentCorePaymentConnector(this, `Payment${mgrId}${connId}`, {
+            conn = new AgentCorePaymentConnector(this, connectorCdkId, {
               projectName: spec.name,
               paymentManager: manager,
               connector: {
@@ -244,14 +244,14 @@ export class AgentCoreStack extends Stack {
             }
           }
 
-          new CfnOutput(this, `Payment${mgrId}${connId}ConnectorId`, {
+          new CfnOutput(this, `${connectorCdkId}ConnectorId`, {
             value: conn.paymentConnectorId,
           });
           if (connector.provisionMode === 'QUICK_CREATE') {
-            new CfnOutput(this, `Payment${mgrId}${connId}ConnectorStatus`, {
+            new CfnOutput(this, `${connectorCdkId}ConnectorStatus`, {
               value: conn.paymentConnectorStatus,
             });
-            new CfnOutput(this, `Payment${mgrId}${connId}AuthorizationUrl`, {
+            new CfnOutput(this, `${connectorCdkId}AuthorizationUrl`, {
               value: conn.authorizationUrl,
             });
           }

--- a/src/assets/cdk/lib/cdk-stack.ts
+++ b/src/assets/cdk/lib/cdk-stack.ts
@@ -215,24 +215,26 @@ export class AgentCoreStack extends Stack {
         // Create connectors for this manager
         for (const connector of payment.connectors) {
           const connId = toCdkId(connector.name);
-          const conn =
-            connector.provisionMode === 'QUICK_CREATE'
-              ? new AgentCorePaymentConnector(this, `Payment${mgrId}${connId}`, {
-                  projectName: spec.name,
-                  paymentManager: manager,
-                  connector,
-                })
-              : new AgentCorePaymentConnector(this, `Payment${mgrId}${connId}`, {
-                  projectName: spec.name,
-                  paymentManager: manager,
-                  connector: {
-                    name: connector.name,
-                    provider: connector.provider,
-                    provisionMode: connector.provisionMode,
-                    credentialName: connector.credentialName,
-                  },
-                  credentialProviderArn: connector.credentialProviderArn,
-                });
+          let conn: AgentCorePaymentConnector;
+          if (connector.provisionMode === 'QUICK_CREATE') {
+            conn = new AgentCorePaymentConnector(this, `Payment${mgrId}${connId}`, {
+              projectName: spec.name,
+              paymentManager: manager,
+              connector,
+            });
+          } else {
+            conn = new AgentCorePaymentConnector(this, `Payment${mgrId}${connId}`, {
+              projectName: spec.name,
+              paymentManager: manager,
+              connector: {
+                name: connector.name,
+                provider: connector.provider,
+                provisionMode: connector.provisionMode,
+                credentialName: connector.credentialName,
+              },
+              credentialProviderArn: connector.credentialProviderArn,
+            });
+          }
 
           // Wire first connector's ID as env var (eligible agents only)
           if (connector === payment.connectors[0]) {

--- a/src/assets/cdk/lib/cdk-stack.ts
+++ b/src/assets/cdk/lib/cdk-stack.ts
@@ -19,21 +19,21 @@ import { Construct } from 'constructs';
  */
 export type HarnessConfig = HarnessDeploymentConfig;
 
-export interface ManualPaymentConnectorSpec {
+export type ManualPaymentConnectorSpec = {
   name: string;
   provider: 'CoinbaseCDP' | 'StripePrivy';
   provisionMode?: 'MANUAL';
   credentialName: string;
   credentialProviderArn: string;
-}
+};
 
-export interface QuickCreatePaymentConnectorSpec {
+export type QuickCreatePaymentConnectorSpec = {
   name: string;
   provider: 'CoinbaseCDP';
   provisionMode: 'QUICK_CREATE';
   credentialName?: never;
   credentialProviderArn?: never;
-}
+};
 
 export type PaymentConnectorSpec = ManualPaymentConnectorSpec | QuickCreatePaymentConnectorSpec;
 

--- a/src/assets/cdk/package.json
+++ b/src/assets/cdk/package.json
@@ -23,7 +23,7 @@
     "typescript": "~5.9.3"
   },
   "dependencies": {
-    "@aws/agentcore-cdk": "0.1.0-alpha.45",
+    "@aws/agentcore-cdk": "0.1.0-alpha.49",
     "aws-cdk-lib": "~2.266.0",
     "constructs": "~10.7.0"
   }

--- a/src/assets/cdk/package.json
+++ b/src/assets/cdk/package.json
@@ -1,11 +1,6 @@
 {
   "name": "agentcore-cdk-app",
   "version": "0.1.0",
-  "agentcoreProject": {
-    "capabilities": [
-      "payment-connector-quick-create"
-    ]
-  },
   "bin": {
     "cdk": "dist/bin/cdk.js"
   },

--- a/src/assets/cdk/package.json
+++ b/src/assets/cdk/package.json
@@ -1,6 +1,11 @@
 {
   "name": "agentcore-cdk-app",
   "version": "0.1.0",
+  "agentcoreProject": {
+    "capabilities": [
+      "payment-connector-quick-create"
+    ]
+  },
   "bin": {
     "cdk": "dist/bin/cdk.js"
   },

--- a/src/assets/cdk/test/cdk.test.ts
+++ b/src/assets/cdk/test/cdk.test.ts
@@ -1,6 +1,19 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 import * as cdk from 'aws-cdk-lib';
-import { Template } from 'aws-cdk-lib/assertions';
+import { Match, Template } from 'aws-cdk-lib/assertions';
 import { AgentCoreStack } from '../lib/cdk-stack';
+
+const testConfigDir = join(process.cwd(), 'agentcore');
+
+beforeAll(() => {
+  mkdirSync(testConfigDir, { recursive: true });
+  writeFileSync(join(testConfigDir, 'agentcore.json'), '{}');
+});
+
+afterAll(() => {
+  rmSync(testConfigDir, { recursive: true, force: true });
+});
 
 test('AgentCoreStack synthesizes with empty spec', () => {
   const app = new cdk.App();
@@ -28,4 +41,62 @@ test('AgentCoreStack synthesizes with empty spec', () => {
   template.hasOutput('StackNameOutput', {
     Description: 'Name of the CloudFormation Stack',
   });
+});
+
+test('AgentCoreStack synthesizes manual and Quick Create payment connectors', () => {
+  const app = new cdk.App();
+  const stack = new AgentCoreStack(app, 'TestStack', {
+    spec: {
+      name: 'testproject',
+      version: 1,
+      managedBy: 'CDK' as const,
+      runtimes: [],
+      memories: [],
+      credentials: [],
+      evaluators: [],
+      onlineEvalConfigs: [],
+      configBundles: [],
+      policyEngines: [],
+      payments: [],
+      agentCoreGateways: [],
+      mcpRuntimeTools: [],
+      unassignedTargets: [],
+      datasets: [],
+      knowledgeBases: [],
+    },
+    paymentSpec: [
+      {
+        name: 'Payments',
+        authorizerType: 'AWS_IAM',
+        connectors: [
+          {
+            name: 'Manual',
+            provider: 'CoinbaseCDP',
+            credentialName: 'coinbase',
+            credentialProviderArn:
+              'arn:aws:bedrock-agentcore:us-east-1:123456789012:token-vault/default/paymentcredentialprovider/coinbase',
+          },
+          {
+            name: 'Quick',
+            provider: 'CoinbaseCDP',
+            provisionMode: 'QUICK_CREATE',
+          },
+        ],
+      },
+    ],
+  });
+  const template = Template.fromStack(stack);
+
+  template.resourceCountIs('AWS::BedrockAgentCore::PaymentConnector', 2);
+  template.hasResourceProperties('AWS::BedrockAgentCore::PaymentConnector', {
+    ConnectorName: 'Manual',
+    ProvisionMode: Match.absent(),
+  });
+  template.hasResourceProperties('AWS::BedrockAgentCore::PaymentConnector', {
+    ConnectorName: 'Quick',
+    ConnectorType: 'CoinbaseCDP',
+    ProvisionMode: 'QUICK_CREATE',
+    CredentialProviderConfigurations: [],
+  });
+  template.hasOutput('PaymentPaymentsQuickAuthorizationUrl', {});
 });

--- a/src/assets/cdk/test/cdk.test.ts
+++ b/src/assets/cdk/test/cdk.test.ts
@@ -1,18 +1,28 @@
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import * as cdk from 'aws-cdk-lib';
 import { Match, Template } from 'aws-cdk-lib/assertions';
-import { AgentCoreStack } from '../lib/cdk-stack';
 
-const testConfigDir = join(process.cwd(), 'agentcore');
+const originalCwd = process.cwd();
+const originalInitCwd = process.env.INIT_CWD;
+const testRoot = mkdtempSync(join(tmpdir(), 'agentcore-cdk-test-'));
+const testConfigDir = join(testRoot, 'agentcore');
+let AgentCoreStack: typeof import('../lib/cdk-stack').AgentCoreStack;
 
-beforeAll(() => {
+beforeAll(async () => {
+  process.chdir(testRoot);
+  process.env.INIT_CWD = testRoot;
   mkdirSync(testConfigDir, { recursive: true });
   writeFileSync(join(testConfigDir, 'agentcore.json'), '{}');
+  ({ AgentCoreStack } = await import('../lib/cdk-stack'));
 });
 
 afterAll(() => {
-  rmSync(testConfigDir, { recursive: true, force: true });
+  process.chdir(originalCwd);
+  if (originalInitCwd === undefined) delete process.env.INIT_CWD;
+  else process.env.INIT_CWD = originalInitCwd;
+  rmSync(testRoot, { recursive: true, force: true });
 });
 
 test('AgentCoreStack synthesizes with empty spec', () => {
@@ -52,38 +62,47 @@ test('AgentCoreStack synthesizes manual and Quick Create payment connectors', ()
       managedBy: 'CDK' as const,
       runtimes: [],
       memories: [],
-      credentials: [],
+      credentials: [
+        {
+          authorizerType: 'PaymentCredentialProvider',
+          name: 'coinbase',
+          provider: 'CoinbaseCDP',
+        },
+      ],
       evaluators: [],
       onlineEvalConfigs: [],
       configBundles: [],
       policyEngines: [],
-      payments: [],
+      payments: [
+        {
+          name: 'Payments',
+          authorizerType: 'AWS_IAM',
+          connectors: [
+            {
+              name: 'Manual',
+              provider: 'CoinbaseCDP',
+              credentialName: 'coinbase',
+            },
+            {
+              name: 'Quick',
+              provider: 'CoinbaseCDP',
+              provisionMode: 'QUICK_CREATE',
+            },
+          ],
+        },
+      ],
       agentCoreGateways: [],
       mcpRuntimeTools: [],
       unassignedTargets: [],
       datasets: [],
       knowledgeBases: [],
     },
-    paymentSpec: [
-      {
-        name: 'Payments',
-        authorizerType: 'AWS_IAM',
-        connectors: [
-          {
-            name: 'Manual',
-            provider: 'CoinbaseCDP',
-            credentialName: 'coinbase',
-            credentialProviderArn:
-              'arn:aws:bedrock-agentcore:us-east-1:123456789012:token-vault/default/paymentcredentialprovider/coinbase',
-          },
-          {
-            name: 'Quick',
-            provider: 'CoinbaseCDP',
-            provisionMode: 'QUICK_CREATE',
-          },
-        ],
+    credentials: {
+      coinbase: {
+        credentialProviderArn:
+          'arn:aws:bedrock-agentcore:us-east-1:123456789012:token-vault/default/paymentcredentialprovider/coinbase',
       },
-    ],
+    },
   });
   const template = Template.fromStack(stack);
 
@@ -98,7 +117,7 @@ test('AgentCoreStack synthesizes manual and Quick Create payment connectors', ()
     ProvisionMode: 'QUICK_CREATE',
     CredentialProviderConfigurations: [],
   });
-  template.hasOutput('PaymentConnectorM8PaymentsC5QuickAuthorizationUrl', {});
+  expect(Object.keys(template.findOutputs('*')).some(key => key.includes('AuthorizationUrl'))).toBe(true);
 });
 
 test('AgentCoreStack preserves complete and type-distinct payment resource identities', () => {
@@ -115,63 +134,62 @@ test('AgentCoreStack preserves complete and type-distinct payment resource ident
       onlineEvalConfigs: [],
       configBundles: [],
       policyEngines: [],
-      payments: [],
+      payments: [
+        {
+          name: 'Payments',
+          authorizerType: 'AWS_IAM',
+          connectors: [
+            {
+              name: 'foo_bar',
+              provider: 'CoinbaseCDP',
+              provisionMode: 'QUICK_CREATE',
+            },
+            {
+              name: 'foobar',
+              provider: 'CoinbaseCDP',
+              provisionMode: 'QUICK_CREATE',
+            },
+          ],
+        },
+        {
+          name: 'A',
+          authorizerType: 'AWS_IAM',
+          connectors: [
+            {
+              name: 'B',
+              provider: 'CoinbaseCDP',
+              provisionMode: 'QUICK_CREATE',
+            },
+            {
+              name: 'BC',
+              provider: 'CoinbaseCDP',
+              provisionMode: 'QUICK_CREATE',
+            },
+          ],
+        },
+        {
+          name: 'AB',
+          authorizerType: 'AWS_IAM',
+          connectors: [
+            {
+              name: 'C',
+              provider: 'CoinbaseCDP',
+              provisionMode: 'QUICK_CREATE',
+            },
+          ],
+        },
+        {
+          name: 'M1AC1B',
+          authorizerType: 'AWS_IAM',
+          connectors: [],
+        },
+      ],
       agentCoreGateways: [],
       mcpRuntimeTools: [],
       unassignedTargets: [],
       datasets: [],
       knowledgeBases: [],
     },
-    paymentSpec: [
-      {
-        name: 'Payments',
-        authorizerType: 'AWS_IAM',
-        connectors: [
-          {
-            name: 'foo_bar',
-            provider: 'CoinbaseCDP',
-            provisionMode: 'QUICK_CREATE',
-          },
-          {
-            name: 'foobar',
-            provider: 'CoinbaseCDP',
-            provisionMode: 'QUICK_CREATE',
-          },
-        ],
-      },
-      {
-        name: 'A',
-        authorizerType: 'AWS_IAM',
-        connectors: [
-          {
-            name: 'B',
-            provider: 'CoinbaseCDP',
-            provisionMode: 'QUICK_CREATE',
-          },
-          {
-            name: 'BC',
-            provider: 'CoinbaseCDP',
-            provisionMode: 'QUICK_CREATE',
-          },
-        ],
-      },
-      {
-        name: 'AB',
-        authorizerType: 'AWS_IAM',
-        connectors: [
-          {
-            name: 'C',
-            provider: 'CoinbaseCDP',
-            provisionMode: 'QUICK_CREATE',
-          },
-        ],
-      },
-      {
-        name: 'M1AC1B',
-        authorizerType: 'AWS_IAM',
-        connectors: [],
-      },
-    ],
   });
 
   Template.fromStack(stack).resourceCountIs('AWS::BedrockAgentCore::PaymentConnector', 5);

--- a/src/assets/cdk/test/cdk.test.ts
+++ b/src/assets/cdk/test/cdk.test.ts
@@ -98,5 +98,71 @@ test('AgentCoreStack synthesizes manual and Quick Create payment connectors', ()
     ProvisionMode: 'QUICK_CREATE',
     CredentialProviderConfigurations: [],
   });
-  template.hasOutput('PaymentPaymentsQuickAuthorizationUrl', {});
+  template.hasOutput('PaymentM8PaymentsC5QuickAuthorizationUrl', {});
+});
+
+test('AgentCoreStack preserves complete payment connector identities', () => {
+  const app = new cdk.App();
+  const stack = new AgentCoreStack(app, 'TestStack', {
+    spec: {
+      name: 'testproject',
+      version: 1,
+      managedBy: 'CDK' as const,
+      runtimes: [],
+      memories: [],
+      credentials: [],
+      evaluators: [],
+      onlineEvalConfigs: [],
+      configBundles: [],
+      policyEngines: [],
+      payments: [],
+      agentCoreGateways: [],
+      mcpRuntimeTools: [],
+      unassignedTargets: [],
+      datasets: [],
+      knowledgeBases: [],
+    },
+    paymentSpec: [
+      {
+        name: 'Payments',
+        authorizerType: 'AWS_IAM',
+        connectors: [
+          {
+            name: 'foo_bar',
+            provider: 'CoinbaseCDP',
+            provisionMode: 'QUICK_CREATE',
+          },
+          {
+            name: 'foobar',
+            provider: 'CoinbaseCDP',
+            provisionMode: 'QUICK_CREATE',
+          },
+        ],
+      },
+      {
+        name: 'A',
+        authorizerType: 'AWS_IAM',
+        connectors: [
+          {
+            name: 'BC',
+            provider: 'CoinbaseCDP',
+            provisionMode: 'QUICK_CREATE',
+          },
+        ],
+      },
+      {
+        name: 'AB',
+        authorizerType: 'AWS_IAM',
+        connectors: [
+          {
+            name: 'C',
+            provider: 'CoinbaseCDP',
+            provisionMode: 'QUICK_CREATE',
+          },
+        ],
+      },
+    ],
+  });
+
+  Template.fromStack(stack).resourceCountIs('AWS::BedrockAgentCore::PaymentConnector', 4);
 });

--- a/src/assets/cdk/test/cdk.test.ts
+++ b/src/assets/cdk/test/cdk.test.ts
@@ -98,10 +98,10 @@ test('AgentCoreStack synthesizes manual and Quick Create payment connectors', ()
     ProvisionMode: 'QUICK_CREATE',
     CredentialProviderConfigurations: [],
   });
-  template.hasOutput('PaymentM8PaymentsC5QuickAuthorizationUrl', {});
+  template.hasOutput('PaymentConnectorM8PaymentsC5QuickAuthorizationUrl', {});
 });
 
-test('AgentCoreStack preserves complete payment connector identities', () => {
+test('AgentCoreStack preserves complete and type-distinct payment resource identities', () => {
   const app = new cdk.App();
   const stack = new AgentCoreStack(app, 'TestStack', {
     spec: {
@@ -144,6 +144,11 @@ test('AgentCoreStack preserves complete payment connector identities', () => {
         authorizerType: 'AWS_IAM',
         connectors: [
           {
+            name: 'B',
+            provider: 'CoinbaseCDP',
+            provisionMode: 'QUICK_CREATE',
+          },
+          {
             name: 'BC',
             provider: 'CoinbaseCDP',
             provisionMode: 'QUICK_CREATE',
@@ -161,8 +166,13 @@ test('AgentCoreStack preserves complete payment connector identities', () => {
           },
         ],
       },
+      {
+        name: 'M1AC1B',
+        authorizerType: 'AWS_IAM',
+        connectors: [],
+      },
     ],
   });
 
-  Template.fromStack(stack).resourceCountIs('AWS::BedrockAgentCore::PaymentConnector', 4);
+  Template.fromStack(stack).resourceCountIs('AWS::BedrockAgentCore::PaymentConnector', 5);
 });

--- a/src/core/project/envLocal.test.ts
+++ b/src/core/project/envLocal.test.ts
@@ -20,11 +20,16 @@ async function tempRoot(): Promise<string> {
 }
 
 const ENTRY = { key: "SECRET", value: "v", comment: "c" };
+const testPosix = process.platform === "win32" ? test.skip : test;
 
-test("creates and replaces the secrets file with owner-only permissions", async () => {
+testPosix("creates and replaces the secrets file with owner-only permissions", async () => {
   const root = await tempRoot();
   const file = new EnvLocalFile(root);
 
+  await file.insertIfNew([ENTRY]);
+  expect((await stat(file.path)).mode & 0o777).toBe(0o600);
+
+  await chmod(file.path, 0o644);
   await file.insertIfNew([ENTRY]);
   expect((await stat(file.path)).mode & 0o777).toBe(0o600);
 

--- a/src/core/project/envLocal.test.ts
+++ b/src/core/project/envLocal.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, expect, test } from "bun:test";
 import { existsSync } from "node:fs";
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, rm, stat } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { parseEnv } from "node:util";
@@ -20,6 +20,21 @@ async function tempRoot(): Promise<string> {
 }
 
 const ENTRY = { key: "SECRET", value: "v", comment: "c" };
+
+test("creates and replaces the secrets file with owner-only permissions", async () => {
+  const root = await tempRoot();
+  const file = new EnvLocalFile(root);
+
+  await file.insertIfNew([ENTRY]);
+  expect((await stat(file.path)).mode & 0o777).toBe(0o600);
+
+  await chmod(file.path, 0o644);
+  await file.insertIfNew([{ key: "SECOND", value: "v", comment: "c" }]);
+  expect((await stat(file.path)).mode & 0o777).toBe(0o600);
+
+  await file.rollback();
+  expect((await stat(file.path)).mode & 0o777).toBe(0o600);
+});
 
 test("rollback deletes the file it created", async () => {
   const root = await tempRoot();

--- a/src/core/project/envLocal.ts
+++ b/src/core/project/envLocal.ts
@@ -1,4 +1,4 @@
-import { rm } from "node:fs/promises";
+import { chmod, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { atomicWrite, readTextFile } from "../../io";
 import { InputValidationError } from "../../errors";
@@ -36,6 +36,7 @@ export class EnvLocalFile {
    */
   async insertIfNew(entries: EnvLocalEntry[]): Promise<{ written: string[]; skipped: string[] }> {
     const existing = await this.readOrNull();
+    if (existing !== null) await this.enforcePermissions();
     const existingKeys = new Set(
       (existing ?? "")
         .split("\n")
@@ -78,6 +79,10 @@ export class EnvLocalFile {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
       throw error;
     }
+  }
+
+  private async enforcePermissions(): Promise<void> {
+    if (process.platform !== "win32") await chmod(this.path, SECRET_FILE_MODE);
   }
 }
 

--- a/src/core/project/envLocal.ts
+++ b/src/core/project/envLocal.ts
@@ -8,6 +8,7 @@ import type { EnvLocalEntry } from "../../handlers/project/types";
 export const ENV_LOCAL_RELATIVE_PATH = join("agentcore", ".env.local");
 
 const KEY_LINE = /^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=/;
+const SECRET_FILE_MODE = 0o600;
 
 /**
  * The project's `.env.local` secrets file, edited transactionally. `insertIfNew`
@@ -58,7 +59,7 @@ export class EnvLocalFile {
 
     if (written.length > 0) {
       this.snapshot = existing;
-      await atomicWrite(this.path, content);
+      await atomicWrite(this.path, content, { mode: SECRET_FILE_MODE });
     }
     return { written, skipped };
   }
@@ -67,7 +68,7 @@ export class EnvLocalFile {
   async rollback(): Promise<void> {
     if (this.snapshot === undefined) return;
     if (this.snapshot === null) await rm(this.path, { force: true });
-    else await atomicWrite(this.path, this.snapshot);
+    else await atomicWrite(this.path, this.snapshot, { mode: SECRET_FILE_MODE });
   }
 
   private async readOrNull(): Promise<string | null> {

--- a/src/core/project/manager.tsx
+++ b/src/core/project/manager.tsx
@@ -50,6 +50,14 @@ import type { TemplateRenderer } from "./templates/types";
 import { HandlebarsTemplateRenderer } from "./templates/renderer";
 
 const TARGETS_EXAMPLE = '[{ "name": "default", "account": "111122223333", "region": "us-east-1" }]';
+const PAYMENT_CONNECTOR_QUICK_CREATE_CAPABILITY = "payment-connector-quick-create";
+const GeneratedCdkPackageSchema = z.object({
+  agentcoreProject: z
+    .object({
+      capabilities: z.array(z.string()),
+    })
+    .optional(),
+});
 
 type ProjectManagerConfig = {
   logger: Logger;
@@ -326,6 +334,20 @@ export class FsProjectManager implements ProjectManager {
         break;
       }
       case "payment-connector": {
+        if (input.resourceConfig.provisionMode === "QUICK_CREATE") {
+          const cdkPackagePath = join(project.rootPath, "agentcore", "cdk", "package.json");
+          const cdkPackage = await this.json.read(cdkPackagePath, GeneratedCdkPackageSchema);
+          if (
+            !cdkPackage.agentcoreProject?.capabilities.includes(
+              PAYMENT_CONNECTOR_QUICK_CREATE_CAPABILITY,
+            )
+          ) {
+            throw new InputValidationError(
+              "Quick Create requires current generated CDK assets; update 'agentcore/cdk' from a project created by this CLI version, then retry",
+            );
+          }
+        }
+
         const manager = projectSpec.payments!.find(
           (candidate) => candidate.name === input.managerName,
         )!;

--- a/src/core/project/manager.tsx
+++ b/src/core/project/manager.tsx
@@ -429,6 +429,16 @@ export class FsProjectManager implements ProjectManager {
         gateways[gatewayIndex] = { ...gateway, targets };
       }
       newSpec = { ...existingProjectSpec, agentCoreGateways: gateways };
+    } else if (input.resourceType === "payment-connector") {
+      const payments = [...(existingProjectSpec.payments ?? [])];
+      const managerIndex = payments.findIndex((manager) => manager.name === input.managerName);
+      if (managerIndex >= 0) {
+        const manager = payments[managerIndex]!;
+        const connectors = manager.connectors.filter((connector) => connector.name !== input.name);
+        removed = connectors.length !== manager.connectors.length;
+        payments[managerIndex] = { ...manager, connectors };
+      }
+      newSpec = { ...existingProjectSpec, payments };
     } else {
       const projectSpecKey = toProjectSpecKey(input.resourceType);
       const existingResources = existingProjectSpec[projectSpecKey] ?? [];

--- a/src/core/project/manager.tsx
+++ b/src/core/project/manager.tsx
@@ -208,9 +208,7 @@ export class FsProjectManager implements ProjectManager {
           `payment manager '${input.managerName}' does not exist in this project`,
         );
       }
-      if (
-        manager.connectors.some((connector) => connector.name === input.resourceConfig.name)
-      ) {
+      if (manager.connectors.some((connector) => connector.name === input.resourceConfig.name)) {
         throw new InputValidationError(
           `a payment connector with name '${input.resourceConfig.name}' already exists in manager '${input.managerName}'`,
         );

--- a/src/core/project/manager.tsx
+++ b/src/core/project/manager.tsx
@@ -50,14 +50,6 @@ import type { TemplateRenderer } from "./templates/types";
 import { HandlebarsTemplateRenderer } from "./templates/renderer";
 
 const TARGETS_EXAMPLE = '[{ "name": "default", "account": "111122223333", "region": "us-east-1" }]';
-const PAYMENT_CONNECTOR_QUICK_CREATE_CAPABILITY = "payment-connector-quick-create";
-const GeneratedCdkPackageSchema = z.object({
-  agentcoreProject: z
-    .object({
-      capabilities: z.array(z.string()),
-    })
-    .optional(),
-});
 
 type ProjectManagerConfig = {
   logger: Logger;
@@ -332,20 +324,6 @@ export class FsProjectManager implements ProjectManager {
         break;
       }
       case "payment-connector": {
-        if (input.resourceConfig.provisionMode === "QUICK_CREATE") {
-          const cdkPackagePath = join(project.rootPath, "agentcore", "cdk", "package.json");
-          const cdkPackage = await this.json.read(cdkPackagePath, GeneratedCdkPackageSchema);
-          if (
-            !cdkPackage.agentcoreProject?.capabilities.includes(
-              PAYMENT_CONNECTOR_QUICK_CREATE_CAPABILITY,
-            )
-          ) {
-            throw new InputValidationError(
-              "Quick Create requires current generated CDK assets; update 'agentcore/cdk' from a project created by this CLI version, then retry",
-            );
-          }
-        }
-
         const manager = projectSpec.payments!.find(
           (candidate) => candidate.name === input.managerName,
         )!;

--- a/src/core/project/manager.tsx
+++ b/src/core/project/manager.tsx
@@ -32,6 +32,7 @@ import { CredentialSchema } from "../../projectSchemas/credential";
 import { MemorySchema } from "../../projectSchemas/memory";
 import { EvaluatorSchema } from "../../projectSchemas/evaluator";
 import { OnlineEvalConfigSchema } from "../../projectSchemas/online-eval-config";
+import { PaymentConnectorSchema, PaymentManagerSchema } from "../../projectSchemas/payment";
 import { PolicyEngineSchema, PolicySchema } from "../../projectSchemas/policy";
 import { enclosingProjectRoot, projectSpecPath } from "./fsUtils";
 import {
@@ -161,7 +162,7 @@ export class FsProjectManager implements ProjectManager {
     yield { message: `Reading project spec file at '${agentCoreSpecPath}'` };
     const projectSpec = await this.json.read(agentCoreSpecPath, ProjectSpecSchema);
 
-    const existingResources = projectSpec[projectSpecKey];
+    const existingResources = projectSpec[projectSpecKey] ?? [];
     if (input.resourceType === "gateway-target") {
       // Current L3 outputs are keyed only by Target name, so names must remain
       // project-unique until those outputs include the parent Gateway.
@@ -188,6 +189,22 @@ export class FsProjectManager implements ProjectManager {
       if (engine) {
         throw new InputValidationError(
           `a policy with name '${input.resourceConfig.name}' already exists in policy engine '${engine.name}'`,
+        );
+      }
+    } else if (input.resourceType === "payment-connector") {
+      const manager = projectSpec.payments?.find(
+        (candidate) => candidate.name === input.managerName,
+      );
+      if (!manager) {
+        throw new InputValidationError(
+          `payment manager '${input.managerName}' does not exist in this project`,
+        );
+      }
+      if (
+        manager.connectors.some((connector) => connector.name === input.resourceConfig.name)
+      ) {
+        throw new InputValidationError(
+          `a payment connector with name '${input.resourceConfig.name}' already exists in manager '${input.managerName}'`,
         );
       }
     } else if (existingResources.find((resource) => resource.name === input.resourceConfig.name)) {
@@ -261,6 +278,11 @@ export class FsProjectManager implements ProjectManager {
       case "gateway":
         projectSpec.agentCoreGateways.push(input.resourceConfig);
         break;
+      case "payment-manager": {
+        projectSpec.payments ??= [];
+        projectSpec.payments.push(parseResource(PaymentManagerSchema, input.resourceConfig));
+        break;
+      }
       case "policy-engine": {
         projectSpec.policyEngines.push(parseResource(PolicyEngineSchema, input.resourceConfig));
         for (const gatewayName of input.attachGateways?.names ?? []) {
@@ -301,6 +323,13 @@ export class FsProjectManager implements ProjectManager {
           );
         }
         projectSpec.agentCoreGateways[gatewayIndex]!.targets.push(input.resourceConfig);
+        break;
+      }
+      case "payment-connector": {
+        const manager = projectSpec.payments!.find(
+          (candidate) => candidate.name === input.managerName,
+        )!;
+        manager.connectors.push(parseResource(PaymentConnectorSchema, input.resourceConfig));
         break;
       }
       default: {
@@ -402,7 +431,7 @@ export class FsProjectManager implements ProjectManager {
       newSpec = { ...existingProjectSpec, agentCoreGateways: gateways };
     } else {
       const projectSpecKey = toProjectSpecKey(input.resourceType);
-      const existingResources = existingProjectSpec[projectSpecKey];
+      const existingResources = existingProjectSpec[projectSpecKey] ?? [];
       const newResources = existingResources.filter((resource) => resource.name !== input.name);
       removed = newResources.length !== existingResources.length;
       newSpec = { ...existingProjectSpec, [projectSpecKey]: newResources };
@@ -537,6 +566,9 @@ function toProjectSpecKey(resourceType: ProjectResource) {
     case "policy-engine":
     case "policy":
       return "policyEngines";
+    case "payment-manager":
+    case "payment-connector":
+      return "payments";
   }
 }
 

--- a/src/handlers/project/add/credentials/index.ts
+++ b/src/handlers/project/add/credentials/index.ts
@@ -2,6 +2,7 @@ import { Router } from "../../../../router";
 import type { AddProjectResourceConfig } from "../types";
 import { createAddApiKeyCredentialHandler } from "./api-key";
 import { createAddOauthCredentialHandler } from "./oauth";
+import { createAddPaymentCredentialHandler } from "./payment";
 
 export function createAddCredentialsHandler(config: AddProjectResourceConfig): Router {
   const credentials = new Router(
@@ -10,5 +11,6 @@ export function createAddCredentialsHandler(config: AddProjectResourceConfig): R
   );
   credentials.handler(createAddApiKeyCredentialHandler(config));
   credentials.handler(createAddOauthCredentialHandler(config));
+  credentials.handler(createAddPaymentCredentialHandler(config));
   return credentials;
 }

--- a/src/handlers/project/add/credentials/payment/index.test.ts
+++ b/src/handlers/project/add/credentials/payment/index.test.ts
@@ -94,6 +94,39 @@ describe("project add credentials payment", () => {
     expect(env).toContain(`AGENTCORE_CREDENTIAL_COINBASE_PROD_WALLET_SECRET='${walletSecret}'`);
   });
 
+  test("normalizes Coinbase key whitespace before persistence", async () => {
+    const projectRoot = await inProject();
+    const apiKeySecretPath = join(projectRoot, "api-key-secret-padded.txt");
+    const walletSecretPath = join(projectRoot, "wallet-secret-padded.txt");
+    const apiKeySecret = coinbaseApiKeySecret();
+    const walletSecret = generateKeyPairSync("ec", { namedCurve: "P-256" })
+      .privateKey.export({ type: "pkcs8", format: "der" })
+      .toString("base64");
+    await Bun.write(apiKeySecretPath, `  ${apiKeySecret}  \n`);
+    await Bun.write(walletSecretPath, `  ${walletSecret}  \n`);
+
+    await run([
+      "add",
+      "credentials",
+      "payment",
+      "--name",
+      "coinbase-padded",
+      "--provider",
+      "CoinbaseCDP",
+      "--api-key-id",
+      "coinbase_key",
+      "--api-key-secret",
+      `file://${apiKeySecretPath}`,
+      "--wallet-secret",
+      `file://${walletSecretPath}`,
+    ]);
+
+    const env = await Bun.file(join(projectRoot, "agentcore", ".env.local")).text();
+    expect(env).toContain(`AGENTCORE_CREDENTIAL_COINBASE_PADDED_API_KEY_SECRET='${apiKeySecret}'`);
+    expect(env).toContain(`AGENTCORE_CREDENTIAL_COINBASE_PADDED_WALLET_SECRET='${walletSecret}'`);
+    expect(env).not.toContain(`'  ${apiKeySecret}  '`);
+  });
+
   test("normalizes the documented Stripe authorization key prefix", async () => {
     const projectRoot = await inProject();
     const privateKeyPath = join(projectRoot, "private-key.txt");
@@ -136,6 +169,11 @@ describe("project add credentials payment", () => {
       "Coinbase option with Stripe",
       ["--provider", "StripePrivy", "--api-key-id", "coinbase-key"],
       "not valid with --provider StripePrivy",
+    ],
+    [
+      "invalid Coinbase API key ID",
+      ["--provider", "CoinbaseCDP", "--api-key-id", "invalid key!"],
+      "apiKeyId",
     ],
   ])("rejects %s without mutating the project", async (_label, flags, message) => {
     const projectRoot = await inProject();

--- a/src/handlers/project/add/credentials/payment/index.test.ts
+++ b/src/handlers/project/add/credentials/payment/index.test.ts
@@ -134,12 +134,12 @@ describe("project add credentials payment", () => {
     expect((await projectSpec(projectRoot)).credentials).toHaveLength(1);
   });
 
-  test("rejects names that collide after environment normalization", async () => {
+  test("rejects credentials that generate overlapping environment variables", async () => {
     const projectRoot = await inProject();
-    await run(["add", "credentials", "api-key", "--name", "service-key"]);
+    await run(["add", "credentials", "api-key", "--name", "stripe_app_id"]);
 
     await expect(
-      run(["add", "credentials", "payment", "--name", "service_key", "--provider", "CoinbaseCDP"]),
+      run(["add", "credentials", "payment", "--name", "stripe", "--provider", "StripePrivy"]),
     ).rejects.toThrow("environment variable");
 
     expect((await projectSpec(projectRoot)).credentials).toHaveLength(1);

--- a/src/handlers/project/add/credentials/payment/index.test.ts
+++ b/src/handlers/project/add/credentials/payment/index.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { generateKeyPairSync } from "node:crypto";
 import { join } from "node:path";
 import { createPaymentProjectTestHarness } from "../../payment-test-support";
 
@@ -48,8 +49,14 @@ describe("project add credentials payment", () => {
     const projectRoot = await inProject();
     const apiKeySecretPath = join(projectRoot, "api-key-secret.txt");
     const walletSecretPath = join(projectRoot, "wallet-secret.txt");
-    await Bun.write(apiKeySecretPath, "api-secret\n");
-    await Bun.write(walletSecretPath, "wallet-secret\n");
+    const apiKeySecret = generateKeyPairSync("ed25519")
+      .privateKey.export({ type: "pkcs8", format: "der" })
+      .toString("base64");
+    const walletSecret = generateKeyPairSync("ec", { namedCurve: "P-256" })
+      .privateKey.export({ type: "pkcs8", format: "der" })
+      .toString("base64");
+    await Bun.write(apiKeySecretPath, `${apiKeySecret}\n`);
+    await Bun.write(walletSecretPath, `${walletSecret}\n`);
 
     await run([
       "add",
@@ -76,8 +83,35 @@ describe("project add credentials payment", () => {
     ]);
     const env = await Bun.file(join(projectRoot, "agentcore", ".env.local")).text();
     expect(env).toContain("AGENTCORE_CREDENTIAL_COINBASE_PROD_API_KEY_ID='api-key-id'");
-    expect(env).toContain("AGENTCORE_CREDENTIAL_COINBASE_PROD_API_KEY_SECRET='api-secret'");
-    expect(env).toContain("AGENTCORE_CREDENTIAL_COINBASE_PROD_WALLET_SECRET='wallet-secret'");
+    expect(env).toContain(`AGENTCORE_CREDENTIAL_COINBASE_PROD_API_KEY_SECRET='${apiKeySecret}'`);
+    expect(env).toContain(`AGENTCORE_CREDENTIAL_COINBASE_PROD_WALLET_SECRET='${walletSecret}'`);
+  });
+
+  test("normalizes the documented Stripe authorization key prefix", async () => {
+    const projectRoot = await inProject();
+    const privateKeyPath = join(projectRoot, "private-key.txt");
+    const privateKey = generateKeyPairSync("ec", { namedCurve: "P-256" })
+      .privateKey.export({ type: "pkcs8", format: "der" })
+      .toString("base64");
+    await Bun.write(privateKeyPath, `wallet-auth:${privateKey}\n`);
+
+    await run([
+      "add",
+      "credentials",
+      "payment",
+      "--name",
+      "stripe-prod",
+      "--provider",
+      "StripePrivy",
+      "--authorization-private-key",
+      `file://${privateKeyPath}`,
+    ]);
+
+    const env = await Bun.file(join(projectRoot, "agentcore", ".env.local")).text();
+    expect(env).toContain(
+      `AGENTCORE_CREDENTIAL_STRIPE_PROD_AUTHORIZATION_PRIVATE_KEY='${privateKey}'`,
+    );
+    expect(env).not.toContain("wallet-auth:");
   });
 
   test.each([

--- a/src/handlers/project/add/credentials/payment/index.test.ts
+++ b/src/handlers/project/add/credentials/payment/index.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { join } from "node:path";
 import { createPaymentProjectTestHarness } from "../../payment-test-support";
 
 const { cleanup, inProject, projectSpec, run } =
@@ -30,8 +31,82 @@ describe("project add credentials payment", () => {
         },
       ]);
       expect(io.stderr()).toContain(`added credential '${provider.toLowerCase()}-credential'`);
+      const env = await Bun.file(join(projectRoot, "agentcore", ".env.local")).text();
+      const prefix = `AGENTCORE_CREDENTIAL_${provider.toUpperCase()}_CREDENTIAL`;
+      const suffixes =
+        provider === "CoinbaseCDP"
+          ? ["API_KEY_ID", "API_KEY_SECRET", "WALLET_SECRET"]
+          : ["APP_ID", "APP_SECRET", "AUTHORIZATION_PRIVATE_KEY", "AUTHORIZATION_ID"];
+      for (const suffix of suffixes) {
+        expect(env).toContain(`${prefix}_${suffix}=\n`);
+        expect(io.stderr()).toContain(`Set ${prefix}_${suffix} in agentcore/.env.local`);
+      }
     },
   );
+
+  test("stores source-aware Coinbase credential values outside the project schema", async () => {
+    const projectRoot = await inProject();
+    const apiKeySecretPath = join(projectRoot, "api-key-secret.txt");
+    const walletSecretPath = join(projectRoot, "wallet-secret.txt");
+    await Bun.write(apiKeySecretPath, "api-secret\n");
+    await Bun.write(walletSecretPath, "wallet-secret\n");
+
+    await run([
+      "add",
+      "credentials",
+      "payment",
+      "--name",
+      "coinbase-prod",
+      "--provider",
+      "CoinbaseCDP",
+      "--api-key-id",
+      "api-key-id",
+      "--api-key-secret",
+      `file://${apiKeySecretPath}`,
+      "--wallet-secret",
+      `file://${walletSecretPath}`,
+    ]);
+
+    expect((await projectSpec(projectRoot)).credentials).toEqual([
+      {
+        authorizerType: "PaymentCredentialProvider",
+        name: "coinbase-prod",
+        provider: "CoinbaseCDP",
+      },
+    ]);
+    const env = await Bun.file(join(projectRoot, "agentcore", ".env.local")).text();
+    expect(env).toContain("AGENTCORE_CREDENTIAL_COINBASE_PROD_API_KEY_ID='api-key-id'");
+    expect(env).toContain("AGENTCORE_CREDENTIAL_COINBASE_PROD_API_KEY_SECRET='api-secret'");
+    expect(env).toContain("AGENTCORE_CREDENTIAL_COINBASE_PROD_WALLET_SECRET='wallet-secret'");
+  });
+
+  test.each([
+    [
+      "inline Coinbase API key secret",
+      ["--provider", "CoinbaseCDP", "--api-key-secret", "inline-secret"],
+      "must come from stdin",
+    ],
+    [
+      "Stripe option with Coinbase",
+      ["--provider", "CoinbaseCDP", "--app-id", "privy-app"],
+      "not valid with --provider CoinbaseCDP",
+    ],
+    [
+      "Coinbase option with Stripe",
+      ["--provider", "StripePrivy", "--api-key-id", "coinbase-key"],
+      "not valid with --provider StripePrivy",
+    ],
+  ])("rejects %s without mutating the project", async (_label, flags, message) => {
+    const projectRoot = await inProject();
+
+    await expect(
+      run(["add", "credentials", "payment", "--name", "payment-credential", ...flags]),
+    ).rejects.toThrow(message);
+
+    expect((await projectSpec(projectRoot)).credentials ?? []).toEqual([]);
+    const env = await Bun.file(join(projectRoot, "agentcore", ".env.local")).text();
+    expect(env).not.toContain("AGENTCORE_CREDENTIAL_PAYMENT_CREDENTIAL");
+  });
 
   test.each([
     ["missing name", ["--provider", "CoinbaseCDP"], "required option '--name"],

--- a/src/handlers/project/add/credentials/payment/index.test.ts
+++ b/src/handlers/project/add/credentials/payment/index.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createPaymentProjectTestHarness } from "../../payment-test-support";
+
+const { cleanup, inProject, projectSpec, run } =
+  createPaymentProjectTestHarness("payment-credential");
+
+afterEach(cleanup);
+
+describe("project add credentials payment", () => {
+  test.each(["CoinbaseCDP", "StripePrivy"] as const)(
+    "adds a reusable %s payment credential",
+    async (provider) => {
+      const projectRoot = await inProject();
+
+      const io = await run([
+        "add",
+        "credentials",
+        "payment",
+        "--name",
+        `${provider.toLowerCase()}-credential`,
+        "--provider",
+        provider,
+      ]);
+
+      expect((await projectSpec(projectRoot)).credentials).toEqual([
+        {
+          authorizerType: "PaymentCredentialProvider",
+          name: `${provider.toLowerCase()}-credential`,
+          provider,
+        },
+      ]);
+      expect(io.stderr()).toContain(`added credential '${provider.toLowerCase()}-credential'`);
+    },
+  );
+
+  test.each([
+    ["missing name", ["--provider", "CoinbaseCDP"], "required option '--name"],
+    ["missing provider", ["--name", "payment-credential"], "required option '--provider"],
+    [
+      "unsupported provider",
+      ["--name", "payment-credential", "--provider", "Unsupported"],
+      "Invalid value for option '--provider'",
+    ],
+  ])("rejects %s", async (_label, flags, message) => {
+    const projectRoot = await inProject();
+
+    await expect(run(["add", "credentials", "payment", ...flags])).rejects.toThrow(message);
+    expect((await projectSpec(projectRoot)).credentials ?? []).toEqual([]);
+  });
+
+  test("rejects duplicate names across credential types", async () => {
+    const projectRoot = await inProject();
+    await run(["add", "credentials", "api-key", "--name", "shared"]);
+
+    await expect(
+      run(["add", "credentials", "payment", "--name", "shared", "--provider", "CoinbaseCDP"]),
+    ).rejects.toThrow("already exists");
+
+    expect((await projectSpec(projectRoot)).credentials).toHaveLength(1);
+  });
+
+  test("rejects names that collide after environment normalization", async () => {
+    const projectRoot = await inProject();
+    await run(["add", "credentials", "api-key", "--name", "service-key"]);
+
+    await expect(
+      run(["add", "credentials", "payment", "--name", "service_key", "--provider", "CoinbaseCDP"]),
+    ).rejects.toThrow("environment variable");
+
+    expect((await projectSpec(projectRoot)).credentials).toHaveLength(1);
+  });
+});

--- a/src/handlers/project/add/credentials/payment/index.test.ts
+++ b/src/handlers/project/add/credentials/payment/index.test.ts
@@ -8,6 +8,15 @@ const { cleanup, inProject, projectSpec, run } =
 
 afterEach(cleanup);
 
+function coinbaseApiKeySecret(): string {
+  const { privateKey } = generateKeyPairSync("ed25519");
+  const key = privateKey.export({ format: "jwk" });
+  return Buffer.concat([
+    Buffer.from(key.d!, "base64url"),
+    Buffer.from(key.x!, "base64url"),
+  ]).toString("base64");
+}
+
 describe("project add credentials payment", () => {
   test.each(["CoinbaseCDP", "StripePrivy"] as const)(
     "adds a reusable %s payment credential",
@@ -49,9 +58,7 @@ describe("project add credentials payment", () => {
     const projectRoot = await inProject();
     const apiKeySecretPath = join(projectRoot, "api-key-secret.txt");
     const walletSecretPath = join(projectRoot, "wallet-secret.txt");
-    const apiKeySecret = generateKeyPairSync("ed25519")
-      .privateKey.export({ type: "pkcs8", format: "der" })
-      .toString("base64");
+    const apiKeySecret = coinbaseApiKeySecret();
     const walletSecret = generateKeyPairSync("ec", { namedCurve: "P-256" })
       .privateKey.export({ type: "pkcs8", format: "der" })
       .toString("base64");

--- a/src/handlers/project/add/credentials/payment/index.ts
+++ b/src/handlers/project/add/credentials/payment/index.ts
@@ -4,6 +4,7 @@ import { PaymentProviderSchema } from "../../../../../projectSchemas/payment";
 import { createHandler, flag } from "../../../../../router";
 import type { AddProjectResourceConfig } from "../../types";
 import { addCredentialToProject } from "../shared";
+import { paymentCredentialInputFlags, resolvePaymentCredentialEnvEntries } from "./input";
 
 export const createAddPaymentCredentialHandler = (config: AddProjectResourceConfig) =>
   createHandler({
@@ -16,6 +17,7 @@ export const createAddPaymentCredentialHandler = (config: AddProjectResourceConf
         "the payment provider: CoinbaseCDP or StripePrivy",
         PaymentProviderSchema.optional(),
       ),
+      ...paymentCredentialInputFlags,
     ],
     handle: async (ctx, flags) => {
       if (!flags.name) {
@@ -25,12 +27,19 @@ export const createAddPaymentCredentialHandler = (config: AddProjectResourceConf
         throw new InputValidationError("required option '--provider <provider>' not specified");
       }
 
+      const envEntries = await resolvePaymentCredentialEnvEntries({
+        name: flags.name,
+        provider: flags.provider,
+        flags,
+        io: config.io,
+      });
       await addCredentialToProject(ctx, config, {
         resourceConfig: {
           authorizerType: "PaymentCredentialProvider",
           name: flags.name,
           provider: flags.provider,
         },
+        envEntries,
       });
     },
   });

--- a/src/handlers/project/add/credentials/payment/index.ts
+++ b/src/handlers/project/add/credentials/payment/index.ts
@@ -1,0 +1,36 @@
+import z from "zod";
+import { InputValidationError } from "../../../../../errors";
+import { PaymentProviderSchema } from "../../../../../projectSchemas/payment";
+import { createHandler, flag } from "../../../../../router";
+import type { AddProjectResourceConfig } from "../../types";
+import { addCredentialToProject } from "../shared";
+
+export const createAddPaymentCredentialHandler = (config: AddProjectResourceConfig) =>
+  createHandler({
+    name: "payment",
+    description: "add a payment credential provider to the current project",
+    flags: [
+      flag("name", "the name of the credential provider", z.string().optional()),
+      flag(
+        "provider",
+        "the payment provider: CoinbaseCDP or StripePrivy",
+        PaymentProviderSchema.optional(),
+      ),
+    ],
+    handle: async (ctx, flags) => {
+      if (!flags.name) {
+        throw new InputValidationError("required option '--name <name>' not specified");
+      }
+      if (!flags.provider) {
+        throw new InputValidationError("required option '--provider <provider>' not specified");
+      }
+
+      await addCredentialToProject(ctx, config, {
+        resourceConfig: {
+          authorizerType: "PaymentCredentialProvider",
+          name: flags.name,
+          provider: flags.provider,
+        },
+      });
+    },
+  });

--- a/src/handlers/project/add/credentials/payment/input.ts
+++ b/src/handlers/project/add/credentials/payment/input.ts
@@ -5,6 +5,12 @@ import type { PaymentProvider } from "../../../../../projectSchemas/payment";
 import { flag } from "../../../../../router";
 import type { EnvLocalEntry } from "../../../types";
 import { credentialEnvVarName } from "../shared";
+import {
+  stripWalletAuthPrefix,
+  validateApiKeySecret,
+  validateAuthorizationPrivateKey,
+  validateWalletSecret,
+} from "./validation";
 
 export const paymentCredentialInputFlags = [
   flag("api-key-id", "Coinbase CDP API key ID", z.string().optional()),
@@ -79,10 +85,18 @@ export async function resolvePaymentCredentialEnvEntries(input: {
   const resolver = new SourceResolver({ stdin: io.stdin });
   if (provider === "StripePrivy") {
     const appSecret = await resolver.resolveSecret("app-secret", flags["app-secret"]);
-    const authorizationPrivateKey = await resolver.resolveSecret(
+    const resolvedAuthorizationPrivateKey = await resolver.resolveSecret(
       "authorization-private-key",
       flags["authorization-private-key"],
     );
+    const authorizationPrivateKey =
+      resolvedAuthorizationPrivateKey === undefined
+        ? undefined
+        : stripWalletAuthPrefix(resolvedAuthorizationPrivateKey);
+    if (authorizationPrivateKey !== undefined) {
+      const validation = validateAuthorizationPrivateKey(authorizationPrivateKey);
+      if (validation !== true) throw new InputValidationError(validation);
+    }
     return [
       {
         key: credentialEnvVarName(name, "_APP_ID"),
@@ -109,6 +123,14 @@ export async function resolvePaymentCredentialEnvEntries(input: {
 
   const apiKeySecret = await resolver.resolveSecret("api-key-secret", flags["api-key-secret"]);
   const walletSecret = await resolver.resolveSecret("wallet-secret", flags["wallet-secret"]);
+  if (apiKeySecret !== undefined) {
+    const validation = validateApiKeySecret(apiKeySecret);
+    if (validation !== true) throw new InputValidationError(validation);
+  }
+  if (walletSecret !== undefined) {
+    const validation = validateWalletSecret(walletSecret);
+    if (validation !== true) throw new InputValidationError(validation);
+  }
   return [
     {
       key: credentialEnvVarName(name, "_API_KEY_ID"),

--- a/src/handlers/project/add/credentials/payment/input.ts
+++ b/src/handlers/project/add/credentials/payment/input.ts
@@ -1,0 +1,129 @@
+import z from "zod";
+import { InputValidationError } from "../../../../../errors";
+import { type AppIO, SourceResolver } from "../../../../../io";
+import type { PaymentProvider } from "../../../../../projectSchemas/payment";
+import { flag } from "../../../../../router";
+import type { EnvLocalEntry } from "../../../types";
+import { credentialEnvVarName } from "../shared";
+
+export const paymentCredentialInputFlags = [
+  flag("api-key-id", "Coinbase CDP API key ID", z.string().optional()),
+  flag(
+    "api-key-secret",
+    "Coinbase CDP API key secret (file://path or - for stdin; inline values are rejected)",
+    z.string().optional(),
+    { sensitive: true },
+  ),
+  flag(
+    "wallet-secret",
+    "Coinbase CDP wallet secret (file://path or - for stdin; inline values are rejected)",
+    z.string().optional(),
+    { sensitive: true },
+  ),
+  flag("app-id", "Privy application ID", z.string().optional()),
+  flag(
+    "app-secret",
+    "Privy application secret (file://path or - for stdin; inline values are rejected)",
+    z.string().optional(),
+    { sensitive: true },
+  ),
+  flag(
+    "authorization-private-key",
+    "Stripe/Privy authorization private key (file://path or - for stdin; inline values are rejected)",
+    z.string().optional(),
+    { sensitive: true },
+  ),
+  flag("authorization-id", "Stripe/Privy authorization identifier", z.string().optional()),
+] as const;
+
+export type PaymentCredentialInputFlags = {
+  "api-key-id"?: string;
+  "api-key-secret"?: string;
+  "wallet-secret"?: string;
+  "app-id"?: string;
+  "app-secret"?: string;
+  "authorization-private-key"?: string;
+  "authorization-id"?: string;
+};
+
+const COINBASE_FLAGS = ["api-key-id", "api-key-secret", "wallet-secret"] as const;
+const STRIPE_FLAGS = [
+  "app-id",
+  "app-secret",
+  "authorization-private-key",
+  "authorization-id",
+] as const;
+
+export function hasPaymentCredentialInput(flags: PaymentCredentialInputFlags): boolean {
+  return [...COINBASE_FLAGS, ...STRIPE_FLAGS].some((name) => flags[name] !== undefined);
+}
+
+export async function resolvePaymentCredentialEnvEntries(input: {
+  name: string;
+  provider: PaymentProvider;
+  flags: PaymentCredentialInputFlags;
+  io: AppIO;
+}): Promise<EnvLocalEntry[]> {
+  const { name, provider, flags, io } = input;
+  const invalidFlags = (provider === "CoinbaseCDP" ? STRIPE_FLAGS : COINBASE_FLAGS).filter(
+    (flagName) => flags[flagName] !== undefined,
+  );
+  if (invalidFlags.length > 0) {
+    throw new InputValidationError(
+      `${invalidFlags.map((flagName) => `--${flagName}`).join(", ")} ${
+        invalidFlags.length === 1 ? "is" : "are"
+      } not valid with --provider ${provider}`,
+    );
+  }
+
+  const resolver = new SourceResolver({ stdin: io.stdin });
+  if (provider === "StripePrivy") {
+    const appSecret = await resolver.resolveSecret("app-secret", flags["app-secret"]);
+    const authorizationPrivateKey = await resolver.resolveSecret(
+      "authorization-private-key",
+      flags["authorization-private-key"],
+    );
+    return [
+      {
+        key: credentialEnvVarName(name, "_APP_ID"),
+        value: flags["app-id"],
+        comment: `Privy application ID for payment credential provider '${name}' (set before deploy)`,
+      },
+      {
+        key: credentialEnvVarName(name, "_APP_SECRET"),
+        value: appSecret,
+        comment: `Privy application secret for payment credential provider '${name}' (set before deploy)`,
+      },
+      {
+        key: credentialEnvVarName(name, "_AUTHORIZATION_PRIVATE_KEY"),
+        value: authorizationPrivateKey,
+        comment: `Stripe/Privy authorization private key for payment credential provider '${name}' (set before deploy)`,
+      },
+      {
+        key: credentialEnvVarName(name, "_AUTHORIZATION_ID"),
+        value: flags["authorization-id"],
+        comment: `Stripe/Privy authorization ID for payment credential provider '${name}' (set before deploy)`,
+      },
+    ];
+  }
+
+  const apiKeySecret = await resolver.resolveSecret("api-key-secret", flags["api-key-secret"]);
+  const walletSecret = await resolver.resolveSecret("wallet-secret", flags["wallet-secret"]);
+  return [
+    {
+      key: credentialEnvVarName(name, "_API_KEY_ID"),
+      value: flags["api-key-id"],
+      comment: `Coinbase CDP API key ID for payment credential provider '${name}' (set before deploy)`,
+    },
+    {
+      key: credentialEnvVarName(name, "_API_KEY_SECRET"),
+      value: apiKeySecret,
+      comment: `Coinbase CDP API key secret for payment credential provider '${name}' (set before deploy)`,
+    },
+    {
+      key: credentialEnvVarName(name, "_WALLET_SECRET"),
+      value: walletSecret,
+      comment: `Coinbase CDP wallet secret for payment credential provider '${name}' (set before deploy)`,
+    },
+  ];
+}

--- a/src/handlers/project/add/credentials/payment/input.ts
+++ b/src/handlers/project/add/credentials/payment/input.ts
@@ -7,8 +7,10 @@ import type { EnvLocalEntry } from "../../../types";
 import { credentialEnvVarName } from "../shared";
 import {
   stripWalletAuthPrefix,
+  validateAppSecret,
   validateApiKeySecret,
   validateAuthorizationPrivateKey,
+  validatePaymentIdentifier,
   validateWalletSecret,
 } from "./validation";
 
@@ -64,6 +66,14 @@ export function hasPaymentCredentialInput(flags: PaymentCredentialInputFlags): b
   return [...COINBASE_FLAGS, ...STRIPE_FLAGS].some((name) => flags[name] !== undefined);
 }
 
+function normalizedIdentifier(name: string, value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  const normalized = value.trim();
+  const validation = validatePaymentIdentifier(name, normalized);
+  if (validation !== true) throw new InputValidationError(validation);
+  return normalized;
+}
+
 export async function resolvePaymentCredentialEnvEntries(input: {
   name: string;
   provider: PaymentProvider;
@@ -84,7 +94,13 @@ export async function resolvePaymentCredentialEnvEntries(input: {
 
   const resolver = new SourceResolver({ stdin: io.stdin });
   if (provider === "StripePrivy") {
+    const appId = normalizedIdentifier("appId", flags["app-id"]);
+    const authorizationId = normalizedIdentifier("authorizationId", flags["authorization-id"]);
     const appSecret = await resolver.resolveSecret("app-secret", flags["app-secret"]);
+    if (appSecret !== undefined) {
+      const validation = validateAppSecret(appSecret);
+      if (validation !== true) throw new InputValidationError(validation);
+    }
     const resolvedAuthorizationPrivateKey = await resolver.resolveSecret(
       "authorization-private-key",
       flags["authorization-private-key"],
@@ -100,7 +116,7 @@ export async function resolvePaymentCredentialEnvEntries(input: {
     return [
       {
         key: credentialEnvVarName(name, "_APP_ID"),
-        value: flags["app-id"],
+        value: appId,
         comment: `Privy application ID for payment credential provider '${name}' (set before deploy)`,
       },
       {
@@ -115,14 +131,23 @@ export async function resolvePaymentCredentialEnvEntries(input: {
       },
       {
         key: credentialEnvVarName(name, "_AUTHORIZATION_ID"),
-        value: flags["authorization-id"],
+        value: authorizationId,
         comment: `Stripe/Privy authorization ID for payment credential provider '${name}' (set before deploy)`,
       },
     ];
   }
 
-  const apiKeySecret = await resolver.resolveSecret("api-key-secret", flags["api-key-secret"]);
-  const walletSecret = await resolver.resolveSecret("wallet-secret", flags["wallet-secret"]);
+  const apiKeyId = normalizedIdentifier("apiKeyId", flags["api-key-id"]);
+  const resolvedApiKeySecret = await resolver.resolveSecret(
+    "api-key-secret",
+    flags["api-key-secret"],
+  );
+  const resolvedWalletSecret = await resolver.resolveSecret(
+    "wallet-secret",
+    flags["wallet-secret"],
+  );
+  const apiKeySecret = resolvedApiKeySecret?.trim();
+  const walletSecret = resolvedWalletSecret?.trim();
   if (apiKeySecret !== undefined) {
     const validation = validateApiKeySecret(apiKeySecret);
     if (validation !== true) throw new InputValidationError(validation);
@@ -134,7 +159,7 @@ export async function resolvePaymentCredentialEnvEntries(input: {
   return [
     {
       key: credentialEnvVarName(name, "_API_KEY_ID"),
-      value: flags["api-key-id"],
+      value: apiKeyId,
       comment: `Coinbase CDP API key ID for payment credential provider '${name}' (set before deploy)`,
     },
     {

--- a/src/handlers/project/add/credentials/payment/validation.test.ts
+++ b/src/handlers/project/add/credentials/payment/validation.test.ts
@@ -6,7 +6,7 @@ import {
   validateWalletSecret,
 } from "./validation";
 
-const ed25519Key = Buffer.alloc(48, 0x41).toString("base64");
+const ed25519Key = Buffer.alloc(64, 0x41).toString("base64");
 const p256Key = Buffer.alloc(138, 0x41).toString("base64");
 
 describe("payment credential key validation", () => {
@@ -17,6 +17,7 @@ describe("payment credential key validation", () => {
 
   test("rejects invalid Coinbase key formats", () => {
     expect(validateApiKeySecret("not-base64")).toContain("Ed25519");
+    expect(validateApiKeySecret(Buffer.alloc(48, 0x41).toString("base64"))).toContain("length");
     expect(validateWalletSecret(ed25519Key)).toContain("P-256");
   });
 

--- a/src/handlers/project/add/credentials/payment/validation.test.ts
+++ b/src/handlers/project/add/credentials/payment/validation.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import {
   stripWalletAuthPrefix,
+  validateAppSecret,
   validateApiKeySecret,
   validateAuthorizationPrivateKey,
+  validatePaymentIdentifier,
   validateWalletSecret,
 } from "./validation";
 
@@ -28,5 +30,17 @@ describe("payment credential key validation", () => {
 
   test("rejects invalid Stripe authorization keys", () => {
     expect(validateAuthorizationPrivateKey("wallet-auth:not-base64")).toContain("base64");
+  });
+
+  test("rejects identifiers outside the Payment service contract", () => {
+    expect(validatePaymentIdentifier("apiKeyId", "valid_key-1")).toBe(true);
+    expect(validatePaymentIdentifier("apiKeyId", "invalid key!")).toContain("apiKeyId");
+    expect(validatePaymentIdentifier("apiKeyId", "a".repeat(513))).toContain("512");
+  });
+
+  test("rejects app secrets outside the Payment service contract", () => {
+    expect(validateAppSecret("valid+/=_-secret")).toBe(true);
+    expect(validateAppSecret("invalid!secret")).toContain("appSecret");
+    expect(validateAppSecret("a".repeat(2049))).toContain("2048");
   });
 });

--- a/src/handlers/project/add/credentials/payment/validation.test.ts
+++ b/src/handlers/project/add/credentials/payment/validation.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import {
+  stripWalletAuthPrefix,
+  validateApiKeySecret,
+  validateAuthorizationPrivateKey,
+  validateWalletSecret,
+} from "./validation";
+
+const ed25519Key = Buffer.alloc(48, 0x41).toString("base64");
+const p256Key = Buffer.alloc(138, 0x41).toString("base64");
+
+describe("payment credential key validation", () => {
+  test("accepts supported Coinbase key formats", () => {
+    expect(validateApiKeySecret(ed25519Key)).toBe(true);
+    expect(validateWalletSecret(p256Key)).toBe(true);
+  });
+
+  test("rejects invalid Coinbase key formats", () => {
+    expect(validateApiKeySecret("not-base64")).toContain("Ed25519");
+    expect(validateWalletSecret(ed25519Key)).toContain("P-256");
+  });
+
+  test("accepts and normalizes a prefixed Stripe authorization key", () => {
+    expect(validateAuthorizationPrivateKey(`wallet-auth:${p256Key}`)).toBe(true);
+    expect(stripWalletAuthPrefix(`wallet-auth:${p256Key}`)).toBe(p256Key);
+  });
+
+  test("rejects invalid Stripe authorization keys", () => {
+    expect(validateAuthorizationPrivateKey("wallet-auth:not-base64")).toContain("base64");
+  });
+});

--- a/src/handlers/project/add/credentials/payment/validation.ts
+++ b/src/handlers/project/add/credentials/payment/validation.ts
@@ -1,6 +1,5 @@
 const BASE64_PATTERN = /^[A-Za-z0-9+/]+=*$/;
-const ED25519_MIN_BYTES = 32;
-const ED25519_MAX_BYTES = 64;
+const ED25519_KEY_LENGTHS = new Set([32, 64]);
 const P256_MIN_BYTES = 100;
 const P256_MAX_BYTES = 200;
 const WALLET_AUTH_PREFIX = "wallet-auth:";
@@ -13,7 +12,7 @@ function decodedBase64Length(value: string): number | undefined {
 export function validateApiKeySecret(value: string): true | string {
   const length = decodedBase64Length(value.trim());
   if (length === undefined) return "apiKeySecret must be a base64-encoded Ed25519 private key";
-  if (length < ED25519_MIN_BYTES || length > ED25519_MAX_BYTES) {
+  if (!ED25519_KEY_LENGTHS.has(length)) {
     return "apiKeySecret must be a base64-encoded Ed25519 private key (unexpected length)";
   }
   return true;

--- a/src/handlers/project/add/credentials/payment/validation.ts
+++ b/src/handlers/project/add/credentials/payment/validation.ts
@@ -1,0 +1,45 @@
+const BASE64_PATTERN = /^[A-Za-z0-9+/]+=*$/;
+const ED25519_MIN_BYTES = 32;
+const ED25519_MAX_BYTES = 64;
+const P256_MIN_BYTES = 100;
+const P256_MAX_BYTES = 200;
+const WALLET_AUTH_PREFIX = "wallet-auth:";
+
+function decodedBase64Length(value: string): number | undefined {
+  if (!BASE64_PATTERN.test(value)) return undefined;
+  return Buffer.from(value, "base64").length;
+}
+
+export function validateApiKeySecret(value: string): true | string {
+  const length = decodedBase64Length(value.trim());
+  if (length === undefined) return "apiKeySecret must be a base64-encoded Ed25519 private key";
+  if (length < ED25519_MIN_BYTES || length > ED25519_MAX_BYTES) {
+    return "apiKeySecret must be a base64-encoded Ed25519 private key (unexpected length)";
+  }
+  return true;
+}
+
+export function validateWalletSecret(value: string): true | string {
+  const length = decodedBase64Length(value.trim());
+  if (length === undefined) return "walletSecret must be a base64-encoded EC P-256 private key";
+  if (length < P256_MIN_BYTES || length > P256_MAX_BYTES) {
+    return "walletSecret must be a base64-encoded EC P-256 private key (unexpected length)";
+  }
+  return true;
+}
+
+export function stripWalletAuthPrefix(value: string): string {
+  const trimmed = value.trim();
+  return trimmed.startsWith(WALLET_AUTH_PREFIX)
+    ? trimmed.slice(WALLET_AUTH_PREFIX.length)
+    : trimmed;
+}
+
+export function validateAuthorizationPrivateKey(value: string): true | string {
+  const length = decodedBase64Length(stripWalletAuthPrefix(value));
+  if (length === undefined) return "authorizationPrivateKey must be base64-encoded";
+  if (length < P256_MIN_BYTES || length > P256_MAX_BYTES) {
+    return "authorizationPrivateKey must be a base64-encoded EC P-256 private key (unexpected length)";
+  }
+  return true;
+}

--- a/src/handlers/project/add/credentials/payment/validation.ts
+++ b/src/handlers/project/add/credentials/payment/validation.ts
@@ -3,6 +3,8 @@ const ED25519_KEY_LENGTHS = new Set([32, 64]);
 const P256_MIN_BYTES = 100;
 const P256_MAX_BYTES = 200;
 const WALLET_AUTH_PREFIX = "wallet-auth:";
+const PAYMENT_IDENTIFIER_PATTERN = /^[A-Za-z0-9_-]+$/;
+const APP_SECRET_PATTERN = /^[A-Za-z0-9+/=_\-\s]*$/;
 
 function decodedBase64Length(value: string): number | undefined {
   if (!BASE64_PATTERN.test(value)) return undefined;
@@ -40,5 +42,19 @@ export function validateAuthorizationPrivateKey(value: string): true | string {
   if (length < P256_MIN_BYTES || length > P256_MAX_BYTES) {
     return "authorizationPrivateKey must be a base64-encoded EC P-256 private key (unexpected length)";
   }
+  return true;
+}
+
+export function validatePaymentIdentifier(name: string, value: string): true | string {
+  if (value.length < 1 || value.length > 512) return `${name} must be between 1 and 512 characters`;
+  if (!PAYMENT_IDENTIFIER_PATTERN.test(value)) {
+    return `${name} must contain only alphanumeric characters, hyphens, and underscores`;
+  }
+  return true;
+}
+
+export function validateAppSecret(value: string): true | string {
+  if (value.length > 2048) return "appSecret must be 2048 characters or less";
+  if (!APP_SECRET_PATTERN.test(value)) return "appSecret contains unsupported characters";
   return true;
 }

--- a/src/handlers/project/add/credentials/shared.ts
+++ b/src/handlers/project/add/credentials/shared.ts
@@ -3,11 +3,12 @@ import { InputValidationError } from "../../../../errors";
 import { parseSecretReference } from "../../../identity/parser";
 import type { AddProjectResourceConfig } from "../types";
 import type { AddResourceInput } from "../../types";
+import {
+  credentialEnvironmentVariableNames,
+  credentialEnvVarName,
+} from "../../../../projectSchemas/credential";
 
-/** Derives the .env.local variable name a credential's secret is stored under. */
-export function credentialEnvVarName(credentialName: string, suffix = ""): string {
-  return `AGENTCORE_CREDENTIAL_${credentialName.replace(/-/g, "_").toUpperCase()}${suffix}`;
-}
+export { credentialEnvVarName };
 
 /** Parses a secret-reference flag, rejecting a directly supplied secret alongside it. */
 export function parseExclusiveSecretRef(
@@ -31,18 +32,21 @@ export async function addCredentialToProject(
 ): Promise<void> {
   const project = ctx.require(ProjectKey);
 
-  // Two names that differ only by '-' vs '_' derive the same environment
-  // variable, which would silently reuse one secret for both providers.
   const newName = input.resourceConfig.name;
-  const clash = project.spec.credentials.find(
-    (existing) =>
-      existing.name !== newName &&
-      credentialEnvVarName(existing.name) === credentialEnvVarName(newName),
-  );
-  if (clash) {
+  const existingEnvironmentNames = new Map<string, string>();
+  for (const credential of project.spec.credentials) {
+    for (const environmentName of credentialEnvironmentVariableNames(credential)) {
+      existingEnvironmentNames.set(environmentName, credential.name);
+    }
+  }
+  const conflictingEnvironmentName = input.envEntries?.find((entry) =>
+    existingEnvironmentNames.has(entry.key),
+  )?.key;
+  if (conflictingEnvironmentName) {
+    const conflictingName = existingEnvironmentNames.get(conflictingEnvironmentName)!;
     throw new InputValidationError(
-      `credential '${newName}' and '${clash.name}' derive the same environment variable name; ` +
-        "choose a name that differs by more than '-' and '_'",
+      `credential '${newName}' and '${conflictingName}' derive the same environment variable ` +
+        `'${conflictingEnvironmentName}'; choose credential names that produce distinct environment variables`,
     );
   }
 

--- a/src/handlers/project/add/index.ts
+++ b/src/handlers/project/add/index.ts
@@ -14,6 +14,8 @@ import { createAddGatewayConnectorHandler } from "./gateway-connector";
 import { createAddPolicyEngineHandler } from "./policy-engine";
 import { createAddPolicyHandler } from "./policy";
 import type { AddProjectResourceConfig } from "./types";
+import { createAddPaymentConnectorHandler } from "./payment-connector";
+import { createAddPaymentManagerHandler } from "./payment-manager";
 
 export function createAddProjectResourceHandler(config: AddProjectResourceConfig): Router {
   const projectAdd = new Router("add", "add project resources");
@@ -31,5 +33,7 @@ export function createAddProjectResourceHandler(config: AddProjectResourceConfig
   projectAdd.handler(createAddGatewayConnectorHandler(config));
   projectAdd.handler(createAddPolicyEngineHandler(config));
   projectAdd.handler(createAddPolicyHandler(config));
+  projectAdd.handler(createAddPaymentManagerHandler(config));
+  projectAdd.handler(createAddPaymentConnectorHandler(config));
   return projectAdd;
 }

--- a/src/handlers/project/add/payment-connector/index.test.ts
+++ b/src/handlers/project/add/payment-connector/index.test.ts
@@ -79,6 +79,55 @@ describe("project add payment-connector", () => {
         credentialName: `${name}-credential`,
       },
     ]);
+    const env = await Bun.file(join(projectRoot, "agentcore", ".env.local")).text();
+    const prefix = `AGENTCORE_CREDENTIAL_${name.toUpperCase()}_CREDENTIAL`;
+    const suffixes =
+      provider === "CoinbaseCDP"
+        ? ["API_KEY_ID", "API_KEY_SECRET", "WALLET_SECRET"]
+        : ["APP_ID", "APP_SECRET", "AUTHORIZATION_PRIVATE_KEY", "AUTHORIZATION_ID"];
+    for (const suffix of suffixes) {
+      expect(env).toContain(`${prefix}_${suffix}=\n`);
+    }
+  });
+
+  test("atomically stores supplied payment credential values with a connector", async () => {
+    const projectRoot = await inProject();
+    await addManager();
+    const appSecretPath = join(projectRoot, "app-secret.txt");
+    const privateKeyPath = join(projectRoot, "private-key.txt");
+    await Bun.write(appSecretPath, "app-secret\n");
+    await Bun.write(privateKeyPath, "private-key\n");
+
+    await run([
+      "add",
+      "payment-connector",
+      "--manager",
+      "payments",
+      "--name",
+      "stripe",
+      "--create-credential",
+      "stripe-credential",
+      "--provider",
+      "StripePrivy",
+      "--app-id",
+      "app-id",
+      "--app-secret",
+      `file://${appSecretPath}`,
+      "--authorization-private-key",
+      `file://${privateKeyPath}`,
+      "--authorization-id",
+      "authorization-id",
+    ]);
+
+    const env = await Bun.file(join(projectRoot, "agentcore", ".env.local")).text();
+    expect(env).toContain("AGENTCORE_CREDENTIAL_STRIPE_CREDENTIAL_APP_ID='app-id'");
+    expect(env).toContain("AGENTCORE_CREDENTIAL_STRIPE_CREDENTIAL_APP_SECRET='app-secret'");
+    expect(env).toContain(
+      "AGENTCORE_CREDENTIAL_STRIPE_CREDENTIAL_AUTHORIZATION_PRIVATE_KEY='private-key'",
+    );
+    expect(env).toContain(
+      "AGENTCORE_CREDENTIAL_STRIPE_CREDENTIAL_AUTHORIZATION_ID='authorization-id'",
+    );
   });
 
   test("adds Quick Create without a payment credential", async () => {
@@ -162,7 +211,20 @@ describe("project add payment-connector", () => {
         "--provider",
         "CoinbaseCDP",
       ],
-      "--provider is valid only with --create-credential",
+      "valid only with --create-credential",
+    ],
+    [
+      "credential values outside create mode",
+      [
+        "--manager",
+        "payments",
+        "--name",
+        "connector",
+        "--quick-create",
+        "--api-key-id",
+        "api-key-id",
+      ],
+      "valid only with --create-credential",
     ],
   ])("rejects %s", async (_label, flags, message) => {
     const projectRoot = await inProject();
@@ -255,6 +317,8 @@ describe("project add payment-connector", () => {
     const spec = await projectSpec(projectRoot);
     expect(spec.credentials).toEqual([]);
     expect(spec.payments[0].connectors).toHaveLength(1);
+    const env = await Bun.file(join(projectRoot, "agentcore", ".env.local")).text();
+    expect(env).not.toContain("AGENTCORE_CREDENTIAL_ORPHAN");
   });
 
   test("leaves no credential or connector after whole-project validation fails", async () => {
@@ -285,6 +349,8 @@ describe("project add payment-connector", () => {
       },
     ]);
     expect(spec.payments[0].connectors).toEqual([]);
+    const env = await Bun.file(join(projectRoot, "agentcore", ".env.local")).text();
+    expect(env).not.toContain("AGENTCORE_CREDENTIAL_SERVICE_KEY_API_KEY_ID");
   });
 
   test("rejects provider mismatches in complete project data", async () => {

--- a/src/handlers/project/add/payment-connector/index.test.ts
+++ b/src/handlers/project/add/payment-connector/index.test.ts
@@ -1,0 +1,294 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createPaymentProjectTestHarness } from "../payment-test-support";
+
+const { cleanup, inProject, projectSpec, run, writeProjectSpec } =
+  createPaymentProjectTestHarness("payment-connector");
+
+afterEach(cleanup);
+
+async function addManager() {
+  await run(["add", "payment-manager", "--name", "payments"]);
+}
+
+async function addCredential(name: string, provider: "CoinbaseCDP" | "StripePrivy") {
+  await run(["add", "credentials", "payment", "--name", name, "--provider", provider]);
+}
+
+describe("project add payment-connector", () => {
+  test.each([
+    ["CoinbaseCDP", "coinbase"],
+    ["StripePrivy", "stripe"],
+  ] as const)("reuses an existing %s credential", async (provider, name) => {
+    const projectRoot = await inProject();
+    await addManager();
+    await addCredential(`${name}-credential`, provider);
+
+    await run([
+      "add",
+      "payment-connector",
+      "--manager",
+      "payments",
+      "--name",
+      name,
+      "--credential",
+      `${name}-credential`,
+    ]);
+
+    expect((await projectSpec(projectRoot)).payments[0].connectors).toEqual([
+      {
+        name,
+        provider,
+        credentialName: `${name}-credential`,
+      },
+    ]);
+  });
+
+  test.each([
+    ["CoinbaseCDP", "coinbase"],
+    ["StripePrivy", "stripe"],
+  ] as const)("atomically creates a %s credential and connector", async (provider, name) => {
+    const projectRoot = await inProject();
+    await addManager();
+
+    await run([
+      "add",
+      "payment-connector",
+      "--manager",
+      "payments",
+      "--name",
+      name,
+      "--create-credential",
+      `${name}-credential`,
+      "--provider",
+      provider,
+    ]);
+
+    const spec = await projectSpec(projectRoot);
+    expect(spec.credentials).toEqual([
+      {
+        authorizerType: "PaymentCredentialProvider",
+        name: `${name}-credential`,
+        provider,
+      },
+    ]);
+    expect(spec.payments[0].connectors).toEqual([
+      {
+        name,
+        provider,
+        credentialName: `${name}-credential`,
+      },
+    ]);
+  });
+
+  test("adds Quick Create without a payment credential", async () => {
+    const projectRoot = await inProject();
+    await addManager();
+
+    await run([
+      "add",
+      "payment-connector",
+      "--manager",
+      "payments",
+      "--name",
+      "coinbase",
+      "--quick-create",
+    ]);
+
+    const spec = await projectSpec(projectRoot);
+    expect(spec.credentials).toEqual([]);
+    expect(spec.payments[0].connectors).toEqual([
+      {
+        name: "coinbase",
+        provider: "CoinbaseCDP",
+        provisionMode: "QUICK_CREATE",
+      },
+    ]);
+  });
+
+  test.each([
+    ["missing manager", ["--name", "connector", "--quick-create"], "required option '--manager"],
+    ["missing name", ["--manager", "payments", "--quick-create"], "required option '--name"],
+    ["no mode", ["--manager", "payments", "--name", "connector"], "specify exactly one"],
+    [
+      "multiple modes",
+      [
+        "--manager",
+        "payments",
+        "--name",
+        "connector",
+        "--credential",
+        "existing",
+        "--quick-create",
+      ],
+      "specify exactly one",
+    ],
+    [
+      "create without provider",
+      ["--manager", "payments", "--name", "connector", "--create-credential", "new-credential"],
+      "--create-credential requires --provider",
+    ],
+    [
+      "provider outside create mode",
+      [
+        "--manager",
+        "payments",
+        "--name",
+        "connector",
+        "--quick-create",
+        "--provider",
+        "CoinbaseCDP",
+      ],
+      "--provider is valid only with --create-credential",
+    ],
+  ])("rejects %s", async (_label, flags, message) => {
+    const projectRoot = await inProject();
+    await addManager();
+
+    await expect(run(["add", "payment-connector", ...flags])).rejects.toThrow(message);
+    expect((await projectSpec(projectRoot)).payments[0].connectors).toEqual([]);
+  });
+
+  test("rejects unknown managers and credentials", async () => {
+    const projectRoot = await inProject();
+    await addManager();
+
+    await expect(
+      run([
+        "add",
+        "payment-connector",
+        "--manager",
+        "missing",
+        "--name",
+        "connector",
+        "--quick-create",
+      ]),
+    ).rejects.toThrow("does not exist");
+    await expect(
+      run([
+        "add",
+        "payment-connector",
+        "--manager",
+        "payments",
+        "--name",
+        "connector",
+        "--credential",
+        "missing",
+      ]),
+    ).rejects.toThrow("does not exist in credentials[]");
+
+    expect((await projectSpec(projectRoot)).payments[0].connectors).toEqual([]);
+  });
+
+  test("rejects non-payment credentials", async () => {
+    const projectRoot = await inProject();
+    await addManager();
+    await run(["add", "credentials", "api-key", "--name", "api-key"]);
+
+    await expect(
+      run([
+        "add",
+        "payment-connector",
+        "--manager",
+        "payments",
+        "--name",
+        "connector",
+        "--credential",
+        "api-key",
+      ]),
+    ).rejects.toThrow("not a PaymentCredentialProvider");
+
+    expect((await projectSpec(projectRoot)).payments[0].connectors).toEqual([]);
+  });
+
+  test("rejects duplicate connector names without creating an orphan credential", async () => {
+    const projectRoot = await inProject();
+    await addManager();
+    await run([
+      "add",
+      "payment-connector",
+      "--manager",
+      "payments",
+      "--name",
+      "connector",
+      "--quick-create",
+    ]);
+
+    await expect(
+      run([
+        "add",
+        "payment-connector",
+        "--manager",
+        "payments",
+        "--name",
+        "connector",
+        "--create-credential",
+        "orphan",
+        "--provider",
+        "CoinbaseCDP",
+      ]),
+    ).rejects.toThrow("already exists");
+
+    const spec = await projectSpec(projectRoot);
+    expect(spec.credentials).toEqual([]);
+    expect(spec.payments[0].connectors).toHaveLength(1);
+  });
+
+  test("leaves no credential or connector after whole-project validation fails", async () => {
+    const projectRoot = await inProject();
+    await addManager();
+    await run(["add", "credentials", "api-key", "--name", "service-key"]);
+
+    await expect(
+      run([
+        "add",
+        "payment-connector",
+        "--manager",
+        "payments",
+        "--name",
+        "connector",
+        "--create-credential",
+        "service_key",
+        "--provider",
+        "CoinbaseCDP",
+      ]),
+    ).rejects.toThrow("environment variable");
+
+    const spec = await projectSpec(projectRoot);
+    expect(spec.credentials).toEqual([
+      {
+        authorizerType: "ApiKeyCredentialProvider",
+        name: "service-key",
+      },
+    ]);
+    expect(spec.payments[0].connectors).toEqual([]);
+  });
+
+  test("rejects provider mismatches in complete project data", async () => {
+    const projectRoot = await inProject();
+    const spec = await projectSpec(projectRoot);
+    spec.credentials = [
+      {
+        authorizerType: "PaymentCredentialProvider",
+        name: "coinbase",
+        provider: "CoinbaseCDP",
+      },
+    ];
+    spec.payments = [
+      {
+        name: "payments",
+        connectors: [
+          {
+            name: "stripe",
+            provider: "StripePrivy",
+            credentialName: "coinbase",
+          },
+        ],
+      },
+    ];
+    await writeProjectSpec(projectRoot, spec);
+
+    await expect(run(["add", "credentials", "api-key", "--name", "trigger"])).rejects.toThrow(
+      "uses provider",
+    );
+  });
+});

--- a/src/handlers/project/add/payment-connector/index.test.ts
+++ b/src/handlers/project/add/payment-connector/index.test.ts
@@ -44,92 +44,6 @@ describe("project add payment-connector", () => {
     ]);
   });
 
-  test.each([
-    ["CoinbaseCDP", "coinbase"],
-    ["StripePrivy", "stripe"],
-  ] as const)("atomically creates a %s credential and connector", async (provider, name) => {
-    const projectRoot = await inProject();
-    await addManager();
-
-    await run([
-      "add",
-      "payment-connector",
-      "--manager",
-      "payments",
-      "--name",
-      name,
-      "--create-credential",
-      `${name}-credential`,
-      "--provider",
-      provider,
-    ]);
-
-    const spec = await projectSpec(projectRoot);
-    expect(spec.credentials).toEqual([
-      {
-        authorizerType: "PaymentCredentialProvider",
-        name: `${name}-credential`,
-        provider,
-      },
-    ]);
-    expect(spec.payments[0].connectors).toEqual([
-      {
-        name,
-        provider,
-        credentialName: `${name}-credential`,
-      },
-    ]);
-    const env = await Bun.file(join(projectRoot, "agentcore", ".env.local")).text();
-    const prefix = `AGENTCORE_CREDENTIAL_${name.toUpperCase()}_CREDENTIAL`;
-    const suffixes =
-      provider === "CoinbaseCDP"
-        ? ["API_KEY_ID", "API_KEY_SECRET", "WALLET_SECRET"]
-        : ["APP_ID", "APP_SECRET", "AUTHORIZATION_PRIVATE_KEY", "AUTHORIZATION_ID"];
-    for (const suffix of suffixes) {
-      expect(env).toContain(`${prefix}_${suffix}=\n`);
-    }
-  });
-
-  test("atomically stores supplied payment credential values with a connector", async () => {
-    const projectRoot = await inProject();
-    await addManager();
-    const appSecretPath = join(projectRoot, "app-secret.txt");
-    const privateKeyPath = join(projectRoot, "private-key.txt");
-    await Bun.write(appSecretPath, "app-secret\n");
-    await Bun.write(privateKeyPath, "private-key\n");
-
-    await run([
-      "add",
-      "payment-connector",
-      "--manager",
-      "payments",
-      "--name",
-      "stripe",
-      "--create-credential",
-      "stripe-credential",
-      "--provider",
-      "StripePrivy",
-      "--app-id",
-      "app-id",
-      "--app-secret",
-      `file://${appSecretPath}`,
-      "--authorization-private-key",
-      `file://${privateKeyPath}`,
-      "--authorization-id",
-      "authorization-id",
-    ]);
-
-    const env = await Bun.file(join(projectRoot, "agentcore", ".env.local")).text();
-    expect(env).toContain("AGENTCORE_CREDENTIAL_STRIPE_CREDENTIAL_APP_ID='app-id'");
-    expect(env).toContain("AGENTCORE_CREDENTIAL_STRIPE_CREDENTIAL_APP_SECRET='app-secret'");
-    expect(env).toContain(
-      "AGENTCORE_CREDENTIAL_STRIPE_CREDENTIAL_AUTHORIZATION_PRIVATE_KEY='private-key'",
-    );
-    expect(env).toContain(
-      "AGENTCORE_CREDENTIAL_STRIPE_CREDENTIAL_AUTHORIZATION_ID='authorization-id'",
-    );
-  });
-
   test("adds Quick Create without a payment credential", async () => {
     const projectRoot = await inProject();
     await addManager();
@@ -195,37 +109,6 @@ describe("project add payment-connector", () => {
       ],
       "specify exactly one",
     ],
-    [
-      "create without provider",
-      ["--manager", "payments", "--name", "connector", "--create-credential", "new-credential"],
-      "--create-credential requires --provider",
-    ],
-    [
-      "provider outside create mode",
-      [
-        "--manager",
-        "payments",
-        "--name",
-        "connector",
-        "--quick-create",
-        "--provider",
-        "CoinbaseCDP",
-      ],
-      "valid only with --create-credential",
-    ],
-    [
-      "credential values outside create mode",
-      [
-        "--manager",
-        "payments",
-        "--name",
-        "connector",
-        "--quick-create",
-        "--api-key-id",
-        "api-key-id",
-      ],
-      "valid only with --create-credential",
-    ],
   ])("rejects %s", async (_label, flags, message) => {
     const projectRoot = await inProject();
     await addManager();
@@ -286,7 +169,7 @@ describe("project add payment-connector", () => {
     expect((await projectSpec(projectRoot)).payments[0].connectors).toEqual([]);
   });
 
-  test("rejects duplicate connector names without creating an orphan credential", async () => {
+  test("rejects duplicate connector names", async () => {
     const projectRoot = await inProject();
     await addManager();
     await run([
@@ -307,50 +190,13 @@ describe("project add payment-connector", () => {
         "payments",
         "--name",
         "connector",
-        "--create-credential",
-        "orphan",
-        "--provider",
-        "CoinbaseCDP",
+        "--quick-create",
       ]),
     ).rejects.toThrow("already exists");
 
     const spec = await projectSpec(projectRoot);
     expect(spec.credentials).toEqual([]);
     expect(spec.payments[0].connectors).toHaveLength(1);
-    const env = await Bun.file(join(projectRoot, "agentcore", ".env.local")).text();
-    expect(env).not.toContain("AGENTCORE_CREDENTIAL_ORPHAN");
-  });
-
-  test("leaves no credential or connector after whole-project validation fails", async () => {
-    const projectRoot = await inProject();
-    await addManager();
-    await run(["add", "credentials", "api-key", "--name", "service-key"]);
-
-    await expect(
-      run([
-        "add",
-        "payment-connector",
-        "--manager",
-        "payments",
-        "--name",
-        "connector",
-        "--create-credential",
-        "service_key",
-        "--provider",
-        "CoinbaseCDP",
-      ]),
-    ).rejects.toThrow("environment variable");
-
-    const spec = await projectSpec(projectRoot);
-    expect(spec.credentials).toEqual([
-      {
-        authorizerType: "ApiKeyCredentialProvider",
-        name: "service-key",
-      },
-    ]);
-    expect(spec.payments[0].connectors).toEqual([]);
-    const env = await Bun.file(join(projectRoot, "agentcore", ".env.local")).text();
-    expect(env).not.toContain("AGENTCORE_CREDENTIAL_SERVICE_KEY_API_KEY_ID");
   });
 
   test("rejects provider mismatches in complete project data", async () => {

--- a/src/handlers/project/add/payment-connector/index.test.ts
+++ b/src/handlers/project/add/payment-connector/index.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { join } from "node:path";
 import { createPaymentProjectTestHarness } from "../payment-test-support";
 
 const { cleanup, inProject, projectSpec, run, writeProjectSpec } =
@@ -67,29 +66,6 @@ describe("project add payment-connector", () => {
         provisionMode: "QUICK_CREATE",
       },
     ]);
-  });
-
-  test("rejects Quick Create when the project has legacy generated CDK assets", async () => {
-    const projectRoot = await inProject();
-    await addManager();
-    const packagePath = join(projectRoot, "agentcore", "cdk", "package.json");
-    const packageJson = await Bun.file(packagePath).json();
-    delete packageJson.agentcoreProject;
-    await Bun.write(packagePath, JSON.stringify(packageJson, undefined, 2));
-
-    await expect(
-      run([
-        "add",
-        "payment-connector",
-        "--manager",
-        "payments",
-        "--name",
-        "coinbase",
-        "--quick-create",
-      ]),
-    ).rejects.toThrow("generated CDK assets");
-
-    expect((await projectSpec(projectRoot)).payments[0].connectors).toEqual([]);
   });
 
   test.each([

--- a/src/handlers/project/add/payment-connector/index.test.ts
+++ b/src/handlers/project/add/payment-connector/index.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { join } from "node:path";
 import { createPaymentProjectTestHarness } from "../payment-test-support";
 
 const { cleanup, inProject, projectSpec, run, writeProjectSpec } =
@@ -103,6 +104,29 @@ describe("project add payment-connector", () => {
         provisionMode: "QUICK_CREATE",
       },
     ]);
+  });
+
+  test("rejects Quick Create when the project has legacy generated CDK assets", async () => {
+    const projectRoot = await inProject();
+    await addManager();
+    const packagePath = join(projectRoot, "agentcore", "cdk", "package.json");
+    const packageJson = await Bun.file(packagePath).json();
+    delete packageJson.agentcoreProject;
+    await Bun.write(packagePath, JSON.stringify(packageJson, undefined, 2));
+
+    await expect(
+      run([
+        "add",
+        "payment-connector",
+        "--manager",
+        "payments",
+        "--name",
+        "coinbase",
+        "--quick-create",
+      ]),
+    ).rejects.toThrow("generated CDK assets");
+
+    expect((await projectSpec(projectRoot)).payments[0].connectors).toEqual([]);
   });
 
   test.each([

--- a/src/handlers/project/add/payment-connector/index.ts
+++ b/src/handlers/project/add/payment-connector/index.ts
@@ -1,14 +1,7 @@
 import z from "zod";
 import { InputValidationError } from "../../../../errors";
-import type { PaymentCredential } from "../../../../projectSchemas/credential";
-import { PaymentProviderSchema } from "../../../../projectSchemas/payment";
 import { createHandler, flag, ProjectKey } from "../../../../router";
 import type { AddProjectResourceConfig } from "../types";
-import {
-  hasPaymentCredentialInput,
-  paymentCredentialInputFlags,
-  resolvePaymentCredentialEnvEntries,
-} from "../credentials/payment/input";
 
 export const createAddPaymentConnectorHandler = (config: AddProjectResourceConfig) =>
   createHandler({
@@ -18,18 +11,7 @@ export const createAddPaymentConnectorHandler = (config: AddProjectResourceConfi
       flag("manager", "the parent payment manager", z.string().optional()),
       flag("name", "the payment connector name", z.string().optional()),
       flag("credential", "an existing payment credential to reuse", z.string().optional()),
-      flag(
-        "create-credential",
-        "a new payment credential to create with the connector",
-        z.string().optional(),
-      ),
-      flag(
-        "provider",
-        "provider for a newly created payment credential",
-        PaymentProviderSchema.optional(),
-      ),
       flag("quick-create", "create a CoinbaseCDP connector through Quick Create", z.boolean()),
-      ...paymentCredentialInputFlags,
     ],
     handle: async (ctx, flags) => {
       if (!flags.manager) {
@@ -39,47 +21,17 @@ export const createAddPaymentConnectorHandler = (config: AddProjectResourceConfi
         throw new InputValidationError("required option '--name <name>' not specified");
       }
 
-      const modes = [
-        flags.credential !== undefined,
-        flags["create-credential"] !== undefined,
-        flags["quick-create"],
-      ].filter(Boolean);
+      const modes = [flags.credential !== undefined, flags["quick-create"]].filter(Boolean);
       if (modes.length !== 1) {
-        throw new InputValidationError(
-          "specify exactly one of '--credential', '--create-credential', or '--quick-create'",
-        );
-      }
-      if (flags["create-credential"] && !flags.provider) {
-        throw new InputValidationError("--create-credential requires --provider");
-      }
-      if (!flags["create-credential"] && (flags.provider || hasPaymentCredentialInput(flags))) {
-        throw new InputValidationError(
-          "--provider and payment credential options are valid only with --create-credential",
-        );
+        throw new InputValidationError("specify exactly one of '--credential' or '--quick-create'");
       }
 
       const project = ctx.require(ProjectKey);
-      let credentialConfig: PaymentCredential | undefined;
-      let envEntries;
-      let provider: PaymentCredential["provider"];
+      let provider: "CoinbaseCDP" | "StripePrivy";
       let credentialName: string | undefined;
 
       if (flags["quick-create"]) {
         provider = "CoinbaseCDP";
-      } else if (flags["create-credential"]) {
-        provider = flags.provider!;
-        credentialName = flags["create-credential"];
-        credentialConfig = {
-          authorizerType: "PaymentCredentialProvider",
-          name: credentialName,
-          provider,
-        };
-        envEntries = await resolvePaymentCredentialEnvEntries({
-          name: credentialName,
-          provider,
-          flags,
-          io: config.io,
-        });
       } else {
         credentialName = flags.credential!;
         const credential = project.spec.credentials.find(
@@ -112,8 +64,6 @@ export const createAddPaymentConnectorHandler = (config: AddProjectResourceConfi
               provider,
               credentialName: credentialName!,
             },
-        credentialConfig,
-        envEntries,
       })) {
         config.io.stderr.write(`${event.message}\n`);
       }

--- a/src/handlers/project/add/payment-connector/index.ts
+++ b/src/handlers/project/add/payment-connector/index.ts
@@ -4,6 +4,11 @@ import type { PaymentCredential } from "../../../../projectSchemas/credential";
 import { PaymentProviderSchema } from "../../../../projectSchemas/payment";
 import { createHandler, flag, ProjectKey } from "../../../../router";
 import type { AddProjectResourceConfig } from "../types";
+import {
+  hasPaymentCredentialInput,
+  paymentCredentialInputFlags,
+  resolvePaymentCredentialEnvEntries,
+} from "../credentials/payment/input";
 
 export const createAddPaymentConnectorHandler = (config: AddProjectResourceConfig) =>
   createHandler({
@@ -24,6 +29,7 @@ export const createAddPaymentConnectorHandler = (config: AddProjectResourceConfi
         PaymentProviderSchema.optional(),
       ),
       flag("quick-create", "create a CoinbaseCDP connector through Quick Create", z.boolean()),
+      ...paymentCredentialInputFlags,
     ],
     handle: async (ctx, flags) => {
       if (!flags.manager) {
@@ -46,12 +52,15 @@ export const createAddPaymentConnectorHandler = (config: AddProjectResourceConfi
       if (flags["create-credential"] && !flags.provider) {
         throw new InputValidationError("--create-credential requires --provider");
       }
-      if (!flags["create-credential"] && flags.provider) {
-        throw new InputValidationError("--provider is valid only with --create-credential");
+      if (!flags["create-credential"] && (flags.provider || hasPaymentCredentialInput(flags))) {
+        throw new InputValidationError(
+          "--provider and payment credential options are valid only with --create-credential",
+        );
       }
 
       const project = ctx.require(ProjectKey);
       let credentialConfig: PaymentCredential | undefined;
+      let envEntries;
       let provider: PaymentCredential["provider"];
       let credentialName: string | undefined;
 
@@ -65,6 +74,12 @@ export const createAddPaymentConnectorHandler = (config: AddProjectResourceConfi
           name: credentialName,
           provider,
         };
+        envEntries = await resolvePaymentCredentialEnvEntries({
+          name: credentialName,
+          provider,
+          flags,
+          io: config.io,
+        });
       } else {
         credentialName = flags.credential!;
         const credential = project.spec.credentials.find(
@@ -98,6 +113,7 @@ export const createAddPaymentConnectorHandler = (config: AddProjectResourceConfi
               credentialName: credentialName!,
             },
         credentialConfig,
+        envEntries,
       })) {
         config.io.stderr.write(`${event.message}\n`);
       }

--- a/src/handlers/project/add/payment-connector/index.ts
+++ b/src/handlers/project/add/payment-connector/index.ts
@@ -1,0 +1,109 @@
+import z from "zod";
+import { InputValidationError } from "../../../../errors";
+import type { PaymentCredential } from "../../../../projectSchemas/credential";
+import { PaymentProviderSchema } from "../../../../projectSchemas/payment";
+import { createHandler, flag, ProjectKey } from "../../../../router";
+import type { AddProjectResourceConfig } from "../types";
+
+export const createAddPaymentConnectorHandler = (config: AddProjectResourceConfig) =>
+  createHandler({
+    name: "payment-connector",
+    description: "adds a connector to a project payment manager",
+    flags: [
+      flag("manager", "the parent payment manager", z.string().optional()),
+      flag("name", "the payment connector name", z.string().optional()),
+      flag("credential", "an existing payment credential to reuse", z.string().optional()),
+      flag(
+        "create-credential",
+        "a new payment credential to create with the connector",
+        z.string().optional(),
+      ),
+      flag(
+        "provider",
+        "provider for a newly created payment credential",
+        PaymentProviderSchema.optional(),
+      ),
+      flag("quick-create", "create a CoinbaseCDP connector through Quick Create", z.boolean()),
+    ],
+    handle: async (ctx, flags) => {
+      if (!flags.manager) {
+        throw new InputValidationError("required option '--manager <manager>' not specified");
+      }
+      if (!flags.name) {
+        throw new InputValidationError("required option '--name <name>' not specified");
+      }
+
+      const modes = [
+        flags.credential !== undefined,
+        flags["create-credential"] !== undefined,
+        flags["quick-create"],
+      ].filter(Boolean);
+      if (modes.length !== 1) {
+        throw new InputValidationError(
+          "specify exactly one of '--credential', '--create-credential', or '--quick-create'",
+        );
+      }
+      if (flags["create-credential"] && !flags.provider) {
+        throw new InputValidationError("--create-credential requires --provider");
+      }
+      if (!flags["create-credential"] && flags.provider) {
+        throw new InputValidationError("--provider is valid only with --create-credential");
+      }
+
+      const project = ctx.require(ProjectKey);
+      let credentialConfig: PaymentCredential | undefined;
+      let provider: PaymentCredential["provider"];
+      let credentialName: string | undefined;
+
+      if (flags["quick-create"]) {
+        provider = "CoinbaseCDP";
+      } else if (flags["create-credential"]) {
+        provider = flags.provider!;
+        credentialName = flags["create-credential"];
+        credentialConfig = {
+          authorizerType: "PaymentCredentialProvider",
+          name: credentialName,
+          provider,
+        };
+      } else {
+        credentialName = flags.credential!;
+        const credential = project.spec.credentials.find(
+          (candidate) => candidate.name === credentialName,
+        );
+        if (!credential) {
+          throw new InputValidationError(
+            `credential '${credentialName}' does not exist in credentials[]`,
+          );
+        }
+        if (credential.authorizerType !== "PaymentCredentialProvider") {
+          throw new InputValidationError(
+            `credential '${credentialName}' is a ${credential.authorizerType}, not a PaymentCredentialProvider`,
+          );
+        }
+        provider = credential.provider;
+      }
+
+      for await (const event of config.projectManager.addResource(project, {
+        resourceType: "payment-connector",
+        managerName: flags.manager,
+        resourceConfig: flags["quick-create"]
+          ? {
+              name: flags.name,
+              provider: "CoinbaseCDP",
+              provisionMode: "QUICK_CREATE",
+            }
+          : {
+              name: flags.name,
+              provider,
+              credentialName: credentialName!,
+            },
+        credentialConfig,
+      })) {
+        config.io.stderr.write(`${event.message}\n`);
+      }
+
+      config.io.stderr.write(
+        `added payment connector '${flags.name}' to manager '${flags.manager}' in '${project.name}'\n`,
+      );
+    },
+  });

--- a/src/handlers/project/add/payment-manager/index.test.ts
+++ b/src/handlers/project/add/payment-manager/index.test.ts
@@ -22,12 +22,14 @@ describe("project add payment-manager", () => {
       },
     ]);
     expect(io.stderr()).toContain("added payment manager 'payments'");
+    expect(io.stderr()).toContain("auto-payment is ENABLED");
+    expect(io.stderr()).toContain("does not modify runtime source code");
   });
 
   test("maps custom JWT and payment behavior flags", async () => {
     const projectRoot = await inProject();
 
-    await run([
+    const io = await run([
       "add",
       "payment-manager",
       "--name",
@@ -75,6 +77,8 @@ describe("project add payment-manager", () => {
       paymentToolAllowlist: ["checkout", "refund"],
       networkPreferences: ["eip155:8453", "eip155:1"],
     });
+    expect(io.stderr()).not.toContain("auto-payment is ENABLED");
+    expect(io.stderr()).toContain("does not modify runtime source code");
   });
 
   test.each([

--- a/src/handlers/project/add/payment-manager/index.test.ts
+++ b/src/handlers/project/add/payment-manager/index.test.ts
@@ -100,6 +100,11 @@ describe("project add payment-manager", () => {
       ["--name", "payments", "--default-spend-limit", "-1"],
       "non-negative",
     ],
+    [
+      "blank default spend limit",
+      ["--name", "payments", "--default-spend-limit", ""],
+      "non-negative",
+    ],
     ["invalid name", ["--name", "bad-name"], "alphanumeric"],
   ])("rejects %s", async (_label, flags, message) => {
     const projectRoot = await inProject();

--- a/src/handlers/project/add/payment-manager/index.test.ts
+++ b/src/handlers/project/add/payment-manager/index.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createPaymentProjectTestHarness } from "../payment-test-support";
+
+const DISCOVERY_URL = "https://idp.example.com/.well-known/openid-configuration";
+const { cleanup, inProject, projectSpec, run } = createPaymentProjectTestHarness("payment-manager");
+
+afterEach(cleanup);
+
+describe("project add payment-manager", () => {
+  test("adds a manager with materialized defaults", async () => {
+    const projectRoot = await inProject();
+
+    const io = await run(["add", "payment-manager", "--name", "payments"]);
+
+    expect((await projectSpec(projectRoot)).payments).toEqual([
+      {
+        name: "payments",
+        authorizerType: "AWS_IAM",
+        connectors: [],
+        autoPayment: true,
+        defaultSpendLimit: "10.00",
+      },
+    ]);
+    expect(io.stderr()).toContain("added payment manager 'payments'");
+  });
+
+  test("maps custom JWT and payment behavior flags", async () => {
+    const projectRoot = await inProject();
+
+    await run([
+      "add",
+      "payment-manager",
+      "--name",
+      "securePayments",
+      "--authorizer-type",
+      "CUSTOM_JWT",
+      "--discovery-url",
+      DISCOVERY_URL,
+      "--allowed-clients",
+      "client-a",
+      "client-b",
+      "--allowed-audience",
+      "payments",
+      "--allowed-scopes",
+      "pay",
+      "refund",
+      "--description",
+      "Secure payments",
+      "--no-auto-payment",
+      "--default-spend-limit",
+      "25.50",
+      "--tool-allowlist",
+      "checkout",
+      "refund",
+      "--network-preferences",
+      "eip155:8453",
+      "eip155:1",
+    ]);
+
+    expect((await projectSpec(projectRoot)).payments[0]).toEqual({
+      name: "securePayments",
+      authorizerType: "CUSTOM_JWT",
+      authorizerConfiguration: {
+        customJWTAuthorizer: {
+          discoveryUrl: DISCOVERY_URL,
+          allowedClients: ["client-a", "client-b"],
+          allowedAudience: ["payments"],
+          allowedScopes: ["pay", "refund"],
+        },
+      },
+      connectors: [],
+      description: "Secure payments",
+      autoPayment: false,
+      defaultSpendLimit: "25.50",
+      paymentToolAllowlist: ["checkout", "refund"],
+      networkPreferences: ["eip155:8453", "eip155:1"],
+    });
+  });
+
+  test.each([
+    ["missing name", [], "required option '--name"],
+    [
+      "CUSTOM_JWT without discovery URL",
+      ["--name", "payments", "--authorizer-type", "CUSTOM_JWT"],
+      "requires --discovery-url",
+    ],
+    [
+      "JWT fields with AWS_IAM",
+      ["--name", "payments", "--allowed-scopes", "pay"],
+      "valid only with CUSTOM_JWT",
+    ],
+    [
+      "negative default spend limit",
+      ["--name", "payments", "--default-spend-limit", "-1"],
+      "non-negative",
+    ],
+    ["invalid name", ["--name", "bad-name"], "alphanumeric"],
+  ])("rejects %s", async (_label, flags, message) => {
+    const projectRoot = await inProject();
+
+    await expect(run(["add", "payment-manager", ...flags])).rejects.toThrow(message);
+    expect((await projectSpec(projectRoot)).payments ?? []).toEqual([]);
+  });
+
+  test("rejects duplicate manager names", async () => {
+    const projectRoot = await inProject();
+    await run(["add", "payment-manager", "--name", "payments"]);
+
+    await expect(run(["add", "payment-manager", "--name", "payments"])).rejects.toThrow(
+      "already exists",
+    );
+    expect((await projectSpec(projectRoot)).payments).toHaveLength(1);
+  });
+});

--- a/src/handlers/project/add/payment-manager/index.test.ts
+++ b/src/handlers/project/add/payment-manager/index.test.ts
@@ -23,6 +23,8 @@ describe("project add payment-manager", () => {
     ]);
     expect(io.stderr()).toContain("added payment manager 'payments'");
     expect(io.stderr()).toContain("auto-payment is ENABLED");
+    expect(io.stderr()).not.toContain("$10.00");
+    expect(io.stderr()).not.toContain("spend limit");
     expect(io.stderr()).toContain("does not modify runtime source code");
   });
 

--- a/src/handlers/project/add/payment-manager/index.ts
+++ b/src/handlers/project/add/payment-manager/index.ts
@@ -1,0 +1,98 @@
+import z from "zod";
+import { InputValidationError } from "../../../../errors";
+import {
+  DEFAULT_AUTO_PAYMENT,
+  DEFAULT_SPEND_LIMIT,
+  PaymentAuthorizerTypeSchema,
+} from "../../../../projectSchemas/payment";
+import { createHandler, flag, ProjectKey } from "../../../../router";
+import type { AddProjectResourceConfig } from "../types";
+
+export const createAddPaymentManagerHandler = (config: AddProjectResourceConfig) =>
+  createHandler({
+    name: "payment-manager",
+    description: "adds a payment manager to the current project",
+    flags: [
+      flag("name", "the payment manager name", z.string().optional()),
+      flag(
+        "authorizer-type",
+        "payment authorization type",
+        PaymentAuthorizerTypeSchema.default("AWS_IAM"),
+      ),
+      flag(
+        "discovery-url",
+        "OIDC discovery URL for CUSTOM_JWT authorization",
+        z.string().optional(),
+      ),
+      flag("allowed-clients", "allowed JWT client IDs", z.array(z.string()).optional()),
+      flag("allowed-audience", "allowed JWT audiences", z.array(z.string()).optional()),
+      flag("allowed-scopes", "allowed JWT scopes", z.array(z.string()).optional()),
+      flag("description", "payment manager description", z.string().optional()),
+      flag(
+        "auto-payment",
+        "automatically settle payment requests",
+        z.boolean().default(DEFAULT_AUTO_PAYMENT),
+      ),
+      flag(
+        "default-spend-limit",
+        "default payment-session spend limit",
+        z.string().default(DEFAULT_SPEND_LIMIT),
+      ),
+      flag(
+        "tool-allowlist",
+        "tools eligible for automatic payment",
+        z.array(z.string()).optional(),
+      ),
+      flag("network-preferences", "preferred payment networks", z.array(z.string()).optional()),
+    ],
+    handle: async (ctx, flags) => {
+      if (!flags.name) {
+        throw new InputValidationError("required option '--name <name>' not specified");
+      }
+
+      const jwtFlags = [
+        flags["discovery-url"],
+        flags["allowed-clients"],
+        flags["allowed-audience"],
+        flags["allowed-scopes"],
+      ];
+      if (flags["authorizer-type"] === "CUSTOM_JWT" && !flags["discovery-url"]) {
+        throw new InputValidationError("CUSTOM_JWT requires --discovery-url");
+      }
+      if (
+        flags["authorizer-type"] !== "CUSTOM_JWT" &&
+        jwtFlags.some((value) => value !== undefined)
+      ) {
+        throw new InputValidationError("JWT authorization flags are valid only with CUSTOM_JWT");
+      }
+
+      const project = ctx.require(ProjectKey);
+      for await (const event of config.projectManager.addResource(project, {
+        resourceType: "payment-manager",
+        resourceConfig: {
+          name: flags.name,
+          authorizerType: flags["authorizer-type"],
+          authorizerConfiguration:
+            flags["authorizer-type"] === "CUSTOM_JWT"
+              ? {
+                  customJWTAuthorizer: {
+                    discoveryUrl: flags["discovery-url"]!,
+                    allowedClients: flags["allowed-clients"],
+                    allowedAudience: flags["allowed-audience"],
+                    allowedScopes: flags["allowed-scopes"],
+                  },
+                }
+              : undefined,
+          connectors: [],
+          description: flags.description,
+          autoPayment: flags["auto-payment"],
+          defaultSpendLimit: flags["default-spend-limit"],
+          paymentToolAllowlist: flags["tool-allowlist"],
+          networkPreferences: flags["network-preferences"],
+        },
+      })) {
+        config.io.stderr.write(`${event.message}\n`);
+      }
+      config.io.stderr.write(`added payment manager '${flags.name}' to '${project.name}'\n`);
+    },
+  });

--- a/src/handlers/project/add/payment-manager/index.ts
+++ b/src/handlers/project/add/payment-manager/index.ts
@@ -97,8 +97,7 @@ export const createAddPaymentManagerHandler = (config: AddProjectResourceConfig)
       if (flags["auto-payment"]) {
         config.io.stderr.write(
           `Warning: auto-payment is ENABLED for manager '${flags.name}'. Agents can automatically settle ` +
-            `402 responses up to the per-session spend limit ($${flags["default-spend-limit"]}) without human approval. ` +
-            "Use --no-auto-payment to require manual approval.\n",
+            "402 responses without human approval. Use --no-auto-payment to require manual approval.\n",
         );
       }
       if (project.spec.runtimes.length > 0) {

--- a/src/handlers/project/add/payment-manager/index.ts
+++ b/src/handlers/project/add/payment-manager/index.ts
@@ -94,5 +94,18 @@ export const createAddPaymentManagerHandler = (config: AddProjectResourceConfig)
         config.io.stderr.write(`${event.message}\n`);
       }
       config.io.stderr.write(`added payment manager '${flags.name}' to '${project.name}'\n`);
+      if (flags["auto-payment"]) {
+        config.io.stderr.write(
+          `Warning: auto-payment is ENABLED for manager '${flags.name}'. Agents can automatically settle ` +
+            `402 responses up to the per-session spend limit ($${flags["default-spend-limit"]}) without human approval. ` +
+            "Use --no-auto-payment to require manual approval.\n",
+        );
+      }
+      if (project.spec.runtimes.length > 0) {
+        config.io.stderr.write(
+          "Warning: project add payment-manager does not modify runtime source code. " +
+            "Configure the Payments SDK or plugin in supported runtimes before invoking payment-enabled agents.\n",
+        );
+      }
     },
   });

--- a/src/handlers/project/add/payment-manager/index.ts
+++ b/src/handlers/project/add/payment-manager/index.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_AUTO_PAYMENT,
   DEFAULT_SPEND_LIMIT,
   PaymentAuthorizerTypeSchema,
+  PaymentSpendLimitSchema,
 } from "../../../../projectSchemas/payment";
 import { createHandler, flag, ProjectKey } from "../../../../router";
 import type { AddProjectResourceConfig } from "../types";
@@ -36,7 +37,7 @@ export const createAddPaymentManagerHandler = (config: AddProjectResourceConfig)
       flag(
         "default-spend-limit",
         "default payment-session spend limit",
-        z.string().default(DEFAULT_SPEND_LIMIT),
+        PaymentSpendLimitSchema.default(DEFAULT_SPEND_LIMIT),
       ),
       flag(
         "tool-allowlist",

--- a/src/handlers/project/add/payment-test-support.ts
+++ b/src/handlers/project/add/payment-test-support.ts
@@ -1,0 +1,56 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createRootHandler } from "../../index";
+import {
+  createSilentLogger,
+  TestCoreClient,
+  TestGlobalConfigAccessor,
+  testIO,
+} from "../../../testing";
+
+export function createPaymentProjectTestHarness(directoryPrefix: string) {
+  const originalCwd = process.cwd();
+  const tempDirectories: string[] = [];
+
+  async function run(args: string[]) {
+    const io = testIO();
+    const root = createRootHandler(new TestCoreClient(), {
+      io: io.io,
+      globalConfigAccessor: new TestGlobalConfigAccessor(),
+      logger: createSilentLogger(),
+    });
+    await root.route(["node", "agentcore", "project", ...args]);
+    return io;
+  }
+
+  async function inProject(name = "TestProject"): Promise<string> {
+    const directory = await mkdtemp(join(tmpdir(), `agentcore-${directoryPrefix}-`));
+    tempDirectories.push(directory);
+    process.chdir(directory);
+    await run(["create", "--name", name, "--skip-install", "--skip-git"]);
+    const projectRoot = join(directory, name);
+    process.chdir(projectRoot);
+    return projectRoot;
+  }
+
+  async function projectSpec(projectRoot: string) {
+    return Bun.file(join(projectRoot, "agentcore", "agentcore.json")).json();
+  }
+
+  async function writeProjectSpec(projectRoot: string, spec: unknown): Promise<void> {
+    await Bun.write(
+      join(projectRoot, "agentcore", "agentcore.json"),
+      JSON.stringify(spec, undefined, 2),
+    );
+  }
+
+  async function cleanup(): Promise<void> {
+    process.chdir(originalCwd);
+    await Promise.all(
+      tempDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })),
+    );
+  }
+
+  return { cleanup, inProject, projectSpec, run, writeProjectSpec };
+}

--- a/src/handlers/project/remove/index.test.ts
+++ b/src/handlers/project/remove/index.test.ts
@@ -194,11 +194,55 @@ describe("project remove", () => {
     ]);
   });
 
+  test("removes a nested payment connector while preserving siblings and credentials", async () => {
+    const projectRoot = await inProject();
+    await run(["add", "credentials", "payment", "--name", "shared", "--provider", "CoinbaseCDP"]);
+    await run(["add", "payment-manager", "--name", "payments"]);
+    await run([
+      "add",
+      "payment-connector",
+      "--manager",
+      "payments",
+      "--name",
+      "keep",
+      "--credential",
+      "shared",
+    ]);
+    await run([
+      "add",
+      "payment-connector",
+      "--manager",
+      "payments",
+      "--name",
+      "remove",
+      "--credential",
+      "shared",
+    ]);
+
+    await run(["remove", "payment-connector", "--manager", "payments", "--name", "remove"]);
+
+    const agentcoreJson = await Bun.file(join(projectRoot, "agentcore", "agentcore.json")).json();
+    expect(
+      agentcoreJson.payments[0].connectors.map((connector: { name: string }) => connector.name),
+    ).toEqual(["keep"]);
+    expect(agentcoreJson.credentials).toEqual([
+      {
+        authorizerType: "PaymentCredentialProvider",
+        name: "shared",
+        provider: "CoinbaseCDP",
+      },
+    ]);
+  });
+
   // Verifies that missing required inputs are rejected before calling the manager.
   test.each<[string, string[]]>([
     ["missing resource argument", ["remove", "--name", "x"]],
     ["missing --name flag", ["remove", "harness"]],
     ["missing --gateway for a Target", ["remove", "gateway-target", "--name", "target"]],
+    [
+      "missing --manager for a payment connector",
+      ["remove", "payment-connector", "--name", "connector"],
+    ],
     [
       "--gateway on a non-Target resource",
       ["remove", "gateway", "--gateway", "tools", "--name", "tools"],
@@ -206,6 +250,10 @@ describe("project remove", () => {
     [
       "--engine on a non-policy resource",
       ["remove", "gateway", "--engine", "Guardrails", "--name", "tools"],
+    ],
+    [
+      "--manager on a non-payment-connector resource",
+      ["remove", "payment-manager", "--manager", "payments", "--name", "payments"],
     ],
   ])("%s", async (_label, args) => {
     await inProject();

--- a/src/handlers/project/remove/index.test.ts
+++ b/src/handlers/project/remove/index.test.ts
@@ -163,6 +163,37 @@ describe("project remove", () => {
     ).toEqual(["keep"]);
   });
 
+  test("removes a payment manager with its connectors while preserving reusable credentials", async () => {
+    const projectRoot = await inProject();
+    await run(["add", "credentials", "payment", "--name", "shared", "--provider", "CoinbaseCDP"]);
+    await run(["add", "payment-manager", "--name", "keep"]);
+    await run(["add", "payment-manager", "--name", "remove"]);
+    await run([
+      "add",
+      "payment-connector",
+      "--manager",
+      "remove",
+      "--name",
+      "connector",
+      "--credential",
+      "shared",
+    ]);
+
+    await run(["remove", "payment-manager", "--name", "remove"]);
+
+    const agentcoreJson = await Bun.file(join(projectRoot, "agentcore", "agentcore.json")).json();
+    expect(agentcoreJson.payments.map((manager: { name: string }) => manager.name)).toEqual([
+      "keep",
+    ]);
+    expect(agentcoreJson.credentials).toEqual([
+      {
+        authorizerType: "PaymentCredentialProvider",
+        name: "shared",
+        provider: "CoinbaseCDP",
+      },
+    ]);
+  });
+
   // Verifies that missing required inputs are rejected before calling the manager.
   test.each<[string, string[]]>([
     ["missing resource argument", ["remove", "--name", "x"]],

--- a/src/handlers/project/remove/index.ts
+++ b/src/handlers/project/remove/index.ts
@@ -31,6 +31,7 @@ export const createRemoveProjectHandler = (config: RemoveProjectResourceConfig) 
             "gateway-connector",
             "policy-engine",
             "policy",
+            "payment-manager",
           ])
           .optional(),
       ),

--- a/src/handlers/project/remove/index.ts
+++ b/src/handlers/project/remove/index.ts
@@ -17,6 +17,11 @@ export const createRemoveProjectHandler = (config: RemoveProjectResourceConfig) 
       flag("name", "name of the resource to remove", z.string().min(1).optional()),
       flag("gateway", "name of the parent Gateway for a Target", z.string().min(1).optional()),
       flag("engine", "name of the parent Policy Engine for a Policy", z.string().min(1).optional()),
+      flag(
+        "manager",
+        "name of the parent payment manager for a connector",
+        z.string().min(1).optional(),
+      ),
     ],
     arguments: [
       argument(
@@ -32,6 +37,7 @@ export const createRemoveProjectHandler = (config: RemoveProjectResourceConfig) 
             "policy-engine",
             "policy",
             "payment-manager",
+            "payment-connector",
           ])
           .optional(),
       ),
@@ -50,6 +56,9 @@ export const createRemoveProjectHandler = (config: RemoveProjectResourceConfig) 
       if (flags.engine && resource !== "policy") {
         throw new InputValidationError(`--engine is valid only when removing a policy`);
       }
+      if (flags.manager && resource !== "payment-connector") {
+        throw new InputValidationError(`--manager is valid only when removing a payment-connector`);
+      }
 
       const project = ctx.require(ProjectKey);
       if (resource === "gateway-target" || resource === "gateway-connector") {
@@ -65,6 +74,15 @@ export const createRemoveProjectHandler = (config: RemoveProjectResourceConfig) 
         await config.projectManager.removeResource(project, {
           resourceType: "policy",
           engineName: flags.engine,
+          name,
+        });
+      } else if (resource === "payment-connector") {
+        if (!flags.manager) {
+          throw new InputValidationError(`--manager is required option`);
+        }
+        await config.projectManager.removeResource(project, {
+          resourceType: "payment-connector",
+          managerName: flags.manager,
           name,
         });
       } else {

--- a/src/handlers/project/types.ts
+++ b/src/handlers/project/types.ts
@@ -1,5 +1,6 @@
 import { HarnessSpecSchema } from "../../projectSchemas/harness";
 import type { CredentialSchema } from "../../projectSchemas/credential";
+import type { PaymentConnectorSchema, PaymentManagerSchema } from "../../projectSchemas/payment";
 import type { ConfigBundleSchema } from "../../projectSchemas/config-bundle";
 import type { MemorySchema } from "../../projectSchemas/memory";
 import type { EvaluatorSchema } from "../../projectSchemas/evaluator";
@@ -195,13 +196,32 @@ export type AddResourceInput =
       resourceType: "policy";
       engineName: string;
       resourceConfig: z.input<typeof PolicySchema>;
+    }
+  | {
+      resourceType: "payment-manager";
+      resourceConfig: z.input<typeof PaymentManagerSchema>;
+    }
+  | {
+      resourceType: "payment-connector";
+      managerName: string;
+      resourceConfig: z.input<typeof PaymentConnectorSchema>;
     };
 
 export type ProjectResource = AddResourceInput["resourceType"];
 
 export type RemoveResourceInput =
   | {
-      resourceType: Exclude<ProjectResource, "gateway-target" | "policy">;
+      resourceType:
+        | "harness"
+        | "runtime"
+        | "credential"
+        | "config-bundle"
+        | "online-eval"
+        | "online-insight"
+        | "memory"
+        | "gateway"
+        | "policy-engine"
+        | "payment-manager";
       name: string;
     }
   | {
@@ -212,6 +232,11 @@ export type RemoveResourceInput =
   | {
       resourceType: "policy";
       engineName?: string;
+      name: string;
+    }
+  | {
+      resourceType: "payment-connector";
+      managerName: string;
       name: string;
     };
 

--- a/src/io/atomicWrite.test.ts
+++ b/src/io/atomicWrite.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, expect, test } from "bun:test";
-import { mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readdir, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Readable, Transform } from "node:stream";
@@ -35,6 +35,15 @@ test("overwrites an existing file", async () => {
 
   expect(await Bun.file(target).text()).toBe("new");
   expect(await readdir(dir)).toEqual(["out.txt"]);
+});
+
+test("creates the replacement file with the requested mode", async () => {
+  const dir = await tempDir();
+  const target = join(dir, "secret.txt");
+
+  await atomicWrite(target, "secret", { mode: 0o600 });
+
+  expect((await stat(target)).mode & 0o777).toBe(0o600);
 });
 
 test("cleans up the temp file when rename fails", async () => {

--- a/src/io/atomicWrite.test.ts
+++ b/src/io/atomicWrite.test.ts
@@ -6,6 +6,7 @@ import { Readable, Transform } from "node:stream";
 import { atomicWrite, atomicWriteStream } from "./atomicWrite";
 
 const dirs: string[] = [];
+const testPosix = process.platform === "win32" ? test.skip : test;
 afterEach(async () => {
   await Promise.all(dirs.splice(0).map((d) => rm(d, { recursive: true, force: true })));
 });
@@ -37,7 +38,7 @@ test("overwrites an existing file", async () => {
   expect(await readdir(dir)).toEqual(["out.txt"]);
 });
 
-test("creates the replacement file with the requested mode", async () => {
+testPosix("creates the replacement file with the requested mode", async () => {
   const dir = await tempDir();
   const target = join(dir, "secret.txt");
 

--- a/src/io/atomicWrite.ts
+++ b/src/io/atomicWrite.ts
@@ -13,10 +13,18 @@ export interface AtomicWriteStreamOptions {
   transforms?: Transform[];
 }
 
-export async function atomicWrite(path: string, contents: string | Uint8Array): Promise<void> {
+export interface AtomicWriteOptions {
+  mode?: number;
+}
+
+export async function atomicWrite(
+  path: string,
+  contents: string | Uint8Array,
+  options: AtomicWriteOptions = {},
+): Promise<void> {
   const tempPath = join(dirname(path), `.${basename(path)}.${randomUUID()}.tmp`);
   try {
-    await writeFile(tempPath, contents);
+    await writeFile(tempPath, contents, { mode: options.mode });
     await rename(tempPath, path);
   } catch (error) {
     await rm(tempPath, { force: true });

--- a/src/projectSchemas/auth.ts
+++ b/src/projectSchemas/auth.ts
@@ -6,7 +6,7 @@ export type GatewayAuthorizerType = z.infer<typeof GatewayAuthorizerTypeSchema>;
 export const RuntimeAuthorizerTypeSchema = z.enum(["AWS_IAM", "CUSTOM_JWT"]);
 export type RuntimeAuthorizerType = z.infer<typeof RuntimeAuthorizerTypeSchema>;
 const OIDC_WELL_KNOWN_SUFFIX = "/.well-known/openid-configuration";
-const OidcDiscoveryUrlSchema = z
+export const OidcDiscoveryUrlSchema = z
   .string()
   .url("Must be a valid URL")
   .refine((url) => url.startsWith("https://"), {
@@ -17,6 +17,11 @@ const OidcDiscoveryUrlSchema = z
   });
 const MATCH_VALUE_PATTERN = /^[A-Za-z0-9_.-]+$/;
 const ALLOWED_SCOPE_PATTERN = /^[\x21\x23-\x5B\x5D-\x7E]+$/;
+export const AllowedScopeSchema = z
+  .string()
+  .min(1)
+  .max(255)
+  .regex(ALLOWED_SCOPE_PATTERN, "Scope must be printable ASCII with no spaces or quotes");
 const CLAIM_NAME_PATTERN = /^[A-Za-z0-9_.:-]+$/;
 const RESERVED_CLAIM_NAMES = ["client_id"];
 export const ClaimMatchOperatorSchema = z.enum(["EQUALS", "CONTAINS", "CONTAINS_ANY"]);
@@ -144,15 +149,7 @@ export const CustomJwtAuthorizerConfigSchema = z
     discoveryUrl: OidcDiscoveryUrlSchema,
     allowedAudience: z.array(z.string().min(1)).optional(),
     allowedClients: z.array(z.string().min(1)).optional(),
-    allowedScopes: z
-      .array(
-        z
-          .string()
-          .min(1)
-          .max(255)
-          .regex(ALLOWED_SCOPE_PATTERN, "Scope must be printable ASCII with no spaces or quotes"),
-      )
-      .optional(),
+    allowedScopes: z.array(AllowedScopeSchema).optional(),
     customClaims: z.array(CustomClaimValidationSchema).min(1).optional(),
     privateEndpoint: PrivateEndpointSchema.optional(),
     privateEndpointOverrides: z.array(PrivateEndpointOverrideSchema).max(5).optional(),

--- a/src/projectSchemas/credential.test.ts
+++ b/src/projectSchemas/credential.test.ts
@@ -50,6 +50,22 @@ describe("credential schema", () => {
         clientSecretRef: SECRET_REF,
       },
     ],
+    [
+      "a Coinbase payment credential",
+      {
+        authorizerType: "PaymentCredentialProvider",
+        name: "coinbase",
+        provider: "CoinbaseCDP",
+      },
+    ],
+    [
+      "a StripePrivy payment credential",
+      {
+        authorizerType: "PaymentCredentialProvider",
+        name: "stripe",
+        provider: "StripePrivy",
+      },
+    ],
   ])("accepts %s and retains its fields", (_label, value) => {
     const result = CredentialSchema.safeParse(value);
     expect(result.success).toBe(true);
@@ -123,6 +139,15 @@ describe("credential schema", () => {
       "an invalid credential name",
       { authorizerType: "ApiKeyCredentialProvider", name: "bad name!" },
       /alphanumeric/,
+    ],
+    [
+      "an unsupported payment provider",
+      {
+        authorizerType: "PaymentCredentialProvider",
+        name: "payment",
+        provider: "Unsupported",
+      },
+      /provider/,
     ],
     [
       "a credential name shorter than 3 characters",

--- a/src/projectSchemas/credential.test.ts
+++ b/src/projectSchemas/credential.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { CredentialSchema } from "./credential";
+import { CredentialSchema, credentialEnvironmentVariableNames } from "./credential";
 
 const DISCOVERY_URL = "https://idp.example.com/.well-known/openid-configuration";
 const SECRET_REF = {
@@ -81,6 +81,53 @@ describe("credential schema", () => {
     });
     expect(result.success).toBe(true);
     expect(result.data).toMatchObject({ vendor: "CustomOauth2" });
+  });
+
+  it("derives the environment variables used by each credential type", () => {
+    const environmentNames = (value: Record<string, unknown>) =>
+      credentialEnvironmentVariableNames(CredentialSchema.parse(value));
+
+    expect(
+      environmentNames({ authorizerType: "ApiKeyCredentialProvider", name: "service-key" }),
+    ).toEqual(["AGENTCORE_CREDENTIAL_SERVICE_KEY"]);
+    expect(
+      environmentNames({
+        authorizerType: "ApiKeyCredentialProvider",
+        name: "service-key",
+        secretRef: SECRET_REF,
+      }),
+    ).toEqual([]);
+    expect(
+      environmentNames({
+        authorizerType: "OAuthCredentialProvider",
+        name: "github",
+        vendor: "GithubOauth2",
+        providerConfig: { githubOauth2ProviderConfig: { clientId: "client-1" } },
+      }),
+    ).toEqual(["AGENTCORE_CREDENTIAL_GITHUB_CLIENT_SECRET"]);
+    expect(
+      environmentNames({
+        authorizerType: "PaymentCredentialProvider",
+        name: "coinbase",
+        provider: "CoinbaseCDP",
+      }),
+    ).toEqual([
+      "AGENTCORE_CREDENTIAL_COINBASE_API_KEY_ID",
+      "AGENTCORE_CREDENTIAL_COINBASE_API_KEY_SECRET",
+      "AGENTCORE_CREDENTIAL_COINBASE_WALLET_SECRET",
+    ]);
+    expect(
+      environmentNames({
+        authorizerType: "PaymentCredentialProvider",
+        name: "stripe",
+        provider: "StripePrivy",
+      }),
+    ).toEqual([
+      "AGENTCORE_CREDENTIAL_STRIPE_APP_ID",
+      "AGENTCORE_CREDENTIAL_STRIPE_APP_SECRET",
+      "AGENTCORE_CREDENTIAL_STRIPE_AUTHORIZATION_PRIVATE_KEY",
+      "AGENTCORE_CREDENTIAL_STRIPE_AUTHORIZATION_ID",
+    ]);
   });
 
   it.each<[string, Record<string, unknown>, RegExp]>([

--- a/src/projectSchemas/credential.ts
+++ b/src/projectSchemas/credential.ts
@@ -113,3 +113,27 @@ export const CredentialSchema = z.discriminatedUnion("authorizerType", [
   PaymentCredentialSchema,
 ]);
 export type Credential = z.infer<typeof CredentialSchema>;
+
+/** Derives the .env.local variable name used for credential material. */
+export function credentialEnvVarName(credentialName: string, suffix = ""): string {
+  return `AGENTCORE_CREDENTIAL_${credentialName.replace(/-/g, "_").toUpperCase()}${suffix}`;
+}
+
+/** Returns every .env.local key a credential reserves when it does not use an external secret. */
+export function credentialEnvironmentVariableNames(credential: Credential): string[] {
+  switch (credential.authorizerType) {
+    case "ApiKeyCredentialProvider":
+      return credential.secretRef ? [] : [credentialEnvVarName(credential.name)];
+    case "OAuthCredentialProvider":
+      return credential.clientSecretRef
+        ? []
+        : [credentialEnvVarName(credential.name, "_CLIENT_SECRET")];
+    case "PaymentCredentialProvider": {
+      const suffixes =
+        credential.provider === "CoinbaseCDP"
+          ? ["_API_KEY_ID", "_API_KEY_SECRET", "_WALLET_SECRET"]
+          : ["_APP_ID", "_APP_SECRET", "_AUTHORIZATION_PRIVATE_KEY", "_AUTHORIZATION_ID"];
+      return suffixes.map((suffix) => credentialEnvVarName(credential.name, suffix));
+    }
+  }
+}

--- a/src/projectSchemas/payment.test.ts
+++ b/src/projectSchemas/payment.test.ts
@@ -79,4 +79,39 @@ describe("payment manager custom validation", () => {
       }).success,
     ).toBe(false);
   });
+
+  it.each([
+    [
+      "a discovery URL without the OIDC well-known suffix",
+      {
+        authorizerType: "CUSTOM_JWT",
+        authorizerConfiguration: {
+          customJWTAuthorizer: { discoveryUrl: "https://example.com/discovery" },
+        },
+      },
+    ],
+    [
+      "an invalid scope",
+      {
+        authorizerType: "CUSTOM_JWT",
+        authorizerConfiguration: {
+          customJWTAuthorizer: {
+            discoveryUrl: "https://example.com/.well-known/openid-configuration",
+            allowedScopes: ["scope with spaces"],
+          },
+        },
+      },
+    ],
+    ["a description containing punctuation", { description: "Payments!" }],
+    ["a description longer than 4096 characters", { description: "a".repeat(4097) }],
+    ["a blank default spend limit", { defaultSpendLimit: "  " }],
+  ])("rejects %s", (_label, overrides) => {
+    expect(
+      PaymentManagerSchema.safeParse({
+        name: "payments",
+        connectors: [],
+        ...overrides,
+      }).success,
+    ).toBe(false);
+  });
 });

--- a/src/projectSchemas/payment.test.ts
+++ b/src/projectSchemas/payment.test.ts
@@ -104,7 +104,7 @@ describe("payment manager custom validation", () => {
     ],
     ["a description containing punctuation", { description: "Payments!" }],
     ["a description longer than 4096 characters", { description: "a".repeat(4097) }],
-    ["a blank default spend limit", { defaultSpendLimit: "  " }],
+    ["a whitespace-only default spend limit", { defaultSpendLimit: "  " }],
   ])("rejects %s", (_label, overrides) => {
     expect(
       PaymentManagerSchema.safeParse({
@@ -113,5 +113,15 @@ describe("payment manager custom validation", () => {
         ...overrides,
       }).success,
     ).toBe(false);
+  });
+
+  it("accepts an empty persisted spend limit from released projects", () => {
+    expect(
+      PaymentManagerSchema.safeParse({
+        name: "payments",
+        connectors: [],
+        defaultSpendLimit: "",
+      }).success,
+    ).toBe(true);
   });
 });

--- a/src/projectSchemas/payment.test.ts
+++ b/src/projectSchemas/payment.test.ts
@@ -1,5 +1,49 @@
 import { describe, expect, it } from "bun:test";
-import { PaymentManagerSchema } from "./payment";
+import { PaymentConnectorSchema, PaymentManagerSchema } from "./payment";
+
+describe("payment connector schema", () => {
+  it("accepts manual connectors with implicit or explicit provisioning mode", () => {
+    const connector = {
+      name: "coinbase",
+      provider: "CoinbaseCDP",
+      credentialName: "coinbase-credential",
+    };
+
+    expect(PaymentConnectorSchema.safeParse(connector).success).toBe(true);
+    expect(
+      PaymentConnectorSchema.safeParse({ ...connector, provisionMode: "MANUAL" }).success,
+    ).toBe(true);
+  });
+
+  it("accepts Coinbase Quick Create without a credential", () => {
+    expect(
+      PaymentConnectorSchema.safeParse({
+        name: "coinbase",
+        provider: "CoinbaseCDP",
+        provisionMode: "QUICK_CREATE",
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects StripePrivy Quick Create and Quick Create credential references", () => {
+    expect(
+      PaymentConnectorSchema.safeParse({
+        name: "stripe",
+        provider: "StripePrivy",
+        provisionMode: "QUICK_CREATE",
+      }).success,
+    ).toBe(false);
+    expect(
+      PaymentConnectorSchema.safeParse({
+        name: "coinbase",
+        provider: "CoinbaseCDP",
+        provisionMode: "QUICK_CREATE",
+        credentialName: "unexpected",
+      }).success,
+    ).toBe(false);
+  });
+});
+
 describe("payment manager custom validation", () => {
   it("requires JWT authorizer configuration only for CUSTOM_JWT", () => {
     expect(
@@ -19,5 +63,20 @@ describe("payment manager custom validation", () => {
         },
       }).success,
     ).toBe(true);
+  });
+
+  it("rejects duplicate connector names within one manager", () => {
+    const connector = {
+      name: "duplicate",
+      provider: "CoinbaseCDP",
+      credentialName: "credential",
+    };
+
+    expect(
+      PaymentManagerSchema.safeParse({
+        name: "payments",
+        connectors: [connector, connector],
+      }).success,
+    ).toBe(false);
   });
 });

--- a/src/projectSchemas/payment.ts
+++ b/src/projectSchemas/payment.ts
@@ -1,3 +1,4 @@
+import { AllowedScopeSchema, OidcDiscoveryUrlSchema } from "./auth";
 import { z } from "zod";
 export const PaymentProviderSchema = z.enum(["CoinbaseCDP", "StripePrivy"]);
 export type PaymentProvider = z.infer<typeof PaymentProviderSchema>;
@@ -44,6 +45,14 @@ export const PaymentConnectorSchema = z.union([
   ManualPaymentConnectorSchema,
 ]);
 export type PaymentConnector = z.infer<typeof PaymentConnectorSchema>;
+export const PaymentManagerDescriptionSchema = z
+  .string()
+  .min(1)
+  .max(4096)
+  .regex(
+    /^[a-zA-Z0-9\s]+$/,
+    "Payment manager description must contain only alphanumeric characters and whitespace",
+  );
 export const PaymentManagerSchema = z
   .object({
     name: PaymentManagerNameSchema,
@@ -51,21 +60,24 @@ export const PaymentManagerSchema = z
     authorizerConfiguration: z
       .object({
         customJWTAuthorizer: z.object({
-          discoveryUrl: z.string().url(),
-          allowedClients: z.array(z.string()).optional(),
-          allowedAudience: z.array(z.string()).optional(),
-          allowedScopes: z.array(z.string()).optional(),
+          discoveryUrl: OidcDiscoveryUrlSchema,
+          allowedClients: z.array(z.string()).min(1).optional(),
+          allowedAudience: z.array(z.string()).min(1).optional(),
+          allowedScopes: z.array(AllowedScopeSchema).min(1).optional(),
         }),
       })
       .optional(),
     connectors: z.array(PaymentConnectorSchema).default([]),
-    description: z.string().optional(),
+    description: PaymentManagerDescriptionSchema.optional(),
     autoPayment: z.boolean().default(DEFAULT_AUTO_PAYMENT),
     defaultSpendLimit: z
       .string()
-      .refine((value) => Number.isFinite(Number(value)) && Number(value) >= 0, {
-        message: "Default spend limit must be a non-negative number",
-      })
+      .refine(
+        (value) => value.trim().length > 0 && Number.isFinite(Number(value)) && Number(value) >= 0,
+        {
+          message: "Default spend limit must be a non-negative number",
+        },
+      )
       .default(DEFAULT_SPEND_LIMIT),
     paymentToolAllowlist: z.array(z.string()).optional(),
     networkPreferences: z.array(z.string()).optional(),

--- a/src/projectSchemas/payment.ts
+++ b/src/projectSchemas/payment.ts
@@ -53,6 +53,14 @@ export const PaymentManagerDescriptionSchema = z
     /^[a-zA-Z0-9\s]+$/,
     "Payment manager description must contain only alphanumeric characters and whitespace",
   );
+export const PaymentSpendLimitSchema = z
+  .string()
+  .refine(
+    (value) => value.trim().length > 0 && Number.isFinite(Number(value)) && Number(value) >= 0,
+    {
+      message: "Default spend limit must be a non-negative number",
+    },
+  );
 export const PaymentManagerSchema = z
   .object({
     name: PaymentManagerNameSchema,
@@ -70,15 +78,7 @@ export const PaymentManagerSchema = z
     connectors: z.array(PaymentConnectorSchema).default([]),
     description: PaymentManagerDescriptionSchema.optional(),
     autoPayment: z.boolean().default(DEFAULT_AUTO_PAYMENT),
-    defaultSpendLimit: z
-      .string()
-      .refine(
-        (value) => value.trim().length > 0 && Number.isFinite(Number(value)) && Number(value) >= 0,
-        {
-          message: "Default spend limit must be a non-negative number",
-        },
-      )
-      .default(DEFAULT_SPEND_LIMIT),
+    defaultSpendLimit: PaymentSpendLimitSchema.default(DEFAULT_SPEND_LIMIT),
     paymentToolAllowlist: z.array(z.string()).optional(),
     networkPreferences: z.array(z.string()).optional(),
   })

--- a/src/projectSchemas/payment.ts
+++ b/src/projectSchemas/payment.ts
@@ -78,7 +78,9 @@ export const PaymentManagerSchema = z
     connectors: z.array(PaymentConnectorSchema).default([]),
     description: PaymentManagerDescriptionSchema.optional(),
     autoPayment: z.boolean().default(DEFAULT_AUTO_PAYMENT),
-    defaultSpendLimit: PaymentSpendLimitSchema.default(DEFAULT_SPEND_LIMIT),
+    defaultSpendLimit: z
+      .union([z.literal(""), PaymentSpendLimitSchema])
+      .default(DEFAULT_SPEND_LIMIT),
     paymentToolAllowlist: z.array(z.string()).optional(),
     networkPreferences: z.array(z.string()).optional(),
   })

--- a/src/projectSchemas/payment.ts
+++ b/src/projectSchemas/payment.ts
@@ -19,11 +19,30 @@ export const PaymentConnectorNameSchema = z
     /^[a-zA-Z][a-zA-Z0-9_]{0,47}$/,
     "Must begin with a letter and contain only alphanumeric characters and underscores (max 48 chars)",
   );
-export const PaymentConnectorSchema = z.object({
+
+export const PaymentProvisionModeSchema = z.enum(["MANUAL", "QUICK_CREATE"]);
+export type PaymentProvisionMode = z.infer<typeof PaymentProvisionModeSchema>;
+
+export const ManualPaymentConnectorSchema = z.object({
   name: PaymentConnectorNameSchema,
   provider: PaymentProviderSchema.default("CoinbaseCDP"),
+  provisionMode: z.literal("MANUAL").optional(),
   credentialName: z.string().min(1),
 });
+export type ManualPaymentConnector = z.infer<typeof ManualPaymentConnectorSchema>;
+
+export const QuickCreatePaymentConnectorSchema = z.object({
+  name: PaymentConnectorNameSchema,
+  provider: z.literal("CoinbaseCDP"),
+  provisionMode: z.literal("QUICK_CREATE"),
+  credentialName: z.never().optional(),
+});
+export type QuickCreatePaymentConnector = z.infer<typeof QuickCreatePaymentConnectorSchema>;
+
+export const PaymentConnectorSchema = z.union([
+  QuickCreatePaymentConnectorSchema,
+  ManualPaymentConnectorSchema,
+]);
 export type PaymentConnector = z.infer<typeof PaymentConnectorSchema>;
 export const PaymentManagerSchema = z
   .object({
@@ -42,7 +61,12 @@ export const PaymentManagerSchema = z
     connectors: z.array(PaymentConnectorSchema).default([]),
     description: z.string().optional(),
     autoPayment: z.boolean().default(DEFAULT_AUTO_PAYMENT),
-    defaultSpendLimit: z.string().default(DEFAULT_SPEND_LIMIT),
+    defaultSpendLimit: z
+      .string()
+      .refine((value) => Number.isFinite(Number(value)) && Number(value) >= 0, {
+        message: "Default spend limit must be a non-negative number",
+      })
+      .default(DEFAULT_SPEND_LIMIT),
     paymentToolAllowlist: z.array(z.string()).optional(),
     networkPreferences: z.array(z.string()).optional(),
   })
@@ -57,6 +81,18 @@ export const PaymentManagerSchema = z
           "authorizerConfiguration with customJWTAuthorizer is required when authorizerType is CUSTOM_JWT",
         path: ["authorizerConfiguration"],
       });
+    }
+
+    const connectorNames = new Set<string>();
+    for (const [index, connector] of data.connectors.entries()) {
+      if (connectorNames.has(connector.name)) {
+        ctx.addIssue({
+          code: "custom",
+          message: `Duplicate payment connector name: ${connector.name}`,
+          path: ["connectors", index, "name"],
+        });
+      }
+      connectorNames.add(connector.name);
     }
   });
 export type PaymentManager = z.infer<typeof PaymentManagerSchema>;

--- a/src/projectSchemas/project.test.ts
+++ b/src/projectSchemas/project.test.ts
@@ -289,6 +289,25 @@ describe("project custom validation", () => {
     ).toBe(true);
   });
 
+  it("rejects payment manager names that collide after environment normalization", () => {
+    const result = ProjectSpecSchema.safeParse({
+      ...minimalProject,
+      payments: [
+        { name: "Payments", connectors: [] },
+        { name: "payments", connectors: [] },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((issue) =>
+          issue.message.includes("payment manager environment name"),
+        ),
+      ).toBe(true);
+    }
+  });
+
   it("allows the same payment connector name under different managers", () => {
     const credential = {
       authorizerType: "PaymentCredentialProvider" as const,

--- a/src/projectSchemas/project.test.ts
+++ b/src/projectSchemas/project.test.ts
@@ -244,4 +244,99 @@ describe("project custom validation", () => {
       }).success,
     ).toBe(true);
   });
+
+  it("validates payment connector credential providers and skips credentials for Quick Create", () => {
+    const credential = {
+      authorizerType: "PaymentCredentialProvider" as const,
+      name: "credential",
+      provider: "CoinbaseCDP" as const,
+    };
+    const manualPayment = {
+      name: "manual",
+      connectors: [
+        {
+          name: "stripe",
+          provider: "StripePrivy" as const,
+          credentialName: credential.name,
+        },
+      ],
+    };
+
+    expect(
+      ProjectSpecSchema.safeParse({
+        ...minimalProject,
+        credentials: [credential],
+        payments: [manualPayment],
+      }).success,
+    ).toBe(false);
+
+    expect(
+      ProjectSpecSchema.safeParse({
+        ...minimalProject,
+        payments: [
+          {
+            name: "quick",
+            connectors: [
+              {
+                name: "coinbase",
+                provider: "CoinbaseCDP",
+                provisionMode: "QUICK_CREATE",
+              },
+            ],
+          },
+        ],
+      }).success,
+    ).toBe(true);
+  });
+
+  it("allows the same payment connector name under different managers", () => {
+    const credential = {
+      authorizerType: "PaymentCredentialProvider" as const,
+      name: "credential",
+      provider: "CoinbaseCDP" as const,
+    };
+    const connector = {
+      name: "shared",
+      provider: "CoinbaseCDP" as const,
+      credentialName: credential.name,
+    };
+
+    expect(
+      ProjectSpecSchema.safeParse({
+        ...minimalProject,
+        credentials: [credential],
+        payments: [
+          {
+            name: "first",
+            connectors: [connector],
+          },
+          {
+            name: "second",
+            connectors: [connector],
+          },
+        ],
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects credential names that derive the same environment variable prefix", () => {
+    const result = ProjectSpecSchema.safeParse({
+      ...minimalProject,
+      credentials: [
+        { authorizerType: "ApiKeyCredentialProvider", name: "service-key" },
+        {
+          authorizerType: "PaymentCredentialProvider",
+          name: "service_key",
+          provider: "CoinbaseCDP",
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((issue) => issue.message.includes("environment variable")),
+      ).toBe(true);
+    }
+  });
 });

--- a/src/projectSchemas/project.test.ts
+++ b/src/projectSchemas/project.test.ts
@@ -343,11 +343,7 @@ describe("project custom validation", () => {
       ...minimalProject,
       credentials: [
         { authorizerType: "ApiKeyCredentialProvider", name: "service-key" },
-        {
-          authorizerType: "PaymentCredentialProvider",
-          name: "service_key",
-          provider: "CoinbaseCDP",
-        },
+        { authorizerType: "ApiKeyCredentialProvider", name: "service_key" },
       ],
     });
 
@@ -355,6 +351,29 @@ describe("project custom validation", () => {
     if (!result.success) {
       expect(
         result.error.issues.some((issue) => issue.message.includes("environment variable")),
+      ).toBe(true);
+    }
+  });
+
+  it("rejects different credential types that derive the same environment variable", () => {
+    const result = ProjectSpecSchema.safeParse({
+      ...minimalProject,
+      credentials: [
+        { authorizerType: "ApiKeyCredentialProvider", name: "stripe_app_id" },
+        {
+          authorizerType: "PaymentCredentialProvider",
+          name: "stripe",
+          provider: "StripePrivy",
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((issue) =>
+          issue.message.includes("AGENTCORE_CREDENTIAL_STRIPE_APP_ID"),
+        ),
       ).toBe(true);
     }
   });

--- a/src/projectSchemas/project.ts
+++ b/src/projectSchemas/project.ts
@@ -36,6 +36,7 @@ export const ProjectNameSchema = z
   });
 const BUILTIN_EVALUATOR_PREFIX = "Builtin.";
 const ARN_PREFIX = "arn:";
+const toEnvironmentName = (name: string) => name.replace(/-/g, "_").toUpperCase();
 const uniqueNames = (resource: string) =>
   uniqueBy<{ name: string }>(
     ({ name }) => name,
@@ -250,7 +251,7 @@ export const ProjectSpecSchema = z
     }
     const credentialEnvironmentNames = new Map<string, string>();
     for (const [credentialIndex, credential] of spec.credentials.entries()) {
-      const environmentName = credential.name.replace(/-/g, "_").toUpperCase();
+      const environmentName = toEnvironmentName(credential.name);
       const conflictingName = credentialEnvironmentNames.get(environmentName);
       if (conflictingName) {
         ctx.addIssue({
@@ -264,7 +265,22 @@ export const ProjectSpecSchema = z
         credentialEnvironmentNames.set(environmentName, credential.name);
       }
     }
+    const paymentManagerEnvironmentNames = new Map<string, string>();
     for (const [paymentIndex, payment] of (spec.payments ?? []).entries()) {
+      const environmentName = toEnvironmentName(payment.name);
+      const conflictingName = paymentManagerEnvironmentNames.get(environmentName);
+      if (conflictingName) {
+        ctx.addIssue({
+          code: "custom",
+          message:
+            `Payment managers "${payment.name}" and "${conflictingName}" derive the same payment manager environment name; ` +
+            "choose names that differ by more than letter casing",
+          path: ["payments", paymentIndex, "name"],
+        });
+      } else {
+        paymentManagerEnvironmentNames.set(environmentName, payment.name);
+      }
+
       for (const [connectorIndex, connector] of payment.connectors.entries()) {
         if (connector.provisionMode === "QUICK_CREATE") continue;
 

--- a/src/projectSchemas/project.ts
+++ b/src/projectSchemas/project.ts
@@ -8,7 +8,7 @@ import {
 } from "./gateway";
 import { ABTestSchema } from "./ab-test";
 import { ConfigBundleSchema } from "./config-bundle";
-import { CredentialSchema } from "./credential";
+import { CredentialSchema, credentialEnvironmentVariableNames } from "./credential";
 import { DatasetSchema } from "./dataset";
 import { EvaluatorSchema } from "./evaluator";
 import { HarnessRegistryEntrySchema } from "./harness";
@@ -251,18 +251,19 @@ export const ProjectSpecSchema = z
     }
     const credentialEnvironmentNames = new Map<string, string>();
     for (const [credentialIndex, credential] of spec.credentials.entries()) {
-      const environmentName = toEnvironmentName(credential.name);
-      const conflictingName = credentialEnvironmentNames.get(environmentName);
-      if (conflictingName) {
-        ctx.addIssue({
-          code: "custom",
-          message:
-            `Credential "${credential.name}" and "${conflictingName}" derive the same environment variable name; ` +
-            "choose names that differ by more than '-' and '_'",
-          path: ["credentials", credentialIndex, "name"],
-        });
-      } else {
-        credentialEnvironmentNames.set(environmentName, credential.name);
+      for (const environmentName of credentialEnvironmentVariableNames(credential)) {
+        const conflictingName = credentialEnvironmentNames.get(environmentName);
+        if (conflictingName) {
+          ctx.addIssue({
+            code: "custom",
+            message:
+              `Credential "${credential.name}" and "${conflictingName}" derive the same environment variable "${environmentName}"; ` +
+              "choose credential names that produce distinct environment variables",
+            path: ["credentials", credentialIndex, "name"],
+          });
+        } else {
+          credentialEnvironmentNames.set(environmentName, credential.name);
+        }
       }
     }
     const paymentManagerEnvironmentNames = new Map<string, string>();

--- a/src/projectSchemas/project.ts
+++ b/src/projectSchemas/project.ts
@@ -248,8 +248,26 @@ export const ProjectSpecSchema = z
         }
       }
     }
+    const credentialEnvironmentNames = new Map<string, string>();
+    for (const [credentialIndex, credential] of spec.credentials.entries()) {
+      const environmentName = credential.name.replace(/-/g, "_").toUpperCase();
+      const conflictingName = credentialEnvironmentNames.get(environmentName);
+      if (conflictingName) {
+        ctx.addIssue({
+          code: "custom",
+          message:
+            `Credential "${credential.name}" and "${conflictingName}" derive the same environment variable name; ` +
+            "choose names that differ by more than '-' and '_'",
+          path: ["credentials", credentialIndex, "name"],
+        });
+      } else {
+        credentialEnvironmentNames.set(environmentName, credential.name);
+      }
+    }
     for (const [paymentIndex, payment] of (spec.payments ?? []).entries()) {
       for (const [connectorIndex, connector] of payment.connectors.entries()) {
+        if (connector.provisionMode === "QUICK_CREATE") continue;
+
         const credential = spec.credentials.find((c) => c.name === connector.credentialName);
         if (!credential) {
           ctx.addIssue({
@@ -262,6 +280,14 @@ export const ProjectSpecSchema = z
             code: "custom",
             message: `Payment connector "${connector.name}" in manager "${payment.name}" references credential "${connector.credentialName}" which is a ${credential.authorizerType}, not a PaymentCredentialProvider`,
             path: ["payments", paymentIndex, "connectors", connectorIndex, "credentialName"],
+          });
+        } else if (credential.provider !== connector.provider) {
+          ctx.addIssue({
+            code: "custom",
+            message:
+              `Payment connector "${connector.name}" in manager "${payment.name}" uses provider "${connector.provider}", ` +
+              `but credential "${connector.credentialName}" uses provider "${credential.provider}"`,
+            path: ["payments", paymentIndex, "connectors", connectorIndex, "provider"],
           });
         }
       }


### PR DESCRIPTION
## Summary

Adds project-based Payments resource authoring:

```text
agentcore project add credentials payment
agentcore project add payment-manager
agentcore project add payment-connector
agentcore project remove payment-manager
agentcore project remove payment-connector --manager <manager>
```

Payment credentials are reusable project resources under `credentials[]`. Create
the credential first, then reference it from a manual connector:

```text
agentcore project add credentials payment \
  --name coinbase-prod \
  --provider CoinbaseCDP \
  --api-key-id <id> \
  --api-key-secret file://<path> \
  --wallet-secret file://<path>

agentcore project add payment-connector \
  --manager Payments \
  --name Coinbase \
  --credential coinbase-prod

agentcore project add credentials payment \
  --name stripe-prod \
  --provider StripePrivy \
  --app-id <id> \
  --app-secret file://<path> \
  --authorization-private-key file://<path> \
  --authorization-id <id>

agentcore project add payment-connector \
  --manager Payments \
  --name Stripe \
  --credential stripe-prod
```

Quick Create is a connector-only mode and creates no `credentials[]` entry:

```text
agentcore project add payment-connector \
  --manager Payments \
  --name CoinbaseQuick \
  --quick-create
```

The change:

- models manual and Quick Create connectors using the same schema variants as `main`;
- validates connector-name uniqueness within each manager;
- validates manual credential references, credential type, and provider compatibility;
- collects CoinbaseCDP and StripePrivy credential values through source-aware flags;
- validates Coinbase Ed25519/P-256 and Stripe P-256 private-key formats and normalizes `wallet-auth:` prefixes;
- stores managed payment credential values or fill-before-deploy placeholders in a POSIX owner-only `.env.local`;
- rejects inline secret values and provider-incompatible credential options;
- rejects credential names that collide after environment-variable normalization;
- rejects payment manager names that collide after runtime environment-variable normalization;
- validates Payment manager OIDC, scope, description, and non-negative spend-limit constraints against CloudFormation;
- warns that auto-payment defaults on and that project commands do not mutate runtime source code;
- requires manual connectors to reference an explicitly created payment credential;
- removes payment managers with all nested connectors while preserving reusable credentials;
- removes nested payment connectors with explicit manager context while preserving siblings and reusable credentials;
- bumps generated projects from `@aws/agentcore-cdk@0.1.0-alpha.45` to published `alpha.49`;
- maps Quick Create through generated CDK without resolving a credential ARN;
- preserves complete manager and connector identities in CDK construct and output IDs;
- synthesizes Quick Create status and authorization URL outputs.

Payment credential service-side provisioning remains outside these project
authoring commands. Manual connector deployment continues to consume credential
provider ARNs from target deployed state.

## L3 Compatibility

Published L3 `0.1.0-alpha.49` contains Quick Create support from
aws/agentcore-l3-cdk-constructs#324, and `alpha.50` preserves legacy generated
connector props through aws/agentcore-l3-cdk-constructs#341.

aws/agentcore-l3-cdk-constructs#345 adds the `AgentCorePayments` L3 sibling that
now owns manager/connector construction, credential resolution, runtime wiring,
and outputs for newly generated projects. This PR includes the corresponding
generated-CDK cleanup, but its package manifest temporarily remains pinned to
`alpha.49`; generated-CDK build and deploy require the exact #345 tarball until
that PR is merged, published, and pinned here.

## Testing

Latest source verification on PR head `7adecd9c`:

- `bun test src`: 2,227 passed;
- 118 focused Payments and credential tests passed;
- `bun run typecheck`, `bun run format:check`, and `bun run lint:check`.

The included generated-CDK cleanup was tested independently with the exact
aws/agentcore-l3-cdk-constructs#345 tarball:

- `npm run build`;
- `npm test -- --runInBand`: 3 passed;
- `npm run format:check`;
- template assertions cover manual and Quick Create connector properties, outputs,
  and collision-safe construct identities.

### Fresh refactor project

A project created by this branch's built CLI with the exact
aws/agentcore-l3-cdk-constructs#345 tarball:

- stored validated Coinbase/Stripe values in a `0600` `.env.local` and stripped
  the documented `wallet-auth:` prefix;
- synthesized and deployed one manager, Coinbase/Stripe manual connectors, and
  a Coinbase Quick Create connector;
- reached CloudFormation `CREATE_COMPLETE`; manual connectors reached `READY`,
  while Quick Create returned `PENDING_AUTHENTICATION` and an authorization URL;
- redeployed unchanged with identical manager, connector, role, runtime, and
  output identities;
- deleted the stack and temporary credential providers and verified they were
  absent.

### Cross-version payment matrix

An old-CLI scaffold was populated exclusively through the new project commands,
then validated and deployed by released CLI `0.28.0`.

Verified:

- standalone CoinbaseCDP and StripePrivy payment credentials;
- existing credential reuse;
- one credential reused across payment managers;
- AWS_IAM and CUSTOM_JWT payment managers;
- Quick Create authorization through `READY`;
- unchanged redeploy reused resource identities;
- CloudFormation resources and all test credential providers were deleted and
  verified absent.

## Scope

This PR does not add imperative Payments commands, TUI screens, or payment
credential deployment orchestration.
