### PR TITLE
feat(templates): support strands py a2a templates

### DIFF
--- a/src/assets/templates/strands-py-a2a/Dockerfile.template
+++ b/src/assets/templates/strands-py-a2a/Dockerfile.template
@@ -1,0 +1,40 @@
+FROM public.ecr.aws/docker/library/python:3.12-slim-trixie
+
+RUN pip install --no-cache-dir uv
+
+ARG UV_DEFAULT_INDEX
+ARG UV_INDEX
+
+WORKDIR /app
+
+ENV UV_SYSTEM_PYTHON=1 \
+    UV_COMPILE_BYTECODE=1 \
+    UV_NO_PROGRESS=1 \
+    PYTHONUNBUFFERED=1 \
+    DOCKER_CONTAINER=1 \
+    UV_DEFAULT_INDEX=${UV_DEFAULT_INDEX} \
+    UV_INDEX=${UV_INDEX} \
+    PATH="/app/.venv/bin:$PATH"
+
+RUN useradd -m -u 1000 bedrock_agentcore
+
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-dev --no-install-project
+
+COPY --chown=bedrock_agentcore:bedrock_agentcore . .
+RUN uv sync --frozen --no-dev
+
+USER bedrock_agentcore
+
+# AgentCore Runtime service contract ports
+# https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-service-contract.html
+# 8080: HTTP Mode
+# 8000: MCP Mode
+# 9000: A2A Mode
+EXPOSE 8080 8000 9000
+
+{{#if enableOtel}}
+CMD ["opentelemetry-instrument", "python", "-m", "{{entrypoint}}"]
+{{else}}
+CMD ["python", "-m", "{{entrypoint}}"]
+{{/if}}

--- a/src/assets/templates/strands-py-a2a/README.md
+++ b/src/assets/templates/strands-py-a2a/README.md
@@ -1,0 +1,31 @@
+# {{ name }}
+
+An A2A (Agent-to-Agent) agent deployed on Amazon Bedrock AgentCore using the Strands SDK.
+
+## Overview
+
+This agent speaks the A2A protocol. Other agents discover it via its agent card at
+`/.well-known/agent-card.json` and invoke it with JSON-RPC (`message/send`, `message/stream`)
+at the server root, matching the AgentCore Runtime A2A service contract.
+
+## Adding Tools
+
+Define tools with the `@tool` decorator in `main.py` and add them to the `tools` list:
+
+```python
+@tool
+def my_tool(param: str) -> str:
+    """Description of what the tool does."""
+    return f"Result: {param}"
+```
+
+## Developing locally
+
+`agentcore project dev` starts the agent locally on `0.0.0.0:9000`. Fetch its agent card at
+`http://127.0.0.1:9000/.well-known/agent-card.json` and send it messages by posting A2A
+JSON-RPC to `http://127.0.0.1:9000/`.
+
+## Deployment
+
+`agentcore project deploy` deploys the agent into Amazon Bedrock AgentCore. Invoke it with the
+AWS CLI (`bedrock-agentcore invoke-agent-runtime`) using an A2A JSON-RPC payload.

--- a/src/assets/templates/strands-py-a2a/dockerignore.template
+++ b/src/assets/templates/strands-py-a2a/dockerignore.template
@@ -1,0 +1,27 @@
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+dist/
+build/
+
+# IDE
+.vscode/
+.idea/
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Secrets and environment files
+.env
+.env.*
+
+# Version control
+.git/
+
+# AgentCore build artifacts
+.agentcore/artifacts/
+*.zip

--- a/src/assets/templates/strands-py-a2a/gitignore.template
+++ b/src/assets/templates/strands-py-a2a/gitignore.template
@@ -1,0 +1,41 @@
+# Environment variables
+.env
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environments
+.venv/
+venv/
+ENV/
+env/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db

--- a/src/assets/templates/strands-py-a2a/main.py
+++ b/src/assets/templates/strands-py-a2a/main.py
@@ -1,0 +1,95 @@
+from strands import Agent, tool
+from strands.multiagent.a2a.executor import StrandsA2AExecutor
+from bedrock_agentcore.runtime import serve_a2a
+from model.load import load_model
+{{#if needsOs}}
+import os
+{{/if}}
+
+
+@tool
+def add_numbers(a: int, b: int) -> int:
+    """Return the sum of two numbers."""
+    return a + b
+
+
+tools = [add_numbers]
+
+{{#if needsOs}}
+_MOUNT_PATHS = [
+    {{#if sessionStorageMountPath}}"{{sessionStorageMountPath}}",{{/if}}
+    {{#each efsMounts}}"{{mountPath}}",{{/each}}
+    {{#each s3Mounts}}"{{mountPath}}",{{/each}}
+]
+
+def _safe_resolve(path: str) -> str:
+    resolved = os.path.realpath(path)
+    if not any(resolved == os.path.realpath(m) or resolved.startswith(os.path.realpath(m) + os.sep) for m in _MOUNT_PATHS):
+        raise ValueError(f"Path '{path}' is not within any configured mount ({', '.join(_MOUNT_PATHS)})")
+    return resolved
+
+@tool
+def file_read(path: str) -> str:
+    """Read a file from a mounted filesystem. Use the absolute path (e.g. /mnt/tools/data.txt)."""
+    try:
+        full_path = _safe_resolve(path)
+        with open(full_path) as f:
+            return f.read()
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error reading '{path}': {e.strerror}"
+
+@tool
+def file_write(path: str, content: str) -> str:
+    """Write a file to a mounted filesystem. Use the absolute path (e.g. /mnt/tools/data.txt)."""
+    try:
+        full_path = _safe_resolve(path)
+        parent = os.path.dirname(full_path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with open(full_path, "w") as f:
+            f.write(content)
+        return f"Written to {path}"
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error writing '{path}': {e.strerror}"
+
+@tool
+def list_files(path: str) -> str:
+    """List files in a mounted filesystem directory. Use the absolute path (e.g. /mnt/tools)."""
+    try:
+        full_path = _safe_resolve(path)
+        entries = os.listdir(full_path)
+        return "\n".join(entries) if entries else "(empty directory)"
+    except ValueError as e:
+        return str(e)
+    except OSError as e:
+        return f"Error listing '{path}': {e.strerror}"
+
+tools.extend([file_read, file_write, list_files])
+{{/if}}
+
+SYSTEM_PROMPT = """
+You are a helpful assistant. Use tools when appropriate.
+{{#if needsOs}}
+You have access to the following mounted filesystems. Use file_read, file_write, and list_files with full absolute paths:
+{{#if sessionStorageMountPath}}- {{sessionStorageMountPath}}: ephemeral session storage (lost when session ends)
+{{/if}}{{#each efsMounts}}- {{mountPath}}: EFS persistent storage (persists across sessions and agent restarts)
+{{/each}}{{#each s3Mounts}}- {{mountPath}}: S3 Files persistent storage (durable, backed by S3)
+{{/each}}{{/if}}
+"""
+
+agent = Agent(
+    name="{{ name }}",
+    model=load_model(),
+    system_prompt=SYSTEM_PROMPT,
+    tools=tools,
+)
+
+# serve_a2a binds 0.0.0.0:9000 in the container (the AgentCore A2A service
+# contract) and publishes the agent card at /.well-known/agent-card.json. The
+# card is derived by introspecting the executor's agent.
+if __name__ == "__main__":
+    serve_a2a(StrandsA2AExecutor(agent))

--- a/src/assets/templates/strands-py-a2a/main.py
+++ b/src/assets/templates/strands-py-a2a/main.py
@@ -2,6 +2,9 @@ from strands import Agent, tool
 from strands.multiagent.a2a.executor import StrandsA2AExecutor
 from bedrock_agentcore.runtime import serve_a2a
 from model.load import load_model
+{{#if hasMemory}}
+from memory.session import get_memory_session_manager
+{{/if}}
 {{#if needsOs}}
 import os
 {{/if}}
@@ -81,9 +84,15 @@ You have access to the following mounted filesystems. Use file_read, file_write,
 {{/each}}{{/if}}
 """
 
+# serve_a2a serves one agent instance, so it is bound to a fixed session and
+# actor; get_memory_session_manager returns None (in-process history only) until
+# the deployed MEMORY_ID env var is set by the CDK.
 agent = Agent(
     name="{{ name }}",
     model=load_model(),
+{{#if hasMemory}}
+    session_manager=get_memory_session_manager("default-session", "default-user"),
+{{/if}}
     system_prompt=SYSTEM_PROMPT,
     tools=tools,
 )

--- a/src/assets/templates/strands-py-a2a/memory/session.py
+++ b/src/assets/templates/strands-py-a2a/memory/session.py
@@ -1,0 +1,47 @@
+import os
+import uuid
+from typing import Optional
+
+from bedrock_agentcore.memory.integrations.strands.config import AgentCoreMemoryConfig{{#if memoryStrategies.length}}, RetrievalConfig{{/if}}
+from bedrock_agentcore.memory.integrations.strands.session_manager import AgentCoreMemorySessionManager
+
+MEMORY_ID = os.getenv("{{memoryEnvVarName}}")
+REGION = os.getenv("AWS_REGION")
+
+
+def get_memory_session_manager(
+    session_id: Optional[str], actor_id: str
+) -> Optional[AgentCoreMemorySessionManager]:
+    if not MEMORY_ID:
+        return None
+
+    session_id = session_id or uuid.uuid4().hex
+
+{{#if memoryStrategies.length}}
+    retrieval_config = {
+{{#if (includes memoryStrategies "SEMANTIC")}}
+        f"/users/{actor_id}/facts": RetrievalConfig(top_k=3, relevance_score=0.5),
+{{/if}}
+{{#if (includes memoryStrategies "USER_PREFERENCE")}}
+        f"/users/{actor_id}/preferences": RetrievalConfig(top_k=3, relevance_score=0.5),
+{{/if}}
+{{#if (includes memoryStrategies "EPISODIC")}}
+        f"/episodes/{actor_id}/{session_id}": RetrievalConfig(top_k=5, relevance_score=0.5),
+{{/if}}
+{{#if (includes memoryStrategies "SUMMARIZATION")}}
+        f"/summaries/{actor_id}": RetrievalConfig(top_k=3, relevance_score=0.5),
+{{/if}}
+    }
+{{/if}}
+
+    return AgentCoreMemorySessionManager(
+        AgentCoreMemoryConfig(
+            memory_id=MEMORY_ID,
+            session_id=session_id,
+            actor_id=actor_id,
+{{#if memoryStrategies.length}}
+            retrieval_config=retrieval_config,
+{{/if}}
+        ),
+        REGION,
+    )

--- a/src/assets/templates/strands-py-a2a/model/__init__.py
+++ b/src/assets/templates/strands-py-a2a/model/__init__.py
@@ -1,0 +1,1 @@
+# Package marker

--- a/src/assets/templates/strands-py-a2a/model/load.py
+++ b/src/assets/templates/strands-py-a2a/model/load.py
@@ -1,0 +1,239 @@
+{{#if (eq modelProvider "Bedrock")}}
+{{#if bedrockMantle}}
+import os
+
+from aws_bedrock_token_generator import provide_token
+{{#if (eq mantleApiFormat "chat_completions")}}
+from strands.models.openai import OpenAIModel
+{{else}}
+{{#if mantleProprietary}}
+from strands.models.openai_responses import OpenAIResponsesModel
+{{else}}
+from model.mantle_compat import MantleCompatResponsesModel
+{{/if}}
+{{/if}}
+
+MODEL_ID = "{{modelId}}"
+
+
+def load_model():
+    """
+    Get a Bedrock Mantle model client. These OpenAI-compatible models (e.g. openai.gpt-5.5,
+    openai.gpt-oss-120b) are served via the Bedrock Mantle endpoint, NOT the Converse API — so they
+    are invoked through an OpenAI-style client authenticated with a short-lived Bedrock bearer token.
+    Region is read from AWS_REGION (set by the AgentCore runtime).
+    """
+    region = os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", "us-east-1"))
+    token = provide_token(region=region)
+    {{#if mantleProprietary}}
+    # Proprietary OpenAI models only work on the /openai/v1 Mantle path.
+    base_url = f"https://bedrock-mantle.{region}.api.aws/openai/v1"
+    {{else}}
+    # Open-source OpenAI models (gpt-oss-*) only work on the /v1 Mantle path.
+    base_url = f"https://bedrock-mantle.{region}.api.aws/v1"
+    {{/if}}
+    client_args = {"api_key": token, "base_url": base_url}
+
+    params = {}
+    {{#if modelMaxTokens}}
+    {{#if (eq mantleApiFormat "chat_completions")}}
+    params["max_completion_tokens"] = {{modelMaxTokens}}
+    {{else}}
+    params["max_output_tokens"] = {{modelMaxTokens}}
+    {{/if}}
+    {{/if}}
+    {{#if modelTemperature}}
+    params["temperature"] = {{modelTemperature}}
+    {{/if}}
+    {{#if modelTopP}}
+    params["top_p"] = {{modelTopP}}
+    {{/if}}
+    {{#if (eq mantleApiFormat "chat_completions")}}
+    return OpenAIModel(client_args=client_args, model_id=MODEL_ID, params=params)
+    {{else}}
+    # Responses API: Mantle does not persist responses, so disable server-side storage.
+    params["store"] = False
+    {{#if mantleProprietary}}
+    return OpenAIResponsesModel(client_args=client_args, model_id=MODEL_ID, params=params)
+    {{else}}
+    return MantleCompatResponsesModel(client_args=client_args, model_id=MODEL_ID, params=params)
+    {{/if}}
+    {{/if}}
+{{else}}
+from strands.models.bedrock import BedrockModel
+
+
+def load_model() -> BedrockModel:
+    """Get Bedrock model client using IAM credentials."""
+    return BedrockModel(model_id="{{#if modelId}}{{modelId}}{{else}}global.anthropic.claude-sonnet-4-5-20250929-v1:0{{/if}}"{{#if modelMaxTokens}}, max_tokens={{modelMaxTokens}}{{/if}}{{#if modelTemperature}}, temperature={{modelTemperature}}{{/if}}{{#if modelTopP}}, top_p={{modelTopP}}{{/if}})
+{{/if}}
+{{/if}}
+{{#if (eq modelProvider "Anthropic")}}
+import os
+
+from strands.models.anthropic import AnthropicModel
+from bedrock_agentcore.identity.auth import requires_api_key
+
+IDENTITY_PROVIDER_NAME = "{{identityProviders.[0].name}}"
+IDENTITY_ENV_VAR = "{{identityProviders.[0].envVarName}}"
+
+
+@requires_api_key(provider_name=IDENTITY_PROVIDER_NAME)
+def _agentcore_identity_api_key_provider(api_key: str) -> str:
+    """Fetch API key from AgentCore Identity."""
+    return api_key
+
+
+def _get_api_key() -> str:
+    """
+    Uses AgentCore Identity for API key management in deployed environments.
+    For local development, run via 'agentcore dev' which loads agentcore/.env.
+    """
+    if os.getenv("LOCAL_DEV") == "1":
+        api_key = os.getenv(IDENTITY_ENV_VAR)
+        if not api_key:
+            raise RuntimeError(
+                f"{IDENTITY_ENV_VAR} not found. Add {IDENTITY_ENV_VAR}=your-key to .env.local"
+            )
+        return api_key
+    return _agentcore_identity_api_key_provider()
+
+
+def load_model() -> AnthropicModel:
+    """Get authenticated Anthropic model client."""
+    return AnthropicModel(
+        client_args={"api_key": _get_api_key()},
+        model_id="claude-sonnet-4-5-20250929",
+        max_tokens=5000,
+    )
+{{/if}}
+{{#if (eq modelProvider "OpenAI")}}
+import os
+
+from strands.models.openai import OpenAIModel
+from bedrock_agentcore.identity.auth import requires_api_key
+
+IDENTITY_PROVIDER_NAME = "{{identityProviders.[0].name}}"
+IDENTITY_ENV_VAR = "{{identityProviders.[0].envVarName}}"
+
+
+@requires_api_key(provider_name=IDENTITY_PROVIDER_NAME)
+def _agentcore_identity_api_key_provider(api_key: str) -> str:
+    """Fetch API key from AgentCore Identity."""
+    return api_key
+
+
+def _get_api_key() -> str:
+    """
+    Uses AgentCore Identity for API key management in deployed environments.
+    For local development, run via 'agentcore dev' which loads agentcore/.env.
+    """
+    if os.getenv("LOCAL_DEV") == "1":
+        api_key = os.getenv(IDENTITY_ENV_VAR)
+        if not api_key:
+            raise RuntimeError(
+                f"{IDENTITY_ENV_VAR} not found. Add {IDENTITY_ENV_VAR}=your-key to .env.local"
+            )
+        return api_key
+    return _agentcore_identity_api_key_provider()
+
+
+def load_model() -> OpenAIModel:
+    """Get authenticated OpenAI model client."""
+    return OpenAIModel(
+        client_args={"api_key": _get_api_key()},
+        model_id="{{#if modelId}}{{modelId}}{{else}}gpt-4.1{{/if}}",
+    )
+{{/if}}
+{{#if (eq modelProvider "Gemini")}}
+import os
+
+from strands.models.gemini import GeminiModel
+from bedrock_agentcore.identity.auth import requires_api_key
+
+IDENTITY_PROVIDER_NAME = "{{identityProviders.[0].name}}"
+IDENTITY_ENV_VAR = "{{identityProviders.[0].envVarName}}"
+
+
+@requires_api_key(provider_name=IDENTITY_PROVIDER_NAME)
+def _agentcore_identity_api_key_provider(api_key: str) -> str:
+    """Fetch API key from AgentCore Identity."""
+    return api_key
+
+
+def _get_api_key() -> str:
+    """
+    Uses AgentCore Identity for API key management in deployed environments.
+    For local development, run via 'agentcore dev' which loads agentcore/.env.
+    """
+    if os.getenv("LOCAL_DEV") == "1":
+        api_key = os.getenv(IDENTITY_ENV_VAR)
+        if not api_key:
+            raise RuntimeError(
+                f"{IDENTITY_ENV_VAR} not found. Add {IDENTITY_ENV_VAR}=your-key to .env.local"
+            )
+        return api_key
+    return _agentcore_identity_api_key_provider()
+
+
+def load_model() -> GeminiModel:
+    """Get authenticated Gemini model client."""
+    return GeminiModel(
+        client_args={"api_key": _get_api_key()},
+        model_id="{{#if modelId}}{{modelId}}{{else}}gemini-2.5-flash{{/if}}",
+    )
+{{/if}}
+{{#if (eq modelProvider "LiteLLM")}}
+import os
+{{#if litellmAdditionalParams}}
+import json
+{{/if}}
+
+from strands.models.litellm import LiteLLMModel
+{{#if identityProviders.[0].name}}
+from bedrock_agentcore.identity.auth import requires_api_key
+
+IDENTITY_PROVIDER_NAME = "{{identityProviders.[0].name}}"
+IDENTITY_ENV_VAR = "{{identityProviders.[0].envVarName}}"
+
+
+@requires_api_key(provider_name=IDENTITY_PROVIDER_NAME)
+def _agentcore_identity_api_key_provider(api_key: str) -> str:
+    """Fetch API key from AgentCore Identity."""
+    return api_key
+
+
+def _get_api_key() -> str:
+    """
+    Uses AgentCore Identity for API key management in deployed environments.
+    For local development, run via 'agentcore dev' which loads agentcore/.env.
+    """
+    if os.getenv("LOCAL_DEV") == "1":
+        api_key = os.getenv(IDENTITY_ENV_VAR)
+        if not api_key:
+            raise RuntimeError(
+                f"{IDENTITY_ENV_VAR} not found. Add {IDENTITY_ENV_VAR}=your-key to .env.local"
+            )
+        return api_key
+    return _agentcore_identity_api_key_provider()
+{{/if}}
+
+
+
+
+def load_model() -> LiteLLMModel:
+    """Get a LiteLLM model client (proxies to the provider encoded in model_id)."""
+    client_args = {}
+    {{#if identityProviders.[0].name}}
+    client_args["api_key"] = _get_api_key()
+    {{/if}}
+    {{#if litellmApiBase}}
+    client_args["api_base"] = {{safeJson litellmApiBase}}
+    {{/if}}
+    params = {{#if litellmAdditionalParams}}json.loads({{pyJsonStr litellmAdditionalParams}}){{else}}{}{{/if}}
+    return LiteLLMModel(
+        client_args=client_args,
+        model_id="{{#if modelId}}{{modelId}}{{else}}bedrock/us.anthropic.claude-sonnet-4-5-20250514-v1:0{{/if}}",
+        params=params,
+    )
+{{/if}}

--- a/src/assets/templates/strands-py-a2a/pyproject.toml
+++ b/src/assets/templates/strands-py-a2a/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["hatchling ~= 1.27.0"]
+build-backend = "hatchling.build"
+
+[project]
+name = "{{ name }}"
+version = "0.1.0"
+description = "AgentCore A2A Agent using Strands SDK"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    {{#if (eq modelProvider "Anthropic")}}"anthropic ~= 0.30.0",
+    {{/if}}"a2a-sdk[all] >= 0.3.0, < 0.4.0",
+    "aws-opentelemetry-distro ~= 0.17.0",
+    "bedrock-agentcore[a2a] ~= 1.9.1",
+    "botocore[crt] ~= 1.43.0",
+    {{#if (eq modelProvider "Gemini")}}"google-genai ~= 1.0.0",
+    {{/if}}{{#if (eq modelProvider "OpenAI")}}"openai ~= 1.0.0",
+    {{/if}}{{#if (eq modelProvider "LiteLLM")}}"litellm ~= 1.0.0",
+    {{/if}}"strands-agents ~= 1.15.0",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]

--- a/src/core/project/__snapshots__/manager.test.ts.snap
+++ b/src/core/project/__snapshots__/manager.test.ts.snap
@@ -176,3 +176,42 @@ exports[`FsProjectManager.create snapshots the Strands TypeScript project manife
   ],
 }
 `;
+
+exports[`FsProjectManager.create snapshots the Strands A2A project manifest and runtime spec 1`] = `
+{
+  "manifest": [
+    ".gitignore",
+    "agentcore/.env.local",
+    "agentcore/agentcore.json",
+    "agentcore/aws-targets.json",
+    "agentcore/cdk/.gitignore",
+    "agentcore/cdk/.npmignore",
+    "agentcore/cdk/.prettierrc",
+    "agentcore/cdk/README.md",
+    "agentcore/cdk/bin/cdk.ts",
+    "agentcore/cdk/cdk.json",
+    "agentcore/cdk/jest.config.js",
+    "agentcore/cdk/lib/cdk-stack.ts",
+    "agentcore/cdk/package.json",
+    "agentcore/cdk/test/cdk.test.ts",
+    "agentcore/cdk/tsconfig.json",
+    "app/a2a_agent/.gitignore",
+    "app/a2a_agent/README.md",
+    "app/a2a_agent/main.py",
+    "app/a2a_agent/model/__init__.py",
+    "app/a2a_agent/model/load.py",
+    "app/a2a_agent/pyproject.toml",
+  ],
+  "memories": undefined,
+  "runtimes": [
+    {
+      "build": "CodeZip",
+      "codeLocation": "app/a2a_agent",
+      "entrypoint": "main.py",
+      "name": "a2a_agent",
+      "protocol": "A2A",
+      "runtimeVersion": "PYTHON_3_14",
+    },
+  ],
+}
+`;

--- a/src/core/project/__snapshots__/manager.test.ts.snap
+++ b/src/core/project/__snapshots__/manager.test.ts.snap
@@ -198,11 +198,47 @@ exports[`FsProjectManager.create snapshots the Strands A2A project manifest and 
     "app/a2a_agent/.gitignore",
     "app/a2a_agent/README.md",
     "app/a2a_agent/main.py",
+    "app/a2a_agent/memory/__init__.py",
+    "app/a2a_agent/memory/session.py",
     "app/a2a_agent/model/__init__.py",
     "app/a2a_agent/model/load.py",
     "app/a2a_agent/pyproject.toml",
   ],
-  "memories": undefined,
+  "memories": [
+    {
+      "eventExpiryDuration": 30,
+      "name": "a2a_agentMemory",
+      "strategies": [
+        {
+          "namespaceTemplates": [
+            "/users/{actorId}/facts",
+          ],
+          "type": "SEMANTIC",
+        },
+        {
+          "namespaceTemplates": [
+            "/users/{actorId}/preferences",
+          ],
+          "type": "USER_PREFERENCE",
+        },
+        {
+          "namespaceTemplates": [
+            "/summaries/{actorId}/{sessionId}",
+          ],
+          "type": "SUMMARIZATION",
+        },
+        {
+          "namespaceTemplates": [
+            "/episodes/{actorId}/{sessionId}",
+          ],
+          "reflectionNamespaceTemplates": [
+            "/episodes/{actorId}",
+          ],
+          "type": "EPISODIC",
+        },
+      ],
+    },
+  ],
   "runtimes": [
     {
       "build": "CodeZip",

--- a/src/core/project/manager.test.ts
+++ b/src/core/project/manager.test.ts
@@ -29,6 +29,10 @@ const HELLO_WORLD_PYTHON = resolveRuntimeTemplateShortcut("hello-world-python");
 const HELLO_WORLD_PYTHON_CONTAINER = resolveRuntimeTemplateShortcut("hello-world-python-container");
 const STRANDS_PYTHON = resolveRuntimeTemplateShortcut("strands-python");
 const STRANDS_TS = resolveRuntimeTemplateShortcut("strands-ts");
+const STRANDS_PY_A2A = resolveRuntimeTemplateShortcut("strands-py-a2a");
+const STRANDS_PY_A2A_CONTAINER = resolveRuntimeTemplateShortcut("strands-py-a2a", {
+  build: "Container",
+});
 
 const originalCwd = process.cwd();
 const tempDirectories: string[] = [];
@@ -129,6 +133,58 @@ describe("FsProjectManager.create", () => {
       runtimes: spec.runtimes,
       memories: spec.memories,
     }).toMatchSnapshot();
+  });
+
+  test("snapshots the Strands A2A project manifest and runtime spec", async () => {
+    const directory = await inTempDirectory();
+    await runCreate(manager().manager, {
+      name: "example",
+      scaffoldRuntimeInput: STRANDS_PY_A2A,
+    });
+
+    const projectRoot = join(directory, "example");
+    const spec = await Bun.file(join(projectRoot, "agentcore", "agentcore.json")).json();
+    expect({
+      manifest: await projectManifest(projectRoot),
+      runtimes: spec.runtimes,
+      memories: spec.memories,
+    }).toMatchSnapshot();
+  });
+
+  test("scaffolds the Strands A2A runtime with the A2A protocol", async () => {
+    const directory = await inTempDirectory();
+    await runCreate(manager().manager, {
+      name: "example",
+      scaffoldRuntimeInput: STRANDS_PY_A2A,
+    });
+
+    const spec = await Bun.file(join(directory, "example", "agentcore", "agentcore.json")).json();
+    expect(spec.runtimes[0]).toMatchObject({
+      name: "a2a_agent",
+      build: "CodeZip",
+      protocol: "A2A",
+      entrypoint: "main.py",
+    });
+    expect(spec.memories).toBeUndefined();
+  });
+
+  test("scaffolds the Strands A2A runtime as a container with --build Container", async () => {
+    const directory = await inTempDirectory();
+    await runCreate(manager().manager, {
+      name: "example",
+      scaffoldRuntimeInput: STRANDS_PY_A2A_CONTAINER,
+    });
+
+    const appDir = join(directory, "example", "app", "a2a_agent");
+    expect(await Bun.file(join(appDir, "Dockerfile")).exists()).toBe(true);
+    expect(await Bun.file(join(appDir, ".dockerignore")).exists()).toBe(true);
+
+    const spec = await Bun.file(join(directory, "example", "agentcore", "agentcore.json")).json();
+    expect(spec.runtimes[0]).toMatchObject({
+      build: "Container",
+      dockerfile: "Dockerfile",
+      protocol: "A2A",
+    });
   });
 
   test("writes a deploy-ready agentcore.json registering the template agent", async () => {

--- a/src/core/project/manager.test.ts
+++ b/src/core/project/manager.test.ts
@@ -165,7 +165,7 @@ describe("FsProjectManager.create", () => {
       protocol: "A2A",
       entrypoint: "main.py",
     });
-    expect(spec.memories).toBeUndefined();
+    expect(spec.memories).toMatchObject([{ name: "a2a_agentMemory" }]);
   });
 
   test("scaffolds the Strands A2A runtime as a container with --build Container", async () => {

--- a/src/core/project/templates/runtime.ts
+++ b/src/core/project/templates/runtime.ts
@@ -288,8 +288,6 @@ const getTemplateResolvers = (assetSource: AssetSource, templateRenderer: Templa
     };
   },
   [buildResolverKey("strands", "Python", "A2A")]: async (input: RuntimeResourceConfig) => {
-    if (input.scaffoldRuntimeInput.memory !== undefined)
-      throw new InputValidationError("memory is not supported with an A2A runtime");
     const filesystemConfigurations = input.filesystemConfigurations ?? [];
     const sessionStorageMountPath = filesystemConfigurations.flatMap((configuration) =>
       "sessionStorage" in configuration ? [configuration.sessionStorage.mountPath] : [],
@@ -304,9 +302,14 @@ const getTemplateResolvers = (assetSource: AssetSource, templateRenderer: Templa
         ? [{ mountPath: configuration.s3FilesAccessPoint.mountPath }]
         : [],
     );
+    const memory = input.scaffoldRuntimeInput.memory;
     const context = {
       name: toPythonPackageName(input.name),
       modelProvider: input.scaffoldRuntimeInput.modelProvider,
+      hasMemory: memory !== undefined,
+      // the CDK injects this env var corresponding to the actual ID once its resolved on deployment.
+      memoryEnvVarName: memory ? `MEMORY_${memory.name.toUpperCase()}_ID` : undefined,
+      memoryStrategies: memory?.strategies.map(({ type }) => type) ?? [],
       sessionStorageMountPath,
       efsMounts,
       s3Mounts,
@@ -324,7 +327,8 @@ const getTemplateResolvers = (assetSource: AssetSource, templateRenderer: Templa
       {
         rootDirName: input.name,
         transformContent: (raw) => templateRenderer.render(raw, context),
-        filter: (name) => {
+        filter: (name, isDir) => {
+          if (isDir && name === "memory") return memory !== undefined;
           if (name === "Dockerfile" || name === ".dockerignore") return isContainer;
           return true;
         },
@@ -332,7 +336,10 @@ const getTemplateResolvers = (assetSource: AssetSource, templateRenderer: Templa
     );
     return {
       tree,
-      spec: { runtimes: [{ ...buildRuntimeSpec(input), protocol: "A2A" as const }] },
+      spec: {
+        runtimes: [{ ...buildRuntimeSpec(input), protocol: "A2A" as const }],
+        ...(memory && { memories: [memory] }),
+      },
     };
   },
 });

--- a/src/core/project/templates/runtime.ts
+++ b/src/core/project/templates/runtime.ts
@@ -287,6 +287,54 @@ const getTemplateResolvers = (assetSource: AssetSource, templateRenderer: Templa
       spec: { runtimes: [{ ...buildRuntimeSpec(input), protocol: "MCP" as const }] },
     };
   },
+  [buildResolverKey("strands", "Python", "A2A")]: async (input: RuntimeResourceConfig) => {
+    if (input.scaffoldRuntimeInput.memory !== undefined)
+      throw new InputValidationError("memory is not supported with an A2A runtime");
+    const filesystemConfigurations = input.filesystemConfigurations ?? [];
+    const sessionStorageMountPath = filesystemConfigurations.flatMap((configuration) =>
+      "sessionStorage" in configuration ? [configuration.sessionStorage.mountPath] : [],
+    )[0];
+    const efsMounts = filesystemConfigurations.flatMap((configuration) =>
+      "efsAccessPoint" in configuration
+        ? [{ mountPath: configuration.efsAccessPoint.mountPath }]
+        : [],
+    );
+    const s3Mounts = filesystemConfigurations.flatMap((configuration) =>
+      "s3FilesAccessPoint" in configuration
+        ? [{ mountPath: configuration.s3FilesAccessPoint.mountPath }]
+        : [],
+    );
+    const context = {
+      name: toPythonPackageName(input.name),
+      modelProvider: input.scaffoldRuntimeInput.modelProvider,
+      sessionStorageMountPath,
+      efsMounts,
+      s3Mounts,
+      needsOs: filesystemConfigurations.length > 0,
+      // The AgentCore Runtime requires OTEL dependencies to be present; the
+      // container launches main.py as the `main` module under
+      // opentelemetry-instrument, and serve_a2a binds the A2A server on port 9000.
+      enableOtel: true,
+      entrypoint: "main",
+    };
+    const isContainer = input.scaffoldRuntimeInput.build === "Container";
+    const tree = await FsTreeNode.fromAssetSource(
+      { assetSource },
+      { assetDir: "templates/strands-py-a2a" },
+      {
+        rootDirName: input.name,
+        transformContent: (raw) => templateRenderer.render(raw, context),
+        filter: (name) => {
+          if (name === "Dockerfile" || name === ".dockerignore") return isContainer;
+          return true;
+        },
+      },
+    );
+    return {
+      tree,
+      spec: { runtimes: [{ ...buildRuntimeSpec(input), protocol: "A2A" as const }] },
+    };
+  },
 });
 
 type GetRuntimeTemplateResolverConfig = {

--- a/src/handlers/project/add/runtime/index.test.ts
+++ b/src/handlers/project/add/runtime/index.test.ts
@@ -246,6 +246,21 @@ describe("project add runtime", () => {
       ],
     ],
     [
+      "strands-py-a2a with session, EFS, and S3 mounts",
+      [
+        "--name",
+        "fs_a2a",
+        "--template",
+        "strands-py-a2a",
+        "--network-mode",
+        "VPC",
+        "--network-config",
+        '{"subnets":["subnet-0123456789abcdef0"],"securityGroups":["sg-0123456789abcdef0"]}',
+        "--filesystem-configurations",
+        '[{"sessionStorage":{"mountPath":"/mnt/session"}},{"efsAccessPoint":{"accessPointArn":"arn:aws:elasticfilesystem:us-east-1:123456789012:access-point/fsap-0123456789abcdef0","mountPath":"/mnt/efs"}},{"s3FilesAccessPoint":{"accessPointArn":"arn:aws:s3files:us-east-1:123456789012:file-system/fs-0123456789abcdef01/access-point/fsap-0123456789abcdef1","mountPath":"/mnt/s3"}}]',
+      ],
+    ],
+    [
       "custom MCP runtime",
       [
         "--name",

--- a/src/handlers/project/add/runtime/index.test.ts
+++ b/src/handlers/project/add/runtime/index.test.ts
@@ -116,6 +116,19 @@ describe("project add runtime", () => {
       build: "CodeZip",
       protocol: "MCP",
     },
+    "strands-py-a2a template preset": {
+      build: "CodeZip",
+      protocol: "A2A",
+    },
+    "strands-py-a2a overrides to Container": {
+      build: "Container",
+      dockerfile: "Dockerfile",
+      protocol: "A2A",
+    },
+    "custom A2A runtime": {
+      build: "CodeZip",
+      protocol: "A2A",
+    },
     "all infrastructure flags": {
       description: "Configured runtime",
       executionRoleArn: "arn:aws:iam::123456789012:role/MyRole",
@@ -177,6 +190,30 @@ describe("project add runtime", () => {
     [
       "py-mcp overrides to Container",
       ["--name", "my_mcp", "--template", "py-mcp", "--build", "Container"],
+    ],
+    ["strands-py-a2a template preset", ["--name", "my_a2a", "--template", "strands-py-a2a"]],
+    [
+      "strands-py-a2a overrides to Container",
+      ["--name", "my_a2a", "--template", "strands-py-a2a", "--build", "Container"],
+    ],
+    [
+      "custom A2A runtime",
+      [
+        "--name",
+        "a2a_custom",
+        "--build",
+        "CodeZip",
+        "--language",
+        "Python",
+        "--framework",
+        "strands",
+        "--protocol",
+        "A2A",
+        "--model-provider",
+        "Bedrock",
+        "--memory",
+        "none",
+      ],
     ],
     [
       "strands-python with session, EFS, and S3 mounts",
@@ -546,6 +583,29 @@ describe("project add runtime", () => {
     [
       "py-mcp does not support memory",
       ["--name", "my_agent", "--template", "py-mcp", "--memory", "shortTerm"],
+    ],
+    [
+      "strands-py-a2a does not support memory",
+      ["--name", "my_agent", "--template", "strands-py-a2a", "--memory", "shortTerm"],
+    ],
+    [
+      "custom A2A runtime does not support memory",
+      [
+        "--name",
+        "my_agent",
+        "--build",
+        "CodeZip",
+        "--language",
+        "Python",
+        "--framework",
+        "strands",
+        "--protocol",
+        "A2A",
+        "--model-provider",
+        "Bedrock",
+        "--memory",
+        "shortTerm",
+      ],
     ],
     [
       "--protocol alone requires --framework and --language",

--- a/src/handlers/project/add/runtime/index.test.ts
+++ b/src/handlers/project/add/runtime/index.test.ts
@@ -480,6 +480,37 @@ describe("project add runtime", () => {
 
   test.each<[string, string[], string[]]>([
     [
+      "template preset defaults to long and short-term memory",
+      ["--name", "my_a2a", "--template", "strands-py-a2a"],
+      ["SEMANTIC", "USER_PREFERENCE", "SUMMARIZATION", "EPISODIC"],
+    ],
+    [
+      "template preset with --memory none",
+      ["--name", "my_a2a", "--template", "strands-py-a2a", "--memory", "none"],
+      [],
+    ],
+  ])("strands-py-a2a %s", async (_label, flags, expectedStrategies) => {
+    const projectRoot = await inProject();
+    await run(["add", "runtime", ...flags]);
+
+    const spec = await Bun.file(join(projectRoot, "agentcore", "agentcore.json")).json();
+    const memory = (spec.memories ?? []).find(
+      (candidate: { name: string }) => candidate.name === "my_a2aMemory",
+    );
+    const memoryDir = join(projectRoot, "app", "my_a2a", "memory", "session.py");
+
+    if (expectedStrategies.length === 0) {
+      expect(memory).toBeUndefined();
+      expect(await Bun.file(memoryDir).exists()).toBe(false);
+      return;
+    }
+
+    expect(memory.strategies.map(({ type }: { type: string }) => type)).toEqual(expectedStrategies);
+    expect(await Bun.file(memoryDir).exists()).toBe(true);
+  });
+
+  test.each<[string, string[], string[]]>([
+    [
       "template preset",
       ["--name", "my_agent", "--template", "strands-ts"],
       ["SEMANTIC", "USER_PREFERENCE", "SUMMARIZATION", "EPISODIC"],
@@ -583,29 +614,6 @@ describe("project add runtime", () => {
     [
       "py-mcp does not support memory",
       ["--name", "my_agent", "--template", "py-mcp", "--memory", "shortTerm"],
-    ],
-    [
-      "strands-py-a2a does not support memory",
-      ["--name", "my_agent", "--template", "strands-py-a2a", "--memory", "shortTerm"],
-    ],
-    [
-      "custom A2A runtime does not support memory",
-      [
-        "--name",
-        "my_agent",
-        "--build",
-        "CodeZip",
-        "--language",
-        "Python",
-        "--framework",
-        "strands",
-        "--protocol",
-        "A2A",
-        "--model-provider",
-        "Bedrock",
-        "--memory",
-        "shortTerm",
-      ],
     ],
     [
       "--protocol alone requires --framework and --language",

--- a/src/handlers/project/add/runtime/index.ts
+++ b/src/handlers/project/add/runtime/index.ts
@@ -87,7 +87,11 @@ export const createAddRuntimeHandler = (config: AddProjectResourceConfig) =>
         "additional IAM policy ARNs or policy document paths for the execution role",
         z.array(z.string()).optional(),
       ),
-      flag("protocol", "server protocol: HTTP or MCP", z.enum(["HTTP", "MCP"]).optional()),
+      flag(
+        "protocol",
+        "server protocol: HTTP, MCP, or A2A",
+        z.enum(["HTTP", "MCP", "A2A"]).optional(),
+      ),
       flag(
         "network-mode",
         "network mode for the runtime environment (PUBLIC or VPC)",

--- a/src/handlers/project/create/index.ts
+++ b/src/handlers/project/create/index.ts
@@ -113,7 +113,11 @@ export const createCreateProjectHandler = (config: CreateProjectHandlerConfig) =
         "agent framework for the scaffolded runtime code",
         z.enum(["strands", "none"]).optional(),
       ),
-      flag("protocol", "server protocol: HTTP or MCP", z.enum(["HTTP", "MCP"]).optional()),
+      flag(
+        "protocol",
+        "server protocol: HTTP, MCP, or A2A",
+        z.enum(["HTTP", "MCP", "A2A"]).optional(),
+      ),
       flag(
         "model-provider",
         "model provider: bedrock, open_ai, gemini, or lite_llm for harnesses; Bedrock for runtime code",
@@ -300,7 +304,7 @@ type RuntimePathFlagValues = {
   build?: "CodeZip" | "Container";
   language?: "Python" | "TypeScript";
   framework?: "strands" | "none";
-  protocol?: "HTTP" | "MCP";
+  protocol?: "HTTP" | "MCP" | "A2A";
   "model-provider"?: ModelProviderFlag;
   "api-key"?: string;
   memory?: (typeof MEMORY_SHORTCUT_NAMES)[number];

--- a/src/handlers/project/create/screen.tsx
+++ b/src/handlers/project/create/screen.tsx
@@ -86,6 +86,11 @@ const TEMPLATE_OPTIONS: {
     label: "py-mcp",
     description: "MCP server exposing tools via FastMCP (CodeZip build)",
   },
+  {
+    template: "strands-py-a2a",
+    label: "strands-py-a2a",
+    description: "Strands agent speaking the A2A protocol on Bedrock (CodeZip build)",
+  },
 ];
 
 const MEMORY_OPTIONS: { memory: MemoryShortcutName; label: string; description: string }[] = [

--- a/src/handlers/project/shortcuts.ts
+++ b/src/handlers/project/shortcuts.ts
@@ -95,6 +95,16 @@ export const RUNTIME_TEMPLATE_SHORTCUTS = {
     memory: "none",
     runtimeVersion: "PYTHON_3_14",
   },
+  "strands-py-a2a": {
+    runtimeName: "a2a_agent",
+    build: "CodeZip",
+    language: "Python",
+    framework: "strands",
+    protocol: "A2A",
+    modelProvider: "Bedrock",
+    memory: "none",
+    runtimeVersion: "PYTHON_3_14",
+  },
 } as const satisfies Record<string, RuntimeTemplateShortcut>;
 
 export type RuntimeTemplateShortcutName = keyof typeof RUNTIME_TEMPLATE_SHORTCUTS;

--- a/src/handlers/project/shortcuts.ts
+++ b/src/handlers/project/shortcuts.ts
@@ -102,7 +102,7 @@ export const RUNTIME_TEMPLATE_SHORTCUTS = {
     framework: "strands",
     protocol: "A2A",
     modelProvider: "Bedrock",
-    memory: "none",
+    memory: "longAndShortTerm",
     runtimeVersion: "PYTHON_3_14",
   },
 } as const satisfies Record<string, RuntimeTemplateShortcut>;


### PR DESCRIPTION
### Problem 
The refactor branch is missing support for the A2A protocol. 

### Solution 
- support A2A as an input flag. 
- define a `strands-py-a2a` template. 
- support container overrides. 

### Verification
```
$ agentcore project create --template strands-py-a2a --name hello
Creating project tree
Installing CDK dependencies with npm
Syncing Python dependencies with uv
Initializing git repository
Created project 'hello' in ./hello
To deploy it: cd hello && agentcore project deploy
$ agentcore project add runtime --name bob --template strands-py-a2a --build Container
Reading project spec file at '[..]'
Scaffolding runtime in project
Syncing Python dependencies with uv
Updating project spec file at '[..]'
added runtime 'bob' to 'hello'
$ agentcore-dev project dev --mode headless --agent a2a_agent
OTEL collector listening on port 46785; traces persist to [..]
[a2a_agent] Starting development server
[a2a_agent] INFO:     Started server process [1777994]
[a2a_agent] INFO:     Waiting for application startup.
[a2a_agent] INFO:     Application startup complete.
[a2a_agent] INFO:     Uvicorn running on http://127.0.0.1:9000 (Press CTRL+C to quit)
[a2a_agent] INFO:     127.0.0.1:37576 - "GET /.well-known/agent-card.json HTTP/1.1" 200 OK
[a2a_agent] Tool #1: add_numbers
[a2a_agent] The answer is **42**.INFO:     127.0.0.1:59252 - "POST / HTTP/1.1" 200 OK
^CShutting down…
[a2a_agent] INFO:     Shutting down
[a2a_agent] INFO:     Waiting for application shutdown.
[a2a_agent] INFO:     Application shutdown complete.
[a2a_agent] INFO:     Finished server process [1777994]

[separate terminal]
$ curl -s http://127.0.0.1:9000/.well-known/agent-card.json | jq
{
  "capabilities": {
    "streaming": true
  },
  "defaultInputModes": [
    "text"
  ],
  "defaultOutputModes": [
    "text"
  ],
  "description": "A Bedrock AgentCore agent",
  "name": "a2a_agent",
  "preferredTransport": "JSONRPC",
  "protocolVersion": "0.3.0",
  "skills": [
    {
      "description": "A Bedrock AgentCore agent",
      "id": "main",
      "name": "a2a_agent",
      "tags": [
        "main"
      ]
    }
  ],
  "url": "http://localhost:9000/",
  "version": "0.1.0"
}
$ curl -s http://127.0.0.1:9000/ -H 'Content-Type: application/json' \
  -d '{"jsonrpc":"2.0","id":"1","method":"message/send","params":{"message":{"role":"user","parts":[{"kind":"text","text":"What is 21 + 21? Use the add_numbers tool."}],"messageId":"m1"}}}'
{"id":"1","jsonrpc":"2.0","result":{"artifacts":[{"artifactId":"c530cfd9-9a0e-484d-89a9-fd5bacc97d1d","name":"agent_response","parts":[{"kind":"text","text":"The answer is **42**.\n"}]}],"contextId":"6de50ed4-8b92-4717-96e4-9673292dad79","history":[{"contextId":"6de50ed4-8b92-4717-96e4-9673292dad79","kind":"message","messageId":"m1","parts":[{"kind":"text","text":"What is 21 + 21? Use the add_numbers tool."}],"role":"user","taskId":"0d2efeba-4e6e-43b7-a472-d6663d923024"},{"contextId":"6de50ed4-8b92-4717-96e4-9673292dad79","kind":"message","messageId":"eca09740-b113-4809-bbde-32cc9e05824d","parts":[{"kind":"text","text":"The answer"}],"role":"agent","taskId":"0d2efeba-4e6e-43b7-a472-d6663d923024"},{"contextId":"6de50ed4-8b92-4717-96e4-9673292dad79","kind":"message","messageId":"4964e59f-ec34-4508-aea4-dfc6f4905d27","parts":[{"kind":"text","text":" is **"}],"role":"agent","taskId":"0d2efeba-4e6e-43b7-a472-d6663d923024"},{"contextId":"6de50ed4-8b92-4717-96e4-9673292dad79","kind":"message","messageId":"f95318dc-0edb-42c4-855b-62767e18773e","parts":[{"kind":"text","text":"42**."}],"role":"agent","taskId":"0d2efeba-4e6e-43b7-a472-d6663d923024"}],"id":"0d2efeba-4e6e-43b7-a472-d6663d923024","kind":"task","status":{"state":"completed","timestamp":"2026-09-01T19:25:41.684724+00:00"}}}%

[back to original] 

$ agentcore project deploy
...
```
invoked both via aws cli (through an agent) 