### PR TITLE
feat(templates): support containers for ts http runtime

### DIFF
--- a/src/assets/templates/strands-http-typescript/Dockerfile.template
+++ b/src/assets/templates/strands-http-typescript/Dockerfile.template
@@ -1,0 +1,25 @@
+FROM public.ecr.aws/docker/library/node:22-slim
+
+WORKDIR /app
+
+ENV NODE_ENV=production \
+    DOCKER_CONTAINER=1
+
+RUN userdel -r node 2>/dev/null || true
+RUN useradd -m -u 1000 bedrock_agentcore
+
+COPY package.json package-lock.json* ./
+RUN npm ci --omit=dev || npm install --omit=dev
+
+COPY --chown=bedrock_agentcore:bedrock_agentcore . .
+
+USER bedrock_agentcore
+
+# AgentCore Runtime service contract ports
+# https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-service-contract.html
+# 8080: HTTP Mode
+# 8000: MCP Mode
+# 9000: A2A Mode
+EXPOSE 8080 8000 9000
+
+CMD ["npx", "tsx", "main.ts"]

--- a/src/assets/templates/strands-http-typescript/dockerignore.template
+++ b/src/assets/templates/strands-http-typescript/dockerignore.template
@@ -1,0 +1,24 @@
+# Node
+node_modules/
+dist/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# IDE
+.vscode/
+.idea/
+
+# Testing
+coverage/
+
+# Secrets and environment files
+.env
+.env.*
+
+# Version control
+.git/
+
+# AgentCore build artifacts
+.agentcore/artifacts/
+*.zip

--- a/src/core/project/manager.test.ts
+++ b/src/core/project/manager.test.ts
@@ -229,6 +229,35 @@ describe("FsProjectManager.create", () => {
     expect(commands).toEqual([{ command: ["git", "init"], cwd: join(directory, "example") }]);
   });
 
+  test.each([
+    [
+      "Python",
+      resolveRuntimeTemplateShortcut("strands-python", { build: "Container" }),
+      ["uv", "lock"],
+    ],
+    [
+      "TypeScript",
+      resolveRuntimeTemplateShortcut("strands-ts", { build: "Container" }),
+      ["npm", "install", "--package-lock-only"],
+    ],
+  ])(
+    "skipInstall still generates the container lockfile for %s",
+    async (_label, scaffoldRuntimeInput, lockCommand) => {
+      const directory = await inTempDirectory();
+      const { manager: subject, commands } = manager();
+      await runCreate(subject, {
+        name: "example",
+        scaffoldRuntimeInput,
+        skipInstall: true,
+        skipGit: true,
+      });
+
+      expect(commands).toEqual([
+        { command: lockCommand, cwd: join(directory, "example", "app", "strands_agent") },
+      ]);
+    },
+  );
+
   test("skipGit skips git init", async () => {
     await inTempDirectory();
     const { manager: subject, commands } = manager();

--- a/src/core/project/manager.tsx
+++ b/src/core/project/manager.tsx
@@ -195,7 +195,7 @@ export class FsProjectManager implements ProjectManager {
         yield* this.installRuntimeDependencies(appDir);
       }
     } else if (scaffoldRuntimeInput?.build === "Container") {
-      // containers require uv.lock to build, so even with no-install we must generate the lock.
+      // Container builds install from a lockfile, so generate it even with no-install.
       const appDir = join(destination, "app", scaffoldRuntimeInput.runtimeName);
       yield* this.ensureLockFileExists(appDir);
     }
@@ -1024,23 +1024,32 @@ export class FsProjectManager implements ProjectManager {
     }
   }
 
-  /**
-   * Check if the uv.lock file exists within the project, and generate it if missing.
-   */
+  /** Generates the container build's lockfile (uv.lock / package-lock.json) when its manifest exists but the lockfile does not. */
   private async *ensureLockFileExists(appDir: string): AsyncGenerator<ProjectEvent, void> {
-    if (!existsSync(join(appDir, "pyproject.toml")) || existsSync(join(appDir, "uv.lock"))) {
+    const lockfileSpecs = [
+      { manifest: "pyproject.toml", lockfile: "uv.lock", command: ["uv", "lock"] },
+      {
+        manifest: "package.json",
+        lockfile: "package-lock.json",
+        command: ["npm", "install", "--package-lock-only"],
+      },
+    ];
+    for (const { manifest, lockfile, command } of lockfileSpecs) {
+      if (!existsSync(join(appDir, manifest)) || existsSync(join(appDir, lockfile))) {
+        continue;
+      }
+      yield { message: `Generating ${lockfile} for container build` };
+      try {
+        await this.run(command, appDir);
+      } catch {
+        yield {
+          message:
+            `Warning: could not generate ${lockfile} in ${appDir}. ` +
+            `Run \`${command.join(" ")}\` there before \`agentcore project dev\` or \`deploy\` — ` +
+            "container builds install from it.",
+        };
+      }
       return;
-    }
-    yield { message: "Generating uv.lock for container build" };
-    try {
-      await this.run(["uv", "lock"], appDir);
-    } catch {
-      yield {
-        message:
-          `Warning: could not generate uv.lock in ${appDir} (is uv installed?). ` +
-          "Run `uv lock` there before `agentcore project dev` or `deploy` — " +
-          "container builds install from uv.lock.",
-      };
     }
   }
 

--- a/src/core/project/templates/runtime.ts
+++ b/src/core/project/templates/runtime.ts
@@ -201,9 +201,6 @@ const getTemplateResolvers = (assetSource: AssetSource, templateRenderer: Templa
     if (input.protocol !== undefined && input.protocol !== "HTTP")
       throw new InputValidationError("the strands-ts template only supports HTTP");
 
-    if (input.scaffoldRuntimeInput.build !== "CodeZip")
-      throw new InputValidationError("the strands template only supports CodeZip builds");
-
     const memory = input.scaffoldRuntimeInput.memory;
     // The TypeScript strands SDK's createAgentCoreMemoryStores requires at least one
     // namespace, so short-term-only memory (no long-term strategies) is unsupported.
@@ -223,13 +220,18 @@ const getTemplateResolvers = (assetSource: AssetSource, templateRenderer: Templa
       hasIdentity: false,
       identityProviders: [],
     };
+    const isContainer = input.scaffoldRuntimeInput.build === "Container";
     const tree = await FsTreeNode.fromAssetSource(
       { assetSource },
       { assetDir: "templates/strands-http-typescript" },
       {
         rootDirName: input.name,
         transformContent: (raw) => templateRenderer.render(raw, context),
-        filter: (name, isDir) => memory !== undefined || !isDir || name !== "memory",
+        filter: (name, isDir) => {
+          if (isDir && name === "memory") return memory !== undefined;
+          if (name === "Dockerfile" || name === ".dockerignore") return isContainer;
+          return true;
+        },
       },
     );
     return {

--- a/src/handlers/project/add/runtime/index.test.ts
+++ b/src/handlers/project/add/runtime/index.test.ts
@@ -465,15 +465,35 @@ describe("project add runtime", () => {
       ],
       [],
     ],
+    [
+      "template overrides to Container",
+      ["--name", "my_agent", "--template", "strands-ts", "--build", "Container"],
+      ["SEMANTIC", "USER_PREFERENCE", "SUMMARIZATION", "EPISODIC"],
+    ],
   ])("strands-ts %s scaffolds a TypeScript agent", async (_label, flags, expectedStrategies) => {
     const projectRoot = await inProject();
     await run(["add", "runtime", ...flags]);
+
+    const buildFlagIndex = flags.indexOf("--build");
+    const isContainer = buildFlagIndex >= 0 && flags[buildFlagIndex + 1] === "Container";
 
     const spec = await Bun.file(join(projectRoot, "agentcore", "agentcore.json")).json();
     const runtime = spec.runtimes.find(
       (candidate: { name: string }) => candidate.name === "my_agent",
     );
-    expect(runtime).toMatchObject({ entrypoint: "main.js", runtimeVersion: "NODE_22" });
+    expect(runtime).toMatchObject({
+      entrypoint: "main.js",
+      ...(isContainer
+        ? { build: "Container", dockerfile: "Dockerfile" }
+        : { build: "CodeZip", runtimeVersion: "NODE_22" }),
+    });
+    expect(runtime.runtimeVersion).toBe(isContainer ? undefined : "NODE_22");
+    expect(await Bun.file(join(projectRoot, "app", "my_agent", "Dockerfile")).exists()).toBe(
+      isContainer,
+    );
+    expect(await Bun.file(join(projectRoot, "app", "my_agent", ".dockerignore")).exists()).toBe(
+      isContainer,
+    );
 
     const memory = (spec.memories ?? []).find(
       (candidate: { name: string }) => candidate.name === "my_agentMemory",


### PR DESCRIPTION
### Problem
The strands ts template does not yet support container builds. 

### Solution 
- copy the dockerfile/dockerignore from mainline, and mirror the pattern done for the strands-py template. z

### Testing / Verification
```
$ agentcore project create --name tsTest --template strands-ts --build Container
Creating project tree
Installing CDK dependencies with npm
Installing Node dependencies with npm
Initializing git repository
Created project 'tsTest' in ./tsTest
To deploy it: cd tsTest && agentcore project deploy

$ cd tsTest

$ agentcore project add runtime --name bob --template strands-ts --build Container --memory none
Reading project spec file at '[..]'
Scaffolding runtime in project
Installing Node dependencies with npm
Updating project spec file at '[..]'
added runtime 'bob' to 'tsTest'

$ agentcore project dev --mode headless --agent bob

[seperate terminal] 
$ curl -N -X POST http://localhost:8080/invocations \
    -H "Content-Type: application/json" -H "Accept: text/event-stream" \
    -H "X-Amzn-Bedrock-AgentCore-Runtime-Session-Id: <session-id>" \
    -d '{"prompt":"Say hello in exactly 3 words."}'
data: "Hello to"

data: " you!"

[back to original]
$ agentcore project dev
Created default deployment target: account 440744214761, region us-east-1 (agentcore/aws-targets.json)
Verifying AWS account 440744214761
Synthesizing CloudFormation templates
Deploying AgentCore-tsTest-default

```

went to console and invoked both created agents. 