### PR TITLE
fix(deps): pin @aws-cdk/toolkit-lib yaml to v1 to fix 'yaml/types' resolution

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -51,6 +51,9 @@
     },
   },
   "overrides": {
+    "@aws-cdk/toolkit-lib": {
+      "yaml": "^1",
+    },
     "@opentelemetry/core": "^2.10.0",
   },
   "packages": {

--- a/package.json
+++ b/package.json
@@ -85,6 +85,9 @@
     "zod": "^4.4.3"
   },
   "overrides": {
-    "@opentelemetry/core": "^2.10.0"
+    "@opentelemetry/core": "^2.10.0",
+    "@aws-cdk/toolkit-lib": {
+      "yaml": "^1"
+    }
   }
 }


### PR DESCRIPTION
## What
Add a nested `overrides` entry forcing `@aws-cdk/toolkit-lib`'s `yaml` dependency to `^1`.

## Why
`@aws-cdk/toolkit-lib`'s `yaml-cfn.js` does `require("yaml/types")` **at import time** — a subpath that only exists in `yaml` v1. `yaml@2` (pulled transitively, e.g. via the `lint-staged` devDep) has an `exports` map that does **not** expose `./types`, so any install topology that resolves toolkit-lib's `yaml` to the hoisted v2 fails to load the module with:

```
Cannot find module 'yaml/types' (ERR_PACKAGE_PATH_NOT_EXPORTED)
```

This is especially dangerous for `bun compile`, which **inlines** toolkit-lib (only `bundle()` marks it external) and embeds whatever `yaml/types` the build machine resolves.

## Fix
```json
"overrides": {
  "@aws-cdk/toolkit-lib": { "yaml": "^1" }
}
```
Guarantees toolkit-lib always resolves the nested `yaml@1` copy (which ships `types.js`).

## Testing
- Verified `require.resolve('yaml/types')` from toolkit-lib resolves to the v1 nested copy under both `node` and `bun`.
- Reproduced the v2 failure (`ERR_PACKAGE_PATH_NOT_EXPORTED`) and confirmed the override prevents it.
- `project deploy` (CDK synth + CloudFormation) exercised end-to-end after the change.