### PR TITLE
fix(eval): mark --header and --bearer-token sensitive in eval simulate

### DIFF
--- a/src/handlers/eval/batch-evaluation/simulate/index.tsx
+++ b/src/handlers/eval/batch-evaluation/simulate/index.tsx
@@ -21,11 +21,14 @@ export const createSimulateBatchEvaluationHandler = (core: Core, _io: AppIO) =>
         'JSON payload template; {input} is the scenario input, e.g. {"prompt":"{input}"}',
         z.string().optional(),
       ),
-      flag("header", "an ordered application header (repeatable)", z.array(z.string()).optional()),
+      flag("header", "an ordered application header (repeatable)", z.array(z.string()).optional(), {
+        sensitive: true,
+      }),
       flag(
         "bearer-token",
         "CUSTOM_JWT bearer token (for JWT-auth runtimes)",
         z.string().optional(),
+        { sensitive: true },
       ),
       flag("user-id", "runtime user id", z.string().optional()),
       flag("dataset", "dataset source: local JSONL path or a dataset id", z.string().optional()),

--- a/src/handlers/eval/ondemand/simulate/index.tsx
+++ b/src/handlers/eval/ondemand/simulate/index.tsx
@@ -22,11 +22,14 @@ export const createSimulateOnDemandHandler = (core: Core, _io: AppIO) =>
         'JSON payload template; {input} is the scenario input, e.g. {"prompt":"{input}"}',
         z.string().optional(),
       ),
-      flag("header", "an ordered application header (repeatable)", z.array(z.string()).optional()),
+      flag("header", "an ordered application header (repeatable)", z.array(z.string()).optional(), {
+        sensitive: true,
+      }),
       flag(
         "bearer-token",
         "CUSTOM_JWT bearer token (for JWT-auth runtimes)",
         z.string().optional(),
+        { sensitive: true },
       ),
       flag("user-id", "runtime user id", z.string().optional()),
       flag("dataset", "dataset source: local JSONL path or a dataset id", z.string().optional()),


### PR DESCRIPTION
## What

Follow-up to #2071. Mark `--header` and `--bearer-token` as `sensitive` on both `eval ondemand simulate` and `eval batch-evaluation simulate`, so the `withLogging` debug middleware redacts them instead of logging the CUSTOM_JWT bearer token and application headers in cleartext.

Addresses nborges-aws's review comment on #2071: *"this and `--header` should be marked sensitive."*

## Why

The canonical `runtime invoke` handler already marks both flags sensitive (`src/handlers/runtime/invoke/index.tsx`). The two `simulate` twins accept the identical secret-carrying flags but omitted the annotation, so a `--debug` run would leak the token/headers. Fixed both twins for consistency — leaving the batch one would be half a fix for the same secret.

## Already done in #2071 (not re-addressed here)

The other two review commitments landed before #2071 merged:
- `withUserCancellation` shared helper — already used
- `expectedResponse` reference inputs — already handled by `toReferenceInputs`

## Test

`bun test` for both simulate handlers: 25 pass / 0 fail. `bun run typecheck` clean.
