### PR TITLE
feat(project): add TUI wizards for four `project add` resources

### DIFF
--- a/src/components/FormCheckboxMultiSelect.tsx
+++ b/src/components/FormCheckboxMultiSelect.tsx
@@ -31,10 +31,14 @@ export function FormCheckboxMultiSelect({
 
   return (
     <Box flexDirection="column">
-      <Box flexDirection="column">
-        <Text color={theme.colors.text}>{name}</Text>
-        <Text color={theme.colors.muted}>{helpText}</Text>
-      </Box>
+      {/* Either row is omitted when empty, so a caller whose surrounding
+          context already asks the question renders just the checkboxes. */}
+      {(name !== "" || helpText !== "") && (
+        <Box flexDirection="column">
+          {name !== "" && <Text color={theme.colors.text}>{name}</Text>}
+          {helpText !== "" && <Text color={theme.colors.muted}>{helpText}</Text>}
+        </Box>
+      )}
       <Box
         flexDirection="column"
         paddingX={1}

--- a/src/components/FormRadioGroup.tsx
+++ b/src/components/FormRadioGroup.tsx
@@ -22,10 +22,14 @@ export function FormRadioGroup({ name, helpText, options, selectedIndex }: FormR
 
   return (
     <Box flexDirection="column">
-      <Box flexDirection="column">
-        <Text color={theme.colors.text}>{name}</Text>
-        <Text color={theme.colors.muted}>{helpText}</Text>
-      </Box>
+      {/* Either row is omitted when empty, so a caller whose surrounding
+          context already asks the question renders just the options. */}
+      {(name !== "" || helpText !== "") && (
+        <Box flexDirection="column">
+          {name !== "" && <Text color={theme.colors.text}>{name}</Text>}
+          {helpText !== "" && <Text color={theme.colors.muted}>{helpText}</Text>}
+        </Box>
+      )}
       <Box
         flexDirection="column"
         paddingX={1}

--- a/src/components/FormTextArea.tsx
+++ b/src/components/FormTextArea.tsx
@@ -54,17 +54,21 @@ export function FormTextArea({
 
   return (
     <Box flexDirection="column">
-      <Box
-        flexDirection="column"
-        borderStyle="single"
-        borderLeft={false}
-        borderRight={false}
-        borderTop={false}
-        borderColor={theme.colors.border}
-      >
-        <Text color={theme.colors.text}>{name}</Text>
-        <Text color={theme.colors.muted}>{helpText}</Text>
-      </Box>
+      {/* Either row is omitted when empty, so a caller whose surrounding
+          context already asks the question renders just the editor. */}
+      {(name !== "" || helpText !== "") && (
+        <Box
+          flexDirection="column"
+          borderStyle="single"
+          borderLeft={false}
+          borderRight={false}
+          borderTop={false}
+          borderColor={theme.colors.border}
+        >
+          {name !== "" && <Text color={theme.colors.text}>{name}</Text>}
+          {helpText !== "" && <Text color={theme.colors.muted}>{helpText}</Text>}
+        </Box>
+      )}
       {hidden > 0 && <Text color={theme.colors.muted}>… (+{hidden} earlier lines)</Text>}
       {visible.length === 0 ? (
         <Text color={theme.colors.muted}>

--- a/src/components/FormTextInput.tsx
+++ b/src/components/FormTextInput.tsx
@@ -31,10 +31,14 @@ export function FormTextInput({
 }: FormTextInputProps) {
   return (
     <Box flexDirection="column">
-      <Box flexDirection="column">
-        <Text color={theme.colors.text}>{name}</Text>
-        <Text color={theme.colors.muted}>{helpText}</Text>
-      </Box>
+      {/* Either row is omitted when empty, so a caller whose surrounding
+          context already asks the question renders just the input. */}
+      {(name !== "" || helpText !== "") && (
+        <Box flexDirection="column">
+          {name !== "" && <Text color={theme.colors.text}>{name}</Text>}
+          {helpText !== "" && <Text color={theme.colors.muted}>{helpText}</Text>}
+        </Box>
+      )}
       <Box borderStyle="round" borderColor={focused ? theme.colors.focus : theme.colors.border}>
         <TextInput
           value={value}

--- a/src/components/Root.tsx
+++ b/src/components/Root.tsx
@@ -110,13 +110,36 @@ import { GatewayInvokeScreen } from "../handlers/gateway/invoke/screen.tsx";
 import { ProjectScreen, ProjectCommandNotImplementedScreen } from "../handlers/project/screen.tsx";
 import { ProjectCreateScreen } from "../handlers/project/create/screen.tsx";
 import { ProjectInvokePickerScreen } from "../handlers/project/invoke/screen.tsx";
+import { AddScreen } from "../handlers/project/add/screen.tsx";
+import { AddMemoryScreen } from "../handlers/project/add/memory/screen.tsx";
+import { AddGatewayScreen } from "../handlers/project/add/gateway/screen.tsx";
+import { AddPolicyEngineScreen } from "../handlers/project/add/policy-engine/screen.tsx";
+import { AddConfigBundleScreen } from "../handlers/project/add/config-bundle/screen.tsx";
 import { RootScreen, HelpScreen } from "../handlers/screen.tsx";
 import type { Context } from "../router";
 
 // PROJECT_COMMANDS are the `agentcore project` subcommands that are listed in
-// the menu but have no screen of their own yet (`create` has the wizard). Each
-// is routed explicitly so selecting it reports "not implemented" error
-const PROJECT_COMMANDS = ["add", "export", "remove", "dev", "deploy", "status", "build"] as const;
+// the menu but have no screen of their own yet (`create` has the wizard, `add`
+// has its own menu). Each is routed explicitly so selecting it reports "not
+// implemented" error
+const PROJECT_COMMANDS = ["export", "remove", "dev", "deploy", "status", "build"] as const;
+
+// ADD_COMMANDS are the `agentcore project add` resources that have no wizard
+// yet. They stay in the menu — every one of them works from the command line —
+// and route here so selecting one says so instead of falling through to help.
+const ADD_COMMANDS = [
+  "harness",
+  "runtime",
+  "online-eval",
+  "online-insight",
+  "evaluator",
+  "credentials",
+  "gateway-target",
+  "gateway-connector",
+  "policy",
+  "payment-manager",
+  "payment-connector",
+] as const;
 
 export interface RootProps {
   // path is the command path to the executing node (e.g. "/agentcore").
@@ -759,6 +782,36 @@ export function Root({ path, ctx, core, queryClient }: RootProps) {
               path={`agentcore/project/${command}`}
               element={
                 <ProjectCommandNotImplementedScreen ctx={ctx} core={core} command={command} />
+              }
+            />
+          ))}
+          <Route path="agentcore/project/add" element={<AddScreen ctx={ctx} core={core} />} />
+          <Route
+            path="agentcore/project/add/memory"
+            element={<AddMemoryScreen ctx={ctx} core={core} />}
+          />
+          <Route
+            path="agentcore/project/add/gateway"
+            element={<AddGatewayScreen ctx={ctx} core={core} />}
+          />
+          <Route
+            path="agentcore/project/add/policy-engine"
+            element={<AddPolicyEngineScreen ctx={ctx} core={core} />}
+          />
+          <Route
+            path="agentcore/project/add/config-bundle"
+            element={<AddConfigBundleScreen ctx={ctx} core={core} />}
+          />
+          {ADD_COMMANDS.map((command) => (
+            <Route
+              key={command}
+              path={`agentcore/project/add/${command}`}
+              element={
+                <ProjectCommandNotImplementedScreen
+                  ctx={ctx}
+                  core={core}
+                  command={`add ${command}`}
+                />
               }
             />
           ))}

--- a/src/components/wizard/Step.tsx
+++ b/src/components/wizard/Step.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { Box, Text } from "ink";
+import { darkTheme } from "../ui/_core.js";
+
+const theme = darkTheme;
+
+export interface StepProps {
+  // name is the step's stable key. Position is tracked by key rather than by
+  // index because branches have different lengths: a conditional step that
+  // appears or disappears must not shift the user to a different question.
+  name: string;
+  // title labels the step in the Stepper; defaults to `name`.
+  title?: string;
+  // question is the one-line prompt shown under the Stepper. The Stepper
+  // already names the step, so the body opens with the question itself.
+  question?: string;
+  children: React.ReactNode;
+}
+
+// Step is one page of a <Wizard>: the stepper entry, the question line, and the
+// field that collects the answer.
+export function Step({ question, children }: StepProps) {
+  return (
+    <Box flexDirection="column" paddingX={1}>
+      {question !== undefined && <Text color={theme.colors.muted}>{question}</Text>}
+      {children}
+    </Box>
+  );
+}
+
+// isStepElement narrows a child to a <Step>. React.Children.toArray already
+// drops the `false`/`null` that a `{condition && <Step/>}` branch produces, so
+// filtering with this yields exactly the steps that apply to the current
+// answers — which is how a wizard branches without a step-list useMemo.
+export function isStepElement(child: React.ReactNode): child is React.ReactElement<StepProps> {
+  return React.isValidElement(child) && child.type === Step;
+}

--- a/src/components/wizard/Step.tsx
+++ b/src/components/wizard/Step.tsx
@@ -19,6 +19,12 @@ export interface StepProps {
 
 // Step is one page of a <Wizard>: the stepper entry, the question line, and the
 // field that collects the answer.
+//
+// One field per step. Every field registers its own useInput and answers enter,
+// esc and the arrows itself; two fields mounted at once would both react to the
+// same keystroke. The shell has no notion of focus and is not meant to grow
+// one — a step that genuinely needs two related inputs should get a single
+// compound field that owns one useInput and manages focus internally.
 export function Step({ question, children }: StepProps) {
   return (
     <Box flexDirection="column" paddingX={1}>

--- a/src/components/wizard/Wizard.tsx
+++ b/src/components/wizard/Wizard.tsx
@@ -80,14 +80,21 @@ export function Wizard({
     [children],
   );
 
-  const steps: StepperStep[] = useMemo(
-    () =>
-      stepElements.map((element) => ({
-        key: element.props.name,
-        title: element.props.title ?? element.props.name,
-      })),
-    [stepElements],
-  );
+  const steps: StepperStep[] = useMemo(() => {
+    const list = stepElements.map((element) => ({
+      key: element.props.name,
+      title: element.props.title ?? element.props.name,
+    }));
+    // Position is keyed by name, so two steps sharing one would make advance()
+    // land on the first of them forever. Catch that at render time, where the
+    // author sees it, instead of as a wizard that quietly cannot move on.
+    const seen = new Set<string>();
+    for (const step of list) {
+      if (seen.has(step.key)) throw new Error(`duplicate <Step name="${step.key}">`);
+      seen.add(step.key);
+    }
+    return list;
+  }, [stepElements]);
 
   const [stepKey, setStepKey] = useState<string>(() => steps[0]?.key ?? "");
 

--- a/src/components/wizard/Wizard.tsx
+++ b/src/components/wizard/Wizard.tsx
@@ -1,0 +1,277 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Box, Text, useApp, useInput } from "ink";
+import { Layout } from "../Layout";
+import { Stepper, type Step as StepperStep } from "../ui/stepper";
+import { Divider } from "../ui/divider";
+import { Spinner } from "../ui/spinner";
+import { darkTheme } from "../ui/_core.js";
+import { isStepElement } from "./Step";
+import { WizardProvider, type KeyHint, type WizardControls } from "./context";
+
+const theme = darkTheme;
+
+// ProgressEvent matches ProjectEvent's shape, so a ProjectManager generator can
+// be handed to onSubmit unchanged and its messages stream into the event log.
+export interface ProgressEvent {
+  message: string;
+}
+
+// A submit either resolves once (a plain control-plane request) or streams
+// progress events (the ProjectManager's async generators). Wizard renders both.
+export type WizardSubmitResult = AsyncIterable<ProgressEvent> | Promise<unknown>;
+
+type Phase =
+  { kind: "form" } | { kind: "running" } | { kind: "success" } | { kind: "error"; error: Error };
+
+export interface WizardProps {
+  breadcrumb: string[];
+  // description is shown dimmed after the breadcrumb; pass the command's own
+  // description so the header matches what `--help` prints.
+  description?: string;
+  // children are the <Step>s. A `{condition && <Step/>}` branch is dropped from
+  // the flow while the condition is false.
+  children: React.ReactNode;
+  onSubmit: () => WizardSubmitResult;
+  // onCancel runs when esc is pressed on the first step.
+  onCancel: () => void;
+  // runningLabel is the spinner label shown while onSubmit is in flight.
+  runningLabel: string;
+  // successLabel is the headline shown once onSubmit resolves.
+  successLabel: string;
+  // successHint is an optional dimmed line under successLabel.
+  successHint?: string;
+  // onDone runs when the success panel is acknowledged; defaults to tearing the
+  // TUI down, which is what a one-shot `project add ...` wants.
+  onDone?: () => void;
+  // onError decides what a failure does. "exit" rejects the waitUntilExit()
+  // that renderTuiAt awaits, so the error takes the normal CLI path and the
+  // process exits nonzero — right for a one-shot command. "retry" reports the
+  // message and returns to the form, right for a screen the user navigated to.
+  onError?: "exit" | "retry";
+}
+
+// Wizard is the shared shell behind every step-based flow: it derives the step
+// list from its <Step> children, owns position, key handling and the
+// form → running → success | error phases, and renders the standard
+// Layout + Stepper frame. Screens supply only the questions.
+export function Wizard({
+  breadcrumb,
+  description,
+  children,
+  onSubmit,
+  onCancel,
+  runningLabel,
+  successLabel,
+  successHint,
+  onDone,
+  onError = "exit",
+}: WizardProps) {
+  const { exit } = useApp();
+
+  const [phase, setPhase] = useState<Phase>({ kind: "form" });
+  const [events, setEvents] = useState<string[]>([]);
+  // Fields publish their hints from an effect, which lands one paint after the
+  // first render. Seeding with the hint every field shares keeps that first
+  // frame from showing a footer with no action key in it.
+  const [hints, setHints] = useState<KeyHint[]>([{ key: "enter", label: "continue" }]);
+
+  const stepElements = useMemo(
+    () => React.Children.toArray(children).filter(isStepElement),
+    [children],
+  );
+
+  const steps: StepperStep[] = useMemo(
+    () =>
+      stepElements.map((element) => ({
+        key: element.props.name,
+        title: element.props.title ?? element.props.name,
+      })),
+    [stepElements],
+  );
+
+  const [stepKey, setStepKey] = useState<string>(() => steps[0]?.key ?? "");
+
+  // Position is a key, not an index, so a branch that adds or removes steps
+  // does not move the user. The clamp covers the one case a key can vanish:
+  // a branch closing while its own step is somehow still active.
+  const found = steps.findIndex((step) => step.key === stepKey);
+  const index = found === -1 ? 0 : found;
+  const activeStep = stepElements[index];
+  const isLast = index === steps.length - 1;
+
+  // Ink drains buffered keystrokes synchronously, so a second enter can arrive
+  // before the form unmounts. The ref makes submitting idempotent.
+  const submitting = useRef(false);
+
+  const submit = useCallback(async () => {
+    if (submitting.current) return;
+    submitting.current = true;
+    setPhase({ kind: "running" });
+    try {
+      const result = onSubmit();
+      if (isProgressStream(result)) {
+        for await (const event of result) {
+          setEvents((current) => [...current, event.message]);
+        }
+      } else {
+        await result;
+      }
+      setPhase({ kind: "success" });
+    } catch (error) {
+      setPhase({ kind: "error", error: toError(error) });
+    } finally {
+      submitting.current = false;
+    }
+  }, [onSubmit]);
+
+  const controls: WizardControls = useMemo(
+    () => ({
+      isLast,
+      setHints,
+      advance: () => {
+        if (isLast) {
+          void submit();
+          return;
+        }
+        const next = steps[index + 1];
+        if (next) setStepKey(next.key);
+      },
+      back: () => {
+        if (index === 0) {
+          onCancel();
+          return;
+        }
+        const previous = steps[index - 1];
+        if (previous) setStepKey(previous.key);
+      },
+    }),
+    [isLast, index, steps, submit, onCancel],
+  );
+
+  return (
+    <Layout breadcrumb={breadcrumb} description={description} keyHints={footerHints(phase, hints)}>
+      <Box flexDirection="column">
+        {phase.kind === "form" && (
+          <>
+            <Box paddingX={1}>
+              <Stepper
+                steps={steps}
+                currentStep={steps[index]?.key ?? ""}
+                completedSteps={steps.slice(0, index).map((step) => step.key)}
+              />
+            </Box>
+            <Divider />
+            <WizardProvider value={controls}>{activeStep}</WizardProvider>
+          </>
+        )}
+
+        {phase.kind !== "form" && (
+          <Box flexDirection="column" paddingX={1}>
+            <EventLog events={events} />
+            {phase.kind === "running" && <Spinner label={runningLabel} />}
+            {phase.kind === "success" && (
+              <SuccessPanel
+                label={successLabel}
+                hint={successHint}
+                onContinue={onDone ?? (() => exit())}
+              />
+            )}
+            {phase.kind === "error" && onError === "exit" && <ExitOnError error={phase.error} />}
+            {phase.kind === "error" && onError === "retry" && (
+              <RetryPanel error={phase.error} onBack={() => setPhase({ kind: "form" })} />
+            )}
+          </Box>
+        )}
+      </Box>
+    </Layout>
+  );
+}
+
+// isProgressStream distinguishes an async generator from a promise. A promise
+// has no Symbol.asyncIterator, so this is a safe discriminator.
+function isProgressStream(result: WizardSubmitResult): result is AsyncIterable<ProgressEvent> {
+  return (
+    result !== null &&
+    typeof result === "object" &&
+    typeof (result as AsyncIterable<ProgressEvent>)[Symbol.asyncIterator] === "function"
+  );
+}
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+// footerHints appends the keys that mean the same thing on every step to
+// whatever the active field published.
+function footerHints(phase: Phase, fieldHints: KeyHint[]): KeyHint[] {
+  if (phase.kind === "running") return [{ key: "ctl+c", label: "quit" }];
+  if (phase.kind === "success") return [{ key: "enter", label: "continue" }];
+  if (phase.kind === "error") {
+    return [
+      { key: "esc", label: "back" },
+      { key: "ctl+c", label: "quit" },
+    ];
+  }
+  return [...fieldHints, { key: "esc", label: "back" }, { key: "ctl+c", label: "quit" }];
+}
+
+function EventLog({ events }: { events: string[] }) {
+  return (
+    <Box flexDirection="column">
+      {events.map((message, i) => (
+        <Text key={`${i}-${message}`} color={theme.colors.muted}>
+          ✓ {message}
+        </Text>
+      ))}
+    </Box>
+  );
+}
+
+function SuccessPanel({
+  label,
+  hint,
+  onContinue,
+}: {
+  label: string;
+  hint?: string;
+  onContinue: () => void;
+}) {
+  useInput((_input, key) => {
+    if (key.return || key.escape) onContinue();
+  });
+
+  return (
+    <Box flexDirection="column">
+      <Text color={theme.colors.success} bold>
+        ✔ {label}
+      </Text>
+      {hint !== undefined && <Text color={theme.colors.muted}>{hint}</Text>}
+    </Box>
+  );
+}
+
+// ExitOnError tears the TUI down through exit(error): that rejects the
+// waitUntilExit() renderTuiAt awaits, so the failure is reported by the normal
+// CLI error path instead of as a React stack trace.
+function ExitOnError({ error }: { error: Error }) {
+  const { exit } = useApp();
+
+  useEffect(() => {
+    exit(error);
+  }, [exit, error]);
+
+  return <Text color={theme.colors.error}>✗ {error.message}</Text>;
+}
+
+function RetryPanel({ error, onBack }: { error: Error; onBack: () => void }) {
+  useInput((_input, key) => {
+    if (key.escape || key.return) onBack();
+  });
+
+  return (
+    <Box flexDirection="column">
+      <Text color={theme.colors.error}>✗ {error.message}</Text>
+      <Text color={theme.colors.muted}>esc returns to the form</Text>
+    </Box>
+  );
+}

--- a/src/components/wizard/context.tsx
+++ b/src/components/wizard/context.tsx
@@ -37,14 +37,15 @@ export function useWizard(): WizardControls {
 export function useKeyHints(hints: KeyHint[]): void {
   const { setHints } = useWizard();
 
-  // The caller passes a fresh array literal on every render, so the effect is
-  // keyed on the hints' content and reads the latest array from a ref. Keying
-  // on the array itself would publish, re-render, and publish again forever.
-  const latest = useRef(hints);
-  latest.current = hints;
-  const signature = hints.map((hint) => `${hint.key}:${hint.label}`).join("|");
-
+  // The caller passes a fresh array literal on every render, so the effect
+  // runs every render — but publishes only when the content changed. Publishing
+  // the array itself unconditionally would re-render, publish, and re-render
+  // again forever; the ref remembers what the footer already shows.
+  const published = useRef<string | undefined>(undefined);
   useEffect(() => {
-    setHints(latest.current);
-  }, [signature, setHints]);
+    const signature = hints.map((hint) => `${hint.key}:${hint.label}`).join("|");
+    if (published.current === signature) return;
+    published.current = signature;
+    setHints(hints);
+  }, [hints, setHints]);
 }

--- a/src/components/wizard/context.tsx
+++ b/src/components/wizard/context.tsx
@@ -1,0 +1,50 @@
+import React, { useContext, useEffect, useRef } from "react";
+
+export interface KeyHint {
+  key: string;
+  label: string;
+}
+
+// WizardControls is what a field needs from the wizard around it: where to go
+// next, where to go back to, and a way to tell the footer what its keys do.
+export interface WizardControls {
+  // advance moves to the next step, or submits when the active step is last.
+  advance: () => void;
+  // back steps to the previous step, or cancels out of the wizard on the first.
+  back: () => void;
+  // isLast reports whether the active step is the final one, so a field can
+  // label its enter hint "submit" rather than "continue".
+  isLast: boolean;
+  // setHints replaces the footer's action hints. Fields call it via useKeyHints.
+  setHints: (hints: KeyHint[]) => void;
+}
+
+const WizardContext = React.createContext<WizardControls | null>(null);
+
+export const WizardProvider = WizardContext.Provider;
+
+export function useWizard(): WizardControls {
+  const controls = useContext(WizardContext);
+  if (!controls) {
+    throw new Error("wizard fields must be rendered inside a <Wizard>");
+  }
+  return controls;
+}
+
+// useKeyHints publishes the active field's footer hints. Each field declares
+// what its own keys do, so <Wizard> never has to switch on step kind the way
+// the hand-written wizards' hintsFor() does.
+export function useKeyHints(hints: KeyHint[]): void {
+  const { setHints } = useWizard();
+
+  // The caller passes a fresh array literal on every render, so the effect is
+  // keyed on the hints' content and reads the latest array from a ref. Keying
+  // on the array itself would publish, re-render, and publish again forever.
+  const latest = useRef(hints);
+  latest.current = hints;
+  const signature = hints.map((hint) => `${hint.key}:${hint.label}`).join("|");
+
+  useEffect(() => {
+    setHints(latest.current);
+  }, [signature, setHints]);
+}

--- a/src/components/wizard/fields.tsx
+++ b/src/components/wizard/fields.tsx
@@ -1,0 +1,397 @@
+import { useState } from "react";
+import { Box, Text, useInput } from "ink";
+import type z from "zod";
+import { FormTextInput } from "../FormTextInput";
+import { FormRadioGroup } from "../FormRadioGroup";
+import { FormCheckboxMultiSelect } from "../FormCheckboxMultiSelect";
+import { FormTextArea } from "../FormTextArea";
+import { KeyValueTable } from "../KeyValueTable";
+import { darkTheme } from "../ui/_core.js";
+import { useKeyHints, useWizard } from "./context";
+
+const theme = darkTheme;
+
+// Every field owns the key handling for its own step — esc goes back, enter
+// advances, arrows move — so a screen never writes that boilerplate again.
+
+// firstIssue renders the schema's own message, so the wizard rejects exactly
+// what the flag-driven path rejects and says the same thing about it. The issue
+// path is prefixed when there is one: for a nested value — a component inside a
+// components map, say — "expected object, received string" alone does not say
+// which key is wrong.
+function firstIssue(schema: z.ZodType, value: unknown): string | undefined {
+  const parsed = schema.safeParse(value);
+  if (parsed.success) return undefined;
+  const issue = parsed.error.issues[0];
+  if (!issue) return "invalid value";
+  const path = issue.path.join(".");
+  return path === "" ? issue.message : `${path}: ${issue.message}`;
+}
+
+interface ValidateOptions {
+  label: string;
+  required: boolean;
+  schema?: z.ZodType;
+  // json parses the value before the schema sees it, so a malformed blob is
+  // reported as bad JSON rather than as a shape the schema cannot read.
+  json?: boolean;
+}
+
+// validateEntry returns the message that should block the step, or undefined to
+// let it advance. Shared by the single-line and multi-line fields so both refuse
+// the same input for the same stated reason.
+function validateEntry(
+  value: string,
+  { label, required, schema, json = false }: ValidateOptions,
+): string | undefined {
+  const trimmed = value.trim();
+  if (trimmed === "") return required ? `${label} is required` : undefined;
+
+  let parsed: unknown = trimmed;
+  if (json) {
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch (cause) {
+      return `${label} is not valid JSON: ${(cause as Error).message}`;
+    }
+  }
+  return schema ? firstIssue(schema, parsed) : undefined;
+}
+
+export interface TextFieldProps {
+  // label names the value in validation messages ("<label> is required").
+  // It is not rendered: the <Step> already asks the question, and repeating
+  // it as a heading only adds a line to read.
+  label: string;
+  // help is the one line under the control, for what the question cannot
+  // carry — a range, a service limit, what an empty answer means. Omit it
+  // rather than restate the question.
+  help?: string;
+  placeholder?: string;
+  value: string;
+  onChange: (value: string) => void;
+  // required blocks advancing while the value is blank. Flag schemas are all
+  // `.optional()` by convention (Commander must not reject a bare command
+  // before the TUI middleware can open a screen), so required-ness is stated
+  // here the same way the handlers state it in their own bodies.
+  required?: boolean;
+  // schema validates the trimmed value before advancing. Pass the schema the
+  // flag declares.
+  schema?: z.ZodType;
+  // json parses the value before validating it. A JSON flag belongs here rather
+  // than in TextAreaField unless the value is genuinely prose: JSON is valid on
+  // one line, and this field can be edited in place.
+  json?: boolean;
+  // example is a dimmed line under `help`, kept on screen while the user types.
+  // A placeholder cannot do this job — it disappears on the first keystroke,
+  // exactly when a fiddly value most needs something to copy the shape from.
+  example?: string;
+}
+
+export function TextField({
+  label,
+  help = "",
+  placeholder = "",
+  value,
+  onChange,
+  required = false,
+  schema,
+  json = false,
+  example,
+}: TextFieldProps) {
+  const { advance, back, isLast } = useWizard();
+  const [error, setError] = useState<string>();
+
+  useKeyHints([{ key: "enter", label: isLast ? "submit" : "continue" }]);
+
+  useInput((_input, key) => {
+    if (key.escape) {
+      back();
+      return;
+    }
+    if (!key.return) return;
+
+    const issue = validateEntry(value, { label, required, schema, json });
+    if (issue !== undefined) {
+      setError(issue);
+      return;
+    }
+    setError(undefined);
+    advance();
+  });
+
+  return (
+    <Box flexDirection="column">
+      {/* The example sits above the input rather than inside it, so it survives
+          the first keystroke and stays there to be copied from. */}
+      {example !== undefined && (
+        <Box flexDirection="column">
+          {help !== "" && <Text color={theme.colors.muted}>{help}</Text>}
+          <Text color={theme.colors.muted}>{`for example  ${example}`}</Text>
+        </Box>
+      )}
+      <FormTextInput
+        name=""
+        helpText={example === undefined ? help : ""}
+        placeholder={placeholder}
+        errorText=""
+        value={value}
+        onChange={(next) => {
+          onChange(next);
+          setError(undefined);
+        }}
+      />
+      {error !== undefined && <Text color={theme.colors.error}>{error}</Text>}
+    </Box>
+  );
+}
+
+export interface Choice<T> {
+  value: T;
+  label: string;
+  description?: string;
+}
+
+export interface ChoiceFieldProps<T> {
+  // help is the one line under the options, for what the question and the
+  // per-option descriptions cannot carry between them. Usually omitted.
+  help?: string;
+  choices: Choice<T>[];
+  value: T;
+  onChange: (value: T) => void;
+}
+
+// ChoiceField is a single-choice step. The arrow arithmetic here replaces the
+// copy of it in each of the hand-written wizards. It takes no `label`: one of
+// the choices is always selected, so there is no validation message to name.
+export function ChoiceField<T>({ help = "", choices, value, onChange }: ChoiceFieldProps<T>) {
+  const { advance, back, isLast } = useWizard();
+
+  useKeyHints([
+    { key: "↑↓", label: "choose" },
+    { key: "enter", label: isLast ? "submit" : "continue" },
+  ]);
+
+  const found = choices.findIndex((choice) => choice.value === value);
+  const index = found === -1 ? 0 : found;
+
+  useInput((_input, key) => {
+    if (key.escape) {
+      back();
+      return;
+    }
+    if (key.upArrow) {
+      onChange(choices[Math.max(0, index - 1)]!.value);
+      return;
+    }
+    if (key.downArrow) {
+      onChange(choices[Math.min(choices.length - 1, index + 1)]!.value);
+      return;
+    }
+    if (key.return) advance();
+  });
+
+  return (
+    <FormRadioGroup
+      name=""
+      helpText={help}
+      options={choices.map((choice) => ({
+        label: choice.label,
+        description: choice.description ?? "",
+      }))}
+      selectedIndex={index}
+    />
+  );
+}
+
+export interface MultiChoiceFieldProps<T> {
+  // label names the value in validation messages ("<label> is required").
+  // It is not rendered: the <Step> already asks the question, and repeating
+  // it as a heading only adds a line to read.
+  label: string;
+  // help is the one line under the control, for what the question cannot
+  // carry — a range, a service limit, what an empty answer means. Omit it
+  // rather than restate the question.
+  help?: string;
+  choices: Choice<T>[];
+  value: T[];
+  onChange: (value: T[]) => void;
+  // requireOne blocks advancing on an empty selection.
+  requireOne?: boolean;
+}
+
+export function MultiChoiceField<T>({
+  label,
+  help = "",
+  choices,
+  value,
+  onChange,
+  requireOne = false,
+}: MultiChoiceFieldProps<T>) {
+  const { advance, back, isLast } = useWizard();
+  const [cursor, setCursor] = useState(0);
+  const [error, setError] = useState<string>();
+
+  useKeyHints([
+    { key: "↑↓", label: "move" },
+    { key: "space", label: "toggle" },
+    { key: "enter", label: isLast ? "submit" : "continue" },
+  ]);
+
+  useInput((input, key) => {
+    if (key.escape) {
+      back();
+      return;
+    }
+    if (key.upArrow) {
+      setCursor((c) => Math.max(0, c - 1));
+      return;
+    }
+    if (key.downArrow) {
+      setCursor((c) => Math.min(choices.length - 1, c + 1));
+      return;
+    }
+    if (input === " ") {
+      const choice = choices[cursor];
+      if (!choice) return;
+      setError(undefined);
+      onChange(
+        value.includes(choice.value)
+          ? value.filter((selected) => selected !== choice.value)
+          : [...value, choice.value],
+      );
+      return;
+    }
+    if (key.return) {
+      if (requireOne && value.length === 0) {
+        setError(`select at least one ${label}`);
+        return;
+      }
+      advance();
+    }
+  });
+
+  return (
+    <Box flexDirection="column">
+      <FormCheckboxMultiSelect
+        name=""
+        helpText={help}
+        options={choices.map((choice) => ({
+          label: choice.label,
+          description: choice.description ?? "",
+          checked: value.includes(choice.value),
+        }))}
+        cursorIndex={cursor}
+      />
+      {error !== undefined && <Text color={theme.colors.error}>{error}</Text>}
+    </Box>
+  );
+}
+
+export interface TextAreaFieldProps {
+  // label names the value in validation messages ("<label> is required").
+  // It is not rendered: the <Step> already asks the question, and repeating
+  // it as a heading only adds a line to read.
+  label: string;
+  // help is the one line under the control, for what the question cannot
+  // carry — a range, a service limit, what an empty answer means. Omit it
+  // rather than restate the question.
+  help?: string;
+  placeholder?: string;
+  value: string;
+  onChange: (value: string) => void;
+  required?: boolean;
+  // schema validates the parsed JSON when `json` is set, or the raw text
+  // otherwise.
+  schema?: z.ZodType;
+  // json parses the value before validating, and reports malformed JSON.
+  json?: boolean;
+}
+
+// TextAreaField collects multi-line text — a JSON blob, a system prompt.
+// FormTextArea spends enter on newlines, so ctl+d advances, matching the prompt
+// step in HarnessWizard.
+export function TextAreaField({
+  label,
+  help = "",
+  placeholder = "",
+  value,
+  onChange,
+  required = false,
+  schema,
+  json = false,
+}: TextAreaFieldProps) {
+  const { advance, back, isLast } = useWizard();
+  const [error, setError] = useState<string>();
+
+  useKeyHints([
+    { key: "enter", label: "newline" },
+    { key: "ctl+d", label: isLast ? "submit" : "continue" },
+  ]);
+
+  useInput((input, key) => {
+    if (key.escape) {
+      back();
+      return;
+    }
+    if (!(key.ctrl && input === "d")) return;
+
+    const issue = validateEntry(value, { label, required, schema, json });
+    if (issue !== undefined) {
+      setError(issue);
+      return;
+    }
+    setError(undefined);
+    advance();
+  });
+
+  return (
+    <Box flexDirection="column">
+      <FormTextArea
+        name=""
+        helpText={help}
+        placeholder={placeholder}
+        value={value}
+        onChange={(next) => {
+          onChange(next);
+          setError(undefined);
+        }}
+      />
+      {error !== undefined && <Text color={theme.colors.error}>{error}</Text>}
+    </Box>
+  );
+}
+
+export interface SummaryProps {
+  // items is the review table: what will be created, and with what settings.
+  items: Record<string, string>;
+}
+
+// Summary is the review step. It sits last, so its enter submits.
+export function Summary({ items }: SummaryProps) {
+  const { advance, back } = useWizard();
+
+  useKeyHints([{ key: "enter", label: "submit" }]);
+
+  useInput((_input, key) => {
+    if (key.escape) {
+      back();
+      return;
+    }
+    if (key.return) advance();
+  });
+
+  return (
+    <Box flexDirection="column">
+      <Box
+        borderStyle="single"
+        borderColor={theme.colors.border}
+        borderLeft={false}
+        borderRight={false}
+        borderBottom={false}
+      >
+        <KeyValueTable items={items} />
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/wizard/index.ts
+++ b/src/components/wizard/index.ts
@@ -1,0 +1,16 @@
+export { Wizard, type WizardProps, type WizardSubmitResult, type ProgressEvent } from "./Wizard";
+export { Step, type StepProps } from "./Step";
+export { useWizard, useKeyHints, type KeyHint, type WizardControls } from "./context";
+export {
+  TextField,
+  ChoiceField,
+  MultiChoiceField,
+  TextAreaField,
+  Summary,
+  type Choice,
+  type TextFieldProps,
+  type ChoiceFieldProps,
+  type MultiChoiceFieldProps,
+  type TextAreaFieldProps,
+  type SummaryProps,
+} from "./fields";

--- a/src/components/wizard/wizard.test.tsx
+++ b/src/components/wizard/wizard.test.tsx
@@ -1,0 +1,287 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { useState } from "react";
+import { render } from "ink-testing-library";
+import { cleanupScreens, keys, tick, waitFor } from "../../testing";
+import { Wizard, type WizardSubmitResult } from "./Wizard";
+import { Step } from "./Step";
+import { ChoiceField, Summary, TextField } from "./fields";
+
+afterEach(cleanupScreens);
+
+// The wizard shell is exercised through a synthetic flow rather than one of the
+// real screens, so these tests describe the shell's own behaviour: how it
+// derives steps from children, moves between them, and reports outcomes.
+
+interface HarnessOptions {
+  onSubmit?: () => WizardSubmitResult;
+  onCancel?: () => void;
+  onError?: "exit" | "retry";
+  onDone?: () => void;
+}
+
+const YES_NO = [
+  { value: false, label: "no", description: "skip the extra question" },
+  { value: true, label: "yes", description: "ask the extra question" },
+];
+
+// TestWizard has one conditional step, so the branch behaviour under test is
+// expressed the way a screen expresses it: `{condition && <Step/>}`.
+function TestWizard({ onSubmit, onCancel, onError, onDone }: HarnessOptions) {
+  const [name, setName] = useState("");
+  const [wantsExtra, setWantsExtra] = useState(false);
+  const [extra, setExtra] = useState("");
+
+  return (
+    <Wizard
+      breadcrumb={["agentcore", "test"]}
+      description="a synthetic flow"
+      onCancel={onCancel ?? (() => {})}
+      onSubmit={onSubmit ?? (async () => {})}
+      onError={onError}
+      onDone={onDone}
+      runningLabel="working…"
+      successLabel="all done"
+      successHint="enter exits"
+    >
+      <Step name="name" question="what is your name?">
+        <TextField label="name" value={name} onChange={setName} required />
+      </Step>
+
+      <Step name="branch" question="want the extra question?">
+        <ChoiceField choices={YES_NO} value={wantsExtra} onChange={setWantsExtra} />
+      </Step>
+
+      {wantsExtra && (
+        <Step name="extra" question="the extra question">
+          <TextField label="extra" value={extra} onChange={setExtra} />
+        </Step>
+      )}
+
+      <Step name="review" question="review">
+        <Summary items={{ name, extra: extra === "" ? "(none)" : extra }} />
+      </Step>
+    </Wizard>
+  );
+}
+
+interface Driver {
+  lastFrame: () => string | undefined;
+  write: (input: string) => Promise<void>;
+  press: (key: keyof typeof keys) => Promise<void>;
+  // pressTwice delivers two discrete key events in one drain, with no render in
+  // between — what a fast typist produces. A single "\r\r" chunk would not do:
+  // Ink reports a multi-character chunk with key.return false, so it never
+  // reaches a return handler at all.
+  pressTwice: (key: keyof typeof keys) => Promise<void>;
+  unmount: () => void;
+}
+
+function drive(options: HarnessOptions = {}): Driver {
+  const instance = render(<></>);
+  Object.defineProperties(instance.stdout, {
+    columns: { configurable: true, value: 100 },
+    rows: { configurable: true, value: 40 },
+  });
+  instance.rerender(<TestWizard {...options} />);
+
+  return {
+    lastFrame: instance.lastFrame,
+    write: async (input) => {
+      await tick();
+      instance.stdin.write(input);
+      await tick();
+    },
+    press: async (key) => {
+      await tick();
+      instance.stdin.write(keys[key]);
+      await tick();
+    },
+    pressTwice: async (key) => {
+      await tick();
+      instance.stdin.write(keys[key]);
+      instance.stdin.write(keys[key]);
+      await tick();
+    },
+    unmount: instance.unmount,
+  };
+}
+
+function waitForFrame(driver: Driver, text: string): Promise<void> {
+  return waitFor(() => (driver.lastFrame() ?? "").includes(text), 1000);
+}
+
+describe("Wizard shell", () => {
+  test("derives the stepper from its Step children", async () => {
+    const d = drive();
+
+    await waitForFrame(d, "what is your name?");
+    const frame = d.lastFrame()!;
+    expect(frame).toContain("● name");
+    expect(frame).toContain("○ branch");
+    expect(frame).toContain("○ review");
+    // The conditional step is not offered while its condition is false.
+    expect(frame).not.toContain("○ extra");
+    d.unmount();
+  });
+
+  test("a step appears mid-flow when its condition turns true", async () => {
+    const d = drive();
+
+    await waitForFrame(d, "what is your name?");
+    await d.write("Ada");
+    await d.press("return");
+
+    await waitForFrame(d, "want the extra question?");
+    expect(d.lastFrame()).not.toContain("○ extra");
+
+    // Choosing "yes" inserts the step between here and review.
+    await d.press("down");
+    await waitForFrame(d, "○ extra");
+    await d.press("return");
+
+    await waitForFrame(d, "the extra question");
+    d.unmount();
+  });
+
+  test("enter advances and esc goes back, keeping answers", async () => {
+    const d = drive();
+
+    await waitForFrame(d, "what is your name?");
+    await d.write("Ada");
+    await d.press("return");
+
+    await waitForFrame(d, "want the extra question?");
+    await d.press("escape");
+
+    await waitForFrame(d, "what is your name?");
+    expect(d.lastFrame()).toContain("Ada");
+    d.unmount();
+  });
+
+  test("esc on the first step cancels out of the wizard", async () => {
+    let cancelled = 0;
+    const d = drive({ onCancel: () => cancelled++ });
+
+    await waitForFrame(d, "what is your name?");
+    await d.press("escape");
+
+    expect(cancelled).toBe(1);
+    d.unmount();
+  });
+
+  test("the footer hints come from the active field", async () => {
+    const d = drive();
+
+    // A text field offers enter; a choice field also offers the arrows.
+    await waitForFrame(d, "what is your name?");
+    expect(d.lastFrame()).toContain("[enter] continue");
+    expect(d.lastFrame()).not.toContain("[↑↓] choose");
+
+    await d.write("Ada");
+    await d.press("return");
+
+    await waitForFrame(d, "want the extra question?");
+    expect(d.lastFrame()).toContain("[↑↓] choose");
+    d.unmount();
+  });
+
+  test("enter on the last step submits and reports success", async () => {
+    let submits = 0;
+    const d = drive({
+      onSubmit: async () => {
+        submits++;
+      },
+    });
+
+    await waitForFrame(d, "what is your name?");
+    await d.write("Ada");
+    await d.press("return");
+    await waitForFrame(d, "want the extra question?");
+    await d.press("return");
+    await waitForFrame(d, "review");
+    expect(d.lastFrame()).toContain("[enter] submit");
+    await d.press("return");
+
+    await waitForFrame(d, "✔ all done");
+    expect(submits).toBe(1);
+    d.unmount();
+  });
+
+  test("a streamed submit renders each progress message", async () => {
+    async function* progress() {
+      yield { message: "wrote agentcore.json" };
+      yield { message: "updated the deploy target" };
+    }
+    const d = drive({ onSubmit: () => progress() });
+
+    await waitForFrame(d, "what is your name?");
+    await d.write("Ada");
+    await d.press("return");
+    await waitForFrame(d, "want the extra question?");
+    await d.press("return");
+    await waitForFrame(d, "review");
+    await d.press("return");
+
+    await waitForFrame(d, "✔ all done");
+    const frame = d.lastFrame()!;
+    expect(frame).toContain("wrote agentcore.json");
+    expect(frame).toContain("updated the deploy target");
+    d.unmount();
+  });
+
+  test("a buffered second enter does not submit twice", async () => {
+    let submits = 0;
+    const d = drive({
+      onSubmit: async () => {
+        submits++;
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      },
+    });
+
+    await waitForFrame(d, "what is your name?");
+    await d.write("Ada");
+    await d.press("return");
+    await waitForFrame(d, "want the extra question?");
+    await d.press("return");
+    await waitForFrame(d, "review");
+    await d.pressTwice("return");
+
+    await waitForFrame(d, "✔ all done");
+    expect(submits).toBe(1);
+    d.unmount();
+  });
+
+  test("onError retry reports the failure and returns to the form", async () => {
+    const d = drive({
+      onError: "retry",
+      onSubmit: () => Promise.reject(new Error("the service said no")),
+    });
+
+    await waitForFrame(d, "what is your name?");
+    await d.write("Ada");
+    await d.press("return");
+    await waitForFrame(d, "want the extra question?");
+    await d.press("return");
+    await waitForFrame(d, "review");
+    await d.press("return");
+
+    await waitForFrame(d, "✗ the service said no");
+    await d.press("escape");
+
+    // Back on the review step, with the answers intact.
+    await waitForFrame(d, "review");
+    expect(d.lastFrame()).toContain("Ada");
+    d.unmount();
+  });
+
+  test("a required field blocks the step until it is filled", async () => {
+    const d = drive();
+
+    await waitForFrame(d, "what is your name?");
+    await d.press("return");
+
+    await waitForFrame(d, "name is required");
+    expect(d.lastFrame()).toContain("what is your name?");
+    d.unmount();
+  });
+});

--- a/src/components/wizard/wizard.test.tsx
+++ b/src/components/wizard/wizard.test.tsx
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { useState } from "react";
 import { render } from "ink-testing-library";
-import { cleanupScreens, keys, tick, waitFor } from "../../testing";
+import { render as inkRender } from "ink";
+import { cleanupScreens, keys, tick, ttyTestIO, waitFor } from "../../testing";
 import { Wizard, type WizardSubmitResult } from "./Wizard";
 import { Step } from "./Step";
 import { ChoiceField, Summary, TextField } from "./fields";
@@ -283,5 +284,33 @@ describe("Wizard shell", () => {
     await waitForFrame(d, "name is required");
     expect(d.lastFrame()).toContain("what is your name?");
     d.unmount();
+  });
+});
+
+describe("Wizard authoring guards", () => {
+  // Ink's own render rather than ink-testing-library: a render-time throw
+  // reaches Ink's error boundary and rejects waitUntilExit, which the testing
+  // library does not expose.
+  test("two steps sharing a name are rejected at render", async () => {
+    const { streams } = ttyTestIO();
+    const { waitUntilExit } = inkRender(
+      <Wizard
+        breadcrumb={["agentcore", "test"]}
+        onCancel={() => {}}
+        onSubmit={async () => {}}
+        runningLabel="working…"
+        successLabel="all done"
+      >
+        <Step name="name" question="first">
+          <Summary items={{}} />
+        </Step>
+        <Step name="name" question="second">
+          <Summary items={{}} />
+        </Step>
+      </Wizard>,
+      { stdin: streams.io.stdin, stdout: streams.io.stdout, stderr: streams.io.stderr },
+    );
+
+    await expect(waitUntilExit()).rejects.toThrow('duplicate <Step name="name">');
   });
 });

--- a/src/handlers/project/ProjectGate.tsx
+++ b/src/handlers/project/ProjectGate.tsx
@@ -1,0 +1,107 @@
+import React, { useEffect, useState } from "react";
+import { Box, Text } from "ink";
+import { Layout } from "../../components/Layout";
+import { Spinner } from "../../components/ui/spinner";
+import { darkTheme } from "../../components/ui/_core.js";
+import type { Core } from "../types";
+import type { Project } from "./types";
+
+const theme = darkTheme;
+
+// projectNotFoundMessage matches what withProject throws on the flag-driven
+// path, so both entry points say the same thing about the same problem.
+function projectNotFoundMessage(from: string): string {
+  return (
+    `No AgentCore project found at ${from} or any parent directory ` +
+    `(looked for agentcore/agentcore.json). ` +
+    `Run 'agentcore project create' to scaffold one.`
+  );
+}
+
+export interface UseProjectResult {
+  project?: Project;
+  error?: string;
+}
+
+// useProject resolves the project enclosing the working directory. Screens need
+// their own resolution because withProject wraps `handle` only: middleware runs
+// when a command executes, and navigating between TUI screens never executes
+// one, so ProjectKey is set only when the launching command happened to be a
+// project command. When it was, pass it as `seed` and no resolution happens.
+export function useProject(core: Core, seed?: Project): UseProjectResult {
+  const [project, setProject] = useState<Project | undefined>(seed);
+  const [error, setError] = useState<string>();
+
+  useEffect(() => {
+    if (project !== undefined) return;
+    let active = true;
+    const from = process.cwd();
+    void core.projectManager
+      .resolve({ filePath: from })
+      .then((resolved) => {
+        if (!active) return;
+        if (!resolved) {
+          setError(projectNotFoundMessage(from));
+          return;
+        }
+        setProject(resolved);
+      })
+      .catch((cause: unknown) => {
+        if (active) setError(cause instanceof Error ? cause.message : String(cause));
+      });
+    return () => {
+      active = false;
+    };
+  }, [core.projectManager, project]);
+
+  return { project, error };
+}
+
+export interface ProjectGateProps {
+  core: Core;
+  breadcrumb: string[];
+  description?: string;
+  // seed is the project already pinned on the launch context, when the command
+  // that opened the TUI was itself a project command.
+  seed?: Project;
+  // children receives the resolved project and returns the screen. It must
+  // return an element rather than call hooks itself — the gate renders a
+  // spinner on the first paint, so a hook called here would change order.
+  children: (project: Project) => React.ReactElement;
+}
+
+// ProjectGate resolves the project before rendering a project screen, showing
+// the same not-found guidance the CLI prints when there is none.
+export function ProjectGate({ core, breadcrumb, description, seed, children }: ProjectGateProps) {
+  const { project, error } = useProject(core, seed);
+
+  if (error !== undefined && project === undefined) {
+    return (
+      <Layout
+        breadcrumb={breadcrumb}
+        description={description}
+        keyHints={[{ key: "ctl+c", label: "quit" }]}
+      >
+        <Box paddingX={1}>
+          <Text color={theme.colors.error}>✗ {error}</Text>
+        </Box>
+      </Layout>
+    );
+  }
+
+  if (project === undefined) {
+    return (
+      <Layout
+        breadcrumb={breadcrumb}
+        description={description}
+        keyHints={[{ key: "ctl+c", label: "quit" }]}
+      >
+        <Box paddingX={1}>
+          <Spinner label="loading project…" />
+        </Box>
+      </Layout>
+    );
+  }
+
+  return children(project);
+}

--- a/src/handlers/project/add/add.screen.test.tsx
+++ b/src/handlers/project/add/add.screen.test.tsx
@@ -1,0 +1,114 @@
+import { test, expect, describe, afterEach } from "bun:test";
+import {
+  renderScreen,
+  waitForText,
+  cleanupScreens,
+  createSilentLogger,
+  TestCoreClient,
+  TestGlobalConfigAccessor,
+  testIO,
+  ttyTestIO,
+} from "../../../testing";
+import { renderTuiAt } from "../../../tui";
+import { NotImplementedError } from "../../../errors";
+import { compile, ValueContext } from "../../../router";
+import { createRootHandler } from "../../index";
+
+afterEach(cleanupScreens);
+
+// addSubcommands reads the resources off the compiled Commander tree, so a
+// `project add` resource added later is covered without editing this file.
+function addSubcommands(): string[] {
+  const root = compile(
+    createRootHandler(new TestCoreClient(), {
+      io: testIO().io,
+      logger: createSilentLogger(),
+      globalConfigAccessor: new TestGlobalConfigAccessor(),
+    }),
+    ValueContext.EmptyContext(),
+  );
+  const project = root.commands.find((command) => command.name() === "project")!;
+  const add = project.commands.find((command) => command.name() === "add")!;
+  return add.commands.map((command) => command.name()).filter((name) => name !== "help");
+}
+
+// The resources with a wizard. Everything else still routes to the
+// not-implemented screen and stays usable from the command line.
+const WITH_SCREENS = ["memory", "gateway", "policy-engine", "config-bundle"];
+
+describe("project add menu", () => {
+  test("lists every add resource", async () => {
+    const r = renderScreen("/agentcore/project/add");
+
+    await waitForText(r.lastFrame, "add project resources");
+    const frame = r.lastFrame()!;
+    for (const command of addSubcommands()) {
+      expect(frame).toContain(command);
+    }
+    r.unmount();
+  });
+
+  test("is reachable from the project menu", async () => {
+    const r = renderScreen("/agentcore/project");
+
+    await waitForText(r.lastFrame, "agentcore → project");
+    await r.write("add");
+    await waitForText(r.lastFrame, "❯ add");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "agentcore → project → add");
+    r.unmount();
+  });
+
+  test("esc returns to the project menu", async () => {
+    const r = renderScreen("/agentcore/project/add");
+
+    await waitForText(r.lastFrame, "agentcore → project → add");
+    await r.press("escape");
+
+    await waitForText(r.lastFrame, "manage an AgentCore project");
+    r.unmount();
+  });
+});
+
+describe("add resources without a wizard", () => {
+  // renderTuiAt rather than renderScreen: ink-testing-library exposes no
+  // waitUntilExit, so it cannot observe the rejection under test. Reading the
+  // cases off the router also guards Root's hand-written ADD_COMMANDS — an
+  // unrouted resource hits the catch-all, which resolves instead of rejecting.
+  test.each(addSubcommands().filter((command) => !WITH_SCREENS.includes(command)))(
+    "add %s tears down the TUI with NotImplementedError",
+    async (command) => {
+      const { streams } = ttyTestIO();
+
+      const rendering = renderTuiAt(
+        `/agentcore/project/add/${command}`,
+        ValueContext.EmptyContext(),
+        new TestCoreClient(),
+        streams.io,
+      );
+
+      await expect(rendering).rejects.toThrow(NotImplementedError);
+      await expect(rendering).rejects.toThrow(`'agentcore project add ${command}'`);
+    },
+  );
+
+  test("the error names the command to run instead", async () => {
+    const { streams } = ttyTestIO();
+
+    const caught: unknown = await renderTuiAt(
+      "/agentcore/project/add/harness",
+      ValueContext.EmptyContext(),
+      new TestCoreClient(),
+      streams.io,
+    ).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    expect(caught).toBeInstanceOf(NotImplementedError);
+    expect((caught as NotImplementedError).message).toContain(
+      "agentcore project add harness --help",
+    );
+  });
+});

--- a/src/handlers/project/add/config-bundle/configBundle.screen.test.tsx
+++ b/src/handlers/project/add/config-bundle/configBundle.screen.test.tsx
@@ -1,0 +1,176 @@
+import { test, expect, describe, afterEach } from "bun:test";
+import {
+  renderScreen,
+  waitForText,
+  waitForFlatText,
+  flatFrame,
+  cleanupScreens,
+} from "../../../../testing";
+import { createGatewayProjectTestHarness } from "../gateway-test-support";
+// The real example, so a test cannot pass against a stale copy of it.
+import { COMPONENTS_EXAMPLE } from "./screen";
+
+const { cleanup, inProject, projectSpec } = createGatewayProjectTestHarness(
+  "add-config-bundle-wizard",
+);
+
+afterEach(cleanup);
+afterEach(cleanupScreens);
+
+const COMPONENTS = '{"flags":{"configuration":{"beta":true}}}';
+
+describe("project add config-bundle wizard", () => {
+  test("collects a components map and writes the bundle", async () => {
+    const projectRoot = await inProject();
+    const r = renderScreen("/agentcore/project/add/config-bundle");
+
+    await waitForText(r.lastFrame, "what should this configuration bundle be called?");
+    await r.write("runtimeConfig");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "which components does the bundle configure?");
+    await r.write(COMPONENTS);
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "what is this bundle for?");
+    await r.press("return");
+
+    // Branch is prefilled with the flag's default.
+    await waitForText(r.lastFrame, "which branch holds the initial configuration?");
+    expect(r.lastFrame()).toContain("mainline");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "describe the initial configuration");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "this configuration bundle will be added to agentcore.json");
+    // The review names the components rather than reprinting the JSON.
+    expect(flatFrame(r.lastFrame)).toContain("components flags");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "added configuration bundle 'runtimeConfig' to 'TestProject'");
+
+    const bundles = (await projectSpec(projectRoot)).configBundles;
+    expect(bundles).toHaveLength(1);
+    expect(bundles[0]).toMatchObject({
+      name: "runtimeConfig",
+      components: { flags: { configuration: { beta: true } } },
+      branchName: "mainline",
+    });
+    r.unmount();
+  });
+
+  test("malformed components JSON does not advance", async () => {
+    await inProject();
+    const r = renderScreen("/agentcore/project/add/config-bundle");
+
+    await waitForText(r.lastFrame, "what should this configuration bundle be called?");
+    await r.write("runtimeConfig");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "which components does the bundle configure?");
+    await r.write('{"flags":');
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "is not valid JSON");
+    expect(r.lastFrame()).toContain("which components does the bundle configure?");
+    r.unmount();
+  });
+
+  test("well-formed JSON of the wrong shape names the offending component", async () => {
+    await inProject();
+    const r = renderScreen("/agentcore/project/add/config-bundle");
+
+    await waitForText(r.lastFrame, "what should this configuration bundle be called?");
+    await r.write("runtimeConfig");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "which components does the bundle configure?");
+    // Parses, but a component maps to an object, not a string.
+    await r.write('{"mycomponent": "mycomponent"}');
+    await r.press("return");
+
+    // The message carries zod's issue path, so it says *which* key is wrong
+    // rather than only that something was the wrong type.
+    await waitForFlatText(r.lastFrame, "mycomponent: Invalid input: expected object");
+    // The schema rejected it, so the wizard stayed put rather than advancing.
+    expect(r.lastFrame()).toContain("which components does the bundle configure?");
+    expect(r.lastFrame()).not.toContain("what is this bundle for?");
+    r.unmount();
+  });
+
+  test("the example stays on screen while the user types over it", async () => {
+    await inProject();
+    const r = renderScreen("/agentcore/project/add/config-bundle");
+
+    await waitForText(r.lastFrame, "what should this configuration bundle be called?");
+    await r.write("runtimeConfig");
+    await r.press("return");
+
+    // A placeholder would vanish on the first keystroke; the example must not,
+    // because that is when the shape is most needed.
+    await waitForText(r.lastFrame, "which components does the bundle configure?");
+    expect(r.lastFrame()).toContain(`for example  ${COMPONENTS_EXAMPLE}`);
+
+    await r.write('{"pri');
+    expect(r.lastFrame()).toContain(`for example  ${COMPONENTS_EXAMPLE}`);
+    r.unmount();
+  });
+
+  test("the example is itself a value the step accepts", async () => {
+    const projectRoot = await inProject();
+    const r = renderScreen("/agentcore/project/add/config-bundle");
+
+    await waitForText(r.lastFrame, "what should this configuration bundle be called?");
+    await r.write("runtimeConfig");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "which components does the bundle configure?");
+    await r.write(COMPONENTS_EXAMPLE);
+    await r.press("return");
+
+    // Advancing proves the example parses and satisfies the schema — an example
+    // that does not work is worse than none.
+    await waitForText(r.lastFrame, "what is this bundle for?");
+    await r.press("return");
+    await waitForText(r.lastFrame, "which branch holds the initial configuration?");
+    await r.press("return");
+    await waitForText(r.lastFrame, "describe the initial configuration");
+    await r.press("return");
+    await waitForText(r.lastFrame, "this configuration bundle will be added to agentcore.json");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "added configuration bundle 'runtimeConfig'");
+    expect((await projectSpec(projectRoot)).configBundles[0].components).toEqual({
+      pricing: { configuration: { currency: "USD" } },
+    });
+    r.unmount();
+  });
+
+  test("an empty components map is refused", async () => {
+    await inProject();
+    const r = renderScreen("/agentcore/project/add/config-bundle");
+
+    await waitForText(r.lastFrame, "what should this configuration bundle be called?");
+    await r.write("runtimeConfig");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "which components does the bundle configure?");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "component configuration map is required");
+    r.unmount();
+  });
+
+  test("a name that breaks the schema's pattern is rejected", async () => {
+    await inProject();
+    const r = renderScreen("/agentcore/project/add/config-bundle");
+
+    await waitForText(r.lastFrame, "what should this configuration bundle be called?");
+    await r.write("1-bad-name");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "Must begin with a letter");
+    r.unmount();
+  });
+});

--- a/src/handlers/project/add/config-bundle/index.ts
+++ b/src/handlers/project/add/config-bundle/index.ts
@@ -13,7 +13,11 @@ import { createHandler, flag, ProjectKey } from "../../../../router";
 import { parseJsonFlagWithSchema } from "../../../utils";
 import type { AddProjectResourceConfig } from "../types";
 
-const ComponentsSchema = z
+/**
+ * The shape --components accepts. Exported so the wizard's components step
+ * validates against the same schema rather than a copy of it.
+ */
+export const ComponentsSchema = z
   .record(z.string().min(1), ComponentConfigurationSchema.strict())
   .refine((components) => Object.keys(components).length > 0, {
     message: "must contain at least one component",

--- a/src/handlers/project/add/config-bundle/index.ts
+++ b/src/handlers/project/add/config-bundle/index.ts
@@ -7,10 +7,13 @@ import {
   ConfigBundleCommitMessageSchema,
   ConfigBundleDescriptionSchema,
   ConfigBundleNameSchema,
+  type ConfigBundleSchema,
 } from "../../../../projectSchemas/config-bundle";
 import { KmsKeyArnSchema } from "../../../../projectSchemas/evaluator";
 import { createHandler, flag, ProjectKey } from "../../../../router";
-import { parseJsonFlagWithSchema } from "../../../utils";
+import { formatZodError } from "../../../../router/schema";
+import { parseJsonFlag } from "../../../utils";
+import type { AddResourceInput } from "../../types";
 import type { AddProjectResourceConfig } from "../types";
 
 /**
@@ -22,6 +25,49 @@ export const ComponentsSchema = z
   .refine((components) => Object.keys(components).length > 0, {
     message: "must contain at least one component",
   });
+
+/** The branch the initial configuration lands on when none is named. */
+export const DEFAULT_BRANCH_NAME = "mainline";
+
+/**
+ * ConfigBundleInput is what every entry point — the flag handler, the wizard —
+ * resolves its own inputs to before a bundle is built. `components` is parsed
+ * JSON, validated here. Anything optional is a field toAddConfigBundleInput
+ * defaults.
+ */
+export interface ConfigBundleInput {
+  name: string;
+  /** Parsed JSON; validated against ComponentsSchema here. */
+  components: unknown;
+  description?: string;
+  branchName?: string;
+  commitMessage?: string;
+  kmsKeyArn?: string;
+}
+
+/**
+ * toAddConfigBundleInput is the one place a configuration bundle is assembled
+ * from user input. Both the flag handler and the wizard call it, so they
+ * cannot disagree about what a bundle is or what it defaults to.
+ */
+export function toAddConfigBundleInput(input: ConfigBundleInput): AddResourceInput {
+  const components = ComponentsSchema.safeParse(input.components);
+  if (!components.success) {
+    throw new InputValidationError(
+      `Invalid value for option '--components': ${formatZodError(components.error)}`,
+      { cause: components.error },
+    );
+  }
+  const resourceConfig: z.input<typeof ConfigBundleSchema> = {
+    name: input.name,
+    description: input.description,
+    components: components.data,
+    branchName: input.branchName ?? DEFAULT_BRANCH_NAME,
+    commitMessage: input.commitMessage,
+    kmsKeyArn: input.kmsKeyArn,
+  };
+  return { resourceType: "config-bundle", resourceConfig };
+}
 
 export const createAddConfigBundleHandler = (config: AddProjectResourceConfig) =>
   createHandler({
@@ -43,7 +89,7 @@ export const createAddConfigBundleHandler = (config: AddProjectResourceConfig) =
       flag(
         "branch-name",
         "branch name for the initial configuration",
-        ConfigBundleBranchNameSchema.default("mainline"),
+        ConfigBundleBranchNameSchema.default(DEFAULT_BRANCH_NAME),
       ),
       flag(
         "commit-message",
@@ -56,6 +102,9 @@ export const createAddConfigBundleHandler = (config: AddProjectResourceConfig) =
         KmsKeyArnSchema.optional(),
       ),
     ],
+    // handle only turns flags into a ConfigBundleInput — resolving the
+    // components source and parsing it. What a bundle is belongs to
+    // toAddConfigBundleInput.
     handle: async (ctx, flags) => {
       if (!flags.name) {
         throw new InputValidationError("required option '--name <name>' not specified");
@@ -65,24 +114,22 @@ export const createAddConfigBundleHandler = (config: AddProjectResourceConfig) =
       }
 
       const source = new SourceResolver({ stdin: config.io.stdin });
-      const componentsText = await source.resolveText("components", flags.components);
-      const components = parseJsonFlagWithSchema("components", componentsText, ComponentsSchema);
-      if (components === undefined) {
-        throw new InputValidationError("required option '--components <components>' not specified");
-      }
+      const components = parseJsonFlag<unknown>(
+        "components",
+        await source.resolveText("components", flags.components),
+      );
+
+      const input = toAddConfigBundleInput({
+        name: flags.name,
+        components,
+        description: flags.description,
+        branchName: flags["branch-name"],
+        commitMessage: flags["commit-message"],
+        kmsKeyArn: flags["kms-key-arn"],
+      });
 
       const project = ctx.require(ProjectKey);
-      for await (const event of config.projectManager.addResource(project, {
-        resourceType: "config-bundle",
-        resourceConfig: {
-          name: flags.name,
-          description: flags.description,
-          components,
-          branchName: flags["branch-name"],
-          commitMessage: flags["commit-message"],
-          kmsKeyArn: flags["kms-key-arn"],
-        },
-      })) {
+      for await (const event of config.projectManager.addResource(project, input)) {
         config.io.stderr.write(`${event.message}\n`);
       }
 

--- a/src/handlers/project/add/config-bundle/screen.tsx
+++ b/src/handlers/project/add/config-bundle/screen.tsx
@@ -1,0 +1,166 @@
+import { useState } from "react";
+import { useNavigate } from "react-router";
+import type z from "zod";
+import { ProjectKey } from "../../../../router";
+import {
+  ConfigBundleBranchNameSchema,
+  ConfigBundleCommitMessageSchema,
+  ConfigBundleDescriptionSchema,
+  ConfigBundleNameSchema,
+  type ConfigBundleSchema,
+} from "../../../../projectSchemas/config-bundle";
+import type { ScreenProps } from "../../../types";
+import type { AddResourceInput, Project } from "../../types";
+import { ProjectGate } from "../../ProjectGate";
+import { Wizard, Step, TextField, Summary } from "../../../../components/wizard";
+import { ComponentsSchema } from "./index";
+
+const BREADCRUMB = ["agentcore", "project", "add", "config-bundle"];
+const DESCRIPTION = "adds a configuration bundle to the current project";
+
+// The default the --branch-name flag applies.
+const DEFAULT_BRANCH_NAME = "mainline";
+
+// A complete, valid components map. It stays on screen while the user types,
+// so the shape can be copied rather than remembered.
+export const COMPONENTS_EXAMPLE = '{"pricing": {"configuration": {"currency": "USD"}}}';
+
+interface ConfigBundleFormValues {
+  name: string;
+  components: string;
+  description: string;
+  branchName: string;
+  commitMessage: string;
+}
+
+export function buildAddConfigBundleInput(values: ConfigBundleFormValues): AddResourceInput {
+  const resourceConfig: z.input<typeof ConfigBundleSchema> = {
+    name: values.name.trim(),
+    description: values.description.trim() === "" ? undefined : values.description.trim(),
+    components: ComponentsSchema.parse(JSON.parse(values.components)),
+    branchName: values.branchName.trim() === "" ? DEFAULT_BRANCH_NAME : values.branchName.trim(),
+    commitMessage: values.commitMessage.trim() === "" ? undefined : values.commitMessage.trim(),
+  };
+  return { resourceType: "config-bundle", resourceConfig };
+}
+
+function summaryOf(values: ConfigBundleFormValues): Record<string, string> {
+  // The components blob can be long, so the review reports its component names
+  // rather than reprinting the JSON the user just typed.
+  let componentNames = "(unreadable)";
+  try {
+    componentNames = Object.keys(JSON.parse(values.components) as object).join(", ");
+  } catch {
+    // The components step refuses to advance on malformed JSON, so this is only
+    // reachable if the value changed afterwards.
+  }
+  return {
+    bundle: values.name.trim(),
+    components: componentNames,
+    branch: values.branchName.trim() === "" ? DEFAULT_BRANCH_NAME : values.branchName.trim(),
+    ...(values.description.trim() === "" ? {} : { description: values.description.trim() }),
+    ...(values.commitMessage.trim() === "" ? {} : { commit: values.commitMessage.trim() }),
+  };
+}
+
+export function AddConfigBundleScreen({ ctx, core }: ScreenProps) {
+  return (
+    <ProjectGate
+      core={core}
+      breadcrumb={BREADCRUMB}
+      description={DESCRIPTION}
+      seed={ctx.value(ProjectKey)}
+    >
+      {(project) => <AddConfigBundleWizard project={project} core={core} />}
+    </ProjectGate>
+  );
+}
+
+function AddConfigBundleWizard({ project, core }: { project: Project; core: ScreenProps["core"] }) {
+  const navigate = useNavigate();
+  const [values, setValues] = useState<ConfigBundleFormValues>({
+    name: "",
+    components: "",
+    description: "",
+    branchName: DEFAULT_BRANCH_NAME,
+    commitMessage: "",
+  });
+  const set = (update: Partial<ConfigBundleFormValues>) =>
+    setValues((current) => ({ ...current, ...update }));
+
+  return (
+    <Wizard
+      breadcrumb={BREADCRUMB}
+      description={DESCRIPTION}
+      onCancel={() => navigate("/agentcore/project/add")}
+      onSubmit={() => core.projectManager.addResource(project, buildAddConfigBundleInput(values))}
+      runningLabel={`adding configuration bundle ${values.name.trim()}…`}
+      successLabel={`added configuration bundle '${values.name.trim()}' to '${project.name}'`}
+      successHint="enter exits"
+    >
+      <Step name="name" question="what should this configuration bundle be called?">
+        <TextField
+          label="bundle name"
+          placeholder="runtime-config"
+          value={values.name}
+          onChange={(name) => set({ name })}
+          required
+          schema={ConfigBundleNameSchema}
+        />
+      </Step>
+
+      {/* Single-line rather than a textarea: JSON is valid on one line, so
+          multi-line editing buys nothing, and this field can be corrected in
+          place — the textarea is append-only. It also keeps enter meaning
+          "continue" here, as it does on every other step. Pasting
+          pretty-printed JSON still works: the input drops the newlines but
+          keeps the spaces around them, so the value stays valid. */}
+      <Step name="components" question="which components does the bundle configure?">
+        <TextField
+          label="component configuration map"
+          help="each component name maps to an object with a configuration"
+          example={COMPONENTS_EXAMPLE}
+          value={values.components}
+          onChange={(components) => set({ components })}
+          required
+          json
+          schema={ComponentsSchema}
+        />
+      </Step>
+
+      <Step name="description" question="what is this bundle for? (optional)">
+        <TextField
+          label="description"
+          placeholder="feature flags for the checkout agent"
+          value={values.description}
+          onChange={(description) => set({ description })}
+          schema={ConfigBundleDescriptionSchema}
+        />
+      </Step>
+
+      <Step name="branch" title="branch" question="which branch holds the initial configuration?">
+        <TextField
+          label="branch name"
+          placeholder={DEFAULT_BRANCH_NAME}
+          value={values.branchName}
+          onChange={(branchName) => set({ branchName })}
+          schema={ConfigBundleBranchNameSchema}
+        />
+      </Step>
+
+      <Step name="commit" title="commit" question="describe the initial configuration (optional)">
+        <TextField
+          label="commit message"
+          placeholder="initial configuration"
+          value={values.commitMessage}
+          onChange={(commitMessage) => set({ commitMessage })}
+          schema={ConfigBundleCommitMessageSchema}
+        />
+      </Step>
+
+      <Step name="review" question="this configuration bundle will be added to agentcore.json">
+        <Summary items={summaryOf(values)} />
+      </Step>
+    </Wizard>
+  );
+}

--- a/src/handlers/project/add/config-bundle/screen.tsx
+++ b/src/handlers/project/add/config-bundle/screen.tsx
@@ -1,25 +1,25 @@
 import { useState } from "react";
 import { useNavigate } from "react-router";
-import type z from "zod";
 import { ProjectKey } from "../../../../router";
 import {
   ConfigBundleBranchNameSchema,
   ConfigBundleCommitMessageSchema,
   ConfigBundleDescriptionSchema,
   ConfigBundleNameSchema,
-  type ConfigBundleSchema,
 } from "../../../../projectSchemas/config-bundle";
 import type { ScreenProps } from "../../../types";
-import type { AddResourceInput, Project } from "../../types";
+import type { Project } from "../../types";
 import { ProjectGate } from "../../ProjectGate";
 import { Wizard, Step, TextField, Summary } from "../../../../components/wizard";
-import { ComponentsSchema } from "./index";
+import {
+  ComponentsSchema,
+  DEFAULT_BRANCH_NAME,
+  toAddConfigBundleInput,
+  type ConfigBundleInput,
+} from "./index";
 
 const BREADCRUMB = ["agentcore", "project", "add", "config-bundle"];
 const DESCRIPTION = "adds a configuration bundle to the current project";
-
-// The default the --branch-name flag applies.
-const DEFAULT_BRANCH_NAME = "mainline";
 
 // A complete, valid components map. It stays on screen while the user types,
 // so the shape can be copied rather than remembered.
@@ -33,15 +33,23 @@ interface ConfigBundleFormValues {
   commitMessage: string;
 }
 
-export function buildAddConfigBundleInput(values: ConfigBundleFormValues): AddResourceInput {
-  const resourceConfig: z.input<typeof ConfigBundleSchema> = {
+// toConfigBundleInput reads the form into the ConfigBundleInput the handler's
+// toAddConfigBundleInput builds a bundle from. It trims and parses; a blank
+// optional answer is passed as undefined so the shared builder applies the
+// same default the flag path applies.
+export function toConfigBundleInput(values: ConfigBundleFormValues): ConfigBundleInput {
+  return {
     name: values.name.trim(),
-    description: values.description.trim() === "" ? undefined : values.description.trim(),
-    components: ComponentsSchema.parse(JSON.parse(values.components)),
-    branchName: values.branchName.trim() === "" ? DEFAULT_BRANCH_NAME : values.branchName.trim(),
-    commitMessage: values.commitMessage.trim() === "" ? undefined : values.commitMessage.trim(),
+    components: JSON.parse(values.components),
+    description: blankToUndefined(values.description),
+    branchName: blankToUndefined(values.branchName),
+    commitMessage: blankToUndefined(values.commitMessage),
   };
-  return { resourceType: "config-bundle", resourceConfig };
+}
+
+function blankToUndefined(value: string): string | undefined {
+  const trimmed = value.trim();
+  return trimmed === "" ? undefined : trimmed;
 }
 
 function summaryOf(values: ConfigBundleFormValues): Record<string, string> {
@@ -93,7 +101,12 @@ function AddConfigBundleWizard({ project, core }: { project: Project; core: Scre
       breadcrumb={BREADCRUMB}
       description={DESCRIPTION}
       onCancel={() => navigate("/agentcore/project/add")}
-      onSubmit={() => core.projectManager.addResource(project, buildAddConfigBundleInput(values))}
+      onSubmit={() =>
+        core.projectManager.addResource(
+          project,
+          toAddConfigBundleInput(toConfigBundleInput(values)),
+        )
+      }
       runningLabel={`adding configuration bundle ${values.name.trim()}…`}
       successLabel={`added configuration bundle '${values.name.trim()}' to '${project.name}'`}
       successHint="enter exits"

--- a/src/handlers/project/add/gateway/gateway.screen.test.tsx
+++ b/src/handlers/project/add/gateway/gateway.screen.test.tsx
@@ -121,6 +121,33 @@ describe("project add gateway wizard", () => {
     r.unmount();
   });
 
+  test("the JWT step rejects the SDK authorizer shape, as the flag path does", async () => {
+    await inProject();
+    const r = renderScreen("/agentcore/project/add/gateway");
+
+    await waitForText(r.lastFrame, "what should this Gateway be called?");
+    await r.write("jwt");
+    await r.press("return");
+    await waitForText(r.lastFrame, "which Target types should this Gateway accept?");
+    await r.press("return");
+    await waitForText(r.lastFrame, "how should inbound callers be authorized?");
+    await r.press("down");
+    await r.press("down");
+    await r.press("return");
+    await waitForText(r.lastFrame, "paste the authorizerConfiguration for your JWT issuer");
+
+    // The SDK's casing is well-formed JSON of the wrong shape. The step must
+    // name the stray key rather than accept it: the project schema would only
+    // reject it later, at submit, as a missing customJwtAuthorizer.
+    await r.write(
+      '{"customJWTAuthorizer":{"discoveryUrl":"https://idp.example.com/.well-known/openid-configuration"}}',
+    );
+    await r.write("\x04");
+    await waitForFlatText(r.lastFrame, "customJWTAuthorizer");
+    expect(r.lastFrame()).toContain("paste the authorizerConfiguration");
+    r.unmount();
+  });
+
   test("a name that would exceed the service limit is rejected", async () => {
     await inProject();
     const r = renderScreen("/agentcore/project/add/gateway");

--- a/src/handlers/project/add/gateway/gateway.screen.test.tsx
+++ b/src/handlers/project/add/gateway/gateway.screen.test.tsx
@@ -1,0 +1,137 @@
+import { test, expect, describe, afterEach } from "bun:test";
+import {
+  renderScreen,
+  waitForText,
+  waitForFlatText,
+  flatFrame,
+  cleanupScreens,
+} from "../../../../testing";
+import { createGatewayProjectTestHarness } from "../gateway-test-support";
+
+const { cleanup, inProject, projectSpec } = createGatewayProjectTestHarness("add-gateway-wizard");
+
+afterEach(cleanup);
+afterEach(cleanupScreens);
+
+describe("project add gateway wizard", () => {
+  test("default flow writes the same defaults the flag-driven path writes", async () => {
+    const projectRoot = await inProject();
+    const r = renderScreen("/agentcore/project/add/gateway");
+
+    await waitForText(r.lastFrame, "what should this Gateway be called?");
+    await r.write("tools");
+    await r.press("return");
+
+    // Protocol: None is the preselected default.
+    await waitForText(r.lastFrame, "which Target types should this Gateway accept?");
+    expect(r.lastFrame()).toContain("● None (default)");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "how should inbound callers be authorized?");
+    expect(r.lastFrame()).toContain("● NONE (default)");
+    await r.press("return");
+
+    // Neither the JWT step nor the semantic-search step applies to these answers.
+    await waitForText(r.lastFrame, "what is this Gateway for?");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "this Gateway will be added to agentcore.json");
+    const review = flatFrame(r.lastFrame);
+    expect(review).toContain("gateway tools");
+    expect(review).toContain("protocol None");
+    expect(review).toContain("authorizer NONE");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "added Gateway 'tools' to 'TestProject'");
+
+    const gateways = (await projectSpec(projectRoot)).agentCoreGateways;
+    expect(gateways).toHaveLength(1);
+    expect(gateways[0]).toMatchObject({
+      name: "tools",
+      protocolType: "None",
+      authorizerType: "NONE",
+      targets: [],
+      enableSemanticSearch: false,
+      exceptionLevel: "NONE",
+    });
+    r.unmount();
+  });
+
+  test("the semantic-search step appears only for MCP", async () => {
+    const projectRoot = await inProject();
+    const r = renderScreen("/agentcore/project/add/gateway");
+
+    await waitForText(r.lastFrame, "what should this Gateway be called?");
+    await r.write("mcp");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "which Target types should this Gateway accept?");
+    await r.press("down");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "how should inbound callers be authorized?");
+    await r.press("return");
+
+    // The MCP-only step is now in the flow.
+    await waitForText(r.lastFrame, "should tools be searchable by meaning?");
+    await r.press("down");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "what is this Gateway for?");
+    await r.press("return");
+    await waitForText(r.lastFrame, "this Gateway will be added to agentcore.json");
+    const review = flatFrame(r.lastFrame);
+    expect(review).toContain("protocol MCP");
+    expect(review).toContain("semantic search on");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "added Gateway 'mcp'");
+    expect((await projectSpec(projectRoot)).agentCoreGateways[0]).toMatchObject({
+      protocolType: "MCP",
+      enableSemanticSearch: true,
+    });
+    r.unmount();
+  });
+
+  test("CUSTOM_JWT adds a configuration step and validates its JSON", async () => {
+    await inProject();
+    const r = renderScreen("/agentcore/project/add/gateway");
+
+    await waitForText(r.lastFrame, "what should this Gateway be called?");
+    await r.write("jwt");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "which Target types should this Gateway accept?");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "how should inbound callers be authorized?");
+    await r.press("down");
+    await r.press("down");
+    await r.press("return");
+
+    // The branch step only exists for CUSTOM_JWT.
+    await waitForText(r.lastFrame, "paste the authorizerConfiguration for your JWT issuer");
+
+    // Malformed JSON is refused before the wizard advances.
+    await r.write("{ not json");
+    await r.write("\x04"); // ctrl+d attempts to continue
+    await waitForText(r.lastFrame, "is not valid JSON");
+    // Still on the configuration step.
+    expect(r.lastFrame()).toContain("paste the authorizerConfiguration");
+    r.unmount();
+  });
+
+  test("a name that would exceed the service limit is rejected", async () => {
+    await inProject();
+    const r = renderScreen("/agentcore/project/add/gateway");
+
+    await waitForText(r.lastFrame, "what should this Gateway be called?");
+    // TestProject- prefix plus this name passes 48 characters.
+    await r.write("a".repeat(40));
+    await r.press("return");
+
+    await waitForFlatText(r.lastFrame, "exceeds the service limit of 48 characters");
+    expect(flatFrame(r.lastFrame)).toContain("what should this Gateway be called?");
+    r.unmount();
+  });
+});

--- a/src/handlers/project/add/gateway/index.ts
+++ b/src/handlers/project/add/gateway/index.ts
@@ -1,13 +1,31 @@
 import z from "zod";
 import { InputValidationError } from "../../../../errors";
 import { SourceResolver } from "../../../../io";
-import { GatewayAuthorizerConfigSchema } from "../../../../projectSchemas/auth";
-import type { AgentCoreGateway } from "../../../../projectSchemas/gateway";
+import {
+  GatewayAuthorizerConfigSchema,
+  type GatewayAuthorizerType,
+} from "../../../../projectSchemas/auth";
+import type {
+  AgentCoreGateway,
+  GatewayExceptionLevel,
+  GatewayProtocolType,
+  PolicyEngineMode,
+} from "../../../../projectSchemas/gateway";
 import { createHandler, flag, ProjectKey } from "../../../../router";
-import { parseJsonFlagWithSchema, parseTags } from "../../../utils";
+import { formatZodError } from "../../../../router/schema";
+import { parseJsonFlag, parseTags } from "../../../utils";
+import type { AddResourceInput, Project } from "../../types";
 import type { AddProjectResourceConfig } from "../types";
 
-const GatewayAuthorizerConfigurationInputSchema = GatewayAuthorizerConfigSchema.strict();
+/**
+ * The authorizerConfiguration shape both entry points accept. Strict, so the
+ * SDK's casing (`customJWTAuthorizer`) is reported as an unknown key rather than
+ * silently dropped and then rejected later as a missing `customJwtAuthorizer`.
+ */
+export const GatewayAuthorizerConfigurationInputSchema = GatewayAuthorizerConfigSchema.strict();
+
+/** The service limit on a Gateway's deployed name. */
+export const MAX_GATEWAY_RESOURCE_NAME_LENGTH = 48;
 
 /**
  The deployed service name of a gateway; mirrors the L3 Gateway construct's rule.
@@ -17,6 +35,93 @@ export function gatewayResourceName(
   gateway: { name: string; resourceName?: string },
 ): string {
   return gateway.resourceName ?? `${projectName}-${gateway.name}`;
+}
+
+/**
+ * GatewayInput is what every entry point — the flag handler, the wizard —
+ * resolves its own inputs to before a Gateway is built. Values are already
+ * typed: flag text has been read from file/stdin, JSON has been parsed, tags
+ * have been split. Anything optional is a field toAddGatewayInput defaults.
+ */
+export interface GatewayInput {
+  name: string;
+  protocolType?: GatewayProtocolType;
+  authorizerType?: GatewayAuthorizerType;
+  /** Parsed JSON; validated against GatewayAuthorizerConfigurationInputSchema here. */
+  authorizerConfiguration?: unknown;
+  enableSemanticSearch?: boolean;
+  description?: string;
+  exceptionLevel?: GatewayExceptionLevel;
+  executionRoleArn?: string;
+  policyEngine?: { name: string; mode: PolicyEngineMode };
+  tags?: Record<string, string>;
+}
+
+/**
+ * toAddGatewayInput is the one place a Gateway is assembled from user input:
+ * the defaults for what was not said, the rules that span fields, and the
+ * schema the authorizer configuration must satisfy. Both the flag handler and
+ * the wizard call it, so they cannot disagree about what a Gateway is.
+ */
+export function toAddGatewayInput(project: Project, input: GatewayInput): AddResourceInput {
+  const resourceName = gatewayResourceName(project.name, { name: input.name });
+  if (resourceName.length > MAX_GATEWAY_RESOURCE_NAME_LENGTH) {
+    throw new InputValidationError(
+      `Gateway resource name '${resourceName}' exceeds the service limit of ` +
+        `${MAX_GATEWAY_RESOURCE_NAME_LENGTH} characters`,
+    );
+  }
+  if (
+    input.policyEngine &&
+    !project.spec.policyEngines.some((engine) => engine.name === input.policyEngine?.name)
+  ) {
+    throw new InputValidationError(
+      `policy engine '${input.policyEngine.name}' does not exist in policyEngines[]`,
+    );
+  }
+
+  const authorizerType = input.authorizerType ?? "NONE";
+  if (authorizerType === "CUSTOM_JWT" && input.authorizerConfiguration === undefined) {
+    throw new InputValidationError("CUSTOM_JWT requires --authorizer-configuration");
+  }
+  if (authorizerType !== "CUSTOM_JWT" && input.authorizerConfiguration !== undefined) {
+    throw new InputValidationError("--authorizer-configuration is valid only with CUSTOM_JWT");
+  }
+  const protocolType = input.protocolType ?? "None";
+  if (input.enableSemanticSearch && protocolType !== "MCP") {
+    throw new InputValidationError("--enable-semantic-search requires --protocol-type MCP");
+  }
+
+  let authorizerConfiguration: AgentCoreGateway["authorizerConfiguration"];
+  if (input.authorizerConfiguration !== undefined) {
+    const parsed = GatewayAuthorizerConfigurationInputSchema.safeParse(
+      input.authorizerConfiguration,
+    );
+    if (!parsed.success) {
+      throw new InputValidationError(
+        `Invalid value for option '--authorizer-configuration': ${formatZodError(parsed.error)}`,
+        { cause: parsed.error },
+      );
+    }
+    authorizerConfiguration = parsed.data;
+  }
+
+  const gateway: AgentCoreGateway = {
+    name: input.name,
+    protocolType,
+    authorizerType,
+    authorizerConfiguration,
+    description: input.description,
+    targets: [],
+    enableSemanticSearch: input.enableSemanticSearch ?? false,
+    exceptionLevel: input.exceptionLevel ?? "NONE",
+    executionRoleArn: input.executionRoleArn,
+    policyEngineConfiguration: input.policyEngine
+      ? { policyEngineName: input.policyEngine.name, mode: input.policyEngine.mode }
+      : undefined,
+    tags: input.tags,
+  };
+  return { resourceType: "gateway", resourceConfig: gateway };
 }
 
 export const createAddGatewayHandler = (config: AddProjectResourceConfig) =>
@@ -60,16 +165,12 @@ export const createAddGatewayHandler = (config: AddProjectResourceConfig) =>
       flag("exception-level", "exception detail level: debug", z.enum(["debug"]).optional()),
       flag("tags", "tags as repeated key=value or a JSON object", z.array(z.string()).optional()),
     ],
+    // handle only turns flags into a GatewayInput — resolving sources, parsing
+    // JSON, pairing flags that only make sense together. What a Gateway is
+    // belongs to toAddGatewayInput.
     handle: async (ctx, flags) => {
       if (!flags.name) {
         throw new InputValidationError("required option '--name <name>' not specified");
-      }
-      const project = ctx.require(ProjectKey);
-      const resourceName = gatewayResourceName(project.name, { name: flags.name });
-      if (resourceName.length > 48) {
-        throw new InputValidationError(
-          `Gateway resource name '${resourceName}' exceeds the service limit of 48 characters`,
-        );
       }
       if (
         (flags["policy-engine-name"] === undefined) !==
@@ -79,56 +180,34 @@ export const createAddGatewayHandler = (config: AddProjectResourceConfig) =>
           "--policy-engine-name and --policy-engine-mode must be supplied together",
         );
       }
-      if (
-        flags["policy-engine-name"] &&
-        !project.spec.policyEngines.some((engine) => engine.name === flags["policy-engine-name"])
-      ) {
-        throw new InputValidationError(
-          `policy engine '${flags["policy-engine-name"]}' does not exist in policyEngines[]`,
-        );
-      }
 
-      const authorizerType = flags["authorizer-type"] ?? "NONE";
-      if (authorizerType === "CUSTOM_JWT" && flags["authorizer-configuration"] === undefined) {
-        throw new InputValidationError("CUSTOM_JWT requires --authorizer-configuration");
-      }
-      if (authorizerType !== "CUSTOM_JWT" && flags["authorizer-configuration"] !== undefined) {
-        throw new InputValidationError("--authorizer-configuration is valid only with CUSTOM_JWT");
-      }
-      if (flags["enable-semantic-search"] && flags["protocol-type"] !== "MCP") {
-        throw new InputValidationError("--enable-semantic-search requires --protocol-type MCP");
-      }
       const source = new SourceResolver({ stdin: config.io.stdin });
-      const authorizerConfiguration = parseJsonFlagWithSchema(
+      const authorizerConfiguration = parseJsonFlag<unknown>(
         "authorizer-configuration",
         await source.resolveText("authorizer-configuration", flags["authorizer-configuration"]),
-        GatewayAuthorizerConfigurationInputSchema,
       );
 
-      const gateway: AgentCoreGateway = {
+      const project = ctx.require(ProjectKey);
+      const input = toAddGatewayInput(project, {
         name: flags.name,
-        protocolType: flags["protocol-type"] ?? "None",
-        authorizerType,
+        protocolType: flags["protocol-type"],
+        authorizerType: flags["authorizer-type"],
         authorizerConfiguration,
+        enableSemanticSearch: flags["enable-semantic-search"],
         description: flags.description,
-        targets: [],
-        enableSemanticSearch: flags["enable-semantic-search"] ?? false,
-        exceptionLevel: flags["exception-level"] ? "DEBUG" : "NONE",
+        exceptionLevel: flags["exception-level"] ? "DEBUG" : undefined,
         executionRoleArn: flags["role-arn"],
-        policyEngineConfiguration:
+        policyEngine:
           flags["policy-engine-name"] && flags["policy-engine-mode"]
             ? {
-                policyEngineName: flags["policy-engine-name"],
+                name: flags["policy-engine-name"],
                 mode: flags["policy-engine-mode"] === "enforce" ? "ENFORCE" : "LOG_ONLY",
               }
             : undefined,
         tags: parseTags(flags.tags),
-      };
+      });
 
-      for await (const event of config.projectManager.addResource(project, {
-        resourceType: "gateway",
-        resourceConfig: gateway,
-      })) {
+      for await (const event of config.projectManager.addResource(project, input)) {
         config.io.stderr.write(`${event.message}\n`);
       }
       config.io.stderr.write(`added Gateway '${flags.name}' to '${project.name}'\n`);

--- a/src/handlers/project/add/gateway/screen.tsx
+++ b/src/handlers/project/add/gateway/screen.tsx
@@ -1,0 +1,236 @@
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router";
+import z from "zod";
+import { ProjectKey } from "../../../../router";
+import { GatewayAuthorizerConfigSchema } from "../../../../projectSchemas/auth";
+import type { AgentCoreGateway } from "../../../../projectSchemas/gateway";
+import type { ScreenProps } from "../../../types";
+import type { AddResourceInput, Project } from "../../types";
+import { ProjectGate } from "../../ProjectGate";
+import {
+  Wizard,
+  Step,
+  TextField,
+  ChoiceField,
+  TextAreaField,
+  Summary,
+} from "../../../../components/wizard";
+import { gatewayResourceName } from "./index";
+
+const BREADCRUMB = ["agentcore", "project", "add", "gateway"];
+const DESCRIPTION = "adds a Gateway to the current project";
+
+// The service limit the handler enforces on the deployed Gateway name.
+const MAX_RESOURCE_NAME_LENGTH = 48;
+
+// The two protocols --protocol-type resolves to: "MCP" when passed, "None" when
+// omitted. The wizard always states one, so `undefined` is not a choice here.
+type ProtocolType = "MCP" | "None";
+type AuthorizerType = "NONE" | "AWS_IAM" | "CUSTOM_JWT";
+
+const PROTOCOL_CHOICES = [
+  {
+    value: "None" as ProtocolType,
+    label: "None (default)",
+    description: "any Target type",
+  },
+  {
+    value: "MCP" as ProtocolType,
+    label: "MCP",
+    description: "restrict to MCP Targets · required for semantic tool search",
+  },
+];
+
+const AUTHORIZER_CHOICES = [
+  {
+    value: "NONE" as AuthorizerType,
+    label: "NONE (default)",
+    description: "no inbound authorizer",
+  },
+  { value: "AWS_IAM" as AuthorizerType, label: "AWS_IAM", description: "SigV4-signed callers" },
+  {
+    value: "CUSTOM_JWT" as AuthorizerType,
+    label: "CUSTOM_JWT",
+    description: "your own JWT issuer · needs a configuration below",
+  },
+];
+
+const SEMANTIC_SEARCH_CHOICES = [
+  { value: false, label: "off (default)", description: "list tools exactly as the Targets expose" },
+  { value: true, label: "on", description: "let callers search tools by meaning" },
+];
+
+interface GatewayFormValues {
+  name: string;
+  protocolType: ProtocolType;
+  authorizerType: AuthorizerType;
+  authorizerConfiguration: string;
+  enableSemanticSearch: boolean;
+  description: string;
+}
+
+// buildAddGatewayInput mirrors the flag-driven handler's construction, including
+// the defaults it applies for the flags this wizard does not ask about.
+export function buildAddGatewayInput(values: GatewayFormValues): AddResourceInput {
+  const isCustomJwt = values.authorizerType === "CUSTOM_JWT";
+  const gateway: AgentCoreGateway = {
+    name: values.name.trim(),
+    protocolType: values.protocolType,
+    authorizerType: values.authorizerType,
+    authorizerConfiguration: isCustomJwt
+      ? GatewayAuthorizerConfigSchema.parse(JSON.parse(values.authorizerConfiguration))
+      : undefined,
+    description: values.description.trim() === "" ? undefined : values.description.trim(),
+    targets: [],
+    // Semantic search is an MCP-only setting; the handler rejects it otherwise,
+    // so a protocol change away from MCP must not leave it on.
+    enableSemanticSearch: values.protocolType === "MCP" ? values.enableSemanticSearch : false,
+    exceptionLevel: "NONE",
+  };
+  return { resourceType: "gateway", resourceConfig: gateway };
+}
+
+function summaryOf(values: GatewayFormValues): Record<string, string> {
+  return {
+    gateway: values.name.trim(),
+    protocol: values.protocolType,
+    authorizer: values.authorizerType,
+    ...(values.protocolType === "MCP"
+      ? { "semantic search": values.enableSemanticSearch ? "on" : "off" }
+      : {}),
+    ...(values.description.trim() === "" ? {} : { description: values.description.trim() }),
+  };
+}
+
+export function AddGatewayScreen({ ctx, core }: ScreenProps) {
+  return (
+    <ProjectGate
+      core={core}
+      breadcrumb={BREADCRUMB}
+      description={DESCRIPTION}
+      seed={ctx.value(ProjectKey)}
+    >
+      {(project) => <AddGatewayWizard project={project} core={core} />}
+    </ProjectGate>
+  );
+}
+
+function AddGatewayWizard({ project, core }: { project: Project; core: ScreenProps["core"] }) {
+  const navigate = useNavigate();
+  const [values, setValues] = useState<GatewayFormValues>({
+    name: "",
+    protocolType: "None",
+    authorizerType: "NONE",
+    authorizerConfiguration: "",
+    enableSemanticSearch: false,
+    description: "",
+  });
+  const set = (update: Partial<GatewayFormValues>) =>
+    setValues((current) => ({ ...current, ...update }));
+
+  // The deployed name is derived from the project name, so the length limit can
+  // only be checked here — and it is checked with the handler's own helper.
+  const nameSchema = useMemo(
+    () =>
+      z.string().superRefine((name, ctx) => {
+        const resourceName = gatewayResourceName(project.name, { name });
+        if (resourceName.length > MAX_RESOURCE_NAME_LENGTH) {
+          ctx.addIssue({
+            code: "custom",
+            message:
+              `Gateway resource name '${resourceName}' exceeds the service limit of ` +
+              `${MAX_RESOURCE_NAME_LENGTH} characters`,
+          });
+        }
+      }),
+    [project.name],
+  );
+
+  const isCustomJwt = values.authorizerType === "CUSTOM_JWT";
+  const isMcp = values.protocolType === "MCP";
+
+  return (
+    <Wizard
+      breadcrumb={BREADCRUMB}
+      description={DESCRIPTION}
+      onCancel={() => navigate("/agentcore/project/add")}
+      onSubmit={() => core.projectManager.addResource(project, buildAddGatewayInput(values))}
+      runningLabel={`adding Gateway ${values.name.trim()}…`}
+      successLabel={`added Gateway '${values.name.trim()}' to '${project.name}'`}
+      successHint="enter exits"
+    >
+      <Step name="name" question="what should this Gateway be called?">
+        <TextField
+          label="gateway name"
+          help={`deployed as ${project.name}-<name>, up to ${MAX_RESOURCE_NAME_LENGTH} characters`}
+          placeholder="tools"
+          value={values.name}
+          onChange={(name) => set({ name })}
+          required
+          schema={nameSchema}
+        />
+      </Step>
+
+      <Step name="protocol" question="which Target types should this Gateway accept?">
+        <ChoiceField
+          choices={PROTOCOL_CHOICES}
+          value={values.protocolType}
+          onChange={(protocolType) => set({ protocolType })}
+        />
+      </Step>
+
+      <Step name="authorizer" question="how should inbound callers be authorized?">
+        <ChoiceField
+          choices={AUTHORIZER_CHOICES}
+          value={values.authorizerType}
+          onChange={(authorizerType) => set({ authorizerType })}
+        />
+      </Step>
+
+      {isCustomJwt && (
+        <Step
+          name="authorizer-configuration"
+          title="jwt config"
+          question="paste the authorizerConfiguration for your JWT issuer"
+        >
+          <TextAreaField
+            label="authorizer configuration"
+            placeholder='{ "customJWTAuthorizer": { "discoveryUrl": "…" } }'
+            value={values.authorizerConfiguration}
+            onChange={(authorizerConfiguration) => set({ authorizerConfiguration })}
+            required
+            json
+            schema={GatewayAuthorizerConfigSchema}
+          />
+        </Step>
+      )}
+
+      {isMcp && (
+        <Step
+          name="semantic-search"
+          title="search"
+          question="should tools be searchable by meaning?"
+        >
+          <ChoiceField
+            choices={SEMANTIC_SEARCH_CHOICES}
+            value={values.enableSemanticSearch}
+            onChange={(enableSemanticSearch) => set({ enableSemanticSearch })}
+          />
+        </Step>
+      )}
+
+      <Step name="description" question="what is this Gateway for? (optional)">
+        <TextField
+          label="description"
+          placeholder="internal tool gateway"
+          value={values.description}
+          onChange={(description) => set({ description })}
+        />
+      </Step>
+
+      <Step name="review" question="this Gateway will be added to agentcore.json">
+        <Summary items={summaryOf(values)} />
+      </Step>
+    </Wizard>
+  );
+}

--- a/src/handlers/project/add/gateway/screen.tsx
+++ b/src/handlers/project/add/gateway/screen.tsx
@@ -2,10 +2,8 @@ import { useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 import z from "zod";
 import { ProjectKey } from "../../../../router";
-import { GatewayAuthorizerConfigSchema } from "../../../../projectSchemas/auth";
-import type { AgentCoreGateway } from "../../../../projectSchemas/gateway";
 import type { ScreenProps } from "../../../types";
-import type { AddResourceInput, Project } from "../../types";
+import type { Project } from "../../types";
 import { ProjectGate } from "../../ProjectGate";
 import {
   Wizard,
@@ -15,13 +13,16 @@ import {
   TextAreaField,
   Summary,
 } from "../../../../components/wizard";
-import { gatewayResourceName } from "./index";
+import {
+  GatewayAuthorizerConfigurationInputSchema,
+  MAX_GATEWAY_RESOURCE_NAME_LENGTH,
+  gatewayResourceName,
+  toAddGatewayInput,
+  type GatewayInput,
+} from "./index";
 
 const BREADCRUMB = ["agentcore", "project", "add", "gateway"];
 const DESCRIPTION = "adds a Gateway to the current project";
-
-// The service limit the handler enforces on the deployed Gateway name.
-const MAX_RESOURCE_NAME_LENGTH = 48;
 
 // The two protocols --protocol-type resolves to: "MCP" when passed, "None" when
 // omitted. The wizard always states one, so `undefined` is not a choice here.
@@ -69,25 +70,24 @@ interface GatewayFormValues {
   description: string;
 }
 
-// buildAddGatewayInput mirrors the flag-driven handler's construction, including
-// the defaults it applies for the flags this wizard does not ask about.
-export function buildAddGatewayInput(values: GatewayFormValues): AddResourceInput {
+// toGatewayInput reads the form into the GatewayInput the handler's
+// toAddGatewayInput builds a Gateway from. It carries no defaults and no rules
+// of its own: it trims, parses, and drops the answers to steps the user never
+// saw — a JWT configuration typed before switching the authorizer to NONE, a
+// semantic-search choice made before switching the protocol away from MCP —
+// so the shared builder sees exactly what was asked.
+export function toGatewayInput(values: GatewayFormValues): GatewayInput {
   const isCustomJwt = values.authorizerType === "CUSTOM_JWT";
-  const gateway: AgentCoreGateway = {
+  const isMcp = values.protocolType === "MCP";
+  const description = values.description.trim();
+  return {
     name: values.name.trim(),
     protocolType: values.protocolType,
     authorizerType: values.authorizerType,
-    authorizerConfiguration: isCustomJwt
-      ? GatewayAuthorizerConfigSchema.parse(JSON.parse(values.authorizerConfiguration))
-      : undefined,
-    description: values.description.trim() === "" ? undefined : values.description.trim(),
-    targets: [],
-    // Semantic search is an MCP-only setting; the handler rejects it otherwise,
-    // so a protocol change away from MCP must not leave it on.
-    enableSemanticSearch: values.protocolType === "MCP" ? values.enableSemanticSearch : false,
-    exceptionLevel: "NONE",
+    authorizerConfiguration: isCustomJwt ? JSON.parse(values.authorizerConfiguration) : undefined,
+    enableSemanticSearch: isMcp ? values.enableSemanticSearch : undefined,
+    description: description === "" ? undefined : description,
   };
-  return { resourceType: "gateway", resourceConfig: gateway };
 }
 
 function summaryOf(values: GatewayFormValues): Record<string, string> {
@@ -134,12 +134,12 @@ function AddGatewayWizard({ project, core }: { project: Project; core: ScreenPro
     () =>
       z.string().superRefine((name, ctx) => {
         const resourceName = gatewayResourceName(project.name, { name });
-        if (resourceName.length > MAX_RESOURCE_NAME_LENGTH) {
+        if (resourceName.length > MAX_GATEWAY_RESOURCE_NAME_LENGTH) {
           ctx.addIssue({
             code: "custom",
             message:
               `Gateway resource name '${resourceName}' exceeds the service limit of ` +
-              `${MAX_RESOURCE_NAME_LENGTH} characters`,
+              `${MAX_GATEWAY_RESOURCE_NAME_LENGTH} characters`,
           });
         }
       }),
@@ -154,7 +154,9 @@ function AddGatewayWizard({ project, core }: { project: Project; core: ScreenPro
       breadcrumb={BREADCRUMB}
       description={DESCRIPTION}
       onCancel={() => navigate("/agentcore/project/add")}
-      onSubmit={() => core.projectManager.addResource(project, buildAddGatewayInput(values))}
+      onSubmit={() =>
+        core.projectManager.addResource(project, toAddGatewayInput(project, toGatewayInput(values)))
+      }
       runningLabel={`adding Gateway ${values.name.trim()}…`}
       successLabel={`added Gateway '${values.name.trim()}' to '${project.name}'`}
       successHint="enter exits"
@@ -162,7 +164,7 @@ function AddGatewayWizard({ project, core }: { project: Project; core: ScreenPro
       <Step name="name" question="what should this Gateway be called?">
         <TextField
           label="gateway name"
-          help={`deployed as ${project.name}-<name>, up to ${MAX_RESOURCE_NAME_LENGTH} characters`}
+          help={`deployed as ${project.name}-<name>, up to ${MAX_GATEWAY_RESOURCE_NAME_LENGTH} characters`}
           placeholder="tools"
           value={values.name}
           onChange={(name) => set({ name })}
@@ -200,7 +202,7 @@ function AddGatewayWizard({ project, core }: { project: Project; core: ScreenPro
             onChange={(authorizerConfiguration) => set({ authorizerConfiguration })}
             required
             json
-            schema={GatewayAuthorizerConfigSchema}
+            schema={GatewayAuthorizerConfigurationInputSchema}
           />
         </Step>
       )}

--- a/src/handlers/project/add/memory/index.ts
+++ b/src/handlers/project/add/memory/index.ts
@@ -10,9 +10,11 @@ import {
   MemoryStrategySchema,
   MemoryStrategyTypeSchema,
   StreamContentLevelSchema,
+  type MemorySchema,
   type MemoryStrategy,
 } from "../../../../projectSchemas/memory";
 import { TagsSchema } from "../../../../projectSchemas/tags";
+import type { AddResourceInput } from "../../types";
 
 // The service default for raw event retention
 export const DEFAULT_EVENT_EXPIRY_DURATION = 30;
@@ -22,6 +24,46 @@ export const DEFAULT_EVENT_EXPIRY_DURATION = 30;
  * retention step enforces the same range rather than a copy of it.
  */
 export const EventExpiryDurationSchema = z.number().int().min(3).max(365);
+
+type MemoryResourceConfig = z.input<typeof MemorySchema>;
+
+/**
+ * MemoryInput is what every entry point — the flag handler, the wizard —
+ * resolves its own inputs to before a memory is built. Values are already
+ * typed: JSON flags have been parsed and validated, shorthand strategies have
+ * been expanded. Anything optional is a field toAddMemoryInput defaults.
+ */
+export interface MemoryInput {
+  name: string;
+  description?: string;
+  eventExpiryDuration?: number;
+  strategies?: MemoryStrategy[];
+  indexedKeys?: MemoryResourceConfig["indexedKeys"];
+  streamDeliveryResources?: MemoryResourceConfig["streamDeliveryResources"];
+  encryptionKeyArn?: string;
+  executionRoleArn?: string;
+  tags?: Record<string, string>;
+}
+
+/**
+ * toAddMemoryInput is the one place a memory is assembled from user input.
+ * Both the flag handler and the wizard call it, so they cannot disagree about
+ * what a memory is or what it defaults to.
+ */
+export function toAddMemoryInput(input: MemoryInput): AddResourceInput {
+  const resourceConfig: MemoryResourceConfig = {
+    name: input.name,
+    description: input.description,
+    eventExpiryDuration: input.eventExpiryDuration ?? DEFAULT_EVENT_EXPIRY_DURATION,
+    strategies: input.strategies,
+    indexedKeys: input.indexedKeys,
+    streamDeliveryResources: input.streamDeliveryResources,
+    encryptionKeyArn: input.encryptionKeyArn,
+    executionRoleArn: input.executionRoleArn,
+    tags: input.tags,
+  };
+  return { resourceType: "memory", resourceConfig };
+}
 
 function projectMemoryObject<T extends z.ZodRawShape>(shape: T, label: string) {
   const supportedFields = new Set(Object.keys(shape));
@@ -150,38 +192,34 @@ export const createAddMemoryHandler = (config: AddProjectResourceConfig) =>
       ),
       flag("tags", "tags to apply (JSON object of key/value strings)", z.string().optional()),
     ],
+    // handle only turns flags into a MemoryInput — parsing JSON, expanding the
+    // strategies shorthand. What a memory is belongs to toAddMemoryInput.
     handle: async (ctx, flags) => {
       if (!flags.name)
         throw new InputValidationError("required option '--name <name>' not specified");
 
-      const inputIndexedKeys = parseJsonFlagWithSchema(
-        "indexed-keys",
-        flags["indexed-keys"],
-        z.array(IndexedKeyInputSchema),
-      );
-      const inputStreamDelivery = parseJsonFlagWithSchema(
-        "stream-delivery-resources",
-        flags["stream-delivery-resources"],
-        StreamDeliveryResourcesInputSchema,
-      );
-
-      const memoryConfig = {
+      const input = toAddMemoryInput({
         name: flags.name,
         description: flags["description"],
         eventExpiryDuration: flags["event-expiry-duration"],
         strategies: flags["strategies"] ? toStrategies(flags["strategies"]) : undefined,
-        indexedKeys: inputIndexedKeys,
+        indexedKeys: parseJsonFlagWithSchema(
+          "indexed-keys",
+          flags["indexed-keys"],
+          z.array(IndexedKeyInputSchema),
+        ),
+        streamDeliveryResources: parseJsonFlagWithSchema(
+          "stream-delivery-resources",
+          flags["stream-delivery-resources"],
+          StreamDeliveryResourcesInputSchema,
+        ),
         encryptionKeyArn: flags["encryption-key-arn"],
         executionRoleArn: flags["execution-role-arn"],
-        streamDeliveryResources: inputStreamDelivery,
         tags: parseJsonFlagWithSchema("tags", flags["tags"], TagsSchema),
-      };
+      });
 
       const project = ctx.require(ProjectKey);
-      for await (const event of config.projectManager.addResource(project, {
-        resourceType: "memory",
-        resourceConfig: memoryConfig,
-      })) {
+      for await (const event of config.projectManager.addResource(project, input)) {
         config.io.stderr.write(`${event.message}\n`);
       }
 

--- a/src/handlers/project/add/memory/index.ts
+++ b/src/handlers/project/add/memory/index.ts
@@ -15,7 +15,13 @@ import {
 import { TagsSchema } from "../../../../projectSchemas/tags";
 
 // The service default for raw event retention
-const DEFAULT_EVENT_EXPIRY_DURATION = 30;
+export const DEFAULT_EVENT_EXPIRY_DURATION = 30;
+
+/**
+ * The bounds --event-expiry-duration accepts. Exported so the wizard's
+ * retention step enforces the same range rather than a copy of it.
+ */
+export const EventExpiryDurationSchema = z.number().int().min(3).max(365);
 
 function projectMemoryObject<T extends z.ZodRawShape>(shape: T, label: string) {
   const supportedFields = new Set(Object.keys(shape));
@@ -114,7 +120,7 @@ export const createAddMemoryHandler = (config: AddProjectResourceConfig) =>
       flag(
         "event-expiry-duration",
         "how long raw events are retained, in days (3-365)",
-        z.number().int().min(3).max(365).default(DEFAULT_EVENT_EXPIRY_DURATION),
+        EventExpiryDurationSchema.default(DEFAULT_EVENT_EXPIRY_DURATION),
       ),
       flag(
         "strategies",
@@ -200,8 +206,12 @@ function toStrategies(raw: string): MemoryStrategy[] {
   return entries.map(toDefaultStrategy);
 }
 
-/** Expands a bare strategy type into a strategy carrying its default namespaces. */
-function toDefaultStrategy(type: string): MemoryStrategy {
+/**
+ * Expands a bare strategy type into a strategy carrying its default namespaces.
+ * Exported so the wizard's strategy picker produces exactly what
+ * `--strategies SEMANTIC,EPISODIC` produces.
+ */
+export function toDefaultStrategy(type: string): MemoryStrategy {
   const parsed = MemoryStrategyTypeSchema.safeParse(type);
   if (!parsed.success)
     throw new InputValidationError(

--- a/src/handlers/project/add/memory/memory.screen.test.tsx
+++ b/src/handlers/project/add/memory/memory.screen.test.tsx
@@ -1,0 +1,173 @@
+import { test, expect, describe, afterEach } from "bun:test";
+import { renderScreen, waitForText, flatFrame, cleanupScreens } from "../../../../testing";
+import { createGatewayProjectTestHarness } from "../gateway-test-support";
+import {
+  DEFAULT_STRATEGY_NAMESPACE_TEMPLATES,
+  DEFAULT_EPISODIC_REFLECTION_NAMESPACE_TEMPLATES,
+} from "../../../../projectSchemas/memory";
+
+// The wizard resolves the project from process.cwd(), exactly as the
+// flag-driven path does, so the tests run inside a real scaffolded project.
+const { cleanup, inProject, projectSpec } = createGatewayProjectTestHarness("add-memory-wizard");
+
+afterEach(cleanup);
+afterEach(cleanupScreens);
+
+describe("project add memory wizard", () => {
+  test("default flow: name → strategies → retention → description → review", async () => {
+    const projectRoot = await inProject();
+    const r = renderScreen("/agentcore/project/add/memory");
+
+    await waitForText(r.lastFrame, "what should this memory be called?");
+    await r.write("conversations");
+    await r.press("return");
+
+    // SEMANTIC is checked by default; enter accepts the selection.
+    await waitForText(r.lastFrame, "what should be extracted from raw events?");
+    expect(r.lastFrame()).toContain("SEMANTIC");
+    await r.press("return");
+
+    // Retention is prefilled with the service default.
+    await waitForText(r.lastFrame, "how long should raw events be kept?");
+    expect(r.lastFrame()).toContain("30");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "what does this memory store?");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "this memory will be added to agentcore.json");
+    // The review table reports every answer the wizard collected.
+    const review = flatFrame(r.lastFrame);
+    expect(review).toContain("memory conversations");
+    expect(review).toContain("strategies SEMANTIC");
+    expect(review).toContain("event expiry 30 days");
+
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "added memory 'conversations' to 'TestProject'");
+
+    // A picked strategy expands to the same namespaces the shorthand expands to.
+    expect((await projectSpec(projectRoot)).memories).toEqual([
+      {
+        name: "conversations",
+        eventExpiryDuration: 30,
+        strategies: [
+          {
+            type: "SEMANTIC",
+            namespaceTemplates: DEFAULT_STRATEGY_NAMESPACE_TEMPLATES.SEMANTIC,
+          },
+        ],
+      },
+    ]);
+    r.unmount();
+  });
+
+  test("toggling strategies writes each one's default namespaces", async () => {
+    const projectRoot = await inProject();
+    const r = renderScreen("/agentcore/project/add/memory");
+
+    await waitForText(r.lastFrame, "what should this memory be called?");
+    await r.write("episodes");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "what should be extracted from raw events?");
+    // Uncheck SEMANTIC (cursor starts on it), then check EPISODIC.
+    await r.write(" ");
+    await r.press("down");
+    await r.press("down");
+    await r.press("down");
+    await r.write(" ");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "how long should raw events be kept?");
+    await r.press("return");
+    await waitForText(r.lastFrame, "what does this memory store?");
+    await r.press("return");
+    await waitForText(r.lastFrame, "this memory will be added to agentcore.json");
+    expect(flatFrame(r.lastFrame)).toContain("strategies EPISODIC");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "added memory 'episodes'");
+
+    // EPISODIC additionally carries reflection namespaces, as its schema demands.
+    expect((await projectSpec(projectRoot)).memories[0].strategies).toEqual([
+      {
+        type: "EPISODIC",
+        namespaceTemplates: DEFAULT_STRATEGY_NAMESPACE_TEMPLATES.EPISODIC,
+        reflectionNamespaceTemplates: DEFAULT_EPISODIC_REFLECTION_NAMESPACE_TEMPLATES,
+      },
+    ]);
+    r.unmount();
+  });
+
+  test("a blank name does not advance", async () => {
+    await inProject();
+    const r = renderScreen("/agentcore/project/add/memory");
+
+    await waitForText(r.lastFrame, "what should this memory be called?");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "memory name is required");
+    // Still on the name step.
+    expect(r.lastFrame()).toContain("what should this memory be called?");
+    r.unmount();
+  });
+
+  test("retention outside 3-365 reports the flag's own bounds", async () => {
+    await inProject();
+    const r = renderScreen("/agentcore/project/add/memory");
+
+    await waitForText(r.lastFrame, "what should this memory be called?");
+    await r.write("shortlived");
+    await r.press("return");
+    await waitForText(r.lastFrame, "what should be extracted from raw events?");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "how long should raw events be kept?");
+    // Clear the prefilled 30 and enter something out of range.
+    for (let i = 0; i < 2; i++) await r.write("\u007F");
+    await r.write("400");
+    await r.press("return");
+
+    // The schema's own message, not a copy of the bounds.
+    await waitForText(r.lastFrame, "Too big: expected number to be <=365");
+    expect(r.lastFrame()).toContain("how long should raw events be kept?");
+    r.unmount();
+  });
+
+  test("esc on the first step returns to the add menu", async () => {
+    await inProject();
+    const r = renderScreen("/agentcore/project/add/memory");
+
+    await waitForText(r.lastFrame, "what should this memory be called?");
+    await r.press("escape");
+
+    await waitForText(r.lastFrame, "add project resources");
+    r.unmount();
+  });
+
+  test("esc on a later step goes back a question", async () => {
+    await inProject();
+    const r = renderScreen("/agentcore/project/add/memory");
+
+    await waitForText(r.lastFrame, "what should this memory be called?");
+    await r.write("conversations");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "what should be extracted from raw events?");
+    await r.press("escape");
+
+    await waitForText(r.lastFrame, "what should this memory be called?");
+    // The answer survives the round trip.
+    expect(r.lastFrame()).toContain("conversations");
+    r.unmount();
+  });
+
+  test("reports the CLI's own guidance outside a project", async () => {
+    const r = renderScreen("/agentcore/project/add/memory");
+
+    await waitForText(r.lastFrame, "No AgentCore project found");
+    expect(r.lastFrame()).toContain("agentcore project create");
+    r.unmount();
+  });
+});

--- a/src/handlers/project/add/memory/screen.tsx
+++ b/src/handlers/project/add/memory/screen.tsx
@@ -4,18 +4,19 @@ import z from "zod";
 import { ProjectKey } from "../../../../router";
 import {
   MemoryNameSchema,
-  MemorySchema,
   MemoryStrategyTypeSchema,
   type MemoryStrategyType,
 } from "../../../../projectSchemas/memory";
 import type { ScreenProps } from "../../../types";
-import type { AddResourceInput, Project } from "../../types";
+import type { Project } from "../../types";
 import { ProjectGate } from "../../ProjectGate";
 import { Wizard, Step, TextField, MultiChoiceField, Summary } from "../../../../components/wizard";
 import {
   DEFAULT_EVENT_EXPIRY_DURATION,
   EventExpiryDurationSchema,
+  toAddMemoryInput,
   toDefaultStrategy,
+  type MemoryInput,
 } from "./index";
 
 // The retention step collects text, so the flag's numeric bounds are reached
@@ -52,18 +53,19 @@ interface MemoryFormValues {
   description: string;
 }
 
-// buildAddMemoryInput translates the form into the AddResourceInput the
-// flag-driven handler builds, reusing its own toDefaultStrategy so a picked
-// strategy expands to the same namespaces `--strategies SEMANTIC` expands to.
-export function buildAddMemoryInput(values: MemoryFormValues): AddResourceInput {
-  const resourceConfig: z.input<typeof MemorySchema> = {
+// toMemoryInput reads the form into the MemoryInput the handler's
+// toAddMemoryInput builds a memory from. It trims and converts; the one piece
+// of handler logic it reaches for, toDefaultStrategy, is the handler's own, so
+// a picked strategy expands to the same namespaces `--strategies SEMANTIC` does.
+export function toMemoryInput(values: MemoryFormValues): MemoryInput {
+  const description = values.description.trim();
+  return {
     name: values.name.trim(),
-    description: values.description.trim() === "" ? undefined : values.description.trim(),
+    description: description === "" ? undefined : description,
     eventExpiryDuration: Number(values.expiry),
     strategies:
       values.strategies.length === 0 ? undefined : values.strategies.map(toDefaultStrategy),
   };
-  return { resourceType: "memory", resourceConfig };
 }
 
 function summaryOf(values: MemoryFormValues): Record<string, string> {
@@ -104,7 +106,9 @@ function AddMemoryWizard({ project, core }: { project: Project; core: ScreenProp
       breadcrumb={BREADCRUMB}
       description={DESCRIPTION}
       onCancel={() => navigate("/agentcore/project/add")}
-      onSubmit={() => core.projectManager.addResource(project, buildAddMemoryInput(values))}
+      onSubmit={() =>
+        core.projectManager.addResource(project, toAddMemoryInput(toMemoryInput(values)))
+      }
       runningLabel={`adding memory ${values.name.trim()}…`}
       successLabel={`added memory '${values.name.trim()}' to '${project.name}'`}
       successHint="enter exits"

--- a/src/handlers/project/add/memory/screen.tsx
+++ b/src/handlers/project/add/memory/screen.tsx
@@ -1,0 +1,159 @@
+import { useState } from "react";
+import { useNavigate } from "react-router";
+import z from "zod";
+import { ProjectKey } from "../../../../router";
+import {
+  MemoryNameSchema,
+  MemorySchema,
+  MemoryStrategyTypeSchema,
+  type MemoryStrategyType,
+} from "../../../../projectSchemas/memory";
+import type { ScreenProps } from "../../../types";
+import type { AddResourceInput, Project } from "../../types";
+import { ProjectGate } from "../../ProjectGate";
+import { Wizard, Step, TextField, MultiChoiceField, Summary } from "../../../../components/wizard";
+import {
+  DEFAULT_EVENT_EXPIRY_DURATION,
+  EventExpiryDurationSchema,
+  toDefaultStrategy,
+} from "./index";
+
+// The retention step collects text, so the flag's numeric bounds are reached
+// through a coercion. Anything unparseable becomes NaN, which the bounds reject.
+const ExpiryInputSchema = z
+  .string()
+  .transform((raw) => Number(raw))
+  .refine((parsed) => Number.isFinite(parsed), { message: "enter a number of days" })
+  .pipe(EventExpiryDurationSchema);
+
+const BREADCRUMB = ["agentcore", "project", "add", "memory"];
+const DESCRIPTION = "adds a memory to the current project";
+
+// STRATEGY_CHOICES mirrors --strategies' comma-separated shorthand, which is
+// the form the flag documents first. The enum is read from the schema so the
+// picker cannot drift from what the flag accepts.
+const STRATEGY_DESCRIPTIONS: Record<MemoryStrategyType, string> = {
+  SEMANTIC: "durable facts extracted from conversations",
+  SUMMARIZATION: "running summaries of each session",
+  USER_PREFERENCE: "preferences the user states or implies",
+  EPISODIC: "past episodes, plus reflections over them",
+};
+
+const STRATEGY_CHOICES = MemoryStrategyTypeSchema.options.map((type) => ({
+  value: type,
+  label: type,
+  description: STRATEGY_DESCRIPTIONS[type],
+}));
+
+interface MemoryFormValues {
+  name: string;
+  strategies: MemoryStrategyType[];
+  expiry: string;
+  description: string;
+}
+
+// buildAddMemoryInput translates the form into the AddResourceInput the
+// flag-driven handler builds, reusing its own toDefaultStrategy so a picked
+// strategy expands to the same namespaces `--strategies SEMANTIC` expands to.
+export function buildAddMemoryInput(values: MemoryFormValues): AddResourceInput {
+  const resourceConfig: z.input<typeof MemorySchema> = {
+    name: values.name.trim(),
+    description: values.description.trim() === "" ? undefined : values.description.trim(),
+    eventExpiryDuration: Number(values.expiry),
+    strategies:
+      values.strategies.length === 0 ? undefined : values.strategies.map(toDefaultStrategy),
+  };
+  return { resourceType: "memory", resourceConfig };
+}
+
+function summaryOf(values: MemoryFormValues): Record<string, string> {
+  return {
+    memory: values.name.trim(),
+    strategies: values.strategies.length === 0 ? "none" : values.strategies.join(", "),
+    "event expiry": `${values.expiry} days`,
+    ...(values.description.trim() === "" ? {} : { description: values.description.trim() }),
+  };
+}
+
+export function AddMemoryScreen({ ctx, core }: ScreenProps) {
+  return (
+    <ProjectGate
+      core={core}
+      breadcrumb={BREADCRUMB}
+      description={DESCRIPTION}
+      seed={ctx.value(ProjectKey)}
+    >
+      {(project) => <AddMemoryWizard project={project} core={core} />}
+    </ProjectGate>
+  );
+}
+
+function AddMemoryWizard({ project, core }: { project: Project; core: ScreenProps["core"] }) {
+  const navigate = useNavigate();
+  const [values, setValues] = useState<MemoryFormValues>({
+    name: "",
+    strategies: ["SEMANTIC"],
+    expiry: String(DEFAULT_EVENT_EXPIRY_DURATION),
+    description: "",
+  });
+  const set = (update: Partial<MemoryFormValues>) =>
+    setValues((current) => ({ ...current, ...update }));
+
+  return (
+    <Wizard
+      breadcrumb={BREADCRUMB}
+      description={DESCRIPTION}
+      onCancel={() => navigate("/agentcore/project/add")}
+      onSubmit={() => core.projectManager.addResource(project, buildAddMemoryInput(values))}
+      runningLabel={`adding memory ${values.name.trim()}…`}
+      successLabel={`added memory '${values.name.trim()}' to '${project.name}'`}
+      successHint="enter exits"
+    >
+      <Step name="name" question="what should this memory be called?">
+        <TextField
+          label="memory name"
+          placeholder="conversations"
+          value={values.name}
+          onChange={(name) => set({ name })}
+          required
+          schema={MemoryNameSchema}
+        />
+      </Step>
+
+      <Step name="strategies" question="what should be extracted from raw events?">
+        <MultiChoiceField
+          label="long-term memory strategies"
+          help="selecting none keeps short-term events only"
+          choices={STRATEGY_CHOICES}
+          value={values.strategies}
+          onChange={(strategies) => set({ strategies })}
+        />
+      </Step>
+
+      <Step name="retention" title="retention" question="how long should raw events be kept?">
+        <TextField
+          label="event expiry, in days"
+          help="3-365 · the service default is 30"
+          placeholder={String(DEFAULT_EVENT_EXPIRY_DURATION)}
+          value={values.expiry}
+          onChange={(expiry) => set({ expiry })}
+          required
+          schema={ExpiryInputSchema}
+        />
+      </Step>
+
+      <Step name="description" question="what does this memory store? (optional)">
+        <TextField
+          label="description"
+          placeholder="user facts and session summaries"
+          value={values.description}
+          onChange={(description) => set({ description })}
+        />
+      </Step>
+
+      <Step name="review" question="this memory will be added to agentcore.json">
+        <Summary items={summaryOf(values)} />
+      </Step>
+    </Wizard>
+  );
+}

--- a/src/handlers/project/add/policy-engine/index.ts
+++ b/src/handlers/project/add/policy-engine/index.ts
@@ -1,15 +1,67 @@
 import z from "zod";
 import { InputValidationError } from "../../../../errors";
+import type { PolicyEngineMode } from "../../../../projectSchemas/gateway";
 import type { PolicyEngineSchema } from "../../../../projectSchemas/policy";
 import { createHandler, flag, ProjectKey } from "../../../../router";
 import { parseTags } from "../../../utils";
+import type { AddResourceInput, Project } from "../../types";
 import type { AddProjectResourceConfig } from "../types";
+
+/** The service limit on a Policy Engine's deployed name. */
+export const MAX_POLICY_ENGINE_RESOURCE_NAME_LENGTH = 48;
 
 /**
  The deployed service name of a policy engine; mirrors the L3 AgentCorePolicyEngine construct's rule.
 **/
 export function policyEngineResourceName(projectName: string, engineName: string): string {
   return `${projectName}_${engineName}`;
+}
+
+/**
+ * PolicyEngineInput is what every entry point — the flag handler, the wizard —
+ * resolves its own inputs to before an engine is built. `attachToGateways`
+ * absent means attach to nothing; `attachMode` is only read alongside it.
+ */
+export interface PolicyEngineInput {
+  name: string;
+  description?: string;
+  encryptionKeyArn?: string;
+  tags?: Record<string, string>;
+  attachToGateways?: string[];
+  attachMode?: PolicyEngineMode;
+}
+
+/**
+ * toAddPolicyEngineInput is the one place a Policy Engine is assembled from
+ * user input: the name limit, the attach default. Both the flag handler and the
+ * wizard call it, so they cannot disagree about what an engine is.
+ */
+export function toAddPolicyEngineInput(
+  project: Project,
+  input: PolicyEngineInput,
+): AddResourceInput {
+  const resourceName = policyEngineResourceName(project.name, input.name);
+  if (resourceName.length > MAX_POLICY_ENGINE_RESOURCE_NAME_LENGTH) {
+    throw new InputValidationError(
+      `Policy Engine resource name '${resourceName}' exceeds the service limit of ` +
+        `${MAX_POLICY_ENGINE_RESOURCE_NAME_LENGTH} characters`,
+    );
+  }
+
+  const engine: z.input<typeof PolicyEngineSchema> = {
+    name: input.name,
+    description: input.description,
+    encryptionKeyArn: input.encryptionKeyArn,
+    tags: input.tags,
+  };
+  return {
+    resourceType: "policy-engine",
+    resourceConfig: engine,
+    attachGateways:
+      input.attachToGateways && input.attachToGateways.length > 0
+        ? { names: input.attachToGateways, mode: input.attachMode ?? "ENFORCE" }
+        : undefined,
+  };
 }
 
 export const createAddPolicyEngineHandler = (config: AddProjectResourceConfig) =>
@@ -32,6 +84,9 @@ export const createAddPolicyEngineHandler = (config: AddProjectResourceConfig) =
         z.enum(["log-only", "enforce"]).optional(),
       ),
     ],
+    // handle only turns flags into a PolicyEngineInput — splitting tags,
+    // pairing flags that only make sense together. What an engine is belongs
+    // to toAddPolicyEngineInput.
     handle: async (ctx, flags) => {
       if (!flags.name) {
         throw new InputValidationError("required option '--name <name>' not specified");
@@ -39,31 +94,23 @@ export const createAddPolicyEngineHandler = (config: AddProjectResourceConfig) =
       if (flags["attach-mode"] !== undefined && flags["attach-to-gateways"] === undefined) {
         throw new InputValidationError("--attach-mode requires --attach-to-gateways");
       }
-      const project = ctx.require(ProjectKey);
-      const resourceName = policyEngineResourceName(project.name, flags.name);
-      if (resourceName.length > 48) {
-        throw new InputValidationError(
-          `Policy Engine resource name '${resourceName}' exceeds the service limit of 48 characters`,
-        );
-      }
 
-      const engine: z.input<typeof PolicyEngineSchema> = {
+      const project = ctx.require(ProjectKey);
+      const input = toAddPolicyEngineInput(project, {
         name: flags.name,
         description: flags.description,
         encryptionKeyArn: flags["encryption-key-arn"],
         tags: parseTags(flags.tags),
-      };
+        attachToGateways: flags["attach-to-gateways"],
+        attachMode:
+          flags["attach-mode"] === undefined
+            ? undefined
+            : flags["attach-mode"] === "log-only"
+              ? "LOG_ONLY"
+              : "ENFORCE",
+      });
 
-      for await (const event of config.projectManager.addResource(project, {
-        resourceType: "policy-engine",
-        resourceConfig: engine,
-        attachGateways: flags["attach-to-gateways"]
-          ? {
-              names: flags["attach-to-gateways"],
-              mode: flags["attach-mode"] === "log-only" ? "LOG_ONLY" : "ENFORCE",
-            }
-          : undefined,
-      })) {
+      for await (const event of config.projectManager.addResource(project, input)) {
         config.io.stderr.write(`${event.message}\n`);
       }
       config.io.stderr.write(`added Policy Engine '${flags.name}' to '${project.name}'\n`);

--- a/src/handlers/project/add/policy-engine/policyEngine.screen.test.tsx
+++ b/src/handlers/project/add/policy-engine/policyEngine.screen.test.tsx
@@ -1,0 +1,103 @@
+import { test, expect, describe, afterEach } from "bun:test";
+import {
+  renderScreen,
+  waitForText,
+  waitForFlatText,
+  flatFrame,
+  cleanupScreens,
+} from "../../../../testing";
+import { createGatewayProjectTestHarness } from "../gateway-test-support";
+
+const { addGateway, cleanup, inProject, projectSpec } = createGatewayProjectTestHarness(
+  "add-policy-engine-wizard",
+);
+
+afterEach(cleanup);
+afterEach(cleanupScreens);
+
+describe("project add policy-engine wizard", () => {
+  test("skips the attach step when the project has no Gateways", async () => {
+    const projectRoot = await inProject();
+    const r = renderScreen("/agentcore/project/add/policy-engine");
+
+    await waitForText(r.lastFrame, "what should this Policy Engine be called?");
+    // Nothing to attach to, so the stepper offers name → description → review.
+    expect(r.lastFrame()).toContain("○ review");
+    expect(r.lastFrame()).not.toContain("attach");
+    await r.write("Guardrails");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "what does this engine govern?");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "this Policy Engine will be added to agentcore.json");
+    expect(r.lastFrame()).toContain("none");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "added Policy Engine 'Guardrails' to 'TestProject'");
+
+    const engines = (await projectSpec(projectRoot)).policyEngines;
+    expect(engines).toHaveLength(1);
+    expect(engines[0]).toMatchObject({ name: "Guardrails" });
+    r.unmount();
+  });
+
+  test("offers the project's Gateways, and the mode step only once one is picked", async () => {
+    const projectRoot = await inProject();
+    await addGateway("tools");
+    const r = renderScreen("/agentcore/project/add/policy-engine");
+
+    await waitForText(r.lastFrame, "what should this Policy Engine be called?");
+    await r.write("Guardrails");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "what does this engine govern?");
+    await r.press("return");
+
+    // The attach step lists the Gateway the project already declares.
+    await waitForText(r.lastFrame, "which Gateways should this engine govern?");
+    expect(r.lastFrame()).toContain("tools");
+    // Nothing is selected yet, so the mode step is not in the flow.
+    expect(r.lastFrame()).not.toContain("○ mode");
+
+    await r.write(" ");
+    await waitForText(r.lastFrame, "○ mode");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "how should the attached Gateways enforce this engine?");
+    expect(r.lastFrame()).toContain("● enforce (default)");
+    // log-only is the second row.
+    await r.press("down");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "this Policy Engine will be added to agentcore.json");
+    const review = flatFrame(r.lastFrame);
+    expect(review).toContain("attached gateways tools");
+    expect(review).toContain("mode log-only");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "added Policy Engine 'Guardrails'");
+
+    const spec = await projectSpec(projectRoot);
+    expect(spec.policyEngines[0]).toMatchObject({ name: "Guardrails" });
+    // The attachment is recorded on the Gateway, as the handler records it.
+    expect(spec.agentCoreGateways[0].policyEngineConfiguration).toEqual({
+      policyEngineName: "Guardrails",
+      mode: "LOG_ONLY",
+    });
+    r.unmount();
+  });
+
+  test("a name that would exceed the service limit is rejected", async () => {
+    await inProject();
+    const r = renderScreen("/agentcore/project/add/policy-engine");
+
+    await waitForText(r.lastFrame, "what should this Policy Engine be called?");
+    await r.write("a".repeat(40));
+    await r.press("return");
+
+    await waitForFlatText(r.lastFrame, "exceeds the service limit of 48 characters");
+    expect(flatFrame(r.lastFrame)).toContain("what should this Policy Engine be called?");
+    r.unmount();
+  });
+});

--- a/src/handlers/project/add/policy-engine/screen.tsx
+++ b/src/handlers/project/add/policy-engine/screen.tsx
@@ -2,9 +2,8 @@ import { useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 import z from "zod";
 import { ProjectKey } from "../../../../router";
-import type { PolicyEngineSchema } from "../../../../projectSchemas/policy";
 import type { ScreenProps } from "../../../types";
-import type { AddResourceInput, Project } from "../../types";
+import type { Project } from "../../types";
 import { ProjectGate } from "../../ProjectGate";
 import {
   Wizard,
@@ -14,13 +13,15 @@ import {
   MultiChoiceField,
   Summary,
 } from "../../../../components/wizard";
-import { policyEngineResourceName } from "./index";
+import {
+  MAX_POLICY_ENGINE_RESOURCE_NAME_LENGTH,
+  policyEngineResourceName,
+  toAddPolicyEngineInput,
+  type PolicyEngineInput,
+} from "./index";
 
 const BREADCRUMB = ["agentcore", "project", "add", "policy-engine"];
 const DESCRIPTION = "adds a Policy Engine to the current project";
-
-// The service limit the handler enforces on the deployed engine name.
-const MAX_RESOURCE_NAME_LENGTH = 48;
 
 type AttachMode = "enforce" | "log-only";
 
@@ -44,23 +45,21 @@ interface PolicyEngineFormValues {
   attachMode: AttachMode;
 }
 
-export function buildAddPolicyEngineInput(values: PolicyEngineFormValues): AddResourceInput {
-  const engine: z.input<typeof PolicyEngineSchema> = {
-    name: values.name.trim(),
-    description: values.description.trim() === "" ? undefined : values.description.trim(),
-  };
+// toPolicyEngineInput reads the form into the PolicyEngineInput the handler's
+// toAddPolicyEngineInput builds an engine from. It trims and converts, and
+// drops the mode when no Gateway was picked — that step was never shown.
+export function toPolicyEngineInput(values: PolicyEngineFormValues): PolicyEngineInput {
+  const description = values.description.trim();
+  const isAttaching = values.attachToGateways.length > 0;
   return {
-    resourceType: "policy-engine",
-    resourceConfig: engine,
-    // The handler treats an absent --attach-to-gateways as "attach to nothing",
-    // and --attach-mode is meaningless without it.
-    attachGateways:
-      values.attachToGateways.length === 0
-        ? undefined
-        : {
-            names: values.attachToGateways,
-            mode: values.attachMode === "log-only" ? "LOG_ONLY" : "ENFORCE",
-          },
+    name: values.name.trim(),
+    description: description === "" ? undefined : description,
+    attachToGateways: isAttaching ? values.attachToGateways : undefined,
+    attachMode: isAttaching
+      ? values.attachMode === "log-only"
+        ? "LOG_ONLY"
+        : "ENFORCE"
+      : undefined,
   };
 }
 
@@ -102,12 +101,12 @@ function AddPolicyEngineWizard({ project, core }: { project: Project; core: Scre
     () =>
       z.string().superRefine((name, ctx) => {
         const resourceName = policyEngineResourceName(project.name, name);
-        if (resourceName.length > MAX_RESOURCE_NAME_LENGTH) {
+        if (resourceName.length > MAX_POLICY_ENGINE_RESOURCE_NAME_LENGTH) {
           ctx.addIssue({
             code: "custom",
             message:
               `Policy Engine resource name '${resourceName}' exceeds the service limit of ` +
-              `${MAX_RESOURCE_NAME_LENGTH} characters`,
+              `${MAX_POLICY_ENGINE_RESOURCE_NAME_LENGTH} characters`,
           });
         }
       }),
@@ -134,7 +133,12 @@ function AddPolicyEngineWizard({ project, core }: { project: Project; core: Scre
       breadcrumb={BREADCRUMB}
       description={DESCRIPTION}
       onCancel={() => navigate("/agentcore/project/add")}
-      onSubmit={() => core.projectManager.addResource(project, buildAddPolicyEngineInput(values))}
+      onSubmit={() =>
+        core.projectManager.addResource(
+          project,
+          toAddPolicyEngineInput(project, toPolicyEngineInput(values)),
+        )
+      }
       runningLabel={`adding Policy Engine ${values.name.trim()}…`}
       successLabel={`added Policy Engine '${values.name.trim()}' to '${project.name}'`}
       successHint="enter exits"
@@ -142,7 +146,7 @@ function AddPolicyEngineWizard({ project, core }: { project: Project; core: Scre
       <Step name="name" question="what should this Policy Engine be called?">
         <TextField
           label="policy engine name"
-          help={`deployed as ${project.name}_<name>, up to ${MAX_RESOURCE_NAME_LENGTH} characters`}
+          help={`deployed as ${project.name}_<name>, up to ${MAX_POLICY_ENGINE_RESOURCE_NAME_LENGTH} characters`}
           placeholder="access"
           value={values.name}
           onChange={(name) => set({ name })}

--- a/src/handlers/project/add/policy-engine/screen.tsx
+++ b/src/handlers/project/add/policy-engine/screen.tsx
@@ -1,0 +1,190 @@
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router";
+import z from "zod";
+import { ProjectKey } from "../../../../router";
+import type { PolicyEngineSchema } from "../../../../projectSchemas/policy";
+import type { ScreenProps } from "../../../types";
+import type { AddResourceInput, Project } from "../../types";
+import { ProjectGate } from "../../ProjectGate";
+import {
+  Wizard,
+  Step,
+  TextField,
+  ChoiceField,
+  MultiChoiceField,
+  Summary,
+} from "../../../../components/wizard";
+import { policyEngineResourceName } from "./index";
+
+const BREADCRUMB = ["agentcore", "project", "add", "policy-engine"];
+const DESCRIPTION = "adds a Policy Engine to the current project";
+
+// The service limit the handler enforces on the deployed engine name.
+const MAX_RESOURCE_NAME_LENGTH = 48;
+
+type AttachMode = "enforce" | "log-only";
+
+const ATTACH_MODE_CHOICES = [
+  {
+    value: "enforce" as AttachMode,
+    label: "enforce (default)",
+    description: "deny requests the policies reject",
+  },
+  {
+    value: "log-only" as AttachMode,
+    label: "log-only",
+    description: "record decisions without blocking anything",
+  },
+];
+
+interface PolicyEngineFormValues {
+  name: string;
+  description: string;
+  attachToGateways: string[];
+  attachMode: AttachMode;
+}
+
+export function buildAddPolicyEngineInput(values: PolicyEngineFormValues): AddResourceInput {
+  const engine: z.input<typeof PolicyEngineSchema> = {
+    name: values.name.trim(),
+    description: values.description.trim() === "" ? undefined : values.description.trim(),
+  };
+  return {
+    resourceType: "policy-engine",
+    resourceConfig: engine,
+    // The handler treats an absent --attach-to-gateways as "attach to nothing",
+    // and --attach-mode is meaningless without it.
+    attachGateways:
+      values.attachToGateways.length === 0
+        ? undefined
+        : {
+            names: values.attachToGateways,
+            mode: values.attachMode === "log-only" ? "LOG_ONLY" : "ENFORCE",
+          },
+  };
+}
+
+function summaryOf(values: PolicyEngineFormValues): Record<string, string> {
+  return {
+    "policy engine": values.name.trim(),
+    ...(values.description.trim() === "" ? {} : { description: values.description.trim() }),
+    "attached gateways":
+      values.attachToGateways.length === 0 ? "none" : values.attachToGateways.join(", "),
+    ...(values.attachToGateways.length === 0 ? {} : { mode: values.attachMode }),
+  };
+}
+
+export function AddPolicyEngineScreen({ ctx, core }: ScreenProps) {
+  return (
+    <ProjectGate
+      core={core}
+      breadcrumb={BREADCRUMB}
+      description={DESCRIPTION}
+      seed={ctx.value(ProjectKey)}
+    >
+      {(project) => <AddPolicyEngineWizard project={project} core={core} />}
+    </ProjectGate>
+  );
+}
+
+function AddPolicyEngineWizard({ project, core }: { project: Project; core: ScreenProps["core"] }) {
+  const navigate = useNavigate();
+  const [values, setValues] = useState<PolicyEngineFormValues>({
+    name: "",
+    description: "",
+    attachToGateways: [],
+    attachMode: "enforce",
+  });
+  const set = (update: Partial<PolicyEngineFormValues>) =>
+    setValues((current) => ({ ...current, ...update }));
+
+  const nameSchema = useMemo(
+    () =>
+      z.string().superRefine((name, ctx) => {
+        const resourceName = policyEngineResourceName(project.name, name);
+        if (resourceName.length > MAX_RESOURCE_NAME_LENGTH) {
+          ctx.addIssue({
+            code: "custom",
+            message:
+              `Policy Engine resource name '${resourceName}' exceeds the service limit of ` +
+              `${MAX_RESOURCE_NAME_LENGTH} characters`,
+          });
+        }
+      }),
+    [project.name],
+  );
+
+  // Attachment targets are the Gateways this project already declares, so the
+  // step is offered only when there is something to attach to.
+  const gatewayChoices = useMemo(
+    () =>
+      (project.spec.agentCoreGateways ?? []).map((gateway) => ({
+        value: gateway.name,
+        label: gateway.name,
+        description: gateway.description ?? gateway.protocolType,
+      })),
+    [project.spec.agentCoreGateways],
+  );
+
+  const hasGateways = gatewayChoices.length > 0;
+  const isAttaching = values.attachToGateways.length > 0;
+
+  return (
+    <Wizard
+      breadcrumb={BREADCRUMB}
+      description={DESCRIPTION}
+      onCancel={() => navigate("/agentcore/project/add")}
+      onSubmit={() => core.projectManager.addResource(project, buildAddPolicyEngineInput(values))}
+      runningLabel={`adding Policy Engine ${values.name.trim()}…`}
+      successLabel={`added Policy Engine '${values.name.trim()}' to '${project.name}'`}
+      successHint="enter exits"
+    >
+      <Step name="name" question="what should this Policy Engine be called?">
+        <TextField
+          label="policy engine name"
+          help={`deployed as ${project.name}_<name>, up to ${MAX_RESOURCE_NAME_LENGTH} characters`}
+          placeholder="access"
+          value={values.name}
+          onChange={(name) => set({ name })}
+          required
+          schema={nameSchema}
+        />
+      </Step>
+
+      <Step name="description" question="what does this engine govern? (optional)">
+        <TextField
+          label="description"
+          placeholder="tool access rules"
+          value={values.description}
+          onChange={(description) => set({ description })}
+        />
+      </Step>
+
+      {hasGateways && (
+        <Step name="attach" title="attach" question="which Gateways should this engine govern?">
+          <MultiChoiceField
+            label="project gateways"
+            help="leave empty to attach nothing for now"
+            choices={gatewayChoices}
+            value={values.attachToGateways}
+            onChange={(attachToGateways) => set({ attachToGateways })}
+          />
+        </Step>
+      )}
+
+      {hasGateways && isAttaching && (
+        <Step name="mode" question="how should the attached Gateways enforce this engine?">
+          <ChoiceField
+            choices={ATTACH_MODE_CHOICES}
+            value={values.attachMode}
+            onChange={(attachMode) => set({ attachMode })}
+          />
+        </Step>
+      )}
+
+      <Step name="review" question="this Policy Engine will be added to agentcore.json">
+        <Summary items={summaryOf(values)} />
+      </Step>
+    </Wizard>
+  );
+}

--- a/src/handlers/project/add/screen.tsx
+++ b/src/handlers/project/add/screen.tsx
@@ -1,0 +1,9 @@
+import { RouterScreen } from "../../../components/RouterScreen";
+import type { ScreenProps } from "../../types";
+
+// AddScreen is the `agentcore project add` menu. RouterScreen reads the
+// subcommands straight off the compiled Commander tree, so a new `project add`
+// resource appears here without touching this file.
+export function AddScreen(props: ScreenProps) {
+  return <RouterScreen {...props} path={["agentcore", "project", "add"]} />;
+}

--- a/src/handlers/project/project.screen.test.tsx
+++ b/src/handlers/project/project.screen.test.tsx
@@ -76,24 +76,23 @@ describe("project subcommands without a screen", () => {
   // Reading the cases off the router also guards Root's hand-written
   // PROJECT_COMMANDS: an unrouted subcommand hits the catch-all, which resolves
   // instead of rejecting. Frames can't detect that — the catch-all exits before
-  // painting, so it and this screen both render empty. `create` and `invoke`
-  // are excluded because both have real screens.
-  test.each(projectSubcommands().filter((command) => command !== "create" && command !== "invoke"))(
-    "%s tears down the TUI with NotImplementedError",
-    async (command) => {
-      const { streams } = ttyTestIO();
+  // painting, so it and this screen both render empty. `create`, `invoke` and
+  // `add` are excluded because all three have real screens.
+  test.each(
+    projectSubcommands().filter((command) => !["create", "invoke", "add"].includes(command)),
+  )("%s tears down the TUI with NotImplementedError", async (command) => {
+    const { streams } = ttyTestIO();
 
-      const rendering = renderTuiAt(
-        `/agentcore/project/${command}`,
-        ValueContext.EmptyContext(),
-        new TestCoreClient(),
-        streams.io,
-      );
+    const rendering = renderTuiAt(
+      `/agentcore/project/${command}`,
+      ValueContext.EmptyContext(),
+      new TestCoreClient(),
+      streams.io,
+    );
 
-      await expect(rendering).rejects.toThrow(NotImplementedError);
-      await expect(rendering).rejects.toThrow(`'agentcore project ${command}'`);
-    },
-  );
+    await expect(rendering).rejects.toThrow(NotImplementedError);
+    await expect(rendering).rejects.toThrow(`'agentcore project ${command}'`);
+  });
 
   test("the error names the command to run instead", async () => {
     const { streams } = ttyTestIO();

--- a/src/testing/index.tsx
+++ b/src/testing/index.tsx
@@ -24,6 +24,8 @@ export {
   cleanupScreens,
   keys,
   waitForText,
+  waitForFlatText,
+  flatFrame,
   type RenderScreenOptions,
   type RenderScreenResult,
 } from "./renderScreen";

--- a/src/testing/renderScreen.tsx
+++ b/src/testing/renderScreen.tsx
@@ -170,3 +170,20 @@ export function waitForText(
 ): Promise<void> {
   return waitFor(() => (lastFrame() ?? "").includes(text), timeoutMs);
 }
+
+// flatFrame collapses a frame's line breaks and runs of spaces into single
+// spaces. Ink hard-wraps at the terminal width, so a long message — a schema's
+// validation error, say — is split across lines at an unpredictable word.
+// Asserting against the flattened frame matches the sentence the user reads.
+export function flatFrame(lastFrame: () => string | undefined): string {
+  return (lastFrame() ?? "").replace(/\s+/g, " ");
+}
+
+// waitForFlatText is waitForText against the flattened frame.
+export function waitForFlatText(
+  lastFrame: () => string | undefined,
+  text: string,
+  timeoutMs = 1000,
+): Promise<void> {
+  return waitFor(() => flatFrame(lastFrame).includes(text), timeoutMs);
+}


### PR DESCRIPTION
## What

Selecting `add` from the project menu now opens a resource menu, and four of the fifteen resources get a wizard: **memory**, **gateway**, **policy-engine**, **config-bundle**. The other eleven keep the not-implemented screen and are unchanged on the command line.

```
 agentcore → project → add → memory → adds a memory to the current project
──────────────────────────────────────────────────────────────────────────
 ✓ name ── ● strategies ── ○ retention ── ○ description ── ○ review
──────────────────────────────────────────────────────────────────────────
 what should be extracted from raw events?
 selecting none keeps short-term events only
 ╭────────────────────────────────────────────────────────────────────────╮
 │ ❯ [✓] SEMANTIC         durable facts extracted from conversations      │
 │   [ ] SUMMARIZATION    running summaries of each session               │
 │   [ ] USER_PREFERENCE  preferences the user states or implies          │
 │   [ ] EPISODIC         past episodes, plus reflections over them       │
 ╰────────────────────────────────────────────────────────────────────────╯
──────────────────────────────────────────────────────────────────────────
[↑↓] move  [space] toggle  [enter] continue  [esc] back  [ctl+c] quit
```

| resource | steps (*italic* = conditional) |
|---|---|
| `memory` | name → strategies → retention → description → review |
| `gateway` | name → protocol → authorizer → *jwt config* → *search* → description → review |
| `policy-engine` | name → description → *attach* → *mode* → review |
| `config-bundle` | name → components → description → branch → commit → review |

## Design

Two pieces, each with one job.

**1. A shared `<Wizard>` shell** (`components/wizard/`, 277 lines). It owns the step list, position, key handling, and the `form → running → success | error` phases. A screen supplies only the questions, as `<Step>` children, and branches with a plain conditional:

```tsx
{isCustomJwt && (
  <Step name="authorizer-configuration" question="paste the authorizerConfiguration">
    <TextAreaField required json schema={GatewayAuthorizerConfigurationInputSchema} … />
  </Step>
)}
```

`React.Children.toArray` drops the `false` a closed branch produces, so an inapplicable step is absent from the flow and the stepper alike. Position is keyed by step **name**, not index, so a step appearing or vanishing never moves the user. Duplicate names throw at render. Each field owns its own `useInput`, so the shell has no focus concept — **one field per step** is the invariant; a step that needs two related inputs gets a compound field, not shell-level focus management.

**2. One input builder per resource**, exported from the handler: `toAddGatewayInput(project, input)`, `toAddMemoryInput(input)`, `toAddConfigBundleInput(input)`, `toAddPolicyEngineInput(project, input)`. Each takes a typed `XxxInput` (already-parsed JSON, already-split tags) and is the *only* place defaults, cross-field rules, and resource assembly live. The flag handler's `handle` reduces to flags → `XxxInput`; the screen's `onSubmit` reduces to form values → `XxxInput`. Neither knows what a Gateway is.

```
flags ──(resolve file://, parse JSON, pair flags)──┐
                                                    ├──► toAddGatewayInput(project, input) ──► projectManager.addResource
form  ──(trim, parse, drop hidden-step answers)────┘
```

This is what stops the two paths drifting. It already caught one: the flag path validated `--authorizer-configuration` with `GatewayAuthorizerConfigSchema.strict()`, the first cut of the wizard used the non-strict schema, so the SDK's `customJWTAuthorizer` casing was rejected by flags but accepted by the wizard — and then failed at submit as a missing `customJwtAuthorizer`. Both now share `GatewayAuthorizerConfigurationInputSchema`; a screen test pins it.

The wizard convention that makes the builders' cross-field errors unreachable from the TUI: pass only the answers to steps the user saw. A JWT config typed before switching the authorizer to `NONE` is dropped, not sent.

## Decisions worth a reviewer's attention

- **Submit goes through `projectManager.addResource`, not `handler.handle`.** Handlers write to a `config.io.stderr` captured at wiring time, which Ink's alternate screen swallows.
- **Flags stay `.optional()`.** Required-ness is a field prop; a non-optional schema lets Commander reject a bare command before the TUI middleware can open a screen (`69aa0c19`).
- **`ProjectGate`** resolves `ProjectKey` for screens the user navigated to (middleware never ran) and reports the CLI's own not-found guidance.
- **`Form*` components** omit label/help rows when passed empty strings, so a field under a `<Step>` renders just the control. Existing callers pass non-empty strings and are unaffected.

## Testing

`bun test`: **2645 pass, 0 fail**. `tsc --noEmit`, `oxlint`, `prettier --check` clean.

38 new tests. Handler flag tests are unchanged and now exercise the shared builders; screen tests exercise the same builders from the form side. `add.screen.test.tsx` reads its case list off the compiled Commander tree, so a resource routed later without a screen fails the suite.

## Not in scope

- A bare `agentcore project add memory` still runs the flag path. Opening the wizard needs a per-command launcher, not the router-wide `withTuiOnEmptyFlagsAndArgs`.
- Migrating `project create`, `HarnessWizard`, `EndpointWizard` onto the shell. `create`'s forks are expressible as `{cond && <Step/>}`; that's the natural next PR.
- The remaining eleven `add` resources. Each follows the same recipe: export `XxxInput` + `toAddXxxInput` from the handler, reduce `handle` to flag conversion, write a screen of `<Step>`s.
