### PR TITLE
fix(create): restore harness-first project options

### DIFF
--- a/src/core/project/manager.test.ts
+++ b/src/core/project/manager.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
 import { mkdir, mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
 import { join, relative } from "node:path";
 import { tmpdir } from "node:os";
@@ -161,6 +162,26 @@ describe("FsProjectManager.create", () => {
 
     await runCreate(manager().manager, input);
     await expect(runCreate(manager().manager, input)).rejects.toBeInstanceOf(ProjectStateError);
+  });
+
+  test("validates a harness Dockerfile before writing the project tree", async () => {
+    const directory = await inTempDirectory();
+    const dockerfile = join(directory, "MissingDockerfile");
+
+    await expect(
+      runCreate(manager().manager, {
+        name: "example",
+        skipInstall: true,
+        skipGit: true,
+        scaffoldHarnessInput: {
+          name: "example",
+          model: { provider: "bedrock", modelId: "global.anthropic.claude-sonnet-4-6" },
+          dockerfile,
+        },
+      }),
+    ).rejects.toThrow(`dockerfile not found: '${dockerfile}'`);
+
+    expect(existsSync(join(directory, "example"))).toBe(false);
   });
 
   test("runs npm install, uv sync, and git init after scaffolding", async () => {

--- a/src/core/project/manager.tsx
+++ b/src/core/project/manager.tsx
@@ -26,7 +26,7 @@ import {
 } from "../../io";
 import { defaultSource, type AssetSource } from "./source";
 import { ENV_LOCAL_RELATIVE_PATH, EnvLocalFile } from "./envLocal";
-import { getHarnessTemplateResolver } from "./templates/harness";
+import { getHarnessTemplateResolver, validateHarnessTemplateSource } from "./templates/harness";
 import { createProjectTree } from "./templates/project";
 import { getRuntimeTemplateResolver } from "./templates/runtime";
 import {
@@ -146,6 +146,10 @@ export class FsProjectManager implements ProjectManager {
       throw new ProjectStateError(
         `You cannot create a project inside an existing project: ${enclosing}`,
       );
+    }
+
+    if (input.scaffoldHarnessInput) {
+      validateHarnessTemplateSource(input.scaffoldHarnessInput);
     }
 
     const scaffoldRuntimeInput = input.scaffoldRuntimeInput;

--- a/src/core/project/templates/harness.ts
+++ b/src/core/project/templates/harness.ts
@@ -12,9 +12,7 @@ const json = (value: unknown): string => `${JSON.stringify(value, null, 2)}\n`;
 export function getHarnessTemplateResolver(): TemplateResolver<z.input<typeof HarnessSpecSchema>> {
   return {
     async resolve(spec) {
-      if (spec.dockerfile && !existsSync(spec.dockerfile)) {
-        throw new InputValidationError(`dockerfile not found: '${spec.dockerfile}'`);
-      }
+      validateHarnessTemplateSource(spec);
 
       // strip system prompt from harness.json to keep file as source of truth. otherwise harness.json system prompt overrides.
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -41,6 +39,12 @@ export function getHarnessTemplateResolver(): TemplateResolver<z.input<typeof Ha
       };
     },
   };
+}
+
+export function validateHarnessTemplateSource(spec: z.input<typeof HarnessSpecSchema>): void {
+  if (spec.dockerfile && !existsSync(spec.dockerfile)) {
+    throw new InputValidationError(`dockerfile not found: '${spec.dockerfile}'`);
+  }
 }
 
 function parseHarnessSpec(spec: z.input<typeof HarnessSpecSchema>) {

--- a/src/handlers/project/create/index.ts
+++ b/src/handlers/project/create/index.ts
@@ -15,7 +15,12 @@ import {
   type ScaffoldRuntimeInput,
 } from "../types";
 import { ProjectNameSchema } from "../../../projectSchemas/project";
-import { CONTAINER_URI_PATTERN, HarnessSpecSchema } from "../../../projectSchemas/harness";
+import {
+  CONTAINER_URI_PATTERN,
+  HarnessModelProviderSchema,
+  HarnessSpecSchema,
+  type HarnessModelProvider,
+} from "../../../projectSchemas/harness";
 import { InputValidationError } from "../../../errors";
 import { parseJsonFlag } from "../../utils";
 import { DEFAULT_HARNESS_MODEL } from "../add/harness";
@@ -41,7 +46,6 @@ const RUNTIME_PATH_FLAGS = [
   "build",
   "language",
   "framework",
-  "model-provider",
   "api-key",
   "runtime-name",
   "memory",
@@ -62,6 +66,16 @@ const HARNESS_ONLY_FLAGS = [
   "truncation-strategy",
   "container",
 ] as const;
+
+const ModelProviderFlagSchema = z.union([z.literal("Bedrock"), HarnessModelProviderSchema]);
+type ModelProviderFlag = z.infer<typeof ModelProviderFlagSchema>;
+
+const HARNESS_DEFAULT_MODEL_IDS: Record<HarnessModelProvider, string> = {
+  bedrock: DEFAULT_HARNESS_MODEL.modelId,
+  open_ai: "gpt-5",
+  gemini: "gemini-2.5-flash",
+  lite_llm: "anthropic/claude-sonnet-4-5",
+};
 
 export const createCreateProjectHandler = (config: CreateProjectHandlerConfig) =>
   createHandler({
@@ -99,8 +113,8 @@ export const createCreateProjectHandler = (config: CreateProjectHandlerConfig) =
       ),
       flag(
         "model-provider",
-        "model provider for the scaffolded runtime code",
-        z.enum(["Bedrock"]).optional(),
+        "model provider: bedrock, open_ai, gemini, or lite_llm for harnesses; Bedrock for runtime code",
+        ModelProviderFlagSchema.optional(),
       ),
       flag(
         "api-key",
@@ -146,9 +160,9 @@ export const createCreateProjectHandler = (config: CreateProjectHandlerConfig) =
         z.string().optional(),
       ),
       flag(
-        "no-harness-memory",
+        "harness-memory",
         "disable memory for the created harness (this is the default)",
-        z.boolean().default(false),
+        z.boolean().default(true),
       ),
       flag(
         "max-iterations",
@@ -189,7 +203,7 @@ export const createCreateProjectHandler = (config: CreateProjectHandlerConfig) =
       const presentHarnessFlags: string[] = HARNESS_ONLY_FLAGS.filter(
         (f) => flags[f] !== undefined,
       );
-      if (flags["no-harness-memory"]) presentHarnessFlags.push("no-harness-memory");
+      if (flags["harness-memory"] === false) presentHarnessFlags.push("no-harness-memory");
 
       // Mirrors the original CLI's dispatch: mixing the two paths is an error,
       // while --defaults on the runtime path is simply ignored.
@@ -275,7 +289,7 @@ type RuntimePathFlagValues = {
   build?: "CodeZip" | "Container";
   language?: "Python";
   framework?: "strands" | "none";
-  "model-provider"?: "Bedrock";
+  "model-provider"?: ModelProviderFlag;
   "api-key"?: string;
   memory?: (typeof MEMORY_SHORTCUT_NAMES)[number];
   "runtime-name"?: string;
@@ -283,6 +297,7 @@ type RuntimePathFlagValues = {
 
 type HarnessPathFlagValues = {
   name: string;
+  "model-provider"?: ModelProviderFlag;
   "model-id"?: string;
   "api-key-arn"?: string;
   "api-base"?: string;
@@ -298,6 +313,7 @@ async function resolveScaffoldRuntimeInput(
   config: CreateProjectHandlerConfig,
   flags: RuntimePathFlagValues,
 ): Promise<ScaffoldRuntimeInput> {
+  const modelProvider = resolveRuntimeModelProvider(flags["model-provider"]);
   const source = new SourceResolver({ stdin: config.io.stdin });
   const apiKey = await source.resolveSecret("api-key", flags["api-key"]);
 
@@ -308,7 +324,7 @@ async function resolveScaffoldRuntimeInput(
     ? resolveRuntimeTemplateShortcut(flags["template"], {
         runtimeName: flags["runtime-name"],
         build: flags["build"],
-        modelProvider: flags["model-provider"],
+        modelProvider,
         apiKey,
         memory: flags["memory"],
       })
@@ -317,7 +333,7 @@ async function resolveScaffoldRuntimeInput(
         build: flags["build"],
         language: flags["language"],
         framework: flags["framework"],
-        modelProvider: flags["model-provider"],
+        modelProvider,
         apiKey,
         memory: MEMORY_SHORTCUTS[flags["memory"] ?? defaultMemory](runtimeName),
         entrypoint: "main.py",
@@ -330,6 +346,7 @@ async function resolveScaffoldRuntimeInput(
 // same addResource path. Exported so the TUI create wizard builds its harness
 // input through the exact same translation as the flag-driven path.
 export function resolveScaffoldHarnessInput(flags: HarnessPathFlagValues): ScaffoldHarnessInput {
+  const provider = resolveHarnessModelProvider(flags["model-provider"]);
   const additionalParams = parseJsonFlag<Record<string, unknown>>(
     "additional-params",
     flags["additional-params"],
@@ -341,8 +358,8 @@ export function resolveScaffoldHarnessInput(flags: HarnessPathFlagValues): Scaff
     // original CLI does.
     name: flags["name"],
     model: {
-      provider: DEFAULT_HARNESS_MODEL.provider,
-      modelId: flags["model-id"] ?? DEFAULT_HARNESS_MODEL.modelId,
+      provider,
+      modelId: flags["model-id"] ?? HARNESS_DEFAULT_MODEL_IDS[provider],
       apiKeyArn: flags["api-key-arn"],
       apiBase: flags["api-base"],
       additionalParams,
@@ -362,6 +379,20 @@ export function resolveScaffoldHarnessInput(flags: HarnessPathFlagValues): Scaff
   if (!result.success)
     throw new InputValidationError(z.prettifyError(result.error), { cause: result.error });
   return input;
+}
+
+function resolveHarnessModelProvider(value: ModelProviderFlag | undefined): HarnessModelProvider {
+  return value === undefined || value === "Bedrock" ? "bedrock" : value;
+}
+
+function resolveRuntimeModelProvider(
+  value: ModelProviderFlag | undefined,
+): ScaffoldRuntimeInput["modelProvider"] | undefined {
+  if (value === undefined) return undefined;
+  if (value === "Bedrock" || value === "bedrock") return "Bedrock";
+  throw new InputValidationError(
+    `runtime scaffolding only supports the Bedrock model provider; received '${value}'`,
+  );
 }
 
 /** A --container value is either an ECR image URI or a local Dockerfile path. */

--- a/src/handlers/project/project.test.ts
+++ b/src/handlers/project/project.test.ts
@@ -133,6 +133,64 @@ describe("project create", () => {
     expect(harness.memory).toBeUndefined();
   });
 
+  test.each([
+    ["bedrock", "global.anthropic.claude-sonnet-4-6", undefined],
+    [
+      "open_ai",
+      "gpt-5",
+      "arn:aws:bedrock-agentcore:us-east-1:111122223333:token-vault/default/apikeycredentialprovider/openai",
+    ],
+    [
+      "gemini",
+      "gemini-2.5-flash",
+      "arn:aws:bedrock-agentcore:us-east-1:111122223333:token-vault/default/apikeycredentialprovider/gemini",
+    ],
+  ])(
+    "--model-provider %s selects the harness path with its provider default",
+    async (provider, modelId, apiKeyArn) => {
+      const directory = await inTempDirectory();
+      const args = ["create", "--name", "MyAgent", "--model-provider", provider];
+      if (apiKeyArn) args.push("--api-key-arn", apiKeyArn);
+
+      await run(args);
+
+      const projectRoot = join(directory, "MyAgent");
+      const spec = await Bun.file(join(projectRoot, "agentcore", "agentcore.json")).json();
+      const harness = await Bun.file(join(projectRoot, "app", "MyAgent", "harness.json")).json();
+      expect(spec.runtimes).toEqual([]);
+      expect(harness.model).toEqual({
+        provider,
+        modelId,
+        ...(apiKeyArn && { apiKeyArn }),
+      });
+    },
+  );
+
+  test("supports LiteLLM model configuration on the harness path", async () => {
+    const directory = await inTempDirectory();
+    await run([
+      "create",
+      "--name",
+      "MyAgent",
+      "--model-provider",
+      "lite_llm",
+      "--api-base",
+      "https://litellm.example.com/v1",
+      "--additional-params",
+      '{"max_retries":2}',
+    ]);
+
+    const harness = await Bun.file(
+      join(directory, "MyAgent", "app", "MyAgent", "harness.json"),
+    ).json();
+    expect(harness.model).toEqual({
+      provider: "lite_llm",
+      modelId: "anthropic/claude-sonnet-4-5",
+      apiBase: "https://litellm.example.com/v1",
+      additionalParams: { max_retries: 2 },
+    });
+  });
+
   test("--container with an image URI records containerUri on the harness", async () => {
     const directory = await inTempDirectory();
     await run([
@@ -169,6 +227,16 @@ describe("project create", () => {
     await expect(
       run(["create", "--name", "MyAgent", "--template", "hello-world-python", "--timeout", "9"]),
     ).rejects.toThrow(/harness-only flags \(--timeout\)/);
+    await expect(
+      run([
+        "create",
+        "--name",
+        "MyAgent",
+        "--template",
+        "hello-world-python",
+        "--no-harness-memory",
+      ]),
+    ).rejects.toThrow(/harness-only flags \(--no-harness-memory\)/);
   });
 
   test("--defaults is ignored when a runtime path flag routes to scaffolding", async () => {
@@ -366,6 +434,22 @@ describe("project create", () => {
       runtimeVersion: "PYTHON_3_14",
     });
     expect(await Bun.file(join(projectRoot, "app", "custom_agent", "main.py")).exists()).toBe(true);
+  });
+
+  test("rejects non-Bedrock model providers on the runtime path", async () => {
+    const directory = await inTempDirectory();
+    await expect(
+      run([
+        "create",
+        "--name",
+        "MyProject",
+        "--template",
+        "strands-python",
+        "--model-provider",
+        "open_ai",
+      ]),
+    ).rejects.toThrow(/runtime scaffolding only supports the Bedrock model provider/);
+    expect(existsSync(join(directory, "MyProject"))).toBe(false);
   });
 
   test("scaffolds a Container agent from the strands template", async () => {


### PR DESCRIPTION
## Context

PR #2146 made harnesses the default `project create` path. Testing that merged behavior found three regressions in the new path. This PR fixes those regressions without changing the existing Bedrock runtime-scaffolding contract.

## Bugs fixed

### 1. Harness model-provider options routed incorrectly

`project create` exposed harness flags for API keys, LiteLLM API base URLs, and provider-specific parameters, but it always wrote `provider: "bedrock"` into `harness.json`. The shared `--model-provider` flag also selected the runtime-scaffolding path by itself. As a result:

- `--api-base` and `--additional-params` always failed validation because they are valid only for LiteLLM.
- `--model-provider open_ai`, `gemini`, or `lite_llm` failed to create a harness.
- Provider-specific default model IDs from the original CLI were unavailable.

The fix keeps Bedrock as the default and restores these harness providers:

- `bedrock` defaults to `global.anthropic.claude-sonnet-4-6`.
- `open_ai` defaults to `gpt-5` and requires `--api-key-arn`.
- `gemini` defaults to `gemini-2.5-flash` and requires `--api-key-arn`.
- `lite_llm` defaults to `anthropic/claude-sonnet-4-5` and accepts `--api-base` and `--additional-params`.

`--model-provider` no longer selects the runtime path on its own. Explicit runtime flags such as `--template`, `--framework`, or `--build` still select runtime scaffolding, where Bedrock remains the only supported model provider.

### 2. A missing Dockerfile left a partial project

For `project create --container <Dockerfile>`, the project manager wrote the base project and CDK files before the harness template checked whether the source Dockerfile existed. A missing file therefore left a partial project directory. Retrying the command then failed because scaffolded files already existed.

The project manager now validates the harness template source before writing the base project tree. A missing Dockerfile returns the existing validation error and leaves no project directory behind.

### 3. `--no-harness-memory` bypassed mixed-flag validation

The flag was registered internally as `no-harness-memory`. Commander treats `--no-*` options as negations and stores their value under the positive attribute name. The router read both an explicit `--no-harness-memory` and an omitted flag as `false`, so this invalid combination created a runtime project:

```bash
agentcore project create \
  --name MyProject \
  --template hello-world-python \
  --no-harness-memory
```

The flag is now represented internally as the positive `harness-memory` boolean while the CLI continues to expose `--no-harness-memory`. The create handler now detects the explicit negation and rejects mixed harness/runtime flags before writing files.

## Validation

### Automated

- `bun test src/handlers/project/project.test.ts src/core/project/manager.test.ts`
  - 129 passed, 0 failed
- `bun test src`
  - 2,556 passed, 0 failed across 185 files
- `bun run typecheck`
- `bun run lint:check`
- `bun run format:check`
- `bun run build`

### Bundled CLI smoke tests

The bundled `dist/index.js` was exercised directly with isolated project directories:

- Explicit `bedrock`, `open_ai`, `gemini`, and `lite_llm` harness creation produced the expected provider-specific model configuration.
- LiteLLM preserved `apiBase` and `additionalParams` in `harness.json`.
- `--template strands-python --model-provider Bedrock` still created a runtime project.
- A non-Bedrock provider on the runtime path failed before writing a project.
- OpenAI without `--api-key-arn` failed before writing a project.
- A missing Dockerfile failed before writing a project.
- Mixing `--template` with `--no-harness-memory` failed before writing a project.

No AWS resources were required for these validation paths.
