### PR TITLE
feat(project): add `project add evaluator code-based`

### DIFF
--- a/src/assets/evaluators/autoevals-lambda/README.md
+++ b/src/assets/evaluators/autoevals-lambda/README.md
@@ -1,0 +1,23 @@
+# {{ Name }}
+
+An AgentCore **code-based evaluator** backed by
+[autoevals](https://github.com/braintrustdata/autoevals) — scores each session
+with autoevals' `{{ EvaluatorClass }}` scorer.
+
+## What's here
+
+- `lambda_function.py` — wraps `{{ EvaluatorClass }}` in an `AutoEvalsAdapter`
+  behind the standard `@custom_code_based_evaluator()` handler. With a Bedrock
+  judge model set, autoevals grades via a LiteLLM client → Bedrock.
+- `pyproject.toml` — autoevals + judge dependencies, managed with
+  [uv](https://docs.astral.sh/uv/).
+- `execution-role-policy.json` — grants the Lambda `bedrock:InvokeModel` for the
+  judge model.
+
+## Customize
+
+- Change the scorer or its arguments in `lambda_function.py`.
+- Scorers like `Factuality` / `ClosedQA` / `SQL` need an expected/reference
+  output — provide it when you invoke the evaluator.
+
+`agentcore project deploy` packages this directory into the evaluator Lambda.

--- a/src/assets/evaluators/autoevals-lambda/execution-role-policy.json
+++ b/src/assets/evaluators/autoevals-lambda/execution-role-policy.json
@@ -1,0 +1,15 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
+      "Resource": "arn:*:logs:*:*:log-group:/aws/lambda/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["bedrock:InvokeModel"],
+      "Resource": "*"
+    }
+  ]
+}

--- a/src/assets/evaluators/autoevals-lambda/lambda_function.py
+++ b/src/assets/evaluators/autoevals-lambda/lambda_function.py
@@ -1,0 +1,37 @@
+{{#if ModelProviderBedrock}}
+import os
+
+# litellm's Bedrock provider reads AWS_REGION_NAME; Lambda only sets AWS_REGION/AWS_DEFAULT_REGION.
+os.environ.setdefault("AWS_REGION_NAME", os.environ.get("AWS_REGION", "us-west-2"))
+
+from autoevals import {{ EvaluatorClass }}, init
+from autoevals.litellm import LiteLLMClient
+
+from bedrock_agentcore.evaluation.custom_code_based_evaluators import (
+    EvaluatorInput,
+    EvaluatorOutput,
+    custom_code_based_evaluator,
+)
+from bedrock_agentcore.evaluation.custom_code_based_evaluators.third_party.autoevals import AutoEvalsAdapter
+
+client = LiteLLMClient()
+init(client=client, default_model="{{ Model }}")
+
+adapter = AutoEvalsAdapter(metric={{ EvaluatorClass }}(client=client, model="{{ Model }}"){{#if EvaluatorParams}}, {{{ EvaluatorParams }}}{{/if}})
+{{else}}
+from autoevals import {{ EvaluatorClass }}
+
+from bedrock_agentcore.evaluation.custom_code_based_evaluators import (
+    EvaluatorInput,
+    EvaluatorOutput,
+    custom_code_based_evaluator,
+)
+from bedrock_agentcore.evaluation.custom_code_based_evaluators.third_party.autoevals import AutoEvalsAdapter
+
+adapter = AutoEvalsAdapter(metric={{ EvaluatorClass }}({{#if Model}}model="{{ Model }}"{{/if}}){{#if EvaluatorParams}}, {{{ EvaluatorParams }}}{{/if}})
+{{/if}}
+
+
+@custom_code_based_evaluator()
+def handler(evaluator_input: EvaluatorInput, context) -> EvaluatorOutput:
+    return adapter(evaluator_input, context)

--- a/src/assets/evaluators/autoevals-lambda/lambda_function.py
+++ b/src/assets/evaluators/autoevals-lambda/lambda_function.py
@@ -15,9 +15,9 @@ from bedrock_agentcore.evaluation.custom_code_based_evaluators import (
 from bedrock_agentcore.evaluation.custom_code_based_evaluators.third_party.autoevals import AutoEvalsAdapter
 
 client = LiteLLMClient()
-init(client=client, default_model="{{ Model }}")
+init(client=client, default_model="bedrock/{{ Model }}")
 
-adapter = AutoEvalsAdapter(metric={{ EvaluatorClass }}(client=client, model="{{ Model }}"){{#if EvaluatorParams}}, {{{ EvaluatorParams }}}{{/if}})
+adapter = AutoEvalsAdapter(metric={{ EvaluatorClass }}(client=client, model="bedrock/{{ Model }}"){{#if EvaluatorParams}}, {{{ EvaluatorParams }}}{{/if}})
 {{else}}
 from autoevals import {{ EvaluatorClass }}
 

--- a/src/assets/evaluators/autoevals-lambda/pyproject.toml
+++ b/src/assets/evaluators/autoevals-lambda/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "{{ Name }}"
+version = "0.1.0"
+description = "AgentCore Code-Based Evaluator (Autoevals)"
+requires-python = ">=3.10"
+dependencies = [
+    "bedrock-agentcore[autoevals]",
+    "autoevals>=0.0.80,<1.0.0",
+{{#if ModelProviderBedrock}}
+    # autoevals grades via LiteLLMClient -> Bedrock (Converse); litellm replaces the openai judge
+    "litellm>=1.60,<1.85",
+{{else}}
+    "openai>=1.0.0",
+{{/if}}
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]

--- a/src/assets/evaluators/autoevals-lambda/pyproject.toml
+++ b/src/assets/evaluators/autoevals-lambda/pyproject.toml
@@ -8,8 +8,9 @@ version = "0.1.0"
 description = "AgentCore Code-Based Evaluator (Autoevals)"
 requires-python = ">=3.10"
 dependencies = [
-    "bedrock-agentcore[autoevals]>=1.6.0,<2.0.0",
-    "autoevals>=0.0.80,<1.0.0",
+    # 1.20.0 is the first release shipping third_party.autoevals.AutoEvalsAdapter;
+    # the extra owns the autoevals version, so pinning it here only conflicts.
+    "bedrock-agentcore[autoevals]>=1.20.0,<2.0.0",
 {{#if ModelProviderBedrock}}
     # autoevals grades via LiteLLMClient -> Bedrock (Converse); litellm replaces the openai judge
     "litellm>=1.60,<1.85",

--- a/src/assets/evaluators/autoevals-lambda/pyproject.toml
+++ b/src/assets/evaluators/autoevals-lambda/pyproject.toml
@@ -8,13 +8,13 @@ version = "0.1.0"
 description = "AgentCore Code-Based Evaluator (Autoevals)"
 requires-python = ">=3.10"
 dependencies = [
-    "bedrock-agentcore[autoevals]",
+    "bedrock-agentcore[autoevals]>=1.6.0,<2.0.0",
     "autoevals>=0.0.80,<1.0.0",
 {{#if ModelProviderBedrock}}
     # autoevals grades via LiteLLMClient -> Bedrock (Converse); litellm replaces the openai judge
     "litellm>=1.60,<1.85",
 {{else}}
-    "openai>=1.0.0",
+    "openai>=1.0.0,<2.0.0",
 {{/if}}
 ]
 

--- a/src/assets/evaluators/deepeval-lambda/README.md
+++ b/src/assets/evaluators/deepeval-lambda/README.md
@@ -1,0 +1,23 @@
+# {{ Name }}
+
+An AgentCore **code-based evaluator** backed by
+[DeepEval](https://docs.confident-ai.com/) — scores each session with DeepEval's
+`{{ EvaluatorClass }}` metric, judged by Amazon Bedrock.
+
+## What's here
+
+- `lambda_function.py` — wraps `{{ EvaluatorClass }}` in a `DeepEvalAdapter`
+  behind the standard `@custom_code_based_evaluator()` handler.
+- `pyproject.toml` — DeepEval + Bedrock dependencies, managed with
+  [uv](https://docs.astral.sh/uv/).
+- `execution-role-policy.json` — grants the Lambda `bedrock:InvokeModel` for the
+  judge model; add more if your metric needs it.
+
+## Customize
+
+- Swap the metric or tune its threshold in `lambda_function.py`.
+- Some DeepEval metrics need retrieval context or a reference/expected output —
+  supply those when you invoke the evaluator, or the metric returns
+  `MISSING_REQUIRED_FIELD`.
+
+`agentcore project deploy` packages this directory into the evaluator Lambda.

--- a/src/assets/evaluators/deepeval-lambda/execution-role-policy.json
+++ b/src/assets/evaluators/deepeval-lambda/execution-role-policy.json
@@ -1,0 +1,15 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
+      "Resource": "arn:*:logs:*:*:log-group:/aws/lambda/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["bedrock:InvokeModel"],
+      "Resource": "*"
+    }
+  ]
+}

--- a/src/assets/evaluators/deepeval-lambda/lambda_function.py
+++ b/src/assets/evaluators/deepeval-lambda/lambda_function.py
@@ -1,0 +1,29 @@
+import os
+
+os.environ.setdefault("DEEPEVAL_RESULTS_FOLDER", "/tmp/.deepeval")
+os.environ.setdefault("DEEPEVAL_TELEMETRY_OPT_OUT", "YES")
+os.chdir("/tmp")
+
+{{#if ModelProviderBedrock}}
+from deepeval.models import AmazonBedrockModel
+{{/if}}
+from deepeval.metrics import {{ EvaluatorClass }}
+
+from bedrock_agentcore.evaluation.custom_code_based_evaluators import (
+    EvaluatorInput,
+    EvaluatorOutput,
+    custom_code_based_evaluator,
+)
+from bedrock_agentcore.evaluation.custom_code_based_evaluators.third_party.deepeval import DeepEvalAdapter
+
+{{#if ModelProviderBedrock}}
+model = AmazonBedrockModel(model="{{ Model }}", region=os.environ.get("AWS_REGION", "us-west-2"))
+adapter = DeepEvalAdapter(metric={{ EvaluatorClass }}(model=model{{#if EvaluatorParams}}, {{{ EvaluatorParams }}}{{/if}}))
+{{else}}
+adapter = DeepEvalAdapter(metric={{ EvaluatorClass }}({{{ EvaluatorParams }}}))
+{{/if}}
+
+
+@custom_code_based_evaluator()
+def handler(evaluator_input: EvaluatorInput, context) -> EvaluatorOutput:
+    return adapter(evaluator_input, context)

--- a/src/assets/evaluators/deepeval-lambda/pyproject.toml
+++ b/src/assets/evaluators/deepeval-lambda/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "{{ Name }}"
+version = "0.1.0"
+description = "AgentCore Code-Based Evaluator (DeepEval)"
+requires-python = ">=3.10"
+dependencies = [
+    "bedrock-agentcore[deepeval]",
+    "deepeval>=2.0.0,<3.0.0",
+{{#if ModelProviderBedrock}}
+    "aiobotocore>=2.13.0",
+{{/if}}
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]

--- a/src/assets/evaluators/deepeval-lambda/pyproject.toml
+++ b/src/assets/evaluators/deepeval-lambda/pyproject.toml
@@ -8,10 +8,13 @@ version = "0.1.0"
 description = "AgentCore Code-Based Evaluator (DeepEval)"
 requires-python = ">=3.10"
 dependencies = [
-    "bedrock-agentcore[deepeval]>=1.6.0,<2.0.0",
-    "deepeval>=2.0.0,<3.0.0",
+    # 1.20.0 is the first release shipping third_party.deepeval.DeepEvalAdapter;
+    # the extra owns the deepeval version, so pinning it here only conflicts.
+    "bedrock-agentcore[deepeval]>=1.20.0,<2.0.0",
 {{#if ModelProviderBedrock}}
-    "aiobotocore>=2.13.0,<3.0.0",
+    # deepeval's AmazonBedrockModel imports aiobotocore at runtime; only 3.x
+    # allows the botocore that bedrock-agentcore requires.
+    "aiobotocore>=3.0.0,<4.0.0",
 {{/if}}
 ]
 

--- a/src/assets/evaluators/deepeval-lambda/pyproject.toml
+++ b/src/assets/evaluators/deepeval-lambda/pyproject.toml
@@ -8,10 +8,10 @@ version = "0.1.0"
 description = "AgentCore Code-Based Evaluator (DeepEval)"
 requires-python = ">=3.10"
 dependencies = [
-    "bedrock-agentcore[deepeval]",
+    "bedrock-agentcore[deepeval]>=1.6.0,<2.0.0",
     "deepeval>=2.0.0,<3.0.0",
 {{#if ModelProviderBedrock}}
-    "aiobotocore>=2.13.0",
+    "aiobotocore>=2.13.0,<3.0.0",
 {{/if}}
 ]
 

--- a/src/assets/evaluators/python-lambda/README.md
+++ b/src/assets/evaluators/python-lambda/README.md
@@ -1,0 +1,28 @@
+# {{ Name }}
+
+An AgentCore **code-based evaluator** — a Lambda that scores an agent session
+with your own logic.
+
+## What's here
+
+- `lambda_function.py` — the evaluator. The `@custom_code_based_evaluator()`
+  handler receives an `EvaluatorInput` (the session / trace / tool-call to
+  grade) and returns an `EvaluatorOutput` (`value` + `label`, or an error). It
+  ships as a stub that returns `Pass` for everything — replace the `TODO` with
+  your scoring logic.
+- `pyproject.toml` — Python dependencies, managed with
+  [uv](https://docs.astral.sh/uv/).
+- `execution-role-policy.json` — extra IAM the evaluator Lambda gets at runtime.
+  Add statements here for anything your logic calls (DynamoDB, S3, …).
+
+## Write your evaluator
+
+```python
+@custom_code_based_evaluator()
+def handler(input: EvaluatorInput, context) -> EvaluatorOutput:
+    # inspect input.session_spans / input.target_trace_id / input.target_span_id
+    return EvaluatorOutput(value=1.0, label="Pass", explanation="…")
+```
+
+Then `agentcore project deploy` packages this directory into the evaluator
+Lambda and registers the evaluator.

--- a/src/assets/evaluators/python-lambda/execution-role-policy.json
+++ b/src/assets/evaluators/python-lambda/execution-role-policy.json
@@ -1,0 +1,10 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
+      "Resource": "arn:*:logs:*:*:log-group:/aws/lambda/*"
+    }
+  ]
+}

--- a/src/assets/evaluators/python-lambda/lambda_function.py
+++ b/src/assets/evaluators/python-lambda/lambda_function.py
@@ -1,0 +1,19 @@
+from bedrock_agentcore.evaluation.custom_code_based_evaluators import (
+    custom_code_based_evaluator,
+    EvaluatorInput,
+    EvaluatorOutput,
+)
+
+
+@custom_code_based_evaluator()
+def handler(input: EvaluatorInput, context) -> EvaluatorOutput:
+    """Evaluate agent behavior with custom logic.
+
+    Args:
+        input: Contains evaluation_level, session_spans, target_trace_id, target_span_id
+
+    Returns:
+        EvaluatorOutput with value/label for success, or errorCode/errorMessage for failure.
+    """
+    # TODO: Replace with your evaluation logic
+    return EvaluatorOutput(value=1.0, label="Pass", explanation="Evaluation passed")

--- a/src/assets/evaluators/python-lambda/pyproject.toml
+++ b/src/assets/evaluators/python-lambda/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "{{ Name }}"
+version = "0.1.0"
+description = "AgentCore Code-Based Evaluator"
+requires-python = ">=3.10"
+dependencies = [
+    "bedrock-agentcore>=1.6.0",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]

--- a/src/assets/evaluators/python-lambda/pyproject.toml
+++ b/src/assets/evaluators/python-lambda/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "AgentCore Code-Based Evaluator"
 requires-python = ">=3.10"
 dependencies = [
-    "bedrock-agentcore>=1.6.0",
+    "bedrock-agentcore>=1.6.0,<2.0.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/core/project/fsUtils.ts
+++ b/src/core/project/fsUtils.ts
@@ -20,3 +20,10 @@ export function enclosingProjectRoot(directory: string): string | undefined {
     }
   }
 }
+
+export function toPythonPackageName(name: string): string {
+  return name
+    .replace(/[^a-zA-Z0-9._-]/g, "-")
+    .replace(/^[^a-zA-Z0-9]+/, "")
+    .replace(/[^a-zA-Z0-9]+$/, "");
+}

--- a/src/core/project/manager.tsx
+++ b/src/core/project/manager.tsx
@@ -337,28 +337,22 @@ export class FsProjectManager implements ProjectManager {
         break;
       }
       case "evaluator": {
-        const evaluator = parseResource(EvaluatorSchema, input.resourceConfig);
         if (input.scaffold) {
           yield { message: "Scaffolding evaluator in project" };
-          const outputPath = join(project.rootPath, "app", evaluator.name);
+          const outputPath = join(project.rootPath, "app", input.scaffold.name);
           if (existsSync(outputPath))
             throw new InputValidationError(
-              `cannot scaffold evaluator '${evaluator.name}': 'app/${evaluator.name}' already exists (another resource may use this name, or a previous scaffold was left behind)`,
+              `cannot scaffold evaluator '${input.scaffold.name}': 'app/${input.scaffold.name}' already exists (another resource may use this name, or a previous scaffold was left behind)`,
             );
           scaffoldedPaths.push(outputPath);
-          const resolver = getEvaluatorTemplateResolver({
+          const result = await getEvaluatorTemplateResolver({
             assetSource: this.assetSource,
             templateRenderer: this.templateRenderer,
-          });
-          const result = await resolver.resolve({
-            evaluator,
-            assetDir: input.scaffold.assetDir,
-            context: input.scaffold.context,
-          });
+          }).resolve(input.scaffold);
           await result.tree.write(dirname(outputPath));
           projectSpec.evaluators.push(...(result.spec.evaluators ?? []));
         } else {
-          projectSpec.evaluators.push(evaluator);
+          projectSpec.evaluators.push(parseResource(EvaluatorSchema, input.resourceConfig));
         }
         break;
       }

--- a/src/core/project/manager.tsx
+++ b/src/core/project/manager.tsx
@@ -343,6 +343,14 @@ export class FsProjectManager implements ProjectManager {
         if (input.scaffold) {
           yield { message: "Scaffolding evaluator in project" };
           const outputPath = join(project.rootPath, "app", evaluator.name);
+          // Runtimes, harnesses, and evaluators all scaffold into app/<name>,
+          // but the dup-name guard above is per-resource-type. Fail up front
+          // rather than let FsTreeNode.write throw mid-write (outside the
+          // rollback try/catch below) and orphan partial files.
+          if (existsSync(outputPath))
+            throw new InputValidationError(
+              `cannot scaffold evaluator '${evaluator.name}': 'app/${evaluator.name}' already exists (another resource may use this name, or a previous scaffold was left behind)`,
+            );
           scaffoldedPaths.push(outputPath);
           const resolver = getEvaluatorTemplateResolver({
             assetSource: this.assetSource,

--- a/src/core/project/manager.tsx
+++ b/src/core/project/manager.tsx
@@ -338,15 +338,9 @@ export class FsProjectManager implements ProjectManager {
       }
       case "evaluator": {
         const evaluator = parseResource(EvaluatorSchema, input.resourceConfig);
-        // Managed code-based evaluators ship generated Lambda source; external
-        // and llm-as-a-judge evaluators are spec-only.
         if (input.scaffold) {
           yield { message: "Scaffolding evaluator in project" };
           const outputPath = join(project.rootPath, "app", evaluator.name);
-          // Runtimes, harnesses, and evaluators all scaffold into app/<name>,
-          // but the dup-name guard above is per-resource-type. Fail up front
-          // rather than let FsTreeNode.write throw mid-write (outside the
-          // rollback try/catch below) and orphan partial files.
           if (existsSync(outputPath))
             throw new InputValidationError(
               `cannot scaffold evaluator '${evaluator.name}': 'app/${evaluator.name}' already exists (another resource may use this name, or a previous scaffold was left behind)`,

--- a/src/core/project/manager.tsx
+++ b/src/core/project/manager.tsx
@@ -42,6 +42,7 @@ import {
 } from "./templates/export";
 import { HarnessSpecSchema } from "../../projectSchemas/harness";
 import { FsTreeNode } from "./templates/fsTree";
+import { getEvaluatorTemplateResolver } from "./templates/evaluator";
 import { ProjectSpecSchema, type ManagedBy } from "../../projectSchemas/project";
 import { ConfigBundleSchema } from "../../projectSchemas/config-bundle";
 import {
@@ -336,7 +337,27 @@ export class FsProjectManager implements ProjectManager {
         break;
       }
       case "evaluator": {
-        projectSpec.evaluators.push(parseResource(EvaluatorSchema, input.resourceConfig));
+        const evaluator = parseResource(EvaluatorSchema, input.resourceConfig);
+        // Managed code-based evaluators ship generated Lambda source; external
+        // and llm-as-a-judge evaluators are spec-only.
+        if (input.scaffold) {
+          yield { message: "Scaffolding evaluator in project" };
+          const outputPath = join(project.rootPath, "app", evaluator.name);
+          scaffoldedPaths.push(outputPath);
+          const resolver = getEvaluatorTemplateResolver({
+            assetSource: this.assetSource,
+            templateRenderer: this.templateRenderer,
+          });
+          const result = await resolver.resolve({
+            evaluator,
+            assetDir: input.scaffold.assetDir,
+            context: input.scaffold.context,
+          });
+          await result.tree.write(dirname(outputPath));
+          projectSpec.evaluators.push(...(result.spec.evaluators ?? []));
+        } else {
+          projectSpec.evaluators.push(evaluator);
+        }
         break;
       }
       case "gateway":

--- a/src/core/project/templates/evaluator.ts
+++ b/src/core/project/templates/evaluator.ts
@@ -1,37 +1,29 @@
 import { FsTreeNode } from "./fsTree";
 import type { AssetSource } from "../source";
-import type { Evaluator, EvaluationLevel } from "../../../projectSchemas/evaluator";
+import type { Evaluator } from "../../../projectSchemas/evaluator";
 import type { TemplateRenderer, TemplateResolver } from "./types";
 import { toPythonPackageName } from "../fsUtils";
+import type {
+  EvaluatorLibrary,
+  ManagedEvaluatorScaffoldInput,
+} from "../../../handlers/project/types";
 
 const DEFAULT_TIMEOUT = 60;
 
-export const EVALUATOR_LIBRARIES = {
+const EVALUATOR_ASSETS: Record<
+  EvaluatorLibrary,
+  { assetDir: string; defaultTimeoutSeconds: number }
+> = {
   deepeval: { assetDir: "evaluators/deepeval-lambda", defaultTimeoutSeconds: 300 },
   autoevals: { assetDir: "evaluators/autoevals-lambda", defaultTimeoutSeconds: DEFAULT_TIMEOUT },
-} as const;
-
-export type EvaluatorLibrary = keyof typeof EVALUATOR_LIBRARIES;
+};
 
 const EMPTY_ASSET_DIR = "evaluators/python-lambda";
-
-export type ManagedEvaluatorScaffoldInput = {
-  name: string;
-  level: EvaluationLevel;
-  description?: string;
-  kmsKeyArn?: string;
-  tags?: Record<string, string>;
-  metric?: { library: EvaluatorLibrary; metricClass: string };
-  model?: string;
-  timeoutSeconds?: number;
-};
 
 function buildManagedEvaluatorSpec(input: ManagedEvaluatorScaffoldInput): Evaluator {
   const timeoutSeconds =
     input.timeoutSeconds ??
-    (input.metric
-      ? EVALUATOR_LIBRARIES[input.metric.library].defaultTimeoutSeconds
-      : DEFAULT_TIMEOUT);
+    (input.metric ? EVALUATOR_ASSETS[input.metric.library].defaultTimeoutSeconds : DEFAULT_TIMEOUT);
   return {
     name: input.name,
     level: input.level,
@@ -73,7 +65,7 @@ export function getEvaluatorTemplateResolver(
   return {
     async resolve(input) {
       const assetDir = input.metric
-        ? EVALUATOR_LIBRARIES[input.metric.library].assetDir
+        ? EVALUATOR_ASSETS[input.metric.library].assetDir
         : EMPTY_ASSET_DIR;
       const tree = await FsTreeNode.fromAssetSource(
         { assetSource: config.assetSource },

--- a/src/core/project/templates/evaluator.ts
+++ b/src/core/project/templates/evaluator.ts
@@ -1,13 +1,66 @@
 import { FsTreeNode } from "./fsTree";
 import type { AssetSource } from "../source";
-import type { Evaluator } from "../../../projectSchemas/evaluator";
+import type { Evaluator, EvaluationLevel } from "../../../projectSchemas/evaluator";
 import type { TemplateRenderer, TemplateResolver } from "./types";
+import { toPythonPackageName } from "../fsUtils";
 
-export type EvaluatorScaffoldInput = {
-  evaluator: Evaluator;
-  assetDir: string;
-  context: Record<string, unknown>;
+const DEFAULT_TIMEOUT = 60;
+
+export const EVALUATOR_LIBRARIES = {
+  deepeval: { assetDir: "evaluators/deepeval-lambda", defaultTimeoutSeconds: 300 },
+  autoevals: { assetDir: "evaluators/autoevals-lambda", defaultTimeoutSeconds: DEFAULT_TIMEOUT },
+} as const;
+
+export type EvaluatorLibrary = keyof typeof EVALUATOR_LIBRARIES;
+
+const EMPTY_ASSET_DIR = "evaluators/python-lambda";
+
+export type ManagedEvaluatorScaffoldInput = {
+  name: string;
+  level: EvaluationLevel;
+  description?: string;
+  kmsKeyArn?: string;
+  tags?: Record<string, string>;
+  metric?: { library: EvaluatorLibrary; metricClass: string };
+  model?: string;
+  timeoutSeconds?: number;
 };
+
+function buildManagedEvaluatorSpec(input: ManagedEvaluatorScaffoldInput): Evaluator {
+  const timeoutSeconds =
+    input.timeoutSeconds ??
+    (input.metric
+      ? EVALUATOR_LIBRARIES[input.metric.library].defaultTimeoutSeconds
+      : DEFAULT_TIMEOUT);
+  return {
+    name: input.name,
+    level: input.level,
+    ...(input.description && { description: input.description }),
+    config: {
+      codeBased: {
+        managed: {
+          codeLocation: `app/${input.name}`,
+          entrypoint: "lambda_function.handler",
+          timeoutSeconds,
+          additionalPolicies: ["execution-role-policy.json"],
+        },
+      },
+    },
+    ...(input.kmsKeyArn && { kmsKeyArn: input.kmsKeyArn }),
+    ...(input.tags && { tags: input.tags }),
+  };
+}
+
+function buildRenderContext(input: ManagedEvaluatorScaffoldInput): Record<string, unknown> {
+  const context: Record<string, unknown> = { Name: toPythonPackageName(input.name) };
+  if (input.metric) {
+    context["EvaluatorClass"] = input.metric.metricClass;
+    context["Model"] = input.model ?? "";
+    context["ModelProviderBedrock"] = input.model !== undefined;
+    context["EvaluatorParams"] = "";
+  }
+  return context;
+}
 
 type GetEvaluatorTemplateResolverConfig = {
   assetSource: AssetSource;
@@ -16,18 +69,21 @@ type GetEvaluatorTemplateResolverConfig = {
 
 export function getEvaluatorTemplateResolver(
   config: GetEvaluatorTemplateResolverConfig,
-): TemplateResolver<EvaluatorScaffoldInput> {
+): TemplateResolver<ManagedEvaluatorScaffoldInput> {
   return {
     async resolve(input) {
+      const assetDir = input.metric
+        ? EVALUATOR_LIBRARIES[input.metric.library].assetDir
+        : EMPTY_ASSET_DIR;
       const tree = await FsTreeNode.fromAssetSource(
         { assetSource: config.assetSource },
-        { assetDir: input.assetDir },
+        { assetDir },
         {
-          rootDirName: input.evaluator.name,
-          transformContent: (raw) => config.templateRenderer.render(raw, input.context),
+          rootDirName: input.name,
+          transformContent: (raw) => config.templateRenderer.render(raw, buildRenderContext(input)),
         },
       );
-      return { tree, spec: { evaluators: [input.evaluator] } };
+      return { tree, spec: { evaluators: [buildManagedEvaluatorSpec(input)] } };
     },
   };
 }

--- a/src/core/project/templates/evaluator.ts
+++ b/src/core/project/templates/evaluator.ts
@@ -1,0 +1,37 @@
+import { FsTreeNode } from "./fsTree";
+import type { AssetSource } from "../source";
+import type { Evaluator } from "../../../projectSchemas/evaluator";
+import type { TemplateRenderer, TemplateResolver } from "./types";
+
+/** Inputs for scaffolding a managed code-based evaluator's Lambda source. */
+export type EvaluatorScaffoldInput = {
+  evaluator: Evaluator;
+  /** Template directory under src/assets/evaluators, e.g. "evaluators/deepeval-lambda". */
+  assetDir: string;
+  /** Handlebars variables for the template (EvaluatorClass, Model, ModelProviderBedrock, ...). */
+  context: Record<string, unknown>;
+};
+
+type GetEvaluatorTemplateResolverConfig = {
+  assetSource: AssetSource;
+  templateRenderer: TemplateRenderer;
+};
+
+/** Resolves the template that renders a managed code-based evaluator's code directory. */
+export function getEvaluatorTemplateResolver(
+  config: GetEvaluatorTemplateResolverConfig,
+): TemplateResolver<EvaluatorScaffoldInput> {
+  return {
+    async resolve(input) {
+      const tree = await FsTreeNode.fromAssetSource(
+        { assetSource: config.assetSource },
+        { assetDir: input.assetDir },
+        {
+          rootDirName: input.evaluator.name,
+          transformContent: (raw) => config.templateRenderer.render(raw, input.context),
+        },
+      );
+      return { tree, spec: { evaluators: [input.evaluator] } };
+    },
+  };
+}

--- a/src/core/project/templates/evaluator.ts
+++ b/src/core/project/templates/evaluator.ts
@@ -3,12 +3,9 @@ import type { AssetSource } from "../source";
 import type { Evaluator } from "../../../projectSchemas/evaluator";
 import type { TemplateRenderer, TemplateResolver } from "./types";
 
-/** Inputs for scaffolding a managed code-based evaluator's Lambda source. */
 export type EvaluatorScaffoldInput = {
   evaluator: Evaluator;
-  /** Template directory under src/assets/evaluators, e.g. "evaluators/deepeval-lambda". */
   assetDir: string;
-  /** Handlebars variables for the template (EvaluatorClass, Model, ModelProviderBedrock, ...). */
   context: Record<string, unknown>;
 };
 
@@ -17,7 +14,6 @@ type GetEvaluatorTemplateResolverConfig = {
   templateRenderer: TemplateRenderer;
 };
 
-/** Resolves the template that renders a managed code-based evaluator's code directory. */
 export function getEvaluatorTemplateResolver(
   config: GetEvaluatorTemplateResolverConfig,
 ): TemplateResolver<EvaluatorScaffoldInput> {

--- a/src/core/project/templates/export.ts
+++ b/src/core/project/templates/export.ts
@@ -16,7 +16,7 @@ import { credentialEnvVarName, type Credential } from "../../../projectSchemas/c
 import type { Memory } from "../../../projectSchemas/memory";
 import type { EnvLocalEntry } from "../../../handlers/project/types";
 import { InputValidationError } from "../../../errors/errors";
-import { toPythonPackageName } from "./runtime";
+import { toPythonPackageName } from "../fsUtils";
 
 type ProjectSpec = z.infer<typeof ProjectSpecSchema>;
 

--- a/src/core/project/templates/runtime.ts
+++ b/src/core/project/templates/runtime.ts
@@ -5,6 +5,7 @@ import type { ProjectRuntime } from "../../../projectSchemas/runtime";
 import type { TemplateRenderer, TemplateResolver } from "./types";
 import type { ScaffoldRuntimeInput } from "../../../handlers/project/types";
 import { InputValidationError } from "../../../errors";
+import { toPythonPackageName } from "../fsUtils";
 
 function buildRuntimeSpec(input: RuntimeResourceConfig): ProjectRuntime {
   const { scaffoldRuntimeInput, name, ...infra } = input;
@@ -36,18 +37,6 @@ function buildRuntimeSpec(input: RuntimeResourceConfig): ProjectRuntime {
     }),
     ...(infra.tags && { tags: infra.tags }),
   };
-}
-
-/**
- * Normalize a name for use as a Python package name per PEP 508.
- * Valid names consist only of ASCII letters, numbers, period, underscore, and
- * hyphen, and must start and end with a letter or number.
- */
-export function toPythonPackageName(name: string): string {
-  return name
-    .replace(/[^a-zA-Z0-9._-]/g, "-")
-    .replace(/^[^a-zA-Z0-9]+/, "")
-    .replace(/[^a-zA-Z0-9]+$/, "");
 }
 
 /**

--- a/src/core/project/templates/types.ts
+++ b/src/core/project/templates/types.ts
@@ -3,6 +3,7 @@ import type { ProjectRuntime } from "../../../projectSchemas/runtime";
 import type { MemorySchema } from "../../../projectSchemas/memory";
 import type { CredentialSchema } from "../../../projectSchemas/credential";
 import type { HarnessRegistryEntry } from "../../../projectSchemas/harness";
+import type { Evaluator } from "../../../projectSchemas/evaluator";
 import type z from "zod";
 
 /** AgentCore Project Spec Entries that rendered as part of a {@link Template} **/
@@ -11,6 +12,7 @@ export type SpecEntries = {
   credentials?: z.infer<typeof CredentialSchema>[];
   memories?: z.infer<typeof MemorySchema>[];
   harnesses?: HarnessRegistryEntry[];
+  evaluators?: Evaluator[];
 };
 
 /** A group of files and resources that can be rendered into a project **/

--- a/src/handlers/project/add/evaluator/code-based/index.test.ts
+++ b/src/handlers/project/add/evaluator/code-based/index.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createRootHandler } from "../../../../index";
@@ -50,7 +50,7 @@ async function inProject(name = "TestProject"): Promise<string> {
 const spec = (projectRoot: string) =>
   Bun.file(join(projectRoot, "agentcore", "agentcore.json")).json();
 const evaluator = async (projectRoot: string, name: string) =>
-  (await spec(projectRoot)).evaluators.find((e: { name: string }) => e.name === name);
+  ((await spec(projectRoot)).evaluators ?? []).find((e: { name: string }) => e.name === name);
 
 describe("project add evaluator code-based", () => {
   test("3P metric → managed config + scaffolded, rendered Lambda source", async () => {
@@ -243,6 +243,22 @@ describe("project add evaluator code-based", () => {
     ];
     await run(flags);
     await expect(run(flags)).rejects.toBeInstanceOf(InputValidationError);
+  });
+
+  test("errors before writing when app/<name> already exists (cross-resource collision)", async () => {
+    const projectRoot = await inProject();
+    const appDir = join(projectRoot, "app", "collide");
+    await mkdir(appDir, { recursive: true });
+    await Bun.write(join(appDir, "pyproject.toml"), "# pre-existing\n");
+
+    await expect(
+      run(["add", "evaluator", "code-based", "--name", "collide", "--level", "SESSION"]),
+    ).rejects.toBeInstanceOf(InputValidationError);
+
+    // no spec entry, and the pre-existing dir is left untouched (no mid-write orphans)
+    expect(await evaluator(projectRoot, "collide")).toBeUndefined();
+    expect(await Bun.file(join(appDir, "pyproject.toml")).text()).toBe("# pre-existing\n");
+    expect(await Bun.file(join(appDir, "lambda_function.py")).exists()).toBe(false);
   });
 
   test("remove evaluator drops it from the spec", async () => {

--- a/src/handlers/project/add/evaluator/code-based/index.test.ts
+++ b/src/handlers/project/add/evaluator/code-based/index.test.ts
@@ -205,6 +205,36 @@ describe("project add evaluator code-based", () => {
       ["--name", "x", "--level", "SESSION", "--metric", "ragas.Faithfulness"],
     ],
     ["metric without a class", ["--name", "x", "--level", "SESSION", "--metric", "deepeval"]],
+    [
+      "namespaced (multi-dot) metric class",
+      ["--name", "x", "--level", "SESSION", "--metric", "deepeval.metrics.Faithfulness"],
+    ],
+    [
+      "non-Bedrock --model",
+      [
+        "--name",
+        "x",
+        "--level",
+        "SESSION",
+        "--metric",
+        "deepeval.FaithfulnessMetric",
+        "--model",
+        "gpt-4o",
+      ],
+    ],
+    [
+      "--model bedrock with no slash/id",
+      [
+        "--name",
+        "x",
+        "--level",
+        "SESSION",
+        "--metric",
+        "autoevals.Factuality",
+        "--model",
+        "bedrock",
+      ],
+    ],
     ["--model without --metric", ["--name", "x", "--level", "SESSION", "--model", "bedrock/foo"]],
     [
       "managed flag with --lambda-arn",
@@ -226,6 +256,26 @@ describe("project add evaluator code-based", () => {
     await expect(run(["add", "evaluator", "code-based", ...flags])).rejects.toBeInstanceOf(
       InputValidationError,
     );
+  });
+
+  test("accepts a bare Bedrock inference-profile model id and renders it into the source", async () => {
+    const projectRoot = await inProject();
+    await run([
+      "add",
+      "evaluator",
+      "code-based",
+      "--name",
+      "prof",
+      "--level",
+      "SESSION",
+      "--metric",
+      "deepeval.FaithfulnessMetric",
+      "--model",
+      "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    ]);
+    expect(await evaluator(projectRoot, "prof")).toBeDefined();
+    const src = await Bun.file(join(projectRoot, "app", "prof", "lambda_function.py")).text();
+    expect(src).toContain("us.anthropic.claude-sonnet-4-5-20250929-v1:0");
   });
 
   test("rejects a duplicate evaluator name", async () => {

--- a/src/handlers/project/add/evaluator/code-based/index.test.ts
+++ b/src/handlers/project/add/evaluator/code-based/index.test.ts
@@ -1,0 +1,255 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createRootHandler } from "../../../../index";
+import {
+  createSilentLogger,
+  TestCoreClient,
+  TestGlobalConfigAccessor,
+  testIO,
+} from "../../../../../testing";
+import { InputValidationError } from "../../../../../errors";
+
+const originalCwd = process.cwd();
+const tempDirectories: string[] = [];
+
+async function inTempDirectory(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "agentcore-code-eval-"));
+  tempDirectories.push(directory);
+  process.chdir(directory);
+  return process.cwd();
+}
+
+afterEach(async () => {
+  process.chdir(originalCwd);
+  await Promise.all(
+    tempDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+async function run(args: string[]) {
+  const io = testIO();
+  const root = createRootHandler(new TestCoreClient(), {
+    io: io.io,
+    globalConfigAccessor: new TestGlobalConfigAccessor(),
+    logger: createSilentLogger(),
+  });
+  await root.route(["node", "agentcore", "project", ...args]);
+  return { io };
+}
+
+async function inProject(name = "TestProject"): Promise<string> {
+  const directory = await inTempDirectory();
+  await run(["create", "--name", name, "--skip-install", "--skip-git"]);
+  const projectRoot = join(directory, name);
+  process.chdir(projectRoot);
+  return projectRoot;
+}
+
+const spec = (projectRoot: string) =>
+  Bun.file(join(projectRoot, "agentcore", "agentcore.json")).json();
+const evaluator = async (projectRoot: string, name: string) =>
+  (await spec(projectRoot)).evaluators.find((e: { name: string }) => e.name === name);
+
+describe("project add evaluator code-based", () => {
+  test("3P metric → managed config + scaffolded, rendered Lambda source", async () => {
+    const projectRoot = await inProject();
+    await run([
+      "add",
+      "evaluator",
+      "code-based",
+      "--name",
+      "answer_faithfulness",
+      "--level",
+      "SESSION",
+      "--metric",
+      "deepeval.FaithfulnessMetric",
+      "--model",
+      "bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0",
+    ]);
+
+    expect(await evaluator(projectRoot, "answer_faithfulness")).toMatchObject({
+      name: "answer_faithfulness",
+      level: "SESSION",
+      config: {
+        codeBased: {
+          managed: {
+            codeLocation: "app/answer_faithfulness",
+            entrypoint: "lambda_function.handler",
+            timeoutSeconds: 300,
+            additionalPolicies: ["execution-role-policy.json"],
+          },
+        },
+      },
+    });
+
+    const appDir = join(projectRoot, "app", "answer_faithfulness");
+    const handler = await Bun.file(join(appDir, "lambda_function.py")).text();
+    expect(handler).toContain("FaithfulnessMetric");
+    expect(handler).toContain("AmazonBedrockModel");
+    expect(handler).toContain("anthropic.claude-3-5-sonnet-20240620-v1:0");
+    expect(await Bun.file(join(appDir, "execution-role-policy.json")).exists()).toBe(true);
+    // no unrendered Handlebars left behind
+    expect(handler).not.toContain("{{");
+  });
+
+  test("autoevals metric with default (non-bedrock) model", async () => {
+    const projectRoot = await inProject();
+    await run([
+      "add",
+      "evaluator",
+      "code-based",
+      "--name",
+      "factuality",
+      "--level",
+      "TRACE",
+      "--metric",
+      "autoevals.Factuality",
+    ]);
+
+    expect(
+      (await evaluator(projectRoot, "factuality")).config.codeBased.managed.timeoutSeconds,
+    ).toBe(60);
+    const handler = await Bun.file(
+      join(projectRoot, "app", "factuality", "lambda_function.py"),
+    ).text();
+    expect(handler).toContain("Factuality");
+    expect(handler).not.toContain("{{");
+  });
+
+  test("no metric, no lambda → empty managed stub", async () => {
+    const projectRoot = await inProject();
+    await run(["add", "evaluator", "code-based", "--name", "custom_eval", "--level", "TOOL_CALL"]);
+
+    expect((await evaluator(projectRoot, "custom_eval")).config.codeBased.managed).toMatchObject({
+      codeLocation: "app/custom_eval",
+      timeoutSeconds: 60,
+    });
+    const handler = await Bun.file(
+      join(projectRoot, "app", "custom_eval", "lambda_function.py"),
+    ).text();
+    expect(handler).toContain("TODO");
+    expect(handler).toContain("custom_code_based_evaluator");
+  });
+
+  test("--lambda-arn → external config, no scaffold", async () => {
+    const projectRoot = await inProject();
+    const arn = "arn:aws:lambda:us-west-2:123456789012:function:refund-policy";
+    await run([
+      "add",
+      "evaluator",
+      "code-based",
+      "--name",
+      "refund_policy",
+      "--level",
+      "SESSION",
+      "--lambda-arn",
+      arn,
+    ]);
+
+    expect((await evaluator(projectRoot, "refund_policy")).config).toEqual({
+      codeBased: { external: { lambdaArn: arn } },
+    });
+    expect(
+      await Bun.file(join(projectRoot, "app", "refund_policy", "lambda_function.py")).exists(),
+    ).toBe(false);
+  });
+
+  test("persists description, kms key, and tags", async () => {
+    const projectRoot = await inProject();
+    const kms = "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012";
+    await run([
+      "add",
+      "evaluator",
+      "code-based",
+      "--name",
+      "full",
+      "--level",
+      "SESSION",
+      "--lambda-arn",
+      "arn:aws:lambda:us-west-2:123456789012:function:f",
+      "--description",
+      "external scorer",
+      "--kms-key-arn",
+      kms,
+      "--tags",
+      '{"team":"ml"}',
+    ]);
+
+    expect(await evaluator(projectRoot, "full")).toMatchObject({
+      description: "external scorer",
+      kmsKeyArn: kms,
+      tags: { team: "ml" },
+    });
+  });
+
+  test.each<[string, string[]]>([
+    ["missing --name", ["--level", "SESSION"]],
+    ["missing --level", ["--name", "x"]],
+    [
+      "--metric and --lambda-arn together",
+      [
+        "--name",
+        "x",
+        "--level",
+        "SESSION",
+        "--metric",
+        "deepeval.FaithfulnessMetric",
+        "--lambda-arn",
+        "arn:aws:lambda:us-west-2:123456789012:function:f",
+      ],
+    ],
+    [
+      "unknown metric library",
+      ["--name", "x", "--level", "SESSION", "--metric", "ragas.Faithfulness"],
+    ],
+    ["metric without a class", ["--name", "x", "--level", "SESSION", "--metric", "deepeval"]],
+    ["--model without --metric", ["--name", "x", "--level", "SESSION", "--model", "bedrock/foo"]],
+    [
+      "managed flag with --lambda-arn",
+      [
+        "--name",
+        "x",
+        "--level",
+        "SESSION",
+        "--lambda-arn",
+        "arn:aws:lambda:us-west-2:123456789012:function:f",
+        "--timeout-seconds",
+        "30",
+      ],
+    ],
+    ["invalid --level", ["--name", "x", "--level", "NOPE"]],
+    ["invalid --lambda-arn", ["--name", "x", "--level", "SESSION", "--lambda-arn", "not-an-arn"]],
+  ])("%s", async (_label, flags) => {
+    await inProject();
+    await expect(run(["add", "evaluator", "code-based", ...flags])).rejects.toBeInstanceOf(
+      InputValidationError,
+    );
+  });
+
+  test("rejects a duplicate evaluator name", async () => {
+    await inProject();
+    const flags = [
+      "add",
+      "evaluator",
+      "code-based",
+      "--name",
+      "dup",
+      "--level",
+      "SESSION",
+      "--lambda-arn",
+      "arn:aws:lambda:us-west-2:123456789012:function:f",
+    ];
+    await run(flags);
+    await expect(run(flags)).rejects.toBeInstanceOf(InputValidationError);
+  });
+
+  test("remove evaluator drops it from the spec", async () => {
+    const projectRoot = await inProject();
+    await run(["add", "evaluator", "code-based", "--name", "gone", "--level", "SESSION"]);
+    expect(await evaluator(projectRoot, "gone")).toBeDefined();
+    await run(["remove", "evaluator", "--name", "gone"]);
+    expect(await evaluator(projectRoot, "gone")).toBeUndefined();
+  });
+});

--- a/src/handlers/project/add/evaluator/code-based/index.test.ts
+++ b/src/handlers/project/add/evaluator/code-based/index.test.ts
@@ -309,7 +309,7 @@ describe("project add evaluator code-based", () => {
     expect(await Bun.file(join(appDir, "lambda_function.py")).exists()).toBe(false);
   });
 
-  test("empty stub warns it returns Pass until implemented, plus the not-deployed note", async () => {
+  test("empty stub warns it returns Pass until implemented", async () => {
     await inProject();
     const { io } = await run([
       "add",
@@ -321,10 +321,9 @@ describe("project add evaluator code-based", () => {
       "SESSION",
     ]);
     expect(io.stderr()).toContain("returns Pass for every session");
-    expect(io.stderr()).toContain("not yet provisioned");
   });
 
-  test("external mode prints neither managed note", async () => {
+  test("external mode prints no stub note", async () => {
     await inProject();
     const { io } = await run([
       "add",
@@ -338,7 +337,6 @@ describe("project add evaluator code-based", () => {
       "arn:aws:lambda:us-west-2:123456789012:function:f",
     ]);
     expect(io.stderr()).not.toContain("returns Pass for every session");
-    expect(io.stderr()).not.toContain("not yet provisioned");
   });
 
   test("remove evaluator drops it from the spec", async () => {

--- a/src/handlers/project/add/evaluator/code-based/index.test.ts
+++ b/src/handlers/project/add/evaluator/code-based/index.test.ts
@@ -311,6 +311,38 @@ describe("project add evaluator code-based", () => {
     expect(await Bun.file(join(appDir, "lambda_function.py")).exists()).toBe(false);
   });
 
+  test("empty stub warns it returns Pass until implemented, plus the not-deployed note", async () => {
+    await inProject();
+    const { io } = await run([
+      "add",
+      "evaluator",
+      "code-based",
+      "--name",
+      "stub",
+      "--level",
+      "SESSION",
+    ]);
+    expect(io.stderr()).toContain("returns Pass for every session");
+    expect(io.stderr()).toContain("not yet provisioned");
+  });
+
+  test("external mode prints neither managed note", async () => {
+    await inProject();
+    const { io } = await run([
+      "add",
+      "evaluator",
+      "code-based",
+      "--name",
+      "ext",
+      "--level",
+      "SESSION",
+      "--lambda-arn",
+      "arn:aws:lambda:us-west-2:123456789012:function:f",
+    ]);
+    expect(io.stderr()).not.toContain("returns Pass for every session");
+    expect(io.stderr()).not.toContain("not yet provisioned");
+  });
+
   test("remove evaluator drops it from the spec", async () => {
     const projectRoot = await inProject();
     await run(["add", "evaluator", "code-based", "--name", "gone", "--level", "SESSION"]);

--- a/src/handlers/project/add/evaluator/code-based/index.test.ts
+++ b/src/handlers/project/add/evaluator/code-based/index.test.ts
@@ -90,7 +90,6 @@ describe("project add evaluator code-based", () => {
     expect(handler).toContain("AmazonBedrockModel");
     expect(handler).toContain("anthropic.claude-3-5-sonnet-20240620-v1:0");
     expect(await Bun.file(join(appDir, "execution-role-policy.json")).exists()).toBe(true);
-    // no unrendered Handlebars left behind
     expect(handler).not.toContain("{{");
   });
 
@@ -305,7 +304,6 @@ describe("project add evaluator code-based", () => {
       run(["add", "evaluator", "code-based", "--name", "collide", "--level", "SESSION"]),
     ).rejects.toBeInstanceOf(InputValidationError);
 
-    // no spec entry, and the pre-existing dir is left untouched (no mid-write orphans)
     expect(await evaluator(projectRoot, "collide")).toBeUndefined();
     expect(await Bun.file(join(appDir, "pyproject.toml")).text()).toBe("# pre-existing\n");
     expect(await Bun.file(join(appDir, "lambda_function.py")).exists()).toBe(false);

--- a/src/handlers/project/add/evaluator/code-based/index.ts
+++ b/src/handlers/project/add/evaluator/code-based/index.ts
@@ -1,0 +1,168 @@
+import z from "zod";
+import { createHandler, flag, ProjectKey } from "../../../../../router";
+import { InputValidationError } from "../../../../../errors";
+import { EvaluatorSchema } from "../../../../../projectSchemas/evaluator";
+import { TagsSchema } from "../../../../../projectSchemas/tags";
+import { parseJsonFlagWithSchema } from "../../../../utils";
+import type { AddProjectResourceConfig } from "../../types";
+
+// 3P evaluator libraries the CLI can scaffold. The metric class is passed
+// through to the library (not allowlisted here) — only the library prefix is
+// validated. Default timeouts mirror the old CLI's THIRD_PARTY_EVALUATOR_LIBRARIES.
+const LIBRARIES: Record<string, { assetDir: string; defaultTimeoutSeconds: number }> = {
+  deepeval: { assetDir: "evaluators/deepeval-lambda", defaultTimeoutSeconds: 300 },
+  autoevals: { assetDir: "evaluators/autoevals-lambda", defaultTimeoutSeconds: 60 },
+};
+
+const EMPTY_ASSET_DIR = "evaluators/python-lambda";
+const EMPTY_DEFAULT_TIMEOUT_SECONDS = 60;
+
+export const createAddCodeBasedEvaluatorHandler = (config: AddProjectResourceConfig) =>
+  createHandler({
+    name: "code-based",
+    description:
+      "add a code-based evaluator — a Lambda that scores a session. Pass a 3P metric, an existing Lambda, or neither to scaffold an empty evaluator you fill in",
+    flags: [
+      flag("name", "the name of the evaluator", z.string().optional()),
+      flag("level", "what to score: SESSION, TRACE, or TOOL_CALL", z.string().optional()),
+      flag(
+        "metric",
+        "3P metric to scaffold as <library.Metric>, e.g. deepeval.FaithfulnessMetric or autoevals.Factuality",
+        z.string().optional(),
+      ),
+      flag(
+        "model",
+        "judge model for the 3P metric, e.g. bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0",
+        z.string().optional(),
+      ),
+      flag("lambda-arn", "ARN of an existing Lambda that scores a session", z.string().optional()),
+      flag(
+        "timeout-seconds",
+        "Lambda timeout in seconds (1-300)",
+        z.number().int().min(1).max(300).optional(),
+      ),
+      flag("description", "a description of what this evaluator measures", z.string().optional()),
+      flag(
+        "kms-key-arn",
+        "customer-managed KMS key ARN to encrypt the evaluator",
+        z.string().optional(),
+      ),
+      flag("tags", "tags to apply (JSON object of key/value strings)", z.string().optional()),
+    ],
+    handle: async (ctx, flags) => {
+      if (!flags["name"])
+        throw new InputValidationError("required option '--name <name>' not specified");
+      if (!flags["level"])
+        throw new InputValidationError("required option '--level <level>' not specified");
+
+      const hasMetric = flags["metric"] !== undefined;
+      const hasLambda = flags["lambda-arn"] !== undefined;
+      if (hasMetric && hasLambda)
+        throw new InputValidationError(
+          "provide either --metric (managed) or --lambda-arn (external), not both",
+        );
+
+      const tags = parseJsonFlagWithSchema("tags", flags["tags"], TagsSchema);
+      const base = {
+        name: flags["name"],
+        level: flags["level"],
+        description: flags["description"],
+        kmsKeyArn: flags["kms-key-arn"],
+        tags,
+      };
+
+      // Kept loose so `--level` stays a plain string for EvaluatorSchema to
+      // validate (mirrors the llm-as-a-judge handler); safeParse narrows it.
+      let candidate: Record<string, unknown>;
+      let scaffold: { assetDir: string; context: Record<string, unknown> } | undefined;
+
+      if (hasLambda) {
+        if (flags["metric"] || flags["model"] || flags["timeout-seconds"] !== undefined)
+          throw new InputValidationError(
+            "--metric, --model, and --timeout-seconds are managed-only and not valid with --lambda-arn",
+          );
+        candidate = {
+          ...base,
+          config: { codeBased: { external: { lambdaArn: flags["lambda-arn"] } } },
+        };
+      } else {
+        // managed: 3P metric, or empty stub when no metric is given.
+        if (flags["model"] && !hasMetric)
+          throw new InputValidationError("--model requires --metric");
+
+        let assetDir = EMPTY_ASSET_DIR;
+        let defaultTimeout = EMPTY_DEFAULT_TIMEOUT_SECONDS;
+        const context: Record<string, unknown> = { Name: toPythonPackageName(flags["name"]) };
+
+        if (hasMetric) {
+          const raw = flags["metric"]!;
+          const dot = raw.indexOf(".");
+          const library = dot > 0 ? raw.slice(0, dot) : "";
+          const metricClass = dot > 0 ? raw.slice(dot + 1) : "";
+          const lib = library && metricClass ? LIBRARIES[library] : undefined;
+          if (!lib)
+            throw new InputValidationError(
+              `invalid --metric "${raw}": expected <library.Metric> where library is one of ${Object.keys(LIBRARIES).join(", ")} (e.g. deepeval.FaithfulnessMetric)`,
+            );
+          assetDir = lib.assetDir;
+          defaultTimeout = lib.defaultTimeoutSeconds;
+
+          const { modelProviderBedrock, model } = parseModel(flags["model"]);
+          context["EvaluatorClass"] = metricClass;
+          context["Model"] = model;
+          context["ModelProviderBedrock"] = modelProviderBedrock;
+          context["EvaluatorParams"] = "";
+        }
+
+        const timeoutSeconds = flags["timeout-seconds"] ?? defaultTimeout;
+        candidate = {
+          ...base,
+          config: {
+            codeBased: {
+              managed: {
+                codeLocation: `app/${flags["name"]}`,
+                entrypoint: "lambda_function.handler",
+                timeoutSeconds,
+                additionalPolicies: ["execution-role-policy.json"],
+              },
+            },
+          },
+        };
+        scaffold = { assetDir, context };
+      }
+
+      const parsed = EvaluatorSchema.safeParse(candidate);
+      if (!parsed.success) throw new InputValidationError(z.prettifyError(parsed.error));
+
+      const project = ctx.require(ProjectKey);
+      for await (const event of config.projectManager.addResource(project, {
+        resourceType: "evaluator",
+        resourceConfig: parsed.data,
+        scaffold,
+      })) {
+        config.io.stderr.write(`${event.message}\n`);
+      }
+
+      config.io.stderr.write(`added evaluator '${flags["name"]}' to '${project.name}'\n`);
+    },
+  });
+
+// `bedrock/<id>` selects the Bedrock judge backend (Model = the id); anything
+// else (openai/gpt-4o, a bare name, or unset) falls through to the library's
+// default model.
+function parseModel(model: string | undefined): { modelProviderBedrock: boolean; model: string } {
+  if (!model) return { modelProviderBedrock: false, model: "" };
+  const slash = model.indexOf("/");
+  const provider = slash > 0 ? model.slice(0, slash) : "";
+  if (provider === "bedrock") return { modelProviderBedrock: true, model: model.slice(slash + 1) };
+  return { modelProviderBedrock: false, model };
+}
+
+// PEP 508 package name: ASCII letters/numbers/period/underscore/hyphen, must
+// start and end alphanumeric. Mirrors the runtime template helper.
+function toPythonPackageName(name: string): string {
+  return name
+    .replace(/[^a-zA-Z0-9._-]/g, "-")
+    .replace(/^[^a-zA-Z0-9]+/, "")
+    .replace(/[^a-zA-Z0-9]+$/, "");
+}

--- a/src/handlers/project/add/evaluator/code-based/index.ts
+++ b/src/handlers/project/add/evaluator/code-based/index.ts
@@ -1,7 +1,7 @@
 import z from "zod";
 import { createHandler, flag, ProjectKey } from "../../../../../router";
 import { InputValidationError } from "../../../../../errors";
-import { EvaluatorSchema } from "../../../../../projectSchemas/evaluator";
+import { EvaluatorSchema, isValidBedrockModelId } from "../../../../../projectSchemas/evaluator";
 import { TagsSchema } from "../../../../../projectSchemas/tags";
 import { parseJsonFlagWithSchema } from "../../../../utils";
 import type { AddProjectResourceConfig } from "../../types";
@@ -104,13 +104,21 @@ export const createAddCodeBasedEvaluatorHandler = (config: AddProjectResourceCon
             throw new InputValidationError(
               `invalid --metric "${raw}": expected <library.Metric> where library is one of ${Object.keys(LIBRARIES).join(", ")} (e.g. deepeval.FaithfulnessMetric)`,
             );
+          // The class is rendered straight into `from <lib> import <class>` and
+          // `<class>(...)`, so it must be a single Python identifier. Reject
+          // dotted/namespaced values (e.g. deepeval.metrics.Faithfulness) that
+          // would emit invalid Python and only fail at deploy/runtime.
+          if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(metricClass))
+            throw new InputValidationError(
+              `invalid metric class "${metricClass}" in --metric "${raw}": expected a single class name like FaithfulnessMetric`,
+            );
           assetDir = lib.assetDir;
           defaultTimeout = lib.defaultTimeoutSeconds;
 
-          const { modelProviderBedrock, model } = parseModel(flags["model"]);
+          const model = resolveBedrockModel(flags["model"]);
           context["EvaluatorClass"] = metricClass;
-          context["Model"] = model;
-          context["ModelProviderBedrock"] = modelProviderBedrock;
+          context["Model"] = model ?? "";
+          context["ModelProviderBedrock"] = model !== undefined;
           context["EvaluatorParams"] = "";
         }
 
@@ -147,15 +155,20 @@ export const createAddCodeBasedEvaluatorHandler = (config: AddProjectResourceCon
     },
   });
 
-// `bedrock/<id>` selects the Bedrock judge backend (Model = the id); anything
-// else (openai/gpt-4o, a bare name, or unset) falls through to the library's
-// default model.
-function parseModel(model: string | undefined): { modelProviderBedrock: boolean; model: string } {
-  if (!model) return { modelProviderBedrock: false, model: "" };
-  const slash = model.indexOf("/");
-  const provider = slash > 0 ? model.slice(0, slash) : "";
-  if (provider === "bedrock") return { modelProviderBedrock: true, model: model.slice(slash + 1) };
-  return { modelProviderBedrock: false, model };
+// Judge model for a 3P metric. Bedrock-only: accepts a bare Bedrock model id /
+// inference-profile-or-foundation-model ARN, optionally prefixed with
+// `bedrock/`, and returns the id with the prefix stripped. Anything else errors
+// rather than silently degrading — a non-Bedrock value is dropped by the
+// deepeval template and passed to the wrong client by autoevals. Returns
+// undefined when no --model was given (library default).
+function resolveBedrockModel(model: string | undefined): string | undefined {
+  if (!model) return undefined;
+  const id = model.startsWith("bedrock/") ? model.slice("bedrock/".length) : model;
+  if (!isValidBedrockModelId(id))
+    throw new InputValidationError(
+      `invalid --model "${model}": expected a Bedrock model ID (e.g. anthropic.claude-3-5-sonnet-20240620-v1:0) or an inference-profile/foundation-model ARN, optionally prefixed with "bedrock/"`,
+    );
+  return id;
 }
 
 // PEP 508 package name: ASCII letters/numbers/period/underscore/hyphen, must

--- a/src/handlers/project/add/evaluator/code-based/index.ts
+++ b/src/handlers/project/add/evaluator/code-based/index.ts
@@ -11,7 +11,7 @@ import {
   EVALUATOR_LIBRARIES,
   type EvaluatorLibrary,
   type ManagedEvaluatorScaffoldInput,
-} from "../../../../../core/project/templates/evaluator";
+} from "../../../types";
 import { parseJsonFlagWithSchema } from "../../../../utils";
 import type { AddProjectResourceConfig } from "../../types";
 
@@ -122,9 +122,9 @@ function parseMetric(raw: string): { library: EvaluatorLibrary; metricClass: str
   const dot = raw.indexOf(".");
   const library = dot > 0 ? raw.slice(0, dot) : "";
   const metricClass = dot > 0 ? raw.slice(dot + 1) : "";
-  if (!(library in EVALUATOR_LIBRARIES))
+  if (!(EVALUATOR_LIBRARIES as readonly string[]).includes(library))
     throw new InputValidationError(
-      `invalid --metric "${raw}": expected <library.Metric> where library is one of ${Object.keys(EVALUATOR_LIBRARIES).join(", ")} (e.g. deepeval.FaithfulnessMetric)`,
+      `invalid --metric "${raw}": expected <library.Metric> where library is one of ${EVALUATOR_LIBRARIES.join(", ")} (e.g. deepeval.FaithfulnessMetric)`,
     );
   if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(metricClass))
     throw new InputValidationError(

--- a/src/handlers/project/add/evaluator/code-based/index.ts
+++ b/src/handlers/project/add/evaluator/code-based/index.ts
@@ -1,20 +1,19 @@
 import z from "zod";
 import { createHandler, flag, ProjectKey } from "../../../../../router";
 import { InputValidationError } from "../../../../../errors";
-import { EvaluatorSchema, isValidBedrockModelId } from "../../../../../projectSchemas/evaluator";
+import {
+  EvaluatorSchema,
+  EvaluationLevelSchema,
+  isValidBedrockModelId,
+} from "../../../../../projectSchemas/evaluator";
 import { TagsSchema } from "../../../../../projectSchemas/tags";
-import { toPythonPackageName } from "../../../../../core/project/fsUtils";
+import {
+  EVALUATOR_LIBRARIES,
+  type EvaluatorLibrary,
+  type ManagedEvaluatorScaffoldInput,
+} from "../../../../../core/project/templates/evaluator";
 import { parseJsonFlagWithSchema } from "../../../../utils";
 import type { AddProjectResourceConfig } from "../../types";
-
-const DEFAULT_TIMEOUT = 60;
-
-const LIBRARIES: Record<string, { assetDir: string; defaultTimeoutSeconds: number }> = {
-  deepeval: { assetDir: "evaluators/deepeval-lambda", defaultTimeoutSeconds: 300 },
-  autoevals: { assetDir: "evaluators/autoevals-lambda", defaultTimeoutSeconds: DEFAULT_TIMEOUT },
-};
-
-const EMPTY_ASSET_DIR = "evaluators/python-lambda";
 
 export const createAddCodeBasedEvaluatorHandler = (config: AddProjectResourceConfig) =>
   createHandler({
@@ -53,6 +52,9 @@ export const createAddCodeBasedEvaluatorHandler = (config: AddProjectResourceCon
         throw new InputValidationError("required option '--name <name>' not specified");
       if (!flags["level"])
         throw new InputValidationError("required option '--level <level>' not specified");
+      const levelParsed = EvaluationLevelSchema.safeParse(flags["level"]);
+      if (!levelParsed.success) throw new InputValidationError(z.prettifyError(levelParsed.error));
+      const level = levelParsed.data;
 
       const hasMetric = flags["metric"] !== undefined;
       const hasLambda = flags["lambda-arn"] !== undefined;
@@ -64,97 +66,75 @@ export const createAddCodeBasedEvaluatorHandler = (config: AddProjectResourceCon
       const tags = parseJsonFlagWithSchema("tags", flags["tags"], TagsSchema);
       const base = {
         name: flags["name"],
-        level: flags["level"],
+        level,
         description: flags["description"],
         kmsKeyArn: flags["kms-key-arn"],
         tags,
       };
-
-      let candidate: Record<string, unknown>;
-      let scaffold: { assetDir: string; context: Record<string, unknown> } | undefined;
+      const project = ctx.require(ProjectKey);
 
       if (hasLambda) {
         if (flags["metric"] || flags["model"] || flags["timeout-seconds"] !== undefined)
           throw new InputValidationError(
             "--metric, --model, and --timeout-seconds are managed-only and not valid with --lambda-arn",
           );
-        candidate = {
+        const parsed = EvaluatorSchema.safeParse({
           ...base,
           config: { codeBased: { external: { lambdaArn: flags["lambda-arn"] } } },
-        };
-      } else {
-        if (flags["model"] && !hasMetric)
-          throw new InputValidationError("--model requires --metric");
-
-        let assetDir = EMPTY_ASSET_DIR;
-        let defaultTimeout = DEFAULT_TIMEOUT;
-        const context: Record<string, unknown> = { Name: toPythonPackageName(flags["name"]) };
-
-        if (hasMetric) {
-          const raw = flags["metric"]!;
-          const dot = raw.indexOf(".");
-          const library = dot > 0 ? raw.slice(0, dot) : "";
-          const metricClass = dot > 0 ? raw.slice(dot + 1) : "";
-          const lib = library && metricClass ? LIBRARIES[library] : undefined;
-          if (!lib)
-            throw new InputValidationError(
-              `invalid --metric "${raw}": expected <library.Metric> where library is one of ${Object.keys(LIBRARIES).join(", ")} (e.g. deepeval.FaithfulnessMetric)`,
-            );
-          if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(metricClass))
-            throw new InputValidationError(
-              `invalid metric class "${metricClass}" in --metric "${raw}": expected a single class name like FaithfulnessMetric`,
-            );
-          assetDir = lib.assetDir;
-          defaultTimeout = lib.defaultTimeoutSeconds;
-
-          const model = resolveBedrockModel(flags["model"]);
-          context["EvaluatorClass"] = metricClass;
-          context["Model"] = model ?? "";
-          context["ModelProviderBedrock"] = model !== undefined;
-          context["EvaluatorParams"] = "";
+        });
+        if (!parsed.success) throw new InputValidationError(z.prettifyError(parsed.error));
+        for await (const event of config.projectManager.addResource(project, {
+          resourceType: "evaluator",
+          resourceConfig: parsed.data,
+        })) {
+          config.io.stderr.write(`${event.message}\n`);
         }
-
-        const timeoutSeconds = flags["timeout-seconds"] ?? defaultTimeout;
-        candidate = {
-          ...base,
-          config: {
-            codeBased: {
-              managed: {
-                codeLocation: `app/${flags["name"]}`,
-                entrypoint: "lambda_function.handler",
-                timeoutSeconds,
-                additionalPolicies: ["execution-role-policy.json"],
-              },
-            },
-          },
-        };
-        scaffold = { assetDir, context };
+        config.io.stderr.write(`added evaluator '${flags["name"]}' to '${project.name}'\n`);
+        return;
       }
 
-      const parsed = EvaluatorSchema.safeParse(candidate);
-      if (!parsed.success) throw new InputValidationError(z.prettifyError(parsed.error));
+      if (flags["model"] && !hasMetric) throw new InputValidationError("--model requires --metric");
 
-      const project = ctx.require(ProjectKey);
+      const scaffold: ManagedEvaluatorScaffoldInput = {
+        ...base,
+        ...(hasMetric && { metric: parseMetric(flags["metric"]!) }),
+        ...(flags["model"] !== undefined && { model: resolveBedrockModel(flags["model"]) }),
+        ...(flags["timeout-seconds"] !== undefined && { timeoutSeconds: flags["timeout-seconds"] }),
+      };
+
       for await (const event of config.projectManager.addResource(project, {
         resourceType: "evaluator",
-        resourceConfig: parsed.data,
+        resourceConfig: { name: scaffold.name },
         scaffold,
       })) {
         config.io.stderr.write(`${event.message}\n`);
       }
 
       config.io.stderr.write(`added evaluator '${flags["name"]}' to '${project.name}'\n`);
-      if (!hasLambda) {
-        if (!hasMetric)
-          config.io.stderr.write(
-            `note: this evaluator returns Pass for every session until you implement app/${flags["name"]}/lambda_function.py\n`,
-          );
+      if (!hasMetric)
         config.io.stderr.write(
-          `note: managed code-based evaluators are scaffolded locally but not yet provisioned by 'project deploy' (pending CDK/L3 support)\n`,
+          `note: this evaluator returns Pass for every session until you implement app/${flags["name"]}/lambda_function.py\n`,
         );
-      }
+      config.io.stderr.write(
+        `note: managed code-based evaluators are scaffolded locally but not yet provisioned by 'project deploy' (pending CDK/L3 support)\n`,
+      );
     },
   });
+
+function parseMetric(raw: string): { library: EvaluatorLibrary; metricClass: string } {
+  const dot = raw.indexOf(".");
+  const library = dot > 0 ? raw.slice(0, dot) : "";
+  const metricClass = dot > 0 ? raw.slice(dot + 1) : "";
+  if (!(library in EVALUATOR_LIBRARIES))
+    throw new InputValidationError(
+      `invalid --metric "${raw}": expected <library.Metric> where library is one of ${Object.keys(EVALUATOR_LIBRARIES).join(", ")} (e.g. deepeval.FaithfulnessMetric)`,
+    );
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(metricClass))
+    throw new InputValidationError(
+      `invalid metric class "${metricClass}" in --metric "${raw}": expected a single class name like FaithfulnessMetric`,
+    );
+  return { library: library as EvaluatorLibrary, metricClass };
+}
 
 function resolveBedrockModel(model: string | undefined): string | undefined {
   if (!model) return undefined;

--- a/src/handlers/project/add/evaluator/code-based/index.ts
+++ b/src/handlers/project/add/evaluator/code-based/index.ts
@@ -3,19 +3,18 @@ import { createHandler, flag, ProjectKey } from "../../../../../router";
 import { InputValidationError } from "../../../../../errors";
 import { EvaluatorSchema, isValidBedrockModelId } from "../../../../../projectSchemas/evaluator";
 import { TagsSchema } from "../../../../../projectSchemas/tags";
+import { toPythonPackageName } from "../../../../../core/project/fsUtils";
 import { parseJsonFlagWithSchema } from "../../../../utils";
 import type { AddProjectResourceConfig } from "../../types";
 
-// 3P evaluator libraries the CLI can scaffold. The metric class is passed
-// through to the library (not allowlisted here) — only the library prefix is
-// validated. Default timeouts mirror the old CLI's THIRD_PARTY_EVALUATOR_LIBRARIES.
+const DEFAULT_TIMEOUT = 60;
+
 const LIBRARIES: Record<string, { assetDir: string; defaultTimeoutSeconds: number }> = {
   deepeval: { assetDir: "evaluators/deepeval-lambda", defaultTimeoutSeconds: 300 },
-  autoevals: { assetDir: "evaluators/autoevals-lambda", defaultTimeoutSeconds: 60 },
+  autoevals: { assetDir: "evaluators/autoevals-lambda", defaultTimeoutSeconds: DEFAULT_TIMEOUT },
 };
 
 const EMPTY_ASSET_DIR = "evaluators/python-lambda";
-const EMPTY_DEFAULT_TIMEOUT_SECONDS = 60;
 
 export const createAddCodeBasedEvaluatorHandler = (config: AddProjectResourceConfig) =>
   createHandler({
@@ -71,8 +70,6 @@ export const createAddCodeBasedEvaluatorHandler = (config: AddProjectResourceCon
         tags,
       };
 
-      // Kept loose so `--level` stays a plain string for EvaluatorSchema to
-      // validate (mirrors the llm-as-a-judge handler); safeParse narrows it.
       let candidate: Record<string, unknown>;
       let scaffold: { assetDir: string; context: Record<string, unknown> } | undefined;
 
@@ -86,12 +83,11 @@ export const createAddCodeBasedEvaluatorHandler = (config: AddProjectResourceCon
           config: { codeBased: { external: { lambdaArn: flags["lambda-arn"] } } },
         };
       } else {
-        // managed: 3P metric, or empty stub when no metric is given.
         if (flags["model"] && !hasMetric)
           throw new InputValidationError("--model requires --metric");
 
         let assetDir = EMPTY_ASSET_DIR;
-        let defaultTimeout = EMPTY_DEFAULT_TIMEOUT_SECONDS;
+        let defaultTimeout = DEFAULT_TIMEOUT;
         const context: Record<string, unknown> = { Name: toPythonPackageName(flags["name"]) };
 
         if (hasMetric) {
@@ -104,10 +100,6 @@ export const createAddCodeBasedEvaluatorHandler = (config: AddProjectResourceCon
             throw new InputValidationError(
               `invalid --metric "${raw}": expected <library.Metric> where library is one of ${Object.keys(LIBRARIES).join(", ")} (e.g. deepeval.FaithfulnessMetric)`,
             );
-          // The class is rendered straight into `from <lib> import <class>` and
-          // `<class>(...)`, so it must be a single Python identifier. Reject
-          // dotted/namespaced values (e.g. deepeval.metrics.Faithfulness) that
-          // would emit invalid Python and only fail at deploy/runtime.
           if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(metricClass))
             throw new InputValidationError(
               `invalid metric class "${metricClass}" in --metric "${raw}": expected a single class name like FaithfulnessMetric`,
@@ -152,9 +144,6 @@ export const createAddCodeBasedEvaluatorHandler = (config: AddProjectResourceCon
       }
 
       config.io.stderr.write(`added evaluator '${flags["name"]}' to '${project.name}'\n`);
-      // Make the inferred mode and its caveats visible: the empty stub silently
-      // passes every session, and no managed evaluator is provisioned by deploy
-      // yet (no CDK/L3 support) — both are silent footguns otherwise.
       if (!hasLambda) {
         if (!hasMetric)
           config.io.stderr.write(
@@ -167,12 +156,6 @@ export const createAddCodeBasedEvaluatorHandler = (config: AddProjectResourceCon
     },
   });
 
-// Judge model for a 3P metric. Bedrock-only: accepts a bare Bedrock model id /
-// inference-profile-or-foundation-model ARN, optionally prefixed with
-// `bedrock/`, and returns the id with the prefix stripped. Anything else errors
-// rather than silently degrading — a non-Bedrock value is dropped by the
-// deepeval template and passed to the wrong client by autoevals. Returns
-// undefined when no --model was given (library default).
 function resolveBedrockModel(model: string | undefined): string | undefined {
   if (!model) return undefined;
   const id = model.startsWith("bedrock/") ? model.slice("bedrock/".length) : model;
@@ -181,13 +164,4 @@ function resolveBedrockModel(model: string | undefined): string | undefined {
       `invalid --model "${model}": expected a Bedrock model ID (e.g. anthropic.claude-3-5-sonnet-20240620-v1:0) or an inference-profile/foundation-model ARN, optionally prefixed with "bedrock/"`,
     );
   return id;
-}
-
-// PEP 508 package name: ASCII letters/numbers/period/underscore/hyphen, must
-// start and end alphanumeric. Mirrors the runtime template helper.
-function toPythonPackageName(name: string): string {
-  return name
-    .replace(/[^a-zA-Z0-9._-]/g, "-")
-    .replace(/^[^a-zA-Z0-9]+/, "")
-    .replace(/[^a-zA-Z0-9]+$/, "");
 }

--- a/src/handlers/project/add/evaluator/code-based/index.ts
+++ b/src/handlers/project/add/evaluator/code-based/index.ts
@@ -152,6 +152,18 @@ export const createAddCodeBasedEvaluatorHandler = (config: AddProjectResourceCon
       }
 
       config.io.stderr.write(`added evaluator '${flags["name"]}' to '${project.name}'\n`);
+      // Make the inferred mode and its caveats visible: the empty stub silently
+      // passes every session, and no managed evaluator is provisioned by deploy
+      // yet (no CDK/L3 support) — both are silent footguns otherwise.
+      if (!hasLambda) {
+        if (!hasMetric)
+          config.io.stderr.write(
+            `note: this evaluator returns Pass for every session until you implement app/${flags["name"]}/lambda_function.py\n`,
+          );
+        config.io.stderr.write(
+          `note: managed code-based evaluators are scaffolded locally but not yet provisioned by 'project deploy' (pending CDK/L3 support)\n`,
+        );
+      }
     },
   });
 

--- a/src/handlers/project/add/evaluator/code-based/index.ts
+++ b/src/handlers/project/add/evaluator/code-based/index.ts
@@ -115,9 +115,6 @@ export const createAddCodeBasedEvaluatorHandler = (config: AddProjectResourceCon
         config.io.stderr.write(
           `note: this evaluator returns Pass for every session until you implement app/${flags["name"]}/lambda_function.py\n`,
         );
-      config.io.stderr.write(
-        `note: managed code-based evaluators are scaffolded locally but not yet provisioned by 'project deploy' (pending CDK/L3 support)\n`,
-      );
     },
   });
 

--- a/src/handlers/project/add/evaluator/index.ts
+++ b/src/handlers/project/add/evaluator/index.ts
@@ -1,9 +1,11 @@
 import { Router } from "../../../../router";
 import type { AddProjectResourceConfig } from "../types";
 import { createAddLlmAsAJudgeEvaluatorHandler } from "./llm-as-a-judge";
+import { createAddCodeBasedEvaluatorHandler } from "./code-based";
 
 export function createAddEvaluatorHandler(config: AddProjectResourceConfig): Router {
   const evaluator = new Router("evaluator", "add a custom evaluator to the current project");
   evaluator.handler(createAddLlmAsAJudgeEvaluatorHandler(config));
+  evaluator.handler(createAddCodeBasedEvaluatorHandler(config));
   return evaluator;
 }

--- a/src/handlers/project/remove/index.ts
+++ b/src/handlers/project/remove/index.ts
@@ -44,6 +44,7 @@ export const createRemoveProjectHandler = (config: RemoveProjectResourceConfig) 
             "online-eval",
             "online-insight",
             "memory",
+            "evaluator",
             "gateway",
             "gateway-target",
             "gateway-connector",

--- a/src/handlers/project/types.ts
+++ b/src/handlers/project/types.ts
@@ -5,8 +5,7 @@ import type { CredentialSchema } from "../../projectSchemas/credential";
 import type { PaymentConnectorSchema, PaymentManagerSchema } from "../../projectSchemas/payment";
 import type { ConfigBundleSchema } from "../../projectSchemas/config-bundle";
 import { MemorySchema } from "../../projectSchemas/memory";
-import type { EvaluatorSchema } from "../../projectSchemas/evaluator";
-import type { ManagedEvaluatorScaffoldInput } from "../../core/project/templates/evaluator";
+import type { EvaluatorSchema, EvaluationLevel } from "../../projectSchemas/evaluator";
 import type { ProjectSpecSchema } from "../../projectSchemas/project";
 import z from "zod";
 import type { ImportBedrockAgentInput, RuntimeResourceConfig } from "./add/runtime/types";
@@ -24,6 +23,21 @@ type CreateProjectInputBase = {
   skipInstall?: boolean;
   /** Skip initializing a git repository. */
   skipGit?: boolean;
+};
+
+export const EVALUATOR_LIBRARIES = ["deepeval", "autoevals"] as const;
+export type EvaluatorLibrary = (typeof EVALUATOR_LIBRARIES)[number];
+
+/** Set of arguments needed to scaffold a managed code-based evaluator. */
+export type ManagedEvaluatorScaffoldInput = {
+  name: string;
+  level: EvaluationLevel;
+  description?: string;
+  kmsKeyArn?: string;
+  tags?: Record<string, string>;
+  metric?: { library: EvaluatorLibrary; metricClass: string };
+  model?: string;
+  timeoutSeconds?: number;
 };
 
 /** Set of arguments needed to scaffold a new Runtime-based agent. */

--- a/src/handlers/project/types.ts
+++ b/src/handlers/project/types.ts
@@ -210,6 +210,13 @@ export type AddResourceInput =
   | {
       resourceType: "evaluator";
       resourceConfig: z.input<typeof EvaluatorSchema>;
+      /**
+       * Present only for managed code-based evaluators, whose code the CLI
+       * generates. `assetDir` picks the template under src/assets/evaluators;
+       * `context` holds its Handlebars variables. External and llm-as-a-judge
+       * evaluators omit this and are spec-only.
+       */
+      scaffold?: { assetDir: string; context: Record<string, unknown> };
     }
   | {
       resourceType: "gateway";

--- a/src/handlers/project/types.ts
+++ b/src/handlers/project/types.ts
@@ -6,6 +6,7 @@ import type { PaymentConnectorSchema, PaymentManagerSchema } from "../../project
 import type { ConfigBundleSchema } from "../../projectSchemas/config-bundle";
 import { MemorySchema } from "../../projectSchemas/memory";
 import type { EvaluatorSchema } from "../../projectSchemas/evaluator";
+import type { ManagedEvaluatorScaffoldInput } from "../../core/project/templates/evaluator";
 import type { ProjectSpecSchema } from "../../projectSchemas/project";
 import z from "zod";
 import type { ImportBedrockAgentInput, RuntimeResourceConfig } from "./add/runtime/types";
@@ -210,13 +211,12 @@ export type AddResourceInput =
   | {
       resourceType: "evaluator";
       resourceConfig: z.input<typeof EvaluatorSchema>;
-      /**
-       * Present only for managed code-based evaluators, whose code the CLI
-       * generates. `assetDir` picks the template under src/assets/evaluators;
-       * `context` holds its Handlebars variables. External and llm-as-a-judge
-       * evaluators omit this and are spec-only.
-       */
-      scaffold?: { assetDir: string; context: Record<string, unknown> };
+      scaffold?: undefined;
+    }
+  | {
+      resourceType: "evaluator";
+      resourceConfig: { name: string };
+      scaffold: ManagedEvaluatorScaffoldInput;
     }
   | {
       resourceType: "gateway";
@@ -288,6 +288,7 @@ export type RemoveResourceInput =
         | "online-eval"
         | "online-insight"
         | "memory"
+        | "evaluator"
         | "gateway"
         | "policy-engine"
         | "payment-manager";


### PR DESCRIPTION
## Command structure

```
agentcore project add evaluator          add a custom evaluator to the current project
├── llm-as-a-judge                       existing — LLM prompted to score a session
└── code-based                           NEW — a Lambda that scores a session
agentcore project remove evaluator --name <name>   NEW — enabled via the generic remove
```

`agentcore project add evaluator code-based --help`:

```
Usage: agentcore project add evaluator code-based [options]

add a code-based evaluator — a Lambda that scores a session. Pass a 3P metric,
an existing Lambda, or neither to scaffold an empty evaluator you fill in

Options:
  --name <name>                        the name of the evaluator
  --level <level>                      what to score: SESSION, TRACE, or TOOL_CALL
  --metric <metric>                    3P metric to scaffold as <library.Metric>,
                                       e.g. deepeval.FaithfulnessMetric or autoevals.Factuality
  --model <model>                      judge model for the 3P metric,
                                       e.g. bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0
  --lambda-arn <lambda-arn>            ARN of an existing Lambda that scores a session
  --timeout-seconds <timeout-seconds>  Lambda timeout in seconds (1-300)
  --description <description>          a description of what this evaluator measures
  --kms-key-arn <kms-key-arn>          customer-managed KMS key ARN to encrypt the evaluator
  --tags <tags>                        tags to apply (JSON object of key/value strings)
  -h, --help                           display help for command
```


## Commits

1. `c4430c03` feat — the command + 3 scaffold templates + `remove evaluator`
2. `baec1630` fix — guard `app/<name>` collisions (up-front, no partial writes)
3. `e7bc3675` fix — validate `--metric` class + require a Bedrock `--model`
4. `9bd79980` fix — echo the inferred mode + caveats at add time
5. `32a10ef9` refactor — share `toPythonPackageName` via `fsUtils`; `DEFAULT_TIMEOUT` const
6. `853dcf86` refactor — move template knowledge into `templates/evaluator.ts` (runtime layering)

## Testing

- `bun run build` OK · `bun test src/handlers/project src/core/project` → **597 pass / 0 fail**.
- **Cloud bug bash** (5 parallel agents; 2 deployed to a non-prod account, us-west-2, then tore down): all 5 flows + a 13-case error matrix pass at the CLI/scaffold/synth layer. The managed evaluator **synthesizes correctly** into `AWS::BedrockAgentCore::Evaluator` + Lambda + role + permissions, and generated Python `ast.parse`s for deepeval + autoevals (bedrock + openai branches). Full report shared separately.

