### PR TITLE
feat(templates): support Container builds in the strands-http-python

### DIFF
--- a/src/assets/templates/strands-http-python/Dockerfile.template
+++ b/src/assets/templates/strands-http-python/Dockerfile.template
@@ -1,0 +1,40 @@
+FROM public.ecr.aws/docker/library/python:3.12-slim-trixie
+
+RUN pip install --no-cache-dir uv
+
+ARG UV_DEFAULT_INDEX
+ARG UV_INDEX
+
+WORKDIR /app
+
+ENV UV_SYSTEM_PYTHON=1 \
+    UV_COMPILE_BYTECODE=1 \
+    UV_NO_PROGRESS=1 \
+    PYTHONUNBUFFERED=1 \
+    DOCKER_CONTAINER=1 \
+    UV_DEFAULT_INDEX=${UV_DEFAULT_INDEX} \
+    UV_INDEX=${UV_INDEX} \
+    PATH="/app/.venv/bin:$PATH"
+
+RUN useradd -m -u 1000 bedrock_agentcore
+
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-dev --no-install-project
+
+COPY --chown=bedrock_agentcore:bedrock_agentcore . .
+RUN uv sync --frozen --no-dev
+
+USER bedrock_agentcore
+
+# AgentCore Runtime service contract ports
+# https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-service-contract.html
+# 8080: HTTP Mode
+# 8000: MCP Mode
+# 9000: A2A Mode
+EXPOSE 8080 8000 9000
+
+{{#if enableOtel}}
+CMD ["opentelemetry-instrument", "python", "-m", "{{entrypoint}}"]
+{{else}}
+CMD ["python", "-m", "{{entrypoint}}"]
+{{/if}}

--- a/src/assets/templates/strands-http-python/dockerignore.template
+++ b/src/assets/templates/strands-http-python/dockerignore.template
@@ -1,0 +1,27 @@
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+dist/
+build/
+
+# IDE
+.vscode/
+.idea/
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Secrets and environment files
+.env
+.env.*
+
+# Version control
+.git/
+
+# AgentCore build artifacts
+.agentcore/artifacts/
+*.zip

--- a/src/core/project/manager.tsx
+++ b/src/core/project/manager.tsx
@@ -134,6 +134,10 @@ export class FsProjectManager implements ProjectManager {
 
       const appDir = join(destination, "app", scaffoldRuntimeInput.runtimeName);
       yield* this.installRuntimeDependencies(appDir);
+    } else if (scaffoldRuntimeInput.build === "Container") {
+      // containers require uv.lock to build, so even with no-install we must generate the lock.
+      const appDir = join(destination, "app", scaffoldRuntimeInput.runtimeName);
+      yield* this.ensureLockFileExists(appDir);
     }
 
     if (!input.skipGit) {
@@ -508,6 +512,26 @@ export class FsProjectManager implements ProjectManager {
       );
       yield { message: "Syncing Python dependencies with uv" };
       await this.run(["uv", "sync"], appDir);
+    }
+  }
+
+  /**
+   * Check if the uv.lock file exists within the project, and generate it if missing.
+   */
+  private async *ensureLockFileExists(appDir: string): AsyncGenerator<ProjectEvent, void> {
+    if (!existsSync(join(appDir, "pyproject.toml")) || existsSync(join(appDir, "uv.lock"))) {
+      return;
+    }
+    yield { message: "Generating uv.lock for container build" };
+    try {
+      await this.run(["uv", "lock"], appDir);
+    } catch {
+      yield {
+        message:
+          `Warning: could not generate uv.lock in ${appDir} (is uv installed?). ` +
+          "Run `uv lock` there before `agentcore project dev` or `deploy` — " +
+          "container builds install from uv.lock.",
+      };
     }
   }
 

--- a/src/core/project/templates/runtime.ts
+++ b/src/core/project/templates/runtime.ts
@@ -113,6 +113,7 @@ const getTemplateResolvers = (assetSource: AssetSource, templateRenderer: Templa
       needsOs: filesystemConfigurations.length > 0,
       hasConfigBundle: false,
       enableOtel: true,
+      // entrypoint is only consumed on container path, where the docker file attempts to launch it as a module (without .py extension)
       entrypoint: input.scaffoldRuntimeInput.entrypoint.replace(/\.py$/, ""),
     };
     const isContainer = input.scaffoldRuntimeInput.build === "Container";

--- a/src/core/project/templates/runtime.ts
+++ b/src/core/project/templates/runtime.ts
@@ -113,8 +113,8 @@ const getTemplateResolvers = (assetSource: AssetSource, templateRenderer: Templa
       needsOs: filesystemConfigurations.length > 0,
       hasConfigBundle: false,
       enableOtel: true,
-      // entrypoint is only consumed on container path, where the docker file attempts to launch it as a module (without .py extension)
-      entrypoint: input.scaffoldRuntimeInput.entrypoint.replace(/\.py$/, ""),
+      // The strands template's entrypoint is fixed to main.py; the container Dockerfile launches it as the `main` module.
+      entrypoint: "main",
     };
     const isContainer = input.scaffoldRuntimeInput.build === "Container";
     const tree = await FsTreeNode.fromAssetSource(

--- a/src/core/project/templates/runtime.ts
+++ b/src/core/project/templates/runtime.ts
@@ -78,9 +78,6 @@ const getTemplateResolvers = (assetSource: AssetSource, templateRenderer: Templa
     if (input.protocol !== undefined && input.protocol !== "HTTP")
       throw new InputValidationError("the strands-python template only supports HTTP");
 
-    if (input.scaffoldRuntimeInput.build !== "CodeZip")
-      throw new InputValidationError("the strands template only supports CodeZip builds");
-
     const filesystemConfigurations = input.filesystemConfigurations ?? [];
     const sessionStorageMountPath = filesystemConfigurations.flatMap((configuration) =>
       "sessionStorage" in configuration ? [configuration.sessionStorage.mountPath] : [],
@@ -115,14 +112,21 @@ const getTemplateResolvers = (assetSource: AssetSource, templateRenderer: Templa
       s3Mounts,
       needsOs: filesystemConfigurations.length > 0,
       hasConfigBundle: false,
+      enableOtel: true,
+      entrypoint: input.scaffoldRuntimeInput.entrypoint.replace(/\.py$/, ""),
     };
+    const isContainer = input.scaffoldRuntimeInput.build === "Container";
     const tree = await FsTreeNode.fromAssetSource(
       { assetSource },
       { assetDir: "templates/strands-http-python" },
       {
         rootDirName: input.name,
         transformContent: (raw) => templateRenderer.render(raw, context),
-        filter: (name, isDir) => memory !== undefined || !isDir || name !== "memory",
+        filter: (name, isDir) => {
+          if (isDir && name === "memory") return memory !== undefined;
+          if (name === "Dockerfile" || name === ".dockerignore") return isContainer;
+          return true;
+        },
       },
     );
     return {

--- a/src/handlers/project/add/runtime/index.test.ts
+++ b/src/handlers/project/add/runtime/index.test.ts
@@ -101,6 +101,10 @@ describe("project add runtime", () => {
     "container template build override to CodeZip": {
       build: "CodeZip",
     },
+    "strands template overrides to Container": {
+      build: "Container",
+      dockerfile: "Dockerfile",
+    },
     "all infrastructure flags": {
       description: "Configured runtime",
       executionRoleArn: "arn:aws:iam::123456789012:role/MyRole",
@@ -154,6 +158,10 @@ describe("project add runtime", () => {
     [
       "container template build override to CodeZip",
       ["--name", "my_agent", "--template", "hello-world-python-container", "--build", "CodeZip"],
+    ],
+    [
+      "strands template overrides to Container",
+      ["--name", "my_agent", "--template", "strands-python", "--build", "Container"],
     ],
     ["custom — all scaffolding flags", ["--name", "my_agent", ...allScaffoldingFlags]],
     [
@@ -319,6 +327,10 @@ describe("project add runtime", () => {
         ? flags[buildFlagIndex + 1] === "Container"
         : flags.includes("hello-world-python-container");
     expect(runtime.runtimeVersion).toBe(isContainer ? undefined : "PYTHON_3_14");
+    expect(await Bun.file(join(projectRoot, "app", name, "Dockerfile")).exists()).toBe(isContainer);
+    expect(await Bun.file(join(projectRoot, "app", name, ".dockerignore")).exists()).toBe(
+      isContainer,
+    );
   });
 
   test.each([
@@ -385,10 +397,6 @@ describe("project add runtime", () => {
     [
       "strands-python only supports HTTP",
       ["--name", "my_agent", "--template", "strands-python", "--protocol", "MCP"],
-    ],
-    [
-      "strands-python only supports CodeZip builds",
-      ["--name", "my_agent", "--template", "strands-python", "--build", "Container"],
     ],
     [
       "invalid JSON in --network-config",

--- a/src/handlers/project/project.test.ts
+++ b/src/handlers/project/project.test.ts
@@ -208,6 +208,26 @@ describe("project create", () => {
     expect(await Bun.file(join(runtimeRoot, ".dockerignore")).exists()).toBe(false);
   });
 
+  test("generates uv.lock for a Container scaffold even with --skip-install", async () => {
+    const directory = await inTempDirectory();
+    const { core } = await run([
+      "create",
+      "--name",
+      "MyProject",
+      "--template",
+      "strands-python",
+      "--build",
+      "Container",
+      "--skip-install",
+      "--skip-git",
+    ]);
+
+    expect(core.projectCommands).toContainEqual({
+      command: ["uv", "lock"],
+      cwd: join(directory, "MyProject", "app", "strands_agent"),
+    });
+  });
+
   test.each([
     ["default", [], ["SEMANTIC", "USER_PREFERENCE", "SUMMARIZATION", "EPISODIC"]],
     ["none", ["--memory", "none"], []],

--- a/src/handlers/project/project.test.ts
+++ b/src/handlers/project/project.test.ts
@@ -163,6 +163,51 @@ describe("project create", () => {
     expect(await Bun.file(join(projectRoot, "app", "custom_agent", "main.py")).exists()).toBe(true);
   });
 
+  test("scaffolds a Container agent from the strands template", async () => {
+    const directory = await inTempDirectory();
+    await run([
+      "create",
+      "--name",
+      "MyProject",
+      "--template",
+      "strands-python",
+      "--build",
+      "Container",
+      "--skip-install",
+      "--skip-git",
+    ]);
+
+    const projectRoot = join(directory, "MyProject");
+    const spec = await Bun.file(join(projectRoot, "agentcore", "agentcore.json")).json();
+    expect(spec.runtimes[0]).toMatchObject({
+      name: "strands_agent",
+      build: "Container",
+      codeLocation: "app/strands_agent",
+      dockerfile: "Dockerfile",
+    });
+    expect(spec.runtimes[0].runtimeVersion).toBeUndefined();
+    const runtimeRoot = join(projectRoot, "app", "strands_agent");
+    expect(await Bun.file(join(runtimeRoot, "Dockerfile")).exists()).toBe(true);
+    expect(await Bun.file(join(runtimeRoot, ".dockerignore")).exists()).toBe(true);
+  });
+
+  test("omits the Dockerfile from a CodeZip strands template", async () => {
+    const directory = await inTempDirectory();
+    await run([
+      "create",
+      "--name",
+      "MyProject",
+      "--template",
+      "strands-python",
+      "--skip-install",
+      "--skip-git",
+    ]);
+
+    const runtimeRoot = join(directory, "MyProject", "app", "strands_agent");
+    expect(await Bun.file(join(runtimeRoot, "Dockerfile")).exists()).toBe(false);
+    expect(await Bun.file(join(runtimeRoot, ".dockerignore")).exists()).toBe(false);
+  });
+
   test.each([
     ["default", [], ["SEMANTIC", "USER_PREFERENCE", "SUMMARIZATION", "EPISODIC"]],
     ["none", ["--memory", "none"], []],


### PR DESCRIPTION
### Problem 
The http strands python container does not include container support (yet)

### Solution 
- Copy over the dockerfile and .dockerignore from mainline and add it to the assets. 
- Render them conditionally based on build type. 
- explicitly enable otel since AFAICT that is what main does: https://github.com/aws/agentcore-cli/blob/cbce86217c23dbe55dfd34e568091bfa133b7712/src/cli/templates/BaseRenderer.ts#L103 and never overwrites it. We could follow-up if we want this to be user configurable so I'm leaving it in the template. 

### Verification

```
> agentcore project create --name testProject2 --template strands-python --b│(26-08-28 17:17:33) <0> [~]
uild Container

Creating project tree
Installing CDK dependencies with npm
Syncing Python dependencies with uv
Initializing git repository
Created project 'testProject2' in ./testProject2

>  cd ./testProject2

> eval "$(aws configure export-credentials --format env)" 
[need to make sure credentials are in shell to be forwarded to container]

> agentcore project dev --mode headless --agent strands_agent
[strands_agent] Building image with docker
[strands_agent] #0 building with "default" instance using docker driver
[strands_agent] #1 [internal] load build definition from Dockerfile
[strands_agent] #1 DONE 0.0s
[strands_agent] #1 [internal] load build definition from Dockerfile
[strands_agent] #1 transferring dockerfile: 971B done
[strands_agent] #1 DONE 0.0s
[strands_agent] #2 [internal] load metadata for public.ecr.aws/docker/library/python:3.12-slim-trixie
[strands_agent] #2 DONE 0.1s
[strands_agent] #3 [internal] load .dockerignore
[strands_agent] #3 transferring context: 358B done
[strands_agent] #3 DONE 0.0s
[strands_agent] #4 [1/8] FROM public.ecr.aws/docker/library/python:3.12-slim-trixie@sha256:09f7da3bc104798d0afb40bc08d23ab2da20a76130cec1f2ef170848f5d85217
[strands_agent] #4 DONE 0.0s
[strands_agent] #5 [internal] load build context
[strands_agent] #5 transferring context: 1.70kB done
[strands_agent] #5 DONE 0.0s
[strands_agent] #6 [6/8] RUN uv sync --frozen --no-dev --no-install-project
[strands_agent] #6 CACHED
[strands_agent] #7 [2/8] RUN pip install --no-cache-dir uv
[strands_agent] #7 CACHED
[strands_agent] #8 [5/8] COPY pyproject.toml uv.lock ./
[strands_agent] #8 CACHED
[strands_agent] #9 [3/8] WORKDIR /app
[strands_agent] #9 CACHED
[strands_agent] #10 [4/8] RUN useradd -m -u 1000 bedrock_agentcore
[strands_agent] #10 CACHED
[strands_agent] #11 [7/8] COPY --chown=bedrock_agentcore:bedrock_agentcore . .
[strands_agent] #11 CACHED
[strands_agent] #12 [8/8] RUN uv sync --frozen --no-dev
[strands_agent] #12 CACHED
[strands_agent] #13 exporting to image
[strands_agent] #13 exporting layers done
[strands_agent] #13 writing image sha256:7f7bcc8c4e2a352b3281845496f10f913bedebf5758df19ad837a268fe9796c1 done
[strands_agent] #13 naming to docker.io/agentcore-dev/strands_agent-e424a700e029 done
[strands_agent] #13 DONE 0.0s
[strands_agent] Starting container
[strands_agent] {"timestamp": "2026-08-28T17:17:30.923Z", "level": "INFO", "message": "Returning streaming response (generator) (0.000s)", "logger": "bedrock_agentcore.app", "requestId": "1827448e-1104-43a5-9b82-dd4be4d29bea"}
[strands_agent] {"timestamp": "2026-08-28T17:17:30.928Z", "level": "INFO", "message": "Invoking Agent.....", "logger": "bedrock_agentcore.app", "requestId": "1827448e-1104-43a5-9b82-dd4be4d29bea"}

```

Then triggered the last part by invoking from another terminal via 

```
 > curl -X POST http://127.0.0.1:8080/invocations \
    -H "Content-Type: application/json" \
    -d '{"prompt":"what is 2+2?"}'
    
data: {"event": {"messageStart": {"role": "assistant"}}}

data: {"event": {"contentBlockStart": {"start": {"toolUse": {"toolUseId": "tooluse_W5GvV972WiaH6bf8cKwDIT", "name": "add_numbers", "type": "tool_use"}}, "contentBlockIndex": 0}}}

data: {"event": {"contentBlockDelta": {"delta": {"toolUse": {"input": ""}}, "contentBlockIndex": 0}}}

data: {"event": {"contentBlockDelta": {"delta": {"toolUse": {"input": "{\"a\":"}}, "contentBlockIndex": 0}}}

data: {"event": {"contentBlockDelta": {"delta": {"toolUse": {"input": " 2"}}, "contentBlockIndex": 0}}}

data: {"event": {"contentBlockDelta": {"delta": {"toolUse": {"input": ", \"b\""}}, "contentBlockIndex": 0}}}

data: {"event": {"contentBlockDelta": {"delta": {"toolUse": {"input": ": 2}"}}, "contentBlockIndex": 0}}}

data: {"event": {"contentBlockStop": {"contentBlockIndex": 0}}}

data: {"event": {"messageStop": {"stopReason": "tool_use"}}}

data: {"event": {"metadata": {"usage": {"inputTokens": 1114, "outputTokens": 70, "totalTokens": 1184}, "metrics": {"latencyMs": 2447}}}}

data: {"event": {"messageStart": {"role": "assistant"}}}

data: {"event": {"contentBlockDelta": {"delta": {"text": "2"}, "contentBlockIndex": 0}}}

data: {"event": {"contentBlockDelta": {"delta": {"text": " "}, "contentBlockIndex": 0}}}

data: {"event": {"contentBlockDelta": {"delta": {"text": "+ 2 = **"}, "contentBlockIndex": 0}}}

data: {"event": {"contentBlockDelta": {"delta": {"text": "4**"}, "contentBlockIndex": 0}}}

data: {"event": {"contentBlockStop": {"contentBlockIndex": 0}}}

data: {"event": {"messageStop": {"stopReason": "end_turn"}}}

data: {"event": {"metadata": {"usage": {"inputTokens": 1198, "outputTokens": 13, "totalTokens": 1211}, "metrics": {"latencyMs": 2067}}}}
```


