### PR TITLE
fix(project): tie evaluator model ARN validation to each resource type's account format

### DIFF
--- a/src/projectSchemas/evaluator.test.ts
+++ b/src/projectSchemas/evaluator.test.ts
@@ -32,7 +32,8 @@ describe("evaluator custom validation", () => {
   it("validates model identifiers and KMS key ARNs through owned helpers", () => {
     expect(isValidBedrockModelId("anthropic.claude-v2:1")).toBe(true);
     expect(isValidBedrockModelId("us.anthropic.claude-sonnet-4-5-20250929-v1:0")).toBe(true);
-    // foundation-model ARNs omit the account segment; inference-profile ARNs carry it.
+    // foundation-model ARNs omit the account segment; (application-)inference-profile
+    // ARNs carry it. Each type must match only its documented shape.
     expect(
       isValidBedrockModelId("arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-v2"),
     ).toBe(true);
@@ -41,6 +42,16 @@ describe("evaluator custom validation", () => {
         "arn:aws:bedrock:us-east-1:123456789012:inference-profile/us.anthropic.claude-v2",
       ),
     ).toBe(true);
+    expect(
+      isValidBedrockModelId(
+        "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/my-profile",
+      ),
+    ).toBe(true);
+    // Wrong account format for the resource type is rejected.
+    expect(isValidBedrockModelId("arn:aws:bedrock:us-east-1:123456789012:foundation-model/x")).toBe(
+      false,
+    );
+    expect(isValidBedrockModelId("arn:aws:bedrock:us-east-1::inference-profile/x")).toBe(false);
     expect(isValidBedrockModelId("not a model")).toBe(false);
     expect(
       isValidKmsKeyArn(

--- a/src/projectSchemas/evaluator.ts
+++ b/src/projectSchemas/evaluator.ts
@@ -36,11 +36,12 @@ export const RatingScaleSchema = z
   );
 export type RatingScale = z.infer<typeof RatingScaleSchema>;
 const BEDROCK_MODEL_ID_PATTERN = /^[a-z][a-z0-9-]*\.[a-zA-Z0-9._-]+(:[0-9]+)?$/;
-// The account segment is optional: foundation-model ARNs omit it
-// (arn:aws:bedrock:us-east-1::foundation-model/...), while inference-profile
-// ARNs carry it (arn:aws:bedrock:us-east-1:123456789012:inference-profile/...).
+// Each resource type is tied to its documented account format: foundation-model
+// ARNs omit the account (arn:aws:bedrock:us-east-1::foundation-model/...), while
+// (application-)inference-profile ARNs carry it
+// (arn:aws:bedrock:us-east-1:123456789012:inference-profile/...).
 const BEDROCK_ARN_PATTERN =
-  /^arn:aws[a-z-]*:bedrock:[a-z0-9-]+:(\d{12})?:(inference-profile|foundation-model)\/.+$/;
+  /^arn:aws[a-z-]*:bedrock:[a-z0-9-]+:(?:\d{12}:(?:application-)?inference-profile|:foundation-model)\/.+$/;
 export function isValidBedrockModelId(value: string): boolean {
   return BEDROCK_MODEL_ID_PATTERN.test(value) || BEDROCK_ARN_PATTERN.test(value);
 }


### PR DESCRIPTION
## What

Follow-up to #2124 addressing @nborges-aws's review comment on the evaluator model-ID ARN validator.

`isValidBedrockModelId`'s ARN pattern made the account segment optional for both resource types:

```
/^arn:aws[a-z-]*:bedrock:[a-z0-9-]+:(\d{12})?:(inference-profile|foundation-model)\/.+$/
```

That fixed the original foundation-model false-negative, but also accepts two impossible shapes: an account-scoped foundation-model and an accountless inference-profile. This ties each resource type to its documented account format instead:

```
/^arn:aws[a-z-]*:bedrock:[a-z0-9-]+:(?:\d{12}:(?:application-)?inference-profile|:foundation-model)\/.+$/
```

- **foundation-model** → no account: `arn:aws:bedrock:us-east-1::foundation-model/…`
- **(application-)inference-profile** → account required: `arn:aws:bedrock:us-east-1:123456789012:inference-profile/…`

Also accepts `application-inference-profile` ARNs, which the previous pattern rejected (a real valid ARN type).

## Testing

Extended the existing helper test to assert the two valid ARN shapes + application-inference-profile pass, and the two wrong-account-format combinations are rejected. `bun test`, lint, format, and typecheck pass.
