### PR TITLE
feat(schema): add ap-south-2 (HYD) and us-west-1 (SFO) to region allowlist

### DIFF
--- a/src/schema/llm-compacted/aws-targets.ts
+++ b/src/schema/llm-compacted/aws-targets.ts
@@ -30,6 +30,7 @@ type AgentCoreRegion =
   | 'ap-northeast-1'
   | 'ap-northeast-2'
   | 'ap-south-1'
+  | 'ap-south-2'
   | 'ap-southeast-1'
   | 'ap-southeast-2'
   | 'ap-southeast-5'
@@ -45,5 +46,6 @@ type AgentCoreRegion =
   | 'sa-east-1'
   | 'us-east-1'
   | 'us-east-2'
+  | 'us-west-1'
   | 'us-west-2'
   | 'us-gov-west-1';

--- a/src/schema/schemas/__tests__/aws-targets.test.ts
+++ b/src/schema/schemas/__tests__/aws-targets.test.ts
@@ -13,6 +13,7 @@ describe('AgentCoreRegionSchema', () => {
       'ap-northeast-1',
       'ap-northeast-2',
       'ap-south-1',
+      'ap-south-2',
       'ap-southeast-1',
       'ap-southeast-2',
       'ap-southeast-5',
@@ -28,13 +29,14 @@ describe('AgentCoreRegionSchema', () => {
       'sa-east-1',
       'us-east-1',
       'us-east-2',
+      'us-west-1',
       'us-west-2',
       'us-gov-west-1',
     ]);
   });
 
   it('rejects unsupported regions and invalid values', () => {
-    expect(AgentCoreRegionSchema.safeParse('us-west-1').success).toBe(false);
+    expect(AgentCoreRegionSchema.safeParse('me-central-1').success).toBe(false);
     expect(AgentCoreRegionSchema.safeParse('af-south-1').success).toBe(false);
     expect(AgentCoreRegionSchema.safeParse('').success).toBe(false);
     expect(AgentCoreRegionSchema.safeParse(123).success).toBe(false);

--- a/src/schema/schemas/aws-targets.ts
+++ b/src/schema/schemas/aws-targets.ts
@@ -10,6 +10,7 @@ export const AgentCoreRegionSchema = z.enum([
   'ap-northeast-1',
   'ap-northeast-2',
   'ap-south-1',
+  'ap-south-2',
   'ap-southeast-1',
   'ap-southeast-2',
   'ap-southeast-5',
@@ -25,6 +26,7 @@ export const AgentCoreRegionSchema = z.enum([
   'sa-east-1',
   'us-east-1',
   'us-east-2',
+  'us-west-1',
   'us-west-2',
   'us-gov-west-1',
 ]);


### PR DESCRIPTION
## What

Add `ap-south-2` (HYD) and `us-west-1` (SFO) to the AgentCore region allowlist so the CLI accepts these launch regions in `validate`/`deploy` and the TUI region picker. The other four launch regions (ap-southeast-7, ap-southeast-5, eu-south-1, eu-south-2) are already present.

## Why

`AgentCoreRegionSchema` is the front-door validation for deployment-target regions. Without these two entries the CLI rejects HYD/SFO before deploy. The partition/ARN/endpoint layer (`src/cli/aws/partition.ts`) is already region-agnostic (SDK-derived) and needs no change.

Must land with the CDK counterpart — aws/agentcore-l3-cdk-constructs#343 — which gates synth on the same enum.

## Changes (per AGENTS.md "Adding a New Region")

- `src/schema/schemas/aws-targets.ts` — `AgentCoreRegionSchema` enum +2
- `src/schema/llm-compacted/aws-targets.ts` — `AgentCoreRegion` type union +2 (kept in sync)
- `src/schema/schemas/__tests__/aws-targets.test.ts` — options list +2; updated the negative assertion (`us-west-1` is now valid → uses `me-central-1`)

`BEDROCK_REGIONS` (Bedrock Agent *import* only) intentionally unchanged — separate scope from AgentCore deployment regions.

## Verification

- `npm run test:unit` — 429 files / 6153 tests pass; typecheck + build pass
- `agentcore validate` on real configs: all 6 launch regions pass; unsupported control (`me-central-1`) correctly rejected
- Live `agentcore deploy` to a CloudFormation stack (us-west-2, patched CLI) verified end to end