### PR TITLE
test(feedback): fix root command-tree assertion broken by the feedback command

### DIFF
--- a/src/handlers/root.test.tsx
+++ b/src/handlers/root.test.tsx
@@ -17,6 +17,7 @@ describe("createRootHandler", () => {
       "memory",
       "gateway",
       "eval",
+      "feedback",
       "config",
       "project",
     ]);


### PR DESCRIPTION
## Why

CI on #2149 fails one unit test: `createRootHandler > builds the agentcore command tree with its subcommands` (`src/handlers/root.test.tsx`). Registering the `feedback` command on the root handler added a subcommand the test's hard-coded expected list didn't include ("Received +1").

## Fix

One line: add `"feedback"` to the expected `root.children()` list, in its registration position (after `eval`, before `config`).

## Notes

- Stacked on `feat/feedback-command` (the feedback-port branch), so this diff is just the test update. Merging it into that branch turns #2149 green.
- `bun test src/handlers/root.test.tsx` → 1 pass.