### PR TITLE
feat(dev): supervise every runtime in headless mode

### DIFF
--- a/src/core/dev/supervisor.test.ts
+++ b/src/core/dev/supervisor.test.ts
@@ -15,17 +15,19 @@ function runtime(name: string, build: ProjectRuntime["build"] = "CodeZip"): Proj
   } as ProjectRuntime;
 }
 
-/** A runner that emits `events`, then stays alive until its signal aborts (like a real server). */
+/** A runner that emits `events`, stays alive until its signal aborts, then rejects with the abort reason (like the real process runner). */
 function serverRunner(events: DevEvent[] = []) {
   const inputs: DevServerInput[] = [];
   const runner: DevRunner = {
     run: async function* (input) {
       inputs.push(input);
       yield* events;
-      if (input.signal.aborted) return;
-      await new Promise<void>((resolve) =>
-        input.signal.addEventListener("abort", () => resolve(), { once: true }),
-      );
+      if (!input.signal.aborted) {
+        await new Promise<void>((resolve) =>
+          input.signal.addEventListener("abort", () => resolve(), { once: true }),
+        );
+      }
+      throw input.signal.reason;
     },
   };
   return { runner, inputs };

--- a/src/core/dev/supervisor.ts
+++ b/src/core/dev/supervisor.ts
@@ -258,6 +258,15 @@ export class DevSupervisor {
         this.push(name, { type: "status", message: `Agent '${name}' stopped.` });
       }
     } catch (error) {
+      /** The runner rejects with the abort reason on teardown, which is a stop, not a crash. */
+      if (input.signal.aborted) {
+        if (entry.phase === "running") {
+          entry.phase = "idle";
+          entry.port = undefined;
+          this.push(name, { type: "status", message: `Agent '${name}' stopped.` });
+        }
+        return;
+      }
       const message = error instanceof Error ? error.message : String(error);
       entry.error = message;
       if (entry.phase === "running") {

--- a/src/handlers/project/dev/index.test.ts
+++ b/src/handlers/project/dev/index.test.ts
@@ -46,17 +46,19 @@ function captureRunner(events: DevEvent[] = []) {
   return { runner, inputs };
 }
 
-/** A runner that emits `events` then stays alive until aborted, like a real dev server. */
+/** A runner that emits `events` then stays alive until aborted, rejecting with the abort reason like the real process runner. */
 function stayingRunner(events: DevEvent[] = []) {
   const inputs: DevServerInput[] = [];
   const runner: DevRunner = {
     run: async function* (input) {
       inputs.push(input);
       yield* events;
-      if (input.signal.aborted) return;
-      await new Promise<void>((resolve) =>
-        input.signal.addEventListener("abort", () => resolve(), { once: true }),
-      );
+      if (!input.signal.aborted) {
+        await new Promise<void>((resolve) =>
+          input.signal.addEventListener("abort", () => resolve(), { once: true }),
+        );
+      }
+      throw input.signal.reason;
     },
   };
   return { runner, inputs };
@@ -283,6 +285,7 @@ describe("project dev headless multi-agent", () => {
 
     process.emit("SIGINT", "SIGINT");
     await expect(pending).rejects.toMatchObject({ exitCode: 130 });
+    expect(subject.io.stderr()).not.toContain("crashed");
     expect(subject.collector.state.closed).toBe(1);
   });
 

--- a/src/handlers/project/dev/index.test.ts
+++ b/src/handlers/project/dev/index.test.ts
@@ -4,6 +4,7 @@ import type { ProjectRuntime } from "../../../projectSchemas/runtime";
 import {
   InputValidationError,
   ResourceNotFoundError,
+  SilentCLIError,
   UserCancellationError,
 } from "../../../errors";
 import type { HttpRequestHandler, PortChecker } from "../../../io";
@@ -40,6 +41,22 @@ function captureRunner(events: DevEvent[] = []) {
     run: async function* (input) {
       inputs.push(input);
       yield* events;
+    },
+  };
+  return { runner, inputs };
+}
+
+/** A runner that emits `events` then stays alive until aborted, like a real dev server. */
+function stayingRunner(events: DevEvent[] = []) {
+  const inputs: DevServerInput[] = [];
+  const runner: DevRunner = {
+    run: async function* (input) {
+      inputs.push(input);
+      yield* events;
+      if (input.signal.aborted) return;
+      await new Promise<void>((resolve) =>
+        input.signal.addEventListener("abort", () => resolve(), { once: true }),
+      );
     },
   };
   return { runner, inputs };
@@ -120,6 +137,9 @@ function harness(options: HarnessOptions = {}) {
       resolve: async () =>
         options.reloadedRuntimes ? project(...options.reloadedRuntimes) : undefined,
     },
+    waitReady: async () => {
+      await Bun.sleep(5);
+    },
   });
   const ctx = ValueContext.EmptyContext()
     .withValue(ProjectKey, options.project ?? project(runtime()))
@@ -168,15 +188,9 @@ describe("project dev selection and dispatch", () => {
   test.each([
     [project(), {}, "This project has no runtimes", InputValidationError],
     [
-      project(runtime("orders")),
-      {},
-      "--mode headless runs a single agent in the terminal. Pass --agent <name> to choose which one. Available: orders",
-      InputValidationError,
-    ],
-    [
       project(runtime("orders"), runtime("support", "Container")),
-      {},
-      "--mode headless runs a single agent in the terminal. Pass --agent <name> to choose which one. Available: orders, support",
+      { port: 4567 },
+      "--port applies to a single runtime. Use --agent to select one.",
       InputValidationError,
     ],
     [
@@ -234,6 +248,64 @@ describe("project dev selection and dispatch", () => {
     expect(checked).toEqual([8080, 8081]);
     expect(subject.codeZip.inputs[0]?.port).toBe(8081);
     expect(subject.io.stderr()).toContain("Port 8080 is in use; using 8081.");
+  });
+});
+
+describe("project dev headless multi-agent", () => {
+  const twoRuntimes = () => project(runtime("orders"), runtime("support", "Container"));
+
+  /** Start a headless multi-agent run and give its agents time to reach "running". */
+  async function supervised(subject: ReturnType<typeof harness>) {
+    const pending = subject.run();
+    pending.catch(() => undefined);
+    await Bun.sleep(30);
+    return { pending };
+  }
+
+  test("supervises every runtime with attributed output and per-runtime env", async () => {
+    const codeZip = stayingRunner([{ type: "stdout", line: "orders says hi" }]);
+    const container = stayingRunner();
+    const subject = harness({ project: twoRuntimes(), codeZip, container });
+    const { pending } = await supervised(subject);
+
+    expect(codeZip.inputs).toHaveLength(1);
+    expect(container.inputs).toHaveLength(1);
+    expect(codeZip.inputs[0]!.env).toMatchObject({
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://127.0.0.1:43180",
+      OTEL_SERVICE_NAME: "orders",
+    });
+    expect(container.inputs[0]!.env).toMatchObject({
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://host.docker.internal:43180",
+      OTEL_SERVICE_NAME: "support",
+    });
+    expect(subject.io.stdout()).toContain("[orders] orders says hi");
+    expect(subject.io.stderr()).toContain("Agent 'orders' is running on port");
+
+    process.emit("SIGINT", "SIGINT");
+    await expect(pending).rejects.toMatchObject({ exitCode: 130 });
+    expect(subject.collector.state.closed).toBe(1);
+  });
+
+  test("one agent failing to start leaves the others running", async () => {
+    const subject = harness({
+      project: twoRuntimes(),
+      codeZip: captureRunner([{ type: "status", message: "dying" }]),
+      container: stayingRunner(),
+    });
+    const { pending } = await supervised(subject);
+
+    expect(subject.io.stderr()).toContain("[orders] Agent 'orders' failed to start");
+    expect(subject.io.stderr()).toContain("Agent 'support' is running on port");
+
+    process.emit("SIGINT", "SIGINT");
+    await pending.catch(() => undefined);
+  });
+
+  test("exits non-zero when every agent fails to start", async () => {
+    const subject = harness({ project: twoRuntimes() });
+
+    await expect(subject.run()).rejects.toBeInstanceOf(SilentCLIError);
+    expect(subject.collector.state.closed).toBe(1);
   });
 });
 
@@ -394,15 +466,6 @@ describe("project dev Inspector UI mode", () => {
     const subject = harness({ checkPort: async () => false });
     await expect(subject.run({ mode: "browser", "ui-port": 9999 })).rejects.toThrow(
       "Port 9999 is already in use",
-    );
-  });
-
-  test("--port with several runtimes is rejected", async () => {
-    const subject = harness({
-      project: project(runtime("orders"), runtime("support", "Container")),
-    });
-    await expect(subject.run({ mode: "browser", port: 4567 })).rejects.toThrow(
-      "--port applies to a single runtime",
     );
   });
 });

--- a/src/handlers/project/dev/index.ts
+++ b/src/handlers/project/dev/index.ts
@@ -10,6 +10,7 @@ import type { ProjectRuntime } from "../../../projectSchemas/runtime";
 import {
   InputValidationError,
   ResourceNotFoundError,
+  SilentCLIError,
   UserCancellationError,
 } from "../../../errors";
 import type { AppIO, BrowserOpener, FileWatcher, PortChecker, startHttpServer } from "../../../io";
@@ -102,7 +103,7 @@ export const createDevProjectHandler = (config: DevProjectHandlerConfig) =>
       flag("traces", "disable local OTEL trace collection", z.boolean().default(true)),
       flag(
         "mode",
-        "how to run: browser (Agent Inspector web UI), headless (one agent in the terminal), or tui",
+        "how to run: browser (Agent Inspector web UI), headless (agents stream to the terminal), or tui",
         z.enum(["browser", "headless", "tui"]).default("browser"),
       ),
       flag(
@@ -132,12 +133,6 @@ export const createDevProjectHandler = (config: DevProjectHandlerConfig) =>
           );
         }
         const runtimes = selectRuntimes(project, flags.agent);
-        if (flags.mode === "headless" && !flags.agent) {
-          const available = runtimes.map((runtime) => runtime.name).join(", ");
-          throw new InputValidationError(
-            `--mode headless runs a single agent in the terminal. Pass --agent <name> to choose which one. Available: ${available}.`,
-          );
-        }
         if (runtimes.length > 1 && flags.port !== undefined) {
           throw new InputValidationError(
             "--port applies to a single runtime. Use --agent to select one.",
@@ -194,7 +189,7 @@ export const createDevProjectHandler = (config: DevProjectHandlerConfig) =>
           return { ...env, ...otel };
         };
 
-        if (flags.mode === "headless") {
+        if (flags.mode === "headless" && flags.agent) {
           await runWithoutUi(
             config,
             runtimes[0]!,
@@ -226,6 +221,23 @@ export const createDevProjectHandler = (config: DevProjectHandlerConfig) =>
           waitReady: config.waitReady,
           signal: controller.signal,
         });
+
+        if (flags.mode === "headless") {
+          const starts = Promise.allSettled(
+            runtimes.map((runtime) => supervisor.start(runtime.name)),
+          );
+          for await (const { agentName, event } of supervisor.events()) {
+            renderAgentEvent(config.io, event, agentName, json);
+            const phases = supervisor.snapshot();
+            if (phases.every(({ phase }) => phase !== "starting" && phase !== "running")) {
+              if (phases.some(({ phase }) => phase === "failed")) throw new SilentCLIError();
+              break;
+            }
+          }
+          controller.signal.throwIfAborted();
+          await starts;
+          return;
+        }
 
         const uiPort = (
           await findFreePort(UI_DEFAULT_PORT, flags["ui-port"], config.checkPort, controller.signal)

--- a/src/handlers/project/dev/index.ts
+++ b/src/handlers/project/dev/index.ts
@@ -223,9 +223,7 @@ export const createDevProjectHandler = (config: DevProjectHandlerConfig) =>
         });
 
         if (flags.mode === "headless") {
-          const starts = Promise.allSettled(
-            runtimes.map((runtime) => supervisor.start(runtime.name)),
-          );
+          void Promise.allSettled(runtimes.map((runtime) => supervisor.start(runtime.name)));
           for await (const { agentName, event } of supervisor.events()) {
             renderAgentEvent(config.io, event, agentName, json);
             const phases = supervisor.snapshot();
@@ -235,7 +233,6 @@ export const createDevProjectHandler = (config: DevProjectHandlerConfig) =>
             }
           }
           controller.signal.throwIfAborted();
-          await starts;
           return;
         }
 


### PR DESCRIPTION
## What

`--mode headless` without `--agent` now supervises every runtime in the project, streaming attributed `[name]` output to the terminal, the same behavior browser mode gets from the Inspector. Follows the discussion on #2086: multi-agent terminal supervision (useful for A2A testing) was the interim behavior on `refactor` between #2041 and #2086, and this restores it as a first-class mode instead of requiring `--agent`.

- `--mode headless` (no `--agent`): all runtimes start eagerly, output is `[name]`-attributed, one agent crashing leaves the others running, and the command exits non-zero only when nothing is left running and something failed.
- `--mode headless --agent <name>`: unchanged, the direct single-runtime path where a crash fails the command with a real exit code (scripts and CI rely on this).
- Browser mode: unchanged.

## Verification

- Handler suite covers the new path: attributed output and per-runtime OTEL env for two supervised runtimes, crash isolation, SIGINT exits 130 and closes the collector, all-agents-failed exits non-zero.
- End to end against a real 2-runtime project: `project dev --mode headless` started both agents eagerly on distinct ports with `[bob]`/`[alice]` attributed output, and SIGTERM tore both down.
- Full suite (2163 pass), typecheck, format clean. The two oxlint errors are pre-existing on `refactor` (DataTable.tsx, usePagedList.tsx).
