### PR TITLE
fix(templates): bump aws-opentelemetry-distro to ~=0.18.0 and normalize python deps

### DIFF
--- a/src/assets/templates/bedrock-agent-proxy-python/pyproject.toml
+++ b/src/assets/templates/bedrock-agent-proxy-python/pyproject.toml
@@ -9,10 +9,10 @@ description = "AgentCore Runtime proxy for the Amazon Bedrock Agent {{agentName}
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "aws-opentelemetry-distro",
-    "bedrock-agentcore >= 1.9.1",
-    "boto3 >= 1.35.0",
-    "botocore[crt] >= 1.35.0",
+    "aws-opentelemetry-distro ~= 0.18.0",
+    "bedrock-agentcore ~= 1.9.1",
+    "boto3 ~= 1.43.0",
+    "botocore[crt] ~= 1.43.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/assets/templates/hello-world-python-container/pyproject.toml
+++ b/src/assets/templates/hello-world-python-container/pyproject.toml
@@ -9,10 +9,10 @@ description = "AgentCore Runtime application using the Strands SDK"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "aws-opentelemetry-distro",
-    "bedrock-agentcore >= 1.9.1",
-    "botocore[crt] >= 1.35.0",
-    "strands-agents >= 1.15.0",
+    "aws-opentelemetry-distro ~= 0.18.0",
+    "bedrock-agentcore ~= 1.9.1",
+    "botocore[crt] ~= 1.43.0",
+    "strands-agents ~= 1.15.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/assets/templates/hello-world-python/pyproject.toml
+++ b/src/assets/templates/hello-world-python/pyproject.toml
@@ -9,10 +9,10 @@ description = "AgentCore Runtime application using the Strands SDK"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "aws-opentelemetry-distro",
-    "bedrock-agentcore >= 1.9.1",
-    "botocore[crt] >= 1.35.0",
-    "strands-agents >= 1.15.0",
+    "aws-opentelemetry-distro ~= 0.18.0",
+    "bedrock-agentcore ~= 1.9.1",
+    "botocore[crt] ~= 1.43.0",
+    "strands-agents ~= 1.15.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/assets/templates/strands-http-python/pyproject.toml
+++ b/src/assets/templates/strands-http-python/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     {{#if (eq modelProvider "Anthropic")}}"anthropic ~= 0.30.0",
-    {{/if}}"aws-opentelemetry-distro ~= 0.17.0",
+    {{/if}}"aws-opentelemetry-distro ~= 0.18.0",
     "bedrock-agentcore ~= 1.9.1",
     "botocore[crt] ~= 1.43.0",
     {{#if (eq modelProvider "Gemini")}}"google-genai ~= 1.0.0",


### PR DESCRIPTION
### Problem 
This PR fixes two related problems.
- the mega PR added some templates with unpinned dependencies. Same with original hello world templates. 
- the aws-opentelemetry-distro dependency was older than 0.18.0, causing spans to be sent to aws/spans, rather than the agents own log group. (this made it difficult for downstream services to find them). 

### Solution 
- use compatible releases to ensure templates do not break on dependency version bumps. 
- bump all aws-opentelemetry-distro to 0.18.0. 


### Related sources
> The agent uses ADOT version 0.18.0 or later (aws-opentelemetry-distro>=0.18.0). Earlier versions ignore the span destination configuration and deliver spans to the shared aws/spans log group.
    
https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/observability-configure.html
### Verification
```
$ agentcore project create --name hw --template strands-python --memory none
...
$ cd ./hw
$ agentcore project deploy
...
$ agentcore-dev project invoke runtime --payload '{"prompt": "what is 10 + 2"}'
...
$ aws logs get-log-events --region us-east-1 --log-group-name "/aws/bedrock-agentcore/runtimes/hw_strands_agent-OaaiQC4HZn-DEFAULT --log-stream-name spans --limit 1
{
      "events": [
          {
              "timestamp": 1788295145497,
              "message": "{\"resource\":{\"attributes\":{\"deployment.environment.name\":\"bedrock-agentcore:default\",\"aws.local.service\":\"hw_strands_agent.DE
  FAULT\",\"service.name\":\"hw_strands_agent.DEFAULT\",\"cloud.region\":\"us-east-1\",\"aws.log.stream.names\":\"otel-rt-logs\",\"telemetry.sdk.name\":\"opentele
  metry\",\"aws.service.type\":\"gen_ai_agent\",\"telemetry.sdk.language\":\"python\",\"cloud.provider\":\"aws\",\"cloud.resource_id\":\"arn:aws:bedrock-agentcore
  :us-east-1:<ACCOUNT_ID>:runtime/hw_strands_agent-<RUNTIME_SUFFIX>/runtime-endpoint/DEFAULT:DEFAULT\",\"aws.log.group.names\":\"/aws/bedrock-agentcore/runtimes/h
  w_strands_agent-<RUNTIME_SUFFIX>-DEFAULT\",\"telemetry.sdk.version\":\"1.42.1\",\"cloud.platform\":\"aws_bedrock_agentcore\",\"telemetry.auto.version\":\"0.18.0
  -aws\"}},\"scope\":{\"name\":\"opentelemetry.instrumentation.starlette\",\"version\":\"0.63b1\"},\"traceId\":\"6a9737df0aa6d345604cf77f397da79d\",\"spanId\":\"4
  1da592ff4dceb15\",\"parentSpanId\":\"32ffe792bf747504\",\"flags\":768,\"name\":\"POST /invocations\",\"kind\":\"SERVER\",\"startTimeUnixNano\":17882951410938751
  26,\"endTimeUnixNano\":1788295145497388066,\"durationNano\":4403512940,\"attributes\":{\"aws.local.service\":\"hw_strands_agent.DEFAULT\",\"net.peer.port\":4539
  2,\"telemetry.extended\":\"true\",\"http.target\":\"/invocations\",\"http.flavor\":\"1.1\",\"http.url\":\"http://<INTERNAL_HOST>/invocations\",\"net.peer.ip\":\
  "127.0.0.1\",\"http.host\":\"127.0.0.1:8080\",\"aws.local.environment\":\"bedrock-agentcore:default\",\"http.status_code\":200,\"aws.local.operation\":\"POST
  /invocations\",\"aws.span.kind\":\"SERVER\",\"http.server_name\":\"<INTERNAL_HOST>\",\"net.host.port\":8080,\"http.route\":\"/invocations\",\"PlatformType\":\"A
  WS::BedrockAgentCore\",\"http.method\":\"POST\",\"http.response.status_code\":200,\"session.id\":\"<SESSION_ID>\",\"http.scheme\":\"http\"},\"status\":{\"code\"
  :\"UNSET\"}}",
              "ingestionTime": 1788295149268
          }
      ],
      "nextForwardToken": "f/39880314379497844863664608711450136701060009346917728256/s",
      "nextBackwardToken": "b/39880314379497844863664608711450136701060009346917728256/s"
  }
```

went into the console, and didn't see the data in aws/spans. 
