### PR TITLE
feat(project): add TUI wizards for six more `project add` resources

### DIFF
--- a/src/components/FormCheckboxMultiSelect.tsx
+++ b/src/components/FormCheckboxMultiSelect.tsx
@@ -31,10 +31,14 @@ export function FormCheckboxMultiSelect({
 
   return (
     <Box flexDirection="column">
-      <Box flexDirection="column">
-        <Text color={theme.colors.text}>{name}</Text>
-        <Text color={theme.colors.muted}>{helpText}</Text>
-      </Box>
+      {/* Either row is omitted when empty, so a caller whose surrounding
+          context already asks the question renders just the checkboxes. */}
+      {(name !== "" || helpText !== "") && (
+        <Box flexDirection="column">
+          {name !== "" && <Text color={theme.colors.text}>{name}</Text>}
+          {helpText !== "" && <Text color={theme.colors.muted}>{helpText}</Text>}
+        </Box>
+      )}
       <Box
         flexDirection="column"
         paddingX={1}

--- a/src/components/FormRadioGroup.tsx
+++ b/src/components/FormRadioGroup.tsx
@@ -22,10 +22,14 @@ export function FormRadioGroup({ name, helpText, options, selectedIndex }: FormR
 
   return (
     <Box flexDirection="column">
-      <Box flexDirection="column">
-        <Text color={theme.colors.text}>{name}</Text>
-        <Text color={theme.colors.muted}>{helpText}</Text>
-      </Box>
+      {/* Either row is omitted when empty, so a caller whose surrounding
+          context already asks the question renders just the options. */}
+      {(name !== "" || helpText !== "") && (
+        <Box flexDirection="column">
+          {name !== "" && <Text color={theme.colors.text}>{name}</Text>}
+          {helpText !== "" && <Text color={theme.colors.muted}>{helpText}</Text>}
+        </Box>
+      )}
       <Box
         flexDirection="column"
         paddingX={1}

--- a/src/components/FormTextArea.tsx
+++ b/src/components/FormTextArea.tsx
@@ -54,17 +54,21 @@ export function FormTextArea({
 
   return (
     <Box flexDirection="column">
-      <Box
-        flexDirection="column"
-        borderStyle="single"
-        borderLeft={false}
-        borderRight={false}
-        borderTop={false}
-        borderColor={theme.colors.border}
-      >
-        <Text color={theme.colors.text}>{name}</Text>
-        <Text color={theme.colors.muted}>{helpText}</Text>
-      </Box>
+      {/* Either row is omitted when empty, so a caller whose surrounding
+          context already asks the question renders just the editor. */}
+      {(name !== "" || helpText !== "") && (
+        <Box
+          flexDirection="column"
+          borderStyle="single"
+          borderLeft={false}
+          borderRight={false}
+          borderTop={false}
+          borderColor={theme.colors.border}
+        >
+          {name !== "" && <Text color={theme.colors.text}>{name}</Text>}
+          {helpText !== "" && <Text color={theme.colors.muted}>{helpText}</Text>}
+        </Box>
+      )}
       {hidden > 0 && <Text color={theme.colors.muted}>… (+{hidden} earlier lines)</Text>}
       {visible.length === 0 ? (
         <Text color={theme.colors.muted}>

--- a/src/components/FormTextInput.tsx
+++ b/src/components/FormTextInput.tsx
@@ -31,10 +31,14 @@ export function FormTextInput({
 }: FormTextInputProps) {
   return (
     <Box flexDirection="column">
-      <Box flexDirection="column">
-        <Text color={theme.colors.text}>{name}</Text>
-        <Text color={theme.colors.muted}>{helpText}</Text>
-      </Box>
+      {/* Either row is omitted when empty, so a caller whose surrounding
+          context already asks the question renders just the input. */}
+      {(name !== "" || helpText !== "") && (
+        <Box flexDirection="column">
+          {name !== "" && <Text color={theme.colors.text}>{name}</Text>}
+          {helpText !== "" && <Text color={theme.colors.muted}>{helpText}</Text>}
+        </Box>
+      )}
       <Box borderStyle="round" borderColor={focused ? theme.colors.focus : theme.colors.border}>
         <TextInput
           value={value}

--- a/src/components/Root.tsx
+++ b/src/components/Root.tsx
@@ -115,6 +115,15 @@ import { AddMemoryScreen } from "../handlers/project/add/memory/screen.tsx";
 import { AddGatewayScreen } from "../handlers/project/add/gateway/screen.tsx";
 import { AddPolicyEngineScreen } from "../handlers/project/add/policy-engine/screen.tsx";
 import { AddConfigBundleScreen } from "../handlers/project/add/config-bundle/screen.tsx";
+import { AddPolicyScreen } from "../handlers/project/add/policy/screen.tsx";
+import { AddGatewayConnectorScreen } from "../handlers/project/add/gateway-connector/screen.tsx";
+import { AddOnlineEvalScreen } from "../handlers/project/add/online-eval/screen.tsx";
+import { AddOnlineInsightScreen } from "../handlers/project/add/online-insight/screen.tsx";
+import {
+  AddEvaluatorScreen,
+  AddLlmAsAJudgeEvaluatorScreen,
+} from "../handlers/project/add/evaluator/screen.tsx";
+import { AddPaymentManagerScreen } from "../handlers/project/add/payment-manager/screen.tsx";
 import { RootScreen, HelpScreen } from "../handlers/screen.tsx";
 import type { Context } from "../router";
 
@@ -130,14 +139,8 @@ const PROJECT_COMMANDS = ["export", "remove", "dev", "deploy", "status", "build"
 const ADD_COMMANDS = [
   "harness",
   "runtime",
-  "online-eval",
-  "online-insight",
-  "evaluator",
   "credentials",
   "gateway-target",
-  "gateway-connector",
-  "policy",
-  "payment-manager",
   "payment-connector",
 ] as const;
 
@@ -801,6 +804,34 @@ export function Root({ path, ctx, core, queryClient }: RootProps) {
           <Route
             path="agentcore/project/add/config-bundle"
             element={<AddConfigBundleScreen ctx={ctx} core={core} />}
+          />
+          <Route
+            path="agentcore/project/add/policy"
+            element={<AddPolicyScreen ctx={ctx} core={core} />}
+          />
+          <Route
+            path="agentcore/project/add/gateway-connector"
+            element={<AddGatewayConnectorScreen ctx={ctx} core={core} />}
+          />
+          <Route
+            path="agentcore/project/add/online-eval"
+            element={<AddOnlineEvalScreen ctx={ctx} core={core} />}
+          />
+          <Route
+            path="agentcore/project/add/online-insight"
+            element={<AddOnlineInsightScreen ctx={ctx} core={core} />}
+          />
+          <Route
+            path="agentcore/project/add/evaluator"
+            element={<AddEvaluatorScreen ctx={ctx} core={core} />}
+          />
+          <Route
+            path="agentcore/project/add/evaluator/llm-as-a-judge"
+            element={<AddLlmAsAJudgeEvaluatorScreen ctx={ctx} core={core} />}
+          />
+          <Route
+            path="agentcore/project/add/payment-manager"
+            element={<AddPaymentManagerScreen ctx={ctx} core={core} />}
           />
           {ADD_COMMANDS.map((command) => (
             <Route

--- a/src/components/Root.tsx
+++ b/src/components/Root.tsx
@@ -110,13 +110,36 @@ import { GatewayInvokeScreen } from "../handlers/gateway/invoke/screen.tsx";
 import { ProjectScreen, ProjectCommandNotImplementedScreen } from "../handlers/project/screen.tsx";
 import { ProjectCreateScreen } from "../handlers/project/create/screen.tsx";
 import { ProjectInvokePickerScreen } from "../handlers/project/invoke/screen.tsx";
+import { AddScreen } from "../handlers/project/add/screen.tsx";
+import { AddMemoryScreen } from "../handlers/project/add/memory/screen.tsx";
+import { AddGatewayScreen } from "../handlers/project/add/gateway/screen.tsx";
+import { AddPolicyEngineScreen } from "../handlers/project/add/policy-engine/screen.tsx";
+import { AddConfigBundleScreen } from "../handlers/project/add/config-bundle/screen.tsx";
 import { RootScreen, HelpScreen } from "../handlers/screen.tsx";
 import type { Context } from "../router";
 
 // PROJECT_COMMANDS are the `agentcore project` subcommands that are listed in
-// the menu but have no screen of their own yet (`create` has the wizard). Each
-// is routed explicitly so selecting it reports "not implemented" error
-const PROJECT_COMMANDS = ["add", "export", "remove", "dev", "deploy", "status", "build"] as const;
+// the menu but have no screen of their own yet (`create` has the wizard, `add`
+// has its own menu). Each is routed explicitly so selecting it reports "not
+// implemented" error
+const PROJECT_COMMANDS = ["export", "remove", "dev", "deploy", "status", "build"] as const;
+
+// ADD_COMMANDS are the `agentcore project add` resources that have no wizard
+// yet. They stay in the menu — every one of them works from the command line —
+// and route here so selecting one says so instead of falling through to help.
+const ADD_COMMANDS = [
+  "harness",
+  "runtime",
+  "online-eval",
+  "online-insight",
+  "evaluator",
+  "credentials",
+  "gateway-target",
+  "gateway-connector",
+  "policy",
+  "payment-manager",
+  "payment-connector",
+] as const;
 
 export interface RootProps {
   // path is the command path to the executing node (e.g. "/agentcore").
@@ -759,6 +782,36 @@ export function Root({ path, ctx, core, queryClient }: RootProps) {
               path={`agentcore/project/${command}`}
               element={
                 <ProjectCommandNotImplementedScreen ctx={ctx} core={core} command={command} />
+              }
+            />
+          ))}
+          <Route path="agentcore/project/add" element={<AddScreen ctx={ctx} core={core} />} />
+          <Route
+            path="agentcore/project/add/memory"
+            element={<AddMemoryScreen ctx={ctx} core={core} />}
+          />
+          <Route
+            path="agentcore/project/add/gateway"
+            element={<AddGatewayScreen ctx={ctx} core={core} />}
+          />
+          <Route
+            path="agentcore/project/add/policy-engine"
+            element={<AddPolicyEngineScreen ctx={ctx} core={core} />}
+          />
+          <Route
+            path="agentcore/project/add/config-bundle"
+            element={<AddConfigBundleScreen ctx={ctx} core={core} />}
+          />
+          {ADD_COMMANDS.map((command) => (
+            <Route
+              key={command}
+              path={`agentcore/project/add/${command}`}
+              element={
+                <ProjectCommandNotImplementedScreen
+                  ctx={ctx}
+                  core={core}
+                  command={`add ${command}`}
+                />
               }
             />
           ))}

--- a/src/components/wizard/Prerequisite.tsx
+++ b/src/components/wizard/Prerequisite.tsx
@@ -1,0 +1,47 @@
+import { Box, Text, useInput } from "ink";
+import { Layout } from "../Layout";
+import { darkTheme } from "../ui/_core.js";
+
+const theme = darkTheme;
+
+export interface PrerequisiteProps {
+  breadcrumb: string[];
+  description?: string;
+  // message says what the project lacks, e.g. "this project has no Gateways yet".
+  message: string;
+  // command is the CLI command that would add it, shown as the way forward.
+  command: string;
+  // onBack runs on esc; the screen the user came from.
+  onBack: () => void;
+}
+
+// Prerequisite stands in for a wizard whose first question has no possible
+// answer — a Policy needs a Policy Engine, a connector needs a Gateway. It
+// names what is missing and how to add it, instead of offering an empty picker.
+export function Prerequisite({
+  breadcrumb,
+  description,
+  message,
+  command,
+  onBack,
+}: PrerequisiteProps) {
+  useInput((_input, key) => {
+    if (key.escape) onBack();
+  });
+
+  return (
+    <Layout
+      breadcrumb={breadcrumb}
+      description={description}
+      keyHints={[
+        { key: "esc", label: "back" },
+        { key: "ctl+c", label: "quit" },
+      ]}
+    >
+      <Box flexDirection="column" paddingX={1}>
+        <Text color={theme.colors.warning}>{message}</Text>
+        <Text color={theme.colors.muted}>add one first with `{command}`</Text>
+      </Box>
+    </Layout>
+  );
+}

--- a/src/components/wizard/Step.tsx
+++ b/src/components/wizard/Step.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { Box, Text } from "ink";
+import { darkTheme } from "../ui/_core.js";
+
+const theme = darkTheme;
+
+export interface StepProps {
+  // name is the step's stable key. Position is tracked by key rather than by
+  // index because branches have different lengths: a conditional step that
+  // appears or disappears must not shift the user to a different question.
+  name: string;
+  // title labels the step in the Stepper; defaults to `name`.
+  title?: string;
+  // question is the one-line prompt shown under the Stepper. The Stepper
+  // already names the step, so the body opens with the question itself.
+  question?: string;
+  children: React.ReactNode;
+}
+
+// Step is one page of a <Wizard>: the stepper entry, the question line, and the
+// field that collects the answer.
+export function Step({ question, children }: StepProps) {
+  return (
+    <Box flexDirection="column" paddingX={1}>
+      {question !== undefined && <Text color={theme.colors.muted}>{question}</Text>}
+      {children}
+    </Box>
+  );
+}
+
+// isStepElement narrows a child to a <Step>. React.Children.toArray already
+// drops the `false`/`null` that a `{condition && <Step/>}` branch produces, so
+// filtering with this yields exactly the steps that apply to the current
+// answers — which is how a wizard branches without a step-list useMemo.
+export function isStepElement(child: React.ReactNode): child is React.ReactElement<StepProps> {
+  return React.isValidElement(child) && child.type === Step;
+}

--- a/src/components/wizard/Step.tsx
+++ b/src/components/wizard/Step.tsx
@@ -19,6 +19,12 @@ export interface StepProps {
 
 // Step is one page of a <Wizard>: the stepper entry, the question line, and the
 // field that collects the answer.
+//
+// One field per step. Every field registers its own useInput and answers enter,
+// esc and the arrows itself; two fields mounted at once would both react to the
+// same keystroke. The shell has no notion of focus and is not meant to grow
+// one — a step that genuinely needs two related inputs should get a single
+// compound field that owns one useInput and manages focus internally.
 export function Step({ question, children }: StepProps) {
   return (
     <Box flexDirection="column" paddingX={1}>

--- a/src/components/wizard/Wizard.tsx
+++ b/src/components/wizard/Wizard.tsx
@@ -80,14 +80,21 @@ export function Wizard({
     [children],
   );
 
-  const steps: StepperStep[] = useMemo(
-    () =>
-      stepElements.map((element) => ({
-        key: element.props.name,
-        title: element.props.title ?? element.props.name,
-      })),
-    [stepElements],
-  );
+  const steps: StepperStep[] = useMemo(() => {
+    const list = stepElements.map((element) => ({
+      key: element.props.name,
+      title: element.props.title ?? element.props.name,
+    }));
+    // Position is keyed by name, so two steps sharing one would make advance()
+    // land on the first of them forever. Catch that at render time, where the
+    // author sees it, instead of as a wizard that quietly cannot move on.
+    const seen = new Set<string>();
+    for (const step of list) {
+      if (seen.has(step.key)) throw new Error(`duplicate <Step name="${step.key}">`);
+      seen.add(step.key);
+    }
+    return list;
+  }, [stepElements]);
 
   const [stepKey, setStepKey] = useState<string>(() => steps[0]?.key ?? "");
 

--- a/src/components/wizard/Wizard.tsx
+++ b/src/components/wizard/Wizard.tsx
@@ -1,0 +1,277 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Box, Text, useApp, useInput } from "ink";
+import { Layout } from "../Layout";
+import { Stepper, type Step as StepperStep } from "../ui/stepper";
+import { Divider } from "../ui/divider";
+import { Spinner } from "../ui/spinner";
+import { darkTheme } from "../ui/_core.js";
+import { isStepElement } from "./Step";
+import { WizardProvider, type KeyHint, type WizardControls } from "./context";
+
+const theme = darkTheme;
+
+// ProgressEvent matches ProjectEvent's shape, so a ProjectManager generator can
+// be handed to onSubmit unchanged and its messages stream into the event log.
+export interface ProgressEvent {
+  message: string;
+}
+
+// A submit either resolves once (a plain control-plane request) or streams
+// progress events (the ProjectManager's async generators). Wizard renders both.
+export type WizardSubmitResult = AsyncIterable<ProgressEvent> | Promise<unknown>;
+
+type Phase =
+  { kind: "form" } | { kind: "running" } | { kind: "success" } | { kind: "error"; error: Error };
+
+export interface WizardProps {
+  breadcrumb: string[];
+  // description is shown dimmed after the breadcrumb; pass the command's own
+  // description so the header matches what `--help` prints.
+  description?: string;
+  // children are the <Step>s. A `{condition && <Step/>}` branch is dropped from
+  // the flow while the condition is false.
+  children: React.ReactNode;
+  onSubmit: () => WizardSubmitResult;
+  // onCancel runs when esc is pressed on the first step.
+  onCancel: () => void;
+  // runningLabel is the spinner label shown while onSubmit is in flight.
+  runningLabel: string;
+  // successLabel is the headline shown once onSubmit resolves.
+  successLabel: string;
+  // successHint is an optional dimmed line under successLabel.
+  successHint?: string;
+  // onDone runs when the success panel is acknowledged; defaults to tearing the
+  // TUI down, which is what a one-shot `project add ...` wants.
+  onDone?: () => void;
+  // onError decides what a failure does. "exit" rejects the waitUntilExit()
+  // that renderTuiAt awaits, so the error takes the normal CLI path and the
+  // process exits nonzero — right for a one-shot command. "retry" reports the
+  // message and returns to the form, right for a screen the user navigated to.
+  onError?: "exit" | "retry";
+}
+
+// Wizard is the shared shell behind every step-based flow: it derives the step
+// list from its <Step> children, owns position, key handling and the
+// form → running → success | error phases, and renders the standard
+// Layout + Stepper frame. Screens supply only the questions.
+export function Wizard({
+  breadcrumb,
+  description,
+  children,
+  onSubmit,
+  onCancel,
+  runningLabel,
+  successLabel,
+  successHint,
+  onDone,
+  onError = "exit",
+}: WizardProps) {
+  const { exit } = useApp();
+
+  const [phase, setPhase] = useState<Phase>({ kind: "form" });
+  const [events, setEvents] = useState<string[]>([]);
+  // Fields publish their hints from an effect, which lands one paint after the
+  // first render. Seeding with the hint every field shares keeps that first
+  // frame from showing a footer with no action key in it.
+  const [hints, setHints] = useState<KeyHint[]>([{ key: "enter", label: "continue" }]);
+
+  const stepElements = useMemo(
+    () => React.Children.toArray(children).filter(isStepElement),
+    [children],
+  );
+
+  const steps: StepperStep[] = useMemo(
+    () =>
+      stepElements.map((element) => ({
+        key: element.props.name,
+        title: element.props.title ?? element.props.name,
+      })),
+    [stepElements],
+  );
+
+  const [stepKey, setStepKey] = useState<string>(() => steps[0]?.key ?? "");
+
+  // Position is a key, not an index, so a branch that adds or removes steps
+  // does not move the user. The clamp covers the one case a key can vanish:
+  // a branch closing while its own step is somehow still active.
+  const found = steps.findIndex((step) => step.key === stepKey);
+  const index = found === -1 ? 0 : found;
+  const activeStep = stepElements[index];
+  const isLast = index === steps.length - 1;
+
+  // Ink drains buffered keystrokes synchronously, so a second enter can arrive
+  // before the form unmounts. The ref makes submitting idempotent.
+  const submitting = useRef(false);
+
+  const submit = useCallback(async () => {
+    if (submitting.current) return;
+    submitting.current = true;
+    setPhase({ kind: "running" });
+    try {
+      const result = onSubmit();
+      if (isProgressStream(result)) {
+        for await (const event of result) {
+          setEvents((current) => [...current, event.message]);
+        }
+      } else {
+        await result;
+      }
+      setPhase({ kind: "success" });
+    } catch (error) {
+      setPhase({ kind: "error", error: toError(error) });
+    } finally {
+      submitting.current = false;
+    }
+  }, [onSubmit]);
+
+  const controls: WizardControls = useMemo(
+    () => ({
+      isLast,
+      setHints,
+      advance: () => {
+        if (isLast) {
+          void submit();
+          return;
+        }
+        const next = steps[index + 1];
+        if (next) setStepKey(next.key);
+      },
+      back: () => {
+        if (index === 0) {
+          onCancel();
+          return;
+        }
+        const previous = steps[index - 1];
+        if (previous) setStepKey(previous.key);
+      },
+    }),
+    [isLast, index, steps, submit, onCancel],
+  );
+
+  return (
+    <Layout breadcrumb={breadcrumb} description={description} keyHints={footerHints(phase, hints)}>
+      <Box flexDirection="column">
+        {phase.kind === "form" && (
+          <>
+            <Box paddingX={1}>
+              <Stepper
+                steps={steps}
+                currentStep={steps[index]?.key ?? ""}
+                completedSteps={steps.slice(0, index).map((step) => step.key)}
+              />
+            </Box>
+            <Divider />
+            <WizardProvider value={controls}>{activeStep}</WizardProvider>
+          </>
+        )}
+
+        {phase.kind !== "form" && (
+          <Box flexDirection="column" paddingX={1}>
+            <EventLog events={events} />
+            {phase.kind === "running" && <Spinner label={runningLabel} />}
+            {phase.kind === "success" && (
+              <SuccessPanel
+                label={successLabel}
+                hint={successHint}
+                onContinue={onDone ?? (() => exit())}
+              />
+            )}
+            {phase.kind === "error" && onError === "exit" && <ExitOnError error={phase.error} />}
+            {phase.kind === "error" && onError === "retry" && (
+              <RetryPanel error={phase.error} onBack={() => setPhase({ kind: "form" })} />
+            )}
+          </Box>
+        )}
+      </Box>
+    </Layout>
+  );
+}
+
+// isProgressStream distinguishes an async generator from a promise. A promise
+// has no Symbol.asyncIterator, so this is a safe discriminator.
+function isProgressStream(result: WizardSubmitResult): result is AsyncIterable<ProgressEvent> {
+  return (
+    result !== null &&
+    typeof result === "object" &&
+    typeof (result as AsyncIterable<ProgressEvent>)[Symbol.asyncIterator] === "function"
+  );
+}
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+// footerHints appends the keys that mean the same thing on every step to
+// whatever the active field published.
+function footerHints(phase: Phase, fieldHints: KeyHint[]): KeyHint[] {
+  if (phase.kind === "running") return [{ key: "ctl+c", label: "quit" }];
+  if (phase.kind === "success") return [{ key: "enter", label: "continue" }];
+  if (phase.kind === "error") {
+    return [
+      { key: "esc", label: "back" },
+      { key: "ctl+c", label: "quit" },
+    ];
+  }
+  return [...fieldHints, { key: "esc", label: "back" }, { key: "ctl+c", label: "quit" }];
+}
+
+function EventLog({ events }: { events: string[] }) {
+  return (
+    <Box flexDirection="column">
+      {events.map((message, i) => (
+        <Text key={`${i}-${message}`} color={theme.colors.muted}>
+          ✓ {message}
+        </Text>
+      ))}
+    </Box>
+  );
+}
+
+function SuccessPanel({
+  label,
+  hint,
+  onContinue,
+}: {
+  label: string;
+  hint?: string;
+  onContinue: () => void;
+}) {
+  useInput((_input, key) => {
+    if (key.return || key.escape) onContinue();
+  });
+
+  return (
+    <Box flexDirection="column">
+      <Text color={theme.colors.success} bold>
+        ✔ {label}
+      </Text>
+      {hint !== undefined && <Text color={theme.colors.muted}>{hint}</Text>}
+    </Box>
+  );
+}
+
+// ExitOnError tears the TUI down through exit(error): that rejects the
+// waitUntilExit() renderTuiAt awaits, so the failure is reported by the normal
+// CLI error path instead of as a React stack trace.
+function ExitOnError({ error }: { error: Error }) {
+  const { exit } = useApp();
+
+  useEffect(() => {
+    exit(error);
+  }, [exit, error]);
+
+  return <Text color={theme.colors.error}>✗ {error.message}</Text>;
+}
+
+function RetryPanel({ error, onBack }: { error: Error; onBack: () => void }) {
+  useInput((_input, key) => {
+    if (key.escape || key.return) onBack();
+  });
+
+  return (
+    <Box flexDirection="column">
+      <Text color={theme.colors.error}>✗ {error.message}</Text>
+      <Text color={theme.colors.muted}>esc returns to the form</Text>
+    </Box>
+  );
+}

--- a/src/components/wizard/context.tsx
+++ b/src/components/wizard/context.tsx
@@ -37,14 +37,15 @@ export function useWizard(): WizardControls {
 export function useKeyHints(hints: KeyHint[]): void {
   const { setHints } = useWizard();
 
-  // The caller passes a fresh array literal on every render, so the effect is
-  // keyed on the hints' content and reads the latest array from a ref. Keying
-  // on the array itself would publish, re-render, and publish again forever.
-  const latest = useRef(hints);
-  latest.current = hints;
-  const signature = hints.map((hint) => `${hint.key}:${hint.label}`).join("|");
-
+  // The caller passes a fresh array literal on every render, so the effect
+  // runs every render — but publishes only when the content changed. Publishing
+  // the array itself unconditionally would re-render, publish, and re-render
+  // again forever; the ref remembers what the footer already shows.
+  const published = useRef<string | undefined>(undefined);
   useEffect(() => {
-    setHints(latest.current);
-  }, [signature, setHints]);
+    const signature = hints.map((hint) => `${hint.key}:${hint.label}`).join("|");
+    if (published.current === signature) return;
+    published.current = signature;
+    setHints(hints);
+  }, [hints, setHints]);
 }

--- a/src/components/wizard/context.tsx
+++ b/src/components/wizard/context.tsx
@@ -1,0 +1,50 @@
+import React, { useContext, useEffect, useRef } from "react";
+
+export interface KeyHint {
+  key: string;
+  label: string;
+}
+
+// WizardControls is what a field needs from the wizard around it: where to go
+// next, where to go back to, and a way to tell the footer what its keys do.
+export interface WizardControls {
+  // advance moves to the next step, or submits when the active step is last.
+  advance: () => void;
+  // back steps to the previous step, or cancels out of the wizard on the first.
+  back: () => void;
+  // isLast reports whether the active step is the final one, so a field can
+  // label its enter hint "submit" rather than "continue".
+  isLast: boolean;
+  // setHints replaces the footer's action hints. Fields call it via useKeyHints.
+  setHints: (hints: KeyHint[]) => void;
+}
+
+const WizardContext = React.createContext<WizardControls | null>(null);
+
+export const WizardProvider = WizardContext.Provider;
+
+export function useWizard(): WizardControls {
+  const controls = useContext(WizardContext);
+  if (!controls) {
+    throw new Error("wizard fields must be rendered inside a <Wizard>");
+  }
+  return controls;
+}
+
+// useKeyHints publishes the active field's footer hints. Each field declares
+// what its own keys do, so <Wizard> never has to switch on step kind the way
+// the hand-written wizards' hintsFor() does.
+export function useKeyHints(hints: KeyHint[]): void {
+  const { setHints } = useWizard();
+
+  // The caller passes a fresh array literal on every render, so the effect is
+  // keyed on the hints' content and reads the latest array from a ref. Keying
+  // on the array itself would publish, re-render, and publish again forever.
+  const latest = useRef(hints);
+  latest.current = hints;
+  const signature = hints.map((hint) => `${hint.key}:${hint.label}`).join("|");
+
+  useEffect(() => {
+    setHints(latest.current);
+  }, [signature, setHints]);
+}

--- a/src/components/wizard/fields.tsx
+++ b/src/components/wizard/fields.tsx
@@ -1,0 +1,397 @@
+import { useState } from "react";
+import { Box, Text, useInput } from "ink";
+import type z from "zod";
+import { FormTextInput } from "../FormTextInput";
+import { FormRadioGroup } from "../FormRadioGroup";
+import { FormCheckboxMultiSelect } from "../FormCheckboxMultiSelect";
+import { FormTextArea } from "../FormTextArea";
+import { KeyValueTable } from "../KeyValueTable";
+import { darkTheme } from "../ui/_core.js";
+import { useKeyHints, useWizard } from "./context";
+
+const theme = darkTheme;
+
+// Every field owns the key handling for its own step — esc goes back, enter
+// advances, arrows move — so a screen never writes that boilerplate again.
+
+// firstIssue renders the schema's own message, so the wizard rejects exactly
+// what the flag-driven path rejects and says the same thing about it. The issue
+// path is prefixed when there is one: for a nested value — a component inside a
+// components map, say — "expected object, received string" alone does not say
+// which key is wrong.
+function firstIssue(schema: z.ZodType, value: unknown): string | undefined {
+  const parsed = schema.safeParse(value);
+  if (parsed.success) return undefined;
+  const issue = parsed.error.issues[0];
+  if (!issue) return "invalid value";
+  const path = issue.path.join(".");
+  return path === "" ? issue.message : `${path}: ${issue.message}`;
+}
+
+interface ValidateOptions {
+  label: string;
+  required: boolean;
+  schema?: z.ZodType;
+  // json parses the value before the schema sees it, so a malformed blob is
+  // reported as bad JSON rather than as a shape the schema cannot read.
+  json?: boolean;
+}
+
+// validateEntry returns the message that should block the step, or undefined to
+// let it advance. Shared by the single-line and multi-line fields so both refuse
+// the same input for the same stated reason.
+function validateEntry(
+  value: string,
+  { label, required, schema, json = false }: ValidateOptions,
+): string | undefined {
+  const trimmed = value.trim();
+  if (trimmed === "") return required ? `${label} is required` : undefined;
+
+  let parsed: unknown = trimmed;
+  if (json) {
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch (cause) {
+      return `${label} is not valid JSON: ${(cause as Error).message}`;
+    }
+  }
+  return schema ? firstIssue(schema, parsed) : undefined;
+}
+
+export interface TextFieldProps {
+  // label names the value in validation messages ("<label> is required").
+  // It is not rendered: the <Step> already asks the question, and repeating
+  // it as a heading only adds a line to read.
+  label: string;
+  // help is the one line under the control, for what the question cannot
+  // carry — a range, a service limit, what an empty answer means. Omit it
+  // rather than restate the question.
+  help?: string;
+  placeholder?: string;
+  value: string;
+  onChange: (value: string) => void;
+  // required blocks advancing while the value is blank. Flag schemas are all
+  // `.optional()` by convention (Commander must not reject a bare command
+  // before the TUI middleware can open a screen), so required-ness is stated
+  // here the same way the handlers state it in their own bodies.
+  required?: boolean;
+  // schema validates the trimmed value before advancing. Pass the schema the
+  // flag declares.
+  schema?: z.ZodType;
+  // json parses the value before validating it. A JSON flag belongs here rather
+  // than in TextAreaField unless the value is genuinely prose: JSON is valid on
+  // one line, and this field can be edited in place.
+  json?: boolean;
+  // example is a dimmed line under `help`, kept on screen while the user types.
+  // A placeholder cannot do this job — it disappears on the first keystroke,
+  // exactly when a fiddly value most needs something to copy the shape from.
+  example?: string;
+}
+
+export function TextField({
+  label,
+  help = "",
+  placeholder = "",
+  value,
+  onChange,
+  required = false,
+  schema,
+  json = false,
+  example,
+}: TextFieldProps) {
+  const { advance, back, isLast } = useWizard();
+  const [error, setError] = useState<string>();
+
+  useKeyHints([{ key: "enter", label: isLast ? "submit" : "continue" }]);
+
+  useInput((_input, key) => {
+    if (key.escape) {
+      back();
+      return;
+    }
+    if (!key.return) return;
+
+    const issue = validateEntry(value, { label, required, schema, json });
+    if (issue !== undefined) {
+      setError(issue);
+      return;
+    }
+    setError(undefined);
+    advance();
+  });
+
+  return (
+    <Box flexDirection="column">
+      {/* The example sits above the input rather than inside it, so it survives
+          the first keystroke and stays there to be copied from. */}
+      {example !== undefined && (
+        <Box flexDirection="column">
+          {help !== "" && <Text color={theme.colors.muted}>{help}</Text>}
+          <Text color={theme.colors.muted}>{`for example  ${example}`}</Text>
+        </Box>
+      )}
+      <FormTextInput
+        name=""
+        helpText={example === undefined ? help : ""}
+        placeholder={placeholder}
+        errorText=""
+        value={value}
+        onChange={(next) => {
+          onChange(next);
+          setError(undefined);
+        }}
+      />
+      {error !== undefined && <Text color={theme.colors.error}>{error}</Text>}
+    </Box>
+  );
+}
+
+export interface Choice<T> {
+  value: T;
+  label: string;
+  description?: string;
+}
+
+export interface ChoiceFieldProps<T> {
+  // help is the one line under the options, for what the question and the
+  // per-option descriptions cannot carry between them. Usually omitted.
+  help?: string;
+  choices: Choice<T>[];
+  value: T;
+  onChange: (value: T) => void;
+}
+
+// ChoiceField is a single-choice step. The arrow arithmetic here replaces the
+// copy of it in each of the hand-written wizards. It takes no `label`: one of
+// the choices is always selected, so there is no validation message to name.
+export function ChoiceField<T>({ help = "", choices, value, onChange }: ChoiceFieldProps<T>) {
+  const { advance, back, isLast } = useWizard();
+
+  useKeyHints([
+    { key: "↑↓", label: "choose" },
+    { key: "enter", label: isLast ? "submit" : "continue" },
+  ]);
+
+  const found = choices.findIndex((choice) => choice.value === value);
+  const index = found === -1 ? 0 : found;
+
+  useInput((_input, key) => {
+    if (key.escape) {
+      back();
+      return;
+    }
+    if (key.upArrow) {
+      onChange(choices[Math.max(0, index - 1)]!.value);
+      return;
+    }
+    if (key.downArrow) {
+      onChange(choices[Math.min(choices.length - 1, index + 1)]!.value);
+      return;
+    }
+    if (key.return) advance();
+  });
+
+  return (
+    <FormRadioGroup
+      name=""
+      helpText={help}
+      options={choices.map((choice) => ({
+        label: choice.label,
+        description: choice.description ?? "",
+      }))}
+      selectedIndex={index}
+    />
+  );
+}
+
+export interface MultiChoiceFieldProps<T> {
+  // label names the value in validation messages ("<label> is required").
+  // It is not rendered: the <Step> already asks the question, and repeating
+  // it as a heading only adds a line to read.
+  label: string;
+  // help is the one line under the control, for what the question cannot
+  // carry — a range, a service limit, what an empty answer means. Omit it
+  // rather than restate the question.
+  help?: string;
+  choices: Choice<T>[];
+  value: T[];
+  onChange: (value: T[]) => void;
+  // requireOne blocks advancing on an empty selection.
+  requireOne?: boolean;
+}
+
+export function MultiChoiceField<T>({
+  label,
+  help = "",
+  choices,
+  value,
+  onChange,
+  requireOne = false,
+}: MultiChoiceFieldProps<T>) {
+  const { advance, back, isLast } = useWizard();
+  const [cursor, setCursor] = useState(0);
+  const [error, setError] = useState<string>();
+
+  useKeyHints([
+    { key: "↑↓", label: "move" },
+    { key: "space", label: "toggle" },
+    { key: "enter", label: isLast ? "submit" : "continue" },
+  ]);
+
+  useInput((input, key) => {
+    if (key.escape) {
+      back();
+      return;
+    }
+    if (key.upArrow) {
+      setCursor((c) => Math.max(0, c - 1));
+      return;
+    }
+    if (key.downArrow) {
+      setCursor((c) => Math.min(choices.length - 1, c + 1));
+      return;
+    }
+    if (input === " ") {
+      const choice = choices[cursor];
+      if (!choice) return;
+      setError(undefined);
+      onChange(
+        value.includes(choice.value)
+          ? value.filter((selected) => selected !== choice.value)
+          : [...value, choice.value],
+      );
+      return;
+    }
+    if (key.return) {
+      if (requireOne && value.length === 0) {
+        setError(`select at least one ${label}`);
+        return;
+      }
+      advance();
+    }
+  });
+
+  return (
+    <Box flexDirection="column">
+      <FormCheckboxMultiSelect
+        name=""
+        helpText={help}
+        options={choices.map((choice) => ({
+          label: choice.label,
+          description: choice.description ?? "",
+          checked: value.includes(choice.value),
+        }))}
+        cursorIndex={cursor}
+      />
+      {error !== undefined && <Text color={theme.colors.error}>{error}</Text>}
+    </Box>
+  );
+}
+
+export interface TextAreaFieldProps {
+  // label names the value in validation messages ("<label> is required").
+  // It is not rendered: the <Step> already asks the question, and repeating
+  // it as a heading only adds a line to read.
+  label: string;
+  // help is the one line under the control, for what the question cannot
+  // carry — a range, a service limit, what an empty answer means. Omit it
+  // rather than restate the question.
+  help?: string;
+  placeholder?: string;
+  value: string;
+  onChange: (value: string) => void;
+  required?: boolean;
+  // schema validates the parsed JSON when `json` is set, or the raw text
+  // otherwise.
+  schema?: z.ZodType;
+  // json parses the value before validating, and reports malformed JSON.
+  json?: boolean;
+}
+
+// TextAreaField collects multi-line text — a JSON blob, a system prompt.
+// FormTextArea spends enter on newlines, so ctl+d advances, matching the prompt
+// step in HarnessWizard.
+export function TextAreaField({
+  label,
+  help = "",
+  placeholder = "",
+  value,
+  onChange,
+  required = false,
+  schema,
+  json = false,
+}: TextAreaFieldProps) {
+  const { advance, back, isLast } = useWizard();
+  const [error, setError] = useState<string>();
+
+  useKeyHints([
+    { key: "enter", label: "newline" },
+    { key: "ctl+d", label: isLast ? "submit" : "continue" },
+  ]);
+
+  useInput((input, key) => {
+    if (key.escape) {
+      back();
+      return;
+    }
+    if (!(key.ctrl && input === "d")) return;
+
+    const issue = validateEntry(value, { label, required, schema, json });
+    if (issue !== undefined) {
+      setError(issue);
+      return;
+    }
+    setError(undefined);
+    advance();
+  });
+
+  return (
+    <Box flexDirection="column">
+      <FormTextArea
+        name=""
+        helpText={help}
+        placeholder={placeholder}
+        value={value}
+        onChange={(next) => {
+          onChange(next);
+          setError(undefined);
+        }}
+      />
+      {error !== undefined && <Text color={theme.colors.error}>{error}</Text>}
+    </Box>
+  );
+}
+
+export interface SummaryProps {
+  // items is the review table: what will be created, and with what settings.
+  items: Record<string, string>;
+}
+
+// Summary is the review step. It sits last, so its enter submits.
+export function Summary({ items }: SummaryProps) {
+  const { advance, back } = useWizard();
+
+  useKeyHints([{ key: "enter", label: "submit" }]);
+
+  useInput((_input, key) => {
+    if (key.escape) {
+      back();
+      return;
+    }
+    if (key.return) advance();
+  });
+
+  return (
+    <Box flexDirection="column">
+      <Box
+        borderStyle="single"
+        borderColor={theme.colors.border}
+        borderLeft={false}
+        borderRight={false}
+        borderBottom={false}
+      >
+        <KeyValueTable items={items} />
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/wizard/index.ts
+++ b/src/components/wizard/index.ts
@@ -14,3 +14,5 @@ export {
   type TextAreaFieldProps,
   type SummaryProps,
 } from "./fields";
+export { Prerequisite, type PrerequisiteProps } from "./Prerequisite";
+export { blankToUndefined, splitList, numberSchema } from "./values";

--- a/src/components/wizard/index.ts
+++ b/src/components/wizard/index.ts
@@ -1,0 +1,16 @@
+export { Wizard, type WizardProps, type WizardSubmitResult, type ProgressEvent } from "./Wizard";
+export { Step, type StepProps } from "./Step";
+export { useWizard, useKeyHints, type KeyHint, type WizardControls } from "./context";
+export {
+  TextField,
+  ChoiceField,
+  MultiChoiceField,
+  TextAreaField,
+  Summary,
+  type Choice,
+  type TextFieldProps,
+  type ChoiceFieldProps,
+  type MultiChoiceFieldProps,
+  type TextAreaFieldProps,
+  type SummaryProps,
+} from "./fields";

--- a/src/components/wizard/values.ts
+++ b/src/components/wizard/values.ts
@@ -1,0 +1,37 @@
+import z from "zod";
+
+// Helpers for turning a wizard's text answers into the typed values a
+// handler's input builder expects. Screens share them so an optional blank, a
+// comma-separated list, or a number typed into a text field mean the same
+// thing on every wizard.
+
+// blankToUndefined trims, and treats an empty answer as "not given" so the
+// builder applies the same default the flag path applies when a flag is absent.
+export function blankToUndefined(value: string): string | undefined {
+  const trimmed = value.trim();
+  return trimmed === "" ? undefined : trimmed;
+}
+
+// splitList reads a comma-separated answer as the list a repeatable flag
+// produces; blanks between commas are dropped, and an empty answer is "not given".
+export function splitList(value: string): string[] | undefined {
+  const entries = value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry !== "");
+  return entries.length === 0 ? undefined : entries;
+}
+
+// numberSchema validates a text answer against a numeric flag schema: anything
+// unparseable is reported before the bounds are, and the bounds are the flag's
+// own. `message` names what was expected, e.g. "enter a number of days".
+export function numberSchema(
+  inner: z.ZodType<number, number>,
+  message = "enter a number",
+): z.ZodType {
+  return z
+    .string()
+    .transform((raw) => Number(raw))
+    .refine((parsed) => Number.isFinite(parsed), { message })
+    .pipe(inner);
+}

--- a/src/components/wizard/wizard.test.tsx
+++ b/src/components/wizard/wizard.test.tsx
@@ -1,0 +1,287 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { useState } from "react";
+import { render } from "ink-testing-library";
+import { cleanupScreens, keys, tick, waitFor } from "../../testing";
+import { Wizard, type WizardSubmitResult } from "./Wizard";
+import { Step } from "./Step";
+import { ChoiceField, Summary, TextField } from "./fields";
+
+afterEach(cleanupScreens);
+
+// The wizard shell is exercised through a synthetic flow rather than one of the
+// real screens, so these tests describe the shell's own behaviour: how it
+// derives steps from children, moves between them, and reports outcomes.
+
+interface HarnessOptions {
+  onSubmit?: () => WizardSubmitResult;
+  onCancel?: () => void;
+  onError?: "exit" | "retry";
+  onDone?: () => void;
+}
+
+const YES_NO = [
+  { value: false, label: "no", description: "skip the extra question" },
+  { value: true, label: "yes", description: "ask the extra question" },
+];
+
+// TestWizard has one conditional step, so the branch behaviour under test is
+// expressed the way a screen expresses it: `{condition && <Step/>}`.
+function TestWizard({ onSubmit, onCancel, onError, onDone }: HarnessOptions) {
+  const [name, setName] = useState("");
+  const [wantsExtra, setWantsExtra] = useState(false);
+  const [extra, setExtra] = useState("");
+
+  return (
+    <Wizard
+      breadcrumb={["agentcore", "test"]}
+      description="a synthetic flow"
+      onCancel={onCancel ?? (() => {})}
+      onSubmit={onSubmit ?? (async () => {})}
+      onError={onError}
+      onDone={onDone}
+      runningLabel="working…"
+      successLabel="all done"
+      successHint="enter exits"
+    >
+      <Step name="name" question="what is your name?">
+        <TextField label="name" value={name} onChange={setName} required />
+      </Step>
+
+      <Step name="branch" question="want the extra question?">
+        <ChoiceField choices={YES_NO} value={wantsExtra} onChange={setWantsExtra} />
+      </Step>
+
+      {wantsExtra && (
+        <Step name="extra" question="the extra question">
+          <TextField label="extra" value={extra} onChange={setExtra} />
+        </Step>
+      )}
+
+      <Step name="review" question="review">
+        <Summary items={{ name, extra: extra === "" ? "(none)" : extra }} />
+      </Step>
+    </Wizard>
+  );
+}
+
+interface Driver {
+  lastFrame: () => string | undefined;
+  write: (input: string) => Promise<void>;
+  press: (key: keyof typeof keys) => Promise<void>;
+  // pressTwice delivers two discrete key events in one drain, with no render in
+  // between — what a fast typist produces. A single "\r\r" chunk would not do:
+  // Ink reports a multi-character chunk with key.return false, so it never
+  // reaches a return handler at all.
+  pressTwice: (key: keyof typeof keys) => Promise<void>;
+  unmount: () => void;
+}
+
+function drive(options: HarnessOptions = {}): Driver {
+  const instance = render(<></>);
+  Object.defineProperties(instance.stdout, {
+    columns: { configurable: true, value: 100 },
+    rows: { configurable: true, value: 40 },
+  });
+  instance.rerender(<TestWizard {...options} />);
+
+  return {
+    lastFrame: instance.lastFrame,
+    write: async (input) => {
+      await tick();
+      instance.stdin.write(input);
+      await tick();
+    },
+    press: async (key) => {
+      await tick();
+      instance.stdin.write(keys[key]);
+      await tick();
+    },
+    pressTwice: async (key) => {
+      await tick();
+      instance.stdin.write(keys[key]);
+      instance.stdin.write(keys[key]);
+      await tick();
+    },
+    unmount: instance.unmount,
+  };
+}
+
+function waitForFrame(driver: Driver, text: string): Promise<void> {
+  return waitFor(() => (driver.lastFrame() ?? "").includes(text), 1000);
+}
+
+describe("Wizard shell", () => {
+  test("derives the stepper from its Step children", async () => {
+    const d = drive();
+
+    await waitForFrame(d, "what is your name?");
+    const frame = d.lastFrame()!;
+    expect(frame).toContain("● name");
+    expect(frame).toContain("○ branch");
+    expect(frame).toContain("○ review");
+    // The conditional step is not offered while its condition is false.
+    expect(frame).not.toContain("○ extra");
+    d.unmount();
+  });
+
+  test("a step appears mid-flow when its condition turns true", async () => {
+    const d = drive();
+
+    await waitForFrame(d, "what is your name?");
+    await d.write("Ada");
+    await d.press("return");
+
+    await waitForFrame(d, "want the extra question?");
+    expect(d.lastFrame()).not.toContain("○ extra");
+
+    // Choosing "yes" inserts the step between here and review.
+    await d.press("down");
+    await waitForFrame(d, "○ extra");
+    await d.press("return");
+
+    await waitForFrame(d, "the extra question");
+    d.unmount();
+  });
+
+  test("enter advances and esc goes back, keeping answers", async () => {
+    const d = drive();
+
+    await waitForFrame(d, "what is your name?");
+    await d.write("Ada");
+    await d.press("return");
+
+    await waitForFrame(d, "want the extra question?");
+    await d.press("escape");
+
+    await waitForFrame(d, "what is your name?");
+    expect(d.lastFrame()).toContain("Ada");
+    d.unmount();
+  });
+
+  test("esc on the first step cancels out of the wizard", async () => {
+    let cancelled = 0;
+    const d = drive({ onCancel: () => cancelled++ });
+
+    await waitForFrame(d, "what is your name?");
+    await d.press("escape");
+
+    expect(cancelled).toBe(1);
+    d.unmount();
+  });
+
+  test("the footer hints come from the active field", async () => {
+    const d = drive();
+
+    // A text field offers enter; a choice field also offers the arrows.
+    await waitForFrame(d, "what is your name?");
+    expect(d.lastFrame()).toContain("[enter] continue");
+    expect(d.lastFrame()).not.toContain("[↑↓] choose");
+
+    await d.write("Ada");
+    await d.press("return");
+
+    await waitForFrame(d, "want the extra question?");
+    expect(d.lastFrame()).toContain("[↑↓] choose");
+    d.unmount();
+  });
+
+  test("enter on the last step submits and reports success", async () => {
+    let submits = 0;
+    const d = drive({
+      onSubmit: async () => {
+        submits++;
+      },
+    });
+
+    await waitForFrame(d, "what is your name?");
+    await d.write("Ada");
+    await d.press("return");
+    await waitForFrame(d, "want the extra question?");
+    await d.press("return");
+    await waitForFrame(d, "review");
+    expect(d.lastFrame()).toContain("[enter] submit");
+    await d.press("return");
+
+    await waitForFrame(d, "✔ all done");
+    expect(submits).toBe(1);
+    d.unmount();
+  });
+
+  test("a streamed submit renders each progress message", async () => {
+    async function* progress() {
+      yield { message: "wrote agentcore.json" };
+      yield { message: "updated the deploy target" };
+    }
+    const d = drive({ onSubmit: () => progress() });
+
+    await waitForFrame(d, "what is your name?");
+    await d.write("Ada");
+    await d.press("return");
+    await waitForFrame(d, "want the extra question?");
+    await d.press("return");
+    await waitForFrame(d, "review");
+    await d.press("return");
+
+    await waitForFrame(d, "✔ all done");
+    const frame = d.lastFrame()!;
+    expect(frame).toContain("wrote agentcore.json");
+    expect(frame).toContain("updated the deploy target");
+    d.unmount();
+  });
+
+  test("a buffered second enter does not submit twice", async () => {
+    let submits = 0;
+    const d = drive({
+      onSubmit: async () => {
+        submits++;
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      },
+    });
+
+    await waitForFrame(d, "what is your name?");
+    await d.write("Ada");
+    await d.press("return");
+    await waitForFrame(d, "want the extra question?");
+    await d.press("return");
+    await waitForFrame(d, "review");
+    await d.pressTwice("return");
+
+    await waitForFrame(d, "✔ all done");
+    expect(submits).toBe(1);
+    d.unmount();
+  });
+
+  test("onError retry reports the failure and returns to the form", async () => {
+    const d = drive({
+      onError: "retry",
+      onSubmit: () => Promise.reject(new Error("the service said no")),
+    });
+
+    await waitForFrame(d, "what is your name?");
+    await d.write("Ada");
+    await d.press("return");
+    await waitForFrame(d, "want the extra question?");
+    await d.press("return");
+    await waitForFrame(d, "review");
+    await d.press("return");
+
+    await waitForFrame(d, "✗ the service said no");
+    await d.press("escape");
+
+    // Back on the review step, with the answers intact.
+    await waitForFrame(d, "review");
+    expect(d.lastFrame()).toContain("Ada");
+    d.unmount();
+  });
+
+  test("a required field blocks the step until it is filled", async () => {
+    const d = drive();
+
+    await waitForFrame(d, "what is your name?");
+    await d.press("return");
+
+    await waitForFrame(d, "name is required");
+    expect(d.lastFrame()).toContain("what is your name?");
+    d.unmount();
+  });
+});

--- a/src/components/wizard/wizard.test.tsx
+++ b/src/components/wizard/wizard.test.tsx
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { useState } from "react";
 import { render } from "ink-testing-library";
-import { cleanupScreens, keys, tick, waitFor } from "../../testing";
+import { render as inkRender } from "ink";
+import { cleanupScreens, keys, tick, ttyTestIO, waitFor } from "../../testing";
 import { Wizard, type WizardSubmitResult } from "./Wizard";
 import { Step } from "./Step";
 import { ChoiceField, Summary, TextField } from "./fields";
@@ -283,5 +284,33 @@ describe("Wizard shell", () => {
     await waitForFrame(d, "name is required");
     expect(d.lastFrame()).toContain("what is your name?");
     d.unmount();
+  });
+});
+
+describe("Wizard authoring guards", () => {
+  // Ink's own render rather than ink-testing-library: a render-time throw
+  // reaches Ink's error boundary and rejects waitUntilExit, which the testing
+  // library does not expose.
+  test("two steps sharing a name are rejected at render", async () => {
+    const { streams } = ttyTestIO();
+    const { waitUntilExit } = inkRender(
+      <Wizard
+        breadcrumb={["agentcore", "test"]}
+        onCancel={() => {}}
+        onSubmit={async () => {}}
+        runningLabel="working…"
+        successLabel="all done"
+      >
+        <Step name="name" question="first">
+          <Summary items={{}} />
+        </Step>
+        <Step name="name" question="second">
+          <Summary items={{}} />
+        </Step>
+      </Wizard>,
+      { stdin: streams.io.stdin, stdout: streams.io.stdout, stderr: streams.io.stderr },
+    );
+
+    await expect(waitUntilExit()).rejects.toThrow('duplicate <Step name="name">');
   });
 });

--- a/src/handlers/project/ProjectGate.tsx
+++ b/src/handlers/project/ProjectGate.tsx
@@ -1,0 +1,107 @@
+import React, { useEffect, useState } from "react";
+import { Box, Text } from "ink";
+import { Layout } from "../../components/Layout";
+import { Spinner } from "../../components/ui/spinner";
+import { darkTheme } from "../../components/ui/_core.js";
+import type { Core } from "../types";
+import type { Project } from "./types";
+
+const theme = darkTheme;
+
+// projectNotFoundMessage matches what withProject throws on the flag-driven
+// path, so both entry points say the same thing about the same problem.
+function projectNotFoundMessage(from: string): string {
+  return (
+    `No AgentCore project found at ${from} or any parent directory ` +
+    `(looked for agentcore/agentcore.json). ` +
+    `Run 'agentcore project create' to scaffold one.`
+  );
+}
+
+export interface UseProjectResult {
+  project?: Project;
+  error?: string;
+}
+
+// useProject resolves the project enclosing the working directory. Screens need
+// their own resolution because withProject wraps `handle` only: middleware runs
+// when a command executes, and navigating between TUI screens never executes
+// one, so ProjectKey is set only when the launching command happened to be a
+// project command. When it was, pass it as `seed` and no resolution happens.
+export function useProject(core: Core, seed?: Project): UseProjectResult {
+  const [project, setProject] = useState<Project | undefined>(seed);
+  const [error, setError] = useState<string>();
+
+  useEffect(() => {
+    if (project !== undefined) return;
+    let active = true;
+    const from = process.cwd();
+    void core.projectManager
+      .resolve({ filePath: from })
+      .then((resolved) => {
+        if (!active) return;
+        if (!resolved) {
+          setError(projectNotFoundMessage(from));
+          return;
+        }
+        setProject(resolved);
+      })
+      .catch((cause: unknown) => {
+        if (active) setError(cause instanceof Error ? cause.message : String(cause));
+      });
+    return () => {
+      active = false;
+    };
+  }, [core.projectManager, project]);
+
+  return { project, error };
+}
+
+export interface ProjectGateProps {
+  core: Core;
+  breadcrumb: string[];
+  description?: string;
+  // seed is the project already pinned on the launch context, when the command
+  // that opened the TUI was itself a project command.
+  seed?: Project;
+  // children receives the resolved project and returns the screen. It must
+  // return an element rather than call hooks itself — the gate renders a
+  // spinner on the first paint, so a hook called here would change order.
+  children: (project: Project) => React.ReactElement;
+}
+
+// ProjectGate resolves the project before rendering a project screen, showing
+// the same not-found guidance the CLI prints when there is none.
+export function ProjectGate({ core, breadcrumb, description, seed, children }: ProjectGateProps) {
+  const { project, error } = useProject(core, seed);
+
+  if (error !== undefined && project === undefined) {
+    return (
+      <Layout
+        breadcrumb={breadcrumb}
+        description={description}
+        keyHints={[{ key: "ctl+c", label: "quit" }]}
+      >
+        <Box paddingX={1}>
+          <Text color={theme.colors.error}>✗ {error}</Text>
+        </Box>
+      </Layout>
+    );
+  }
+
+  if (project === undefined) {
+    return (
+      <Layout
+        breadcrumb={breadcrumb}
+        description={description}
+        keyHints={[{ key: "ctl+c", label: "quit" }]}
+      >
+        <Box paddingX={1}>
+          <Spinner label="loading project…" />
+        </Box>
+      </Layout>
+    );
+  }
+
+  return children(project);
+}

--- a/src/handlers/project/add/add.screen.test.tsx
+++ b/src/handlers/project/add/add.screen.test.tsx
@@ -34,7 +34,18 @@ function addSubcommands(): string[] {
 
 // The resources with a wizard. Everything else still routes to the
 // not-implemented screen and stays usable from the command line.
-const WITH_SCREENS = ["memory", "gateway", "policy-engine", "config-bundle"];
+const WITH_SCREENS = [
+  "memory",
+  "gateway",
+  "policy-engine",
+  "config-bundle",
+  "policy",
+  "gateway-connector",
+  "online-eval",
+  "online-insight",
+  "evaluator",
+  "payment-manager",
+];
 
 describe("project add menu", () => {
   test("lists every add resource", async () => {

--- a/src/handlers/project/add/add.screen.test.tsx
+++ b/src/handlers/project/add/add.screen.test.tsx
@@ -1,0 +1,114 @@
+import { test, expect, describe, afterEach } from "bun:test";
+import {
+  renderScreen,
+  waitForText,
+  cleanupScreens,
+  createSilentLogger,
+  TestCoreClient,
+  TestGlobalConfigAccessor,
+  testIO,
+  ttyTestIO,
+} from "../../../testing";
+import { renderTuiAt } from "../../../tui";
+import { NotImplementedError } from "../../../errors";
+import { compile, ValueContext } from "../../../router";
+import { createRootHandler } from "../../index";
+
+afterEach(cleanupScreens);
+
+// addSubcommands reads the resources off the compiled Commander tree, so a
+// `project add` resource added later is covered without editing this file.
+function addSubcommands(): string[] {
+  const root = compile(
+    createRootHandler(new TestCoreClient(), {
+      io: testIO().io,
+      logger: createSilentLogger(),
+      globalConfigAccessor: new TestGlobalConfigAccessor(),
+    }),
+    ValueContext.EmptyContext(),
+  );
+  const project = root.commands.find((command) => command.name() === "project")!;
+  const add = project.commands.find((command) => command.name() === "add")!;
+  return add.commands.map((command) => command.name()).filter((name) => name !== "help");
+}
+
+// The resources with a wizard. Everything else still routes to the
+// not-implemented screen and stays usable from the command line.
+const WITH_SCREENS = ["memory", "gateway", "policy-engine", "config-bundle"];
+
+describe("project add menu", () => {
+  test("lists every add resource", async () => {
+    const r = renderScreen("/agentcore/project/add");
+
+    await waitForText(r.lastFrame, "add project resources");
+    const frame = r.lastFrame()!;
+    for (const command of addSubcommands()) {
+      expect(frame).toContain(command);
+    }
+    r.unmount();
+  });
+
+  test("is reachable from the project menu", async () => {
+    const r = renderScreen("/agentcore/project");
+
+    await waitForText(r.lastFrame, "agentcore → project");
+    await r.write("add");
+    await waitForText(r.lastFrame, "❯ add");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "agentcore → project → add");
+    r.unmount();
+  });
+
+  test("esc returns to the project menu", async () => {
+    const r = renderScreen("/agentcore/project/add");
+
+    await waitForText(r.lastFrame, "agentcore → project → add");
+    await r.press("escape");
+
+    await waitForText(r.lastFrame, "manage an AgentCore project");
+    r.unmount();
+  });
+});
+
+describe("add resources without a wizard", () => {
+  // renderTuiAt rather than renderScreen: ink-testing-library exposes no
+  // waitUntilExit, so it cannot observe the rejection under test. Reading the
+  // cases off the router also guards Root's hand-written ADD_COMMANDS — an
+  // unrouted resource hits the catch-all, which resolves instead of rejecting.
+  test.each(addSubcommands().filter((command) => !WITH_SCREENS.includes(command)))(
+    "add %s tears down the TUI with NotImplementedError",
+    async (command) => {
+      const { streams } = ttyTestIO();
+
+      const rendering = renderTuiAt(
+        `/agentcore/project/add/${command}`,
+        ValueContext.EmptyContext(),
+        new TestCoreClient(),
+        streams.io,
+      );
+
+      await expect(rendering).rejects.toThrow(NotImplementedError);
+      await expect(rendering).rejects.toThrow(`'agentcore project add ${command}'`);
+    },
+  );
+
+  test("the error names the command to run instead", async () => {
+    const { streams } = ttyTestIO();
+
+    const caught: unknown = await renderTuiAt(
+      "/agentcore/project/add/harness",
+      ValueContext.EmptyContext(),
+      new TestCoreClient(),
+      streams.io,
+    ).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    expect(caught).toBeInstanceOf(NotImplementedError);
+    expect((caught as NotImplementedError).message).toContain(
+      "agentcore project add harness --help",
+    );
+  });
+});

--- a/src/handlers/project/add/config-bundle/configBundle.screen.test.tsx
+++ b/src/handlers/project/add/config-bundle/configBundle.screen.test.tsx
@@ -1,0 +1,176 @@
+import { test, expect, describe, afterEach } from "bun:test";
+import {
+  renderScreen,
+  waitForText,
+  waitForFlatText,
+  flatFrame,
+  cleanupScreens,
+} from "../../../../testing";
+import { createGatewayProjectTestHarness } from "../gateway-test-support";
+// The real example, so a test cannot pass against a stale copy of it.
+import { COMPONENTS_EXAMPLE } from "./screen";
+
+const { cleanup, inProject, projectSpec } = createGatewayProjectTestHarness(
+  "add-config-bundle-wizard",
+);
+
+afterEach(cleanup);
+afterEach(cleanupScreens);
+
+const COMPONENTS = '{"flags":{"configuration":{"beta":true}}}';
+
+describe("project add config-bundle wizard", () => {
+  test("collects a components map and writes the bundle", async () => {
+    const projectRoot = await inProject();
+    const r = renderScreen("/agentcore/project/add/config-bundle");
+
+    await waitForText(r.lastFrame, "what should this configuration bundle be called?");
+    await r.write("runtimeConfig");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "which components does the bundle configure?");
+    await r.write(COMPONENTS);
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "what is this bundle for?");
+    await r.press("return");
+
+    // Branch is prefilled with the flag's default.
+    await waitForText(r.lastFrame, "which branch holds the initial configuration?");
+    expect(r.lastFrame()).toContain("mainline");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "describe the initial configuration");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "this configuration bundle will be added to agentcore.json");
+    // The review names the components rather than reprinting the JSON.
+    expect(flatFrame(r.lastFrame)).toContain("components flags");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "added configuration bundle 'runtimeConfig' to 'TestProject'");
+
+    const bundles = (await projectSpec(projectRoot)).configBundles;
+    expect(bundles).toHaveLength(1);
+    expect(bundles[0]).toMatchObject({
+      name: "runtimeConfig",
+      components: { flags: { configuration: { beta: true } } },
+      branchName: "mainline",
+    });
+    r.unmount();
+  });
+
+  test("malformed components JSON does not advance", async () => {
+    await inProject();
+    const r = renderScreen("/agentcore/project/add/config-bundle");
+
+    await waitForText(r.lastFrame, "what should this configuration bundle be called?");
+    await r.write("runtimeConfig");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "which components does the bundle configure?");
+    await r.write('{"flags":');
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "is not valid JSON");
+    expect(r.lastFrame()).toContain("which components does the bundle configure?");
+    r.unmount();
+  });
+
+  test("well-formed JSON of the wrong shape names the offending component", async () => {
+    await inProject();
+    const r = renderScreen("/agentcore/project/add/config-bundle");
+
+    await waitForText(r.lastFrame, "what should this configuration bundle be called?");
+    await r.write("runtimeConfig");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "which components does the bundle configure?");
+    // Parses, but a component maps to an object, not a string.
+    await r.write('{"mycomponent": "mycomponent"}');
+    await r.press("return");
+
+    // The message carries zod's issue path, so it says *which* key is wrong
+    // rather than only that something was the wrong type.
+    await waitForFlatText(r.lastFrame, "mycomponent: Invalid input: expected object");
+    // The schema rejected it, so the wizard stayed put rather than advancing.
+    expect(r.lastFrame()).toContain("which components does the bundle configure?");
+    expect(r.lastFrame()).not.toContain("what is this bundle for?");
+    r.unmount();
+  });
+
+  test("the example stays on screen while the user types over it", async () => {
+    await inProject();
+    const r = renderScreen("/agentcore/project/add/config-bundle");
+
+    await waitForText(r.lastFrame, "what should this configuration bundle be called?");
+    await r.write("runtimeConfig");
+    await r.press("return");
+
+    // A placeholder would vanish on the first keystroke; the example must not,
+    // because that is when the shape is most needed.
+    await waitForText(r.lastFrame, "which components does the bundle configure?");
+    expect(r.lastFrame()).toContain(`for example  ${COMPONENTS_EXAMPLE}`);
+
+    await r.write('{"pri');
+    expect(r.lastFrame()).toContain(`for example  ${COMPONENTS_EXAMPLE}`);
+    r.unmount();
+  });
+
+  test("the example is itself a value the step accepts", async () => {
+    const projectRoot = await inProject();
+    const r = renderScreen("/agentcore/project/add/config-bundle");
+
+    await waitForText(r.lastFrame, "what should this configuration bundle be called?");
+    await r.write("runtimeConfig");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "which components does the bundle configure?");
+    await r.write(COMPONENTS_EXAMPLE);
+    await r.press("return");
+
+    // Advancing proves the example parses and satisfies the schema — an example
+    // that does not work is worse than none.
+    await waitForText(r.lastFrame, "what is this bundle for?");
+    await r.press("return");
+    await waitForText(r.lastFrame, "which branch holds the initial configuration?");
+    await r.press("return");
+    await waitForText(r.lastFrame, "describe the initial configuration");
+    await r.press("return");
+    await waitForText(r.lastFrame, "this configuration bundle will be added to agentcore.json");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "added configuration bundle 'runtimeConfig'");
+    expect((await projectSpec(projectRoot)).configBundles[0].components).toEqual({
+      pricing: { configuration: { currency: "USD" } },
+    });
+    r.unmount();
+  });
+
+  test("an empty components map is refused", async () => {
+    await inProject();
+    const r = renderScreen("/agentcore/project/add/config-bundle");
+
+    await waitForText(r.lastFrame, "what should this configuration bundle be called?");
+    await r.write("runtimeConfig");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "which components does the bundle configure?");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "component configuration map is required");
+    r.unmount();
+  });
+
+  test("a name that breaks the schema's pattern is rejected", async () => {
+    await inProject();
+    const r = renderScreen("/agentcore/project/add/config-bundle");
+
+    await waitForText(r.lastFrame, "what should this configuration bundle be called?");
+    await r.write("1-bad-name");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "Must begin with a letter");
+    r.unmount();
+  });
+});

--- a/src/handlers/project/add/config-bundle/index.ts
+++ b/src/handlers/project/add/config-bundle/index.ts
@@ -13,7 +13,11 @@ import { createHandler, flag, ProjectKey } from "../../../../router";
 import { parseJsonFlagWithSchema } from "../../../utils";
 import type { AddProjectResourceConfig } from "../types";
 
-const ComponentsSchema = z
+/**
+ * The shape --components accepts. Exported so the wizard's components step
+ * validates against the same schema rather than a copy of it.
+ */
+export const ComponentsSchema = z
   .record(z.string().min(1), ComponentConfigurationSchema.strict())
   .refine((components) => Object.keys(components).length > 0, {
     message: "must contain at least one component",

--- a/src/handlers/project/add/config-bundle/index.ts
+++ b/src/handlers/project/add/config-bundle/index.ts
@@ -7,10 +7,13 @@ import {
   ConfigBundleCommitMessageSchema,
   ConfigBundleDescriptionSchema,
   ConfigBundleNameSchema,
+  type ConfigBundleSchema,
 } from "../../../../projectSchemas/config-bundle";
 import { KmsKeyArnSchema } from "../../../../projectSchemas/evaluator";
 import { createHandler, flag, ProjectKey } from "../../../../router";
-import { parseJsonFlagWithSchema } from "../../../utils";
+import { formatZodError } from "../../../../router/schema";
+import { parseJsonFlag } from "../../../utils";
+import type { AddResourceInput } from "../../types";
 import type { AddProjectResourceConfig } from "../types";
 
 /**
@@ -22,6 +25,49 @@ export const ComponentsSchema = z
   .refine((components) => Object.keys(components).length > 0, {
     message: "must contain at least one component",
   });
+
+/** The branch the initial configuration lands on when none is named. */
+export const DEFAULT_BRANCH_NAME = "mainline";
+
+/**
+ * ConfigBundleInput is what every entry point — the flag handler, the wizard —
+ * resolves its own inputs to before a bundle is built. `components` is parsed
+ * JSON, validated here. Anything optional is a field toAddConfigBundleInput
+ * defaults.
+ */
+export interface ConfigBundleInput {
+  name: string;
+  /** Parsed JSON; validated against ComponentsSchema here. */
+  components: unknown;
+  description?: string;
+  branchName?: string;
+  commitMessage?: string;
+  kmsKeyArn?: string;
+}
+
+/**
+ * toAddConfigBundleInput is the one place a configuration bundle is assembled
+ * from user input. Both the flag handler and the wizard call it, so they
+ * cannot disagree about what a bundle is or what it defaults to.
+ */
+export function toAddConfigBundleInput(input: ConfigBundleInput): AddResourceInput {
+  const components = ComponentsSchema.safeParse(input.components);
+  if (!components.success) {
+    throw new InputValidationError(
+      `Invalid value for option '--components': ${formatZodError(components.error)}`,
+      { cause: components.error },
+    );
+  }
+  const resourceConfig: z.input<typeof ConfigBundleSchema> = {
+    name: input.name,
+    description: input.description,
+    components: components.data,
+    branchName: input.branchName ?? DEFAULT_BRANCH_NAME,
+    commitMessage: input.commitMessage,
+    kmsKeyArn: input.kmsKeyArn,
+  };
+  return { resourceType: "config-bundle", resourceConfig };
+}
 
 export const createAddConfigBundleHandler = (config: AddProjectResourceConfig) =>
   createHandler({
@@ -43,7 +89,7 @@ export const createAddConfigBundleHandler = (config: AddProjectResourceConfig) =
       flag(
         "branch-name",
         "branch name for the initial configuration",
-        ConfigBundleBranchNameSchema.default("mainline"),
+        ConfigBundleBranchNameSchema.default(DEFAULT_BRANCH_NAME),
       ),
       flag(
         "commit-message",
@@ -56,6 +102,9 @@ export const createAddConfigBundleHandler = (config: AddProjectResourceConfig) =
         KmsKeyArnSchema.optional(),
       ),
     ],
+    // handle only turns flags into a ConfigBundleInput — resolving the
+    // components source and parsing it. What a bundle is belongs to
+    // toAddConfigBundleInput.
     handle: async (ctx, flags) => {
       if (!flags.name) {
         throw new InputValidationError("required option '--name <name>' not specified");
@@ -65,24 +114,22 @@ export const createAddConfigBundleHandler = (config: AddProjectResourceConfig) =
       }
 
       const source = new SourceResolver({ stdin: config.io.stdin });
-      const componentsText = await source.resolveText("components", flags.components);
-      const components = parseJsonFlagWithSchema("components", componentsText, ComponentsSchema);
-      if (components === undefined) {
-        throw new InputValidationError("required option '--components <components>' not specified");
-      }
+      const components = parseJsonFlag<unknown>(
+        "components",
+        await source.resolveText("components", flags.components),
+      );
+
+      const input = toAddConfigBundleInput({
+        name: flags.name,
+        components,
+        description: flags.description,
+        branchName: flags["branch-name"],
+        commitMessage: flags["commit-message"],
+        kmsKeyArn: flags["kms-key-arn"],
+      });
 
       const project = ctx.require(ProjectKey);
-      for await (const event of config.projectManager.addResource(project, {
-        resourceType: "config-bundle",
-        resourceConfig: {
-          name: flags.name,
-          description: flags.description,
-          components,
-          branchName: flags["branch-name"],
-          commitMessage: flags["commit-message"],
-          kmsKeyArn: flags["kms-key-arn"],
-        },
-      })) {
+      for await (const event of config.projectManager.addResource(project, input)) {
         config.io.stderr.write(`${event.message}\n`);
       }
 

--- a/src/handlers/project/add/config-bundle/screen.tsx
+++ b/src/handlers/project/add/config-bundle/screen.tsx
@@ -1,0 +1,166 @@
+import { useState } from "react";
+import { useNavigate } from "react-router";
+import type z from "zod";
+import { ProjectKey } from "../../../../router";
+import {
+  ConfigBundleBranchNameSchema,
+  ConfigBundleCommitMessageSchema,
+  ConfigBundleDescriptionSchema,
+  ConfigBundleNameSchema,
+  type ConfigBundleSchema,
+} from "../../../../projectSchemas/config-bundle";
+import type { ScreenProps } from "../../../types";
+import type { AddResourceInput, Project } from "../../types";
+import { ProjectGate } from "../../ProjectGate";
+import { Wizard, Step, TextField, Summary } from "../../../../components/wizard";
+import { ComponentsSchema } from "./index";
+
+const BREADCRUMB = ["agentcore", "project", "add", "config-bundle"];
+const DESCRIPTION = "adds a configuration bundle to the current project";
+
+// The default the --branch-name flag applies.
+const DEFAULT_BRANCH_NAME = "mainline";
+
+// A complete, valid components map. It stays on screen while the user types,
+// so the shape can be copied rather than remembered.
+export const COMPONENTS_EXAMPLE = '{"pricing": {"configuration": {"currency": "USD"}}}';
+
+interface ConfigBundleFormValues {
+  name: string;
+  components: string;
+  description: string;
+  branchName: string;
+  commitMessage: string;
+}
+
+export function buildAddConfigBundleInput(values: ConfigBundleFormValues): AddResourceInput {
+  const resourceConfig: z.input<typeof ConfigBundleSchema> = {
+    name: values.name.trim(),
+    description: values.description.trim() === "" ? undefined : values.description.trim(),
+    components: ComponentsSchema.parse(JSON.parse(values.components)),
+    branchName: values.branchName.trim() === "" ? DEFAULT_BRANCH_NAME : values.branchName.trim(),
+    commitMessage: values.commitMessage.trim() === "" ? undefined : values.commitMessage.trim(),
+  };
+  return { resourceType: "config-bundle", resourceConfig };
+}
+
+function summaryOf(values: ConfigBundleFormValues): Record<string, string> {
+  // The components blob can be long, so the review reports its component names
+  // rather than reprinting the JSON the user just typed.
+  let componentNames = "(unreadable)";
+  try {
+    componentNames = Object.keys(JSON.parse(values.components) as object).join(", ");
+  } catch {
+    // The components step refuses to advance on malformed JSON, so this is only
+    // reachable if the value changed afterwards.
+  }
+  return {
+    bundle: values.name.trim(),
+    components: componentNames,
+    branch: values.branchName.trim() === "" ? DEFAULT_BRANCH_NAME : values.branchName.trim(),
+    ...(values.description.trim() === "" ? {} : { description: values.description.trim() }),
+    ...(values.commitMessage.trim() === "" ? {} : { commit: values.commitMessage.trim() }),
+  };
+}
+
+export function AddConfigBundleScreen({ ctx, core }: ScreenProps) {
+  return (
+    <ProjectGate
+      core={core}
+      breadcrumb={BREADCRUMB}
+      description={DESCRIPTION}
+      seed={ctx.value(ProjectKey)}
+    >
+      {(project) => <AddConfigBundleWizard project={project} core={core} />}
+    </ProjectGate>
+  );
+}
+
+function AddConfigBundleWizard({ project, core }: { project: Project; core: ScreenProps["core"] }) {
+  const navigate = useNavigate();
+  const [values, setValues] = useState<ConfigBundleFormValues>({
+    name: "",
+    components: "",
+    description: "",
+    branchName: DEFAULT_BRANCH_NAME,
+    commitMessage: "",
+  });
+  const set = (update: Partial<ConfigBundleFormValues>) =>
+    setValues((current) => ({ ...current, ...update }));
+
+  return (
+    <Wizard
+      breadcrumb={BREADCRUMB}
+      description={DESCRIPTION}
+      onCancel={() => navigate("/agentcore/project/add")}
+      onSubmit={() => core.projectManager.addResource(project, buildAddConfigBundleInput(values))}
+      runningLabel={`adding configuration bundle ${values.name.trim()}…`}
+      successLabel={`added configuration bundle '${values.name.trim()}' to '${project.name}'`}
+      successHint="enter exits"
+    >
+      <Step name="name" question="what should this configuration bundle be called?">
+        <TextField
+          label="bundle name"
+          placeholder="runtime-config"
+          value={values.name}
+          onChange={(name) => set({ name })}
+          required
+          schema={ConfigBundleNameSchema}
+        />
+      </Step>
+
+      {/* Single-line rather than a textarea: JSON is valid on one line, so
+          multi-line editing buys nothing, and this field can be corrected in
+          place — the textarea is append-only. It also keeps enter meaning
+          "continue" here, as it does on every other step. Pasting
+          pretty-printed JSON still works: the input drops the newlines but
+          keeps the spaces around them, so the value stays valid. */}
+      <Step name="components" question="which components does the bundle configure?">
+        <TextField
+          label="component configuration map"
+          help="each component name maps to an object with a configuration"
+          example={COMPONENTS_EXAMPLE}
+          value={values.components}
+          onChange={(components) => set({ components })}
+          required
+          json
+          schema={ComponentsSchema}
+        />
+      </Step>
+
+      <Step name="description" question="what is this bundle for? (optional)">
+        <TextField
+          label="description"
+          placeholder="feature flags for the checkout agent"
+          value={values.description}
+          onChange={(description) => set({ description })}
+          schema={ConfigBundleDescriptionSchema}
+        />
+      </Step>
+
+      <Step name="branch" title="branch" question="which branch holds the initial configuration?">
+        <TextField
+          label="branch name"
+          placeholder={DEFAULT_BRANCH_NAME}
+          value={values.branchName}
+          onChange={(branchName) => set({ branchName })}
+          schema={ConfigBundleBranchNameSchema}
+        />
+      </Step>
+
+      <Step name="commit" title="commit" question="describe the initial configuration (optional)">
+        <TextField
+          label="commit message"
+          placeholder="initial configuration"
+          value={values.commitMessage}
+          onChange={(commitMessage) => set({ commitMessage })}
+          schema={ConfigBundleCommitMessageSchema}
+        />
+      </Step>
+
+      <Step name="review" question="this configuration bundle will be added to agentcore.json">
+        <Summary items={summaryOf(values)} />
+      </Step>
+    </Wizard>
+  );
+}

--- a/src/handlers/project/add/config-bundle/screen.tsx
+++ b/src/handlers/project/add/config-bundle/screen.tsx
@@ -1,25 +1,25 @@
 import { useState } from "react";
 import { useNavigate } from "react-router";
-import type z from "zod";
 import { ProjectKey } from "../../../../router";
 import {
   ConfigBundleBranchNameSchema,
   ConfigBundleCommitMessageSchema,
   ConfigBundleDescriptionSchema,
   ConfigBundleNameSchema,
-  type ConfigBundleSchema,
 } from "../../../../projectSchemas/config-bundle";
 import type { ScreenProps } from "../../../types";
-import type { AddResourceInput, Project } from "../../types";
+import type { Project } from "../../types";
 import { ProjectGate } from "../../ProjectGate";
 import { Wizard, Step, TextField, Summary } from "../../../../components/wizard";
-import { ComponentsSchema } from "./index";
+import {
+  ComponentsSchema,
+  DEFAULT_BRANCH_NAME,
+  toAddConfigBundleInput,
+  type ConfigBundleInput,
+} from "./index";
 
 const BREADCRUMB = ["agentcore", "project", "add", "config-bundle"];
 const DESCRIPTION = "adds a configuration bundle to the current project";
-
-// The default the --branch-name flag applies.
-const DEFAULT_BRANCH_NAME = "mainline";
 
 // A complete, valid components map. It stays on screen while the user types,
 // so the shape can be copied rather than remembered.
@@ -33,15 +33,23 @@ interface ConfigBundleFormValues {
   commitMessage: string;
 }
 
-export function buildAddConfigBundleInput(values: ConfigBundleFormValues): AddResourceInput {
-  const resourceConfig: z.input<typeof ConfigBundleSchema> = {
+// toConfigBundleInput reads the form into the ConfigBundleInput the handler's
+// toAddConfigBundleInput builds a bundle from. It trims and parses; a blank
+// optional answer is passed as undefined so the shared builder applies the
+// same default the flag path applies.
+export function toConfigBundleInput(values: ConfigBundleFormValues): ConfigBundleInput {
+  return {
     name: values.name.trim(),
-    description: values.description.trim() === "" ? undefined : values.description.trim(),
-    components: ComponentsSchema.parse(JSON.parse(values.components)),
-    branchName: values.branchName.trim() === "" ? DEFAULT_BRANCH_NAME : values.branchName.trim(),
-    commitMessage: values.commitMessage.trim() === "" ? undefined : values.commitMessage.trim(),
+    components: JSON.parse(values.components),
+    description: blankToUndefined(values.description),
+    branchName: blankToUndefined(values.branchName),
+    commitMessage: blankToUndefined(values.commitMessage),
   };
-  return { resourceType: "config-bundle", resourceConfig };
+}
+
+function blankToUndefined(value: string): string | undefined {
+  const trimmed = value.trim();
+  return trimmed === "" ? undefined : trimmed;
 }
 
 function summaryOf(values: ConfigBundleFormValues): Record<string, string> {
@@ -93,7 +101,12 @@ function AddConfigBundleWizard({ project, core }: { project: Project; core: Scre
       breadcrumb={BREADCRUMB}
       description={DESCRIPTION}
       onCancel={() => navigate("/agentcore/project/add")}
-      onSubmit={() => core.projectManager.addResource(project, buildAddConfigBundleInput(values))}
+      onSubmit={() =>
+        core.projectManager.addResource(
+          project,
+          toAddConfigBundleInput(toConfigBundleInput(values)),
+        )
+      }
       runningLabel={`adding configuration bundle ${values.name.trim()}…`}
       successLabel={`added configuration bundle '${values.name.trim()}' to '${project.name}'`}
       successHint="enter exits"

--- a/src/handlers/project/add/evaluator/evaluator.screen.test.tsx
+++ b/src/handlers/project/add/evaluator/evaluator.screen.test.tsx
@@ -1,0 +1,154 @@
+import { test, expect, describe, afterEach } from "bun:test";
+import {
+  renderScreen,
+  waitForText,
+  waitForFlatText,
+  flatFrame,
+  cleanupScreens,
+} from "../../../../testing";
+import { createGatewayProjectTestHarness } from "../gateway-test-support";
+import { RATING_SCALE_PRESETS } from "./llm-as-a-judge/ratingScales";
+
+const { cleanup, inProject, projectSpec } = createGatewayProjectTestHarness("add-evaluator-wizard");
+
+afterEach(cleanup);
+afterEach(cleanupScreens);
+
+const MODEL = "anthropic.claude-3-5-sonnet-20240620-v1:0";
+
+describe("project add evaluator menu", () => {
+  test("lists the evaluator kinds and opens the picked one", async () => {
+    await inProject();
+    const r = renderScreen("/agentcore/project/add/evaluator");
+
+    await waitForText(r.lastFrame, "agentcore → project → add → evaluator");
+    expect(r.lastFrame()).toContain("llm-as-a-judge");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "what should this evaluator be called?");
+    r.unmount();
+  });
+});
+
+describe("project add evaluator llm-as-a-judge wizard", () => {
+  test("a preset scale expands exactly as --rating-scale <preset> does", async () => {
+    const projectRoot = await inProject();
+    const r = renderScreen("/agentcore/project/add/evaluator/llm-as-a-judge");
+
+    await waitForText(r.lastFrame, "what should this evaluator be called?");
+    await r.write("judge");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "what should the judge score?");
+    await r.press("down");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "which Bedrock model should act as the judge?");
+    await r.write("not a model");
+    await r.press("return");
+    await waitForFlatText(r.lastFrame, "expected a Bedrock model ID");
+    for (let i = 0; i < "not a model".length; i++) await r.write("\x7f");
+    await r.write(MODEL);
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "how should the judge score a session?");
+    await r.write("Rate {context} for helpfulness.");
+    await r.write("\x04");
+
+    await waitForText(r.lastFrame, "which rating scale should the judge use?");
+    expect(r.lastFrame()).toContain("● 1-5-quality");
+    expect(r.lastFrame()).toContain("custom");
+    await r.press("return");
+
+    // A preset was picked, so no JSON step follows.
+    await waitForText(r.lastFrame, "what does this evaluator measure?");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "this evaluator will be added to agentcore.json");
+    const review = flatFrame(r.lastFrame);
+    expect(review).toContain("level TRACE");
+    expect(review).toContain("rating scale 1-5-quality");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "added evaluator 'judge'");
+
+    const evaluators = (await projectSpec(projectRoot)).evaluators;
+    expect(evaluators).toEqual([
+      {
+        name: "judge",
+        level: "TRACE",
+        config: {
+          llmAsAJudge: {
+            model: MODEL,
+            instructions: "Rate {context} for helpfulness.",
+            ratingScale: RATING_SCALE_PRESETS["1-5-quality"],
+          },
+        },
+      },
+    ]);
+    r.unmount();
+  });
+
+  test("custom opens a JSON step that validates the scale's shape", async () => {
+    const projectRoot = await inProject();
+    const r = renderScreen("/agentcore/project/add/evaluator/llm-as-a-judge");
+
+    await waitForText(r.lastFrame, "what should this evaluator be called?");
+    await r.write("pass_fail");
+    await r.press("return");
+    await waitForText(r.lastFrame, "what should the judge score?");
+    await r.press("return");
+    await waitForText(r.lastFrame, "which Bedrock model should act as the judge?");
+    await r.write(MODEL);
+    await r.press("return");
+    await waitForText(r.lastFrame, "how should the judge score a session?");
+    await r.write("Did it work?");
+    await r.write("\x04");
+
+    await waitForText(r.lastFrame, "which rating scale should the judge use?");
+    // The last entry, after the four presets, is "custom".
+    for (let i = 0; i < 4; i++) await r.press("down");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "paste the rating scale as JSON");
+    await r.write('{"numerical": [], "categorical": []}');
+    await r.press("return");
+    await waitForFlatText(r.lastFrame, "either numerical or categorical, not both");
+    r.unmount();
+
+    const again = renderScreen("/agentcore/project/add/evaluator/llm-as-a-judge");
+    await waitForText(again.lastFrame, "what should this evaluator be called?");
+    await again.write("pass_fail");
+    await again.press("return");
+    await waitForText(again.lastFrame, "what should the judge score?");
+    await again.press("return");
+    await waitForText(again.lastFrame, "which Bedrock model should act as the judge?");
+    await again.write(MODEL);
+    await again.press("return");
+    await waitForText(again.lastFrame, "how should the judge score a session?");
+    await again.write("Did it work?");
+    await again.write("\x04");
+    await waitForText(again.lastFrame, "which rating scale should the judge use?");
+    for (let i = 0; i < 4; i++) await again.press("down");
+    await again.press("return");
+    await waitForText(again.lastFrame, "paste the rating scale as JSON");
+    await again.write(
+      '{"categorical": [{"label": "PASS", "definition": "it worked"}, {"label": "FAIL", "definition": "it did not"}]}',
+    );
+    await again.press("return");
+    await waitForText(again.lastFrame, "what does this evaluator measure?");
+    await again.press("return");
+    await waitForText(again.lastFrame, "this evaluator will be added to agentcore.json");
+    expect(flatFrame(again.lastFrame)).toContain("rating scale custom");
+    await again.press("return");
+    await waitForText(again.lastFrame, "added evaluator 'pass_fail'");
+
+    expect((await projectSpec(projectRoot)).evaluators[0].config.llmAsAJudge.ratingScale).toEqual({
+      categorical: [
+        { label: "PASS", definition: "it worked" },
+        { label: "FAIL", definition: "it did not" },
+      ],
+    });
+    again.unmount();
+  });
+});

--- a/src/handlers/project/add/evaluator/llm-as-a-judge/index.ts
+++ b/src/handlers/project/add/evaluator/llm-as-a-judge/index.ts
@@ -6,16 +6,74 @@ import {
   EvaluatorSchema,
   isValidBedrockModelId,
   RatingScaleSchema,
+  type EvaluationLevel,
   type RatingScale,
 } from "../../../../../projectSchemas/evaluator";
 import { TagsSchema } from "../../../../../projectSchemas/tags";
 import { parseJsonFlagWithSchema } from "../../../../utils";
+import type { AddResourceInput } from "../../../types";
 import type { AddProjectResourceConfig } from "../../types";
 import {
   isRatingScalePreset,
   RATING_SCALE_PRESETS,
   RATING_SCALE_PRESET_NAMES,
 } from "./ratingScales";
+
+/**
+ * JudgeModelSchema is what --model must look like. Exported so the wizard's
+ * model step refuses the same values the flag path refuses, with the same words.
+ */
+export const JudgeModelSchema = z.string().refine(isValidBedrockModelId, {
+  message:
+    "expected a Bedrock model ID (e.g. anthropic.claude-3-5-sonnet-20240620-v1:0) or an inference-profile/foundation-model ARN",
+});
+
+/**
+ * LlmAsAJudgeEvaluatorInput is what every entry point — the flag handler, the
+ * wizard — resolves its own inputs to before an evaluator is built. The rating
+ * scale is already resolved (see resolveRatingScale) and the instructions
+ * already read from wherever the user kept them.
+ */
+export interface LlmAsAJudgeEvaluatorInput {
+  name: string;
+  level: EvaluationLevel;
+  model: string;
+  instructions: string;
+  ratingScale: RatingScale;
+  description?: string;
+  kmsKeyArn?: string;
+  tags?: Record<string, string>;
+}
+
+/**
+ * toAddLlmAsAJudgeEvaluatorInput is the one place an LLM-as-a-Judge evaluator
+ * is assembled and checked against the project schema. Both the flag handler
+ * and the wizard call it.
+ */
+export function toAddLlmAsAJudgeEvaluatorInput(input: LlmAsAJudgeEvaluatorInput): AddResourceInput {
+  const model = JudgeModelSchema.safeParse(input.model);
+  if (!model.success)
+    throw new InputValidationError(
+      `invalid --model "${input.model}": ${model.error.issues[0]?.message}`,
+    );
+
+  const parsed = EvaluatorSchema.safeParse({
+    name: input.name,
+    level: input.level,
+    description: input.description,
+    config: {
+      llmAsAJudge: {
+        model: input.model,
+        instructions: input.instructions,
+        ratingScale: input.ratingScale,
+      },
+    },
+    kmsKeyArn: input.kmsKeyArn,
+    tags: input.tags,
+  });
+  if (!parsed.success) throw new InputValidationError(z.prettifyError(parsed.error));
+  return { resourceType: "evaluator", resourceConfig: parsed.data };
+}
 
 export const createAddLlmAsAJudgeEvaluatorHandler = (config: AddProjectResourceConfig) =>
   createHandler({
@@ -48,6 +106,9 @@ export const createAddLlmAsAJudgeEvaluatorHandler = (config: AddProjectResourceC
       ),
       flag("tags", "tags to apply (JSON object of key/value strings)", z.string().optional()),
     ],
+    // handle only turns flags into an LlmAsAJudgeEvaluatorInput — reading the
+    // instructions from their source, expanding the rating-scale preset. What an
+    // evaluator is belongs to toAddLlmAsAJudgeEvaluatorInput.
     handle: async (ctx, flags) => {
       if (!flags["name"])
         throw new InputValidationError("required option '--name <name>' not specified");
@@ -64,39 +125,24 @@ export const createAddLlmAsAJudgeEvaluatorHandler = (config: AddProjectResourceC
           "required option '--rating-scale <rating-scale>' not specified",
         );
 
-      if (!isValidBedrockModelId(flags["model"]))
-        throw new InputValidationError(
-          `invalid --model "${flags["model"]}": expected a Bedrock model ID (e.g. anthropic.claude-3-5-sonnet-20240620-v1:0) or an inference-profile/foundation-model ARN`,
-        );
-
-      const ratingScale = resolveRatingScale(flags["rating-scale"]);
-
       const resolver = new SourceResolver({ stdin: config.io.stdin });
-      const instructions = await resolver.resolveText("instructions", flags["instructions"]);
+      const instructions = (await resolver.resolveText("instructions", flags["instructions"]))!;
 
-      const candidate = {
+      const input = toAddLlmAsAJudgeEvaluatorInput({
         name: flags["name"],
-        level: flags["level"],
+        // The level's enum is checked by the schema inside the builder, so an
+        // unknown level is reported in the schema's words.
+        level: flags["level"] as EvaluationLevel,
+        model: flags["model"],
+        instructions,
+        ratingScale: resolveRatingScale(flags["rating-scale"]),
         description: flags["description"],
-        config: {
-          llmAsAJudge: {
-            model: flags["model"],
-            instructions,
-            ratingScale,
-          },
-        },
         kmsKeyArn: flags["kms-key-arn"],
         tags: parseJsonFlagWithSchema("tags", flags["tags"], TagsSchema),
-      };
-
-      const parsed = EvaluatorSchema.safeParse(candidate);
-      if (!parsed.success) throw new InputValidationError(z.prettifyError(parsed.error));
+      });
 
       const project = ctx.require(ProjectKey);
-      for await (const event of config.projectManager.addResource(project, {
-        resourceType: "evaluator",
-        resourceConfig: parsed.data,
-      })) {
+      for await (const event of config.projectManager.addResource(project, input)) {
         config.io.stderr.write(`${event.message}\n`);
       }
 
@@ -104,9 +150,12 @@ export const createAddLlmAsAJudgeEvaluatorHandler = (config: AddProjectResourceC
     },
   });
 
-// A preset name expands to a fresh copy of the shared table; anything else is
-// treated as an inline JSON rating scale and validated against the schema.
-function resolveRatingScale(value: string): RatingScale {
+/**
+ * A preset name expands to a fresh copy of the shared table; anything else is
+ * treated as an inline JSON rating scale and validated against the schema.
+ * Exported so the wizard's custom-scale step resolves exactly as the flag does.
+ */
+export function resolveRatingScale(value: string): RatingScale {
   if (isRatingScalePreset(value)) {
     return structuredClone(RATING_SCALE_PRESETS[value]) as RatingScale;
   }

--- a/src/handlers/project/add/evaluator/screen.tsx
+++ b/src/handlers/project/add/evaluator/screen.tsx
@@ -1,0 +1,244 @@
+import { useState } from "react";
+import { useNavigate } from "react-router";
+import { ProjectKey } from "../../../../router";
+import { RouterScreen } from "../../../../components/RouterScreen";
+import {
+  EvaluationLevelSchema,
+  EvaluatorNameSchema,
+  RatingScaleSchema,
+  type EvaluationLevel,
+} from "../../../../projectSchemas/evaluator";
+import type { ScreenProps } from "../../../types";
+import type { Project } from "../../types";
+import { ProjectGate } from "../../ProjectGate";
+import {
+  Wizard,
+  Step,
+  TextField,
+  TextAreaField,
+  ChoiceField,
+  Summary,
+  blankToUndefined,
+} from "../../../../components/wizard";
+import {
+  JudgeModelSchema,
+  resolveRatingScale,
+  toAddLlmAsAJudgeEvaluatorInput,
+  type LlmAsAJudgeEvaluatorInput,
+} from "./llm-as-a-judge";
+import {
+  RATING_SCALE_PRESET_NAMES,
+  RATING_SCALE_PRESETS,
+  type RatingScalePreset,
+} from "./llm-as-a-judge/ratingScales";
+
+// AddEvaluatorScreen is the `agentcore project add evaluator` menu: evaluator
+// is a command group, so its kinds are read off the Commander tree like the
+// add menu's resources are.
+export function AddEvaluatorScreen(props: ScreenProps) {
+  return <RouterScreen {...props} path={["agentcore", "project", "add", "evaluator"]} />;
+}
+
+const BREADCRUMB = ["agentcore", "project", "add", "evaluator", "llm-as-a-judge"];
+const DESCRIPTION =
+  "add an LLM-as-a-Judge evaluator — another LLM prompted with instructions on how to score a session";
+const EVALUATOR_MENU = "/agentcore/project/add/evaluator";
+
+const LEVEL_DESCRIPTIONS: Record<EvaluationLevel, string> = {
+  SESSION: "one score for the whole conversation",
+  TRACE: "one score per agent turn",
+  TOOL_CALL: "one score per tool invocation",
+};
+
+const LEVEL_CHOICES = EvaluationLevelSchema.options.map((level) => ({
+  value: level,
+  label: level,
+  description: LEVEL_DESCRIPTIONS[level],
+}));
+
+// CUSTOM_SCALE is the picker entry that opens the JSON step.
+const CUSTOM_SCALE = "\u0000custom";
+type ScaleChoice = RatingScalePreset | typeof CUSTOM_SCALE;
+
+function describePreset(preset: RatingScalePreset): string {
+  const scale = RATING_SCALE_PRESETS[preset];
+  const rungs = "numerical" in scale ? scale.numerical : scale.categorical;
+  return rungs.map((rung) => rung.label).join(" · ");
+}
+
+const SCALE_CHOICES: { value: ScaleChoice; label: string; description: string }[] = [
+  ...RATING_SCALE_PRESET_NAMES.map((preset) => ({
+    value: preset as ScaleChoice,
+    label: preset,
+    description: describePreset(preset),
+  })),
+  { value: CUSTOM_SCALE, label: "custom", description: "paste a rating scale as JSON" },
+];
+
+interface EvaluatorFormValues {
+  name: string;
+  level: EvaluationLevel;
+  model: string;
+  instructions: string;
+  scale: ScaleChoice;
+  customScale: string;
+  description: string;
+}
+
+// toLlmAsAJudgeEvaluatorInput reads the form into the input the handler's
+// builder expects. The rating scale goes through the handler's own
+// resolveRatingScale, whether a preset was picked or JSON was pasted, so the
+// wizard's scale is exactly what `--rating-scale <same value>` produces.
+export function toLlmAsAJudgeEvaluatorInput(
+  values: EvaluatorFormValues,
+): LlmAsAJudgeEvaluatorInput {
+  return {
+    name: values.name.trim(),
+    level: values.level,
+    model: values.model.trim(),
+    instructions: values.instructions.trim(),
+    ratingScale: resolveRatingScale(
+      values.scale === CUSTOM_SCALE ? values.customScale.trim() : values.scale,
+    ),
+    description: blankToUndefined(values.description),
+  };
+}
+
+function summaryOf(values: EvaluatorFormValues): Record<string, string> {
+  return {
+    evaluator: values.name.trim(),
+    level: values.level,
+    model: values.model.trim(),
+    "rating scale": values.scale === CUSTOM_SCALE ? "custom" : values.scale,
+    ...(values.description.trim() === "" ? {} : { description: values.description.trim() }),
+  };
+}
+
+export function AddLlmAsAJudgeEvaluatorScreen({ ctx, core }: ScreenProps) {
+  return (
+    <ProjectGate
+      core={core}
+      breadcrumb={BREADCRUMB}
+      description={DESCRIPTION}
+      seed={ctx.value(ProjectKey)}
+    >
+      {(project) => <AddLlmAsAJudgeEvaluatorWizard project={project} core={core} />}
+    </ProjectGate>
+  );
+}
+
+function AddLlmAsAJudgeEvaluatorWizard({
+  project,
+  core,
+}: {
+  project: Project;
+  core: ScreenProps["core"];
+}) {
+  const navigate = useNavigate();
+  const [values, setValues] = useState<EvaluatorFormValues>({
+    name: "",
+    level: "SESSION",
+    model: "",
+    instructions: "",
+    scale: RATING_SCALE_PRESET_NAMES[0]!,
+    customScale: "",
+    description: "",
+  });
+  const set = (update: Partial<EvaluatorFormValues>) =>
+    setValues((current) => ({ ...current, ...update }));
+
+  return (
+    <Wizard
+      breadcrumb={BREADCRUMB}
+      description={DESCRIPTION}
+      onCancel={() => navigate(EVALUATOR_MENU)}
+      onSubmit={() =>
+        core.projectManager.addResource(
+          project,
+          toAddLlmAsAJudgeEvaluatorInput(toLlmAsAJudgeEvaluatorInput(values)),
+        )
+      }
+      runningLabel={`adding evaluator ${values.name.trim()}…`}
+      successLabel={`added evaluator '${values.name.trim()}' to '${project.name}'`}
+      successHint="enter exits"
+    >
+      <Step name="name" question="what should this evaluator be called?">
+        <TextField
+          label="evaluator name"
+          placeholder="helpfulness_judge"
+          value={values.name}
+          onChange={(name) => set({ name })}
+          required
+          schema={EvaluatorNameSchema}
+        />
+      </Step>
+
+      <Step name="level" question="what should the judge score?">
+        <ChoiceField
+          choices={LEVEL_CHOICES}
+          value={values.level}
+          onChange={(level) => set({ level })}
+        />
+      </Step>
+
+      <Step name="model" question="which Bedrock model should act as the judge?">
+        <TextField
+          label="model"
+          help="a Bedrock model ID, or an inference-profile or foundation-model ARN"
+          placeholder="anthropic.claude-3-5-sonnet-20240620-v1:0"
+          value={values.model}
+          onChange={(model) => set({ model })}
+          required
+          schema={JudgeModelSchema}
+        />
+      </Step>
+
+      <Step name="instructions" question="how should the judge score a session?">
+        <TextAreaField
+          label="instructions"
+          help="placeholders such as {context} are filled per level"
+          placeholder="Rate how helpful the assistant was in {context}."
+          value={values.instructions}
+          onChange={(instructions) => set({ instructions })}
+          required
+        />
+      </Step>
+
+      <Step name="scale" title="rating scale" question="which rating scale should the judge use?">
+        <ChoiceField
+          choices={SCALE_CHOICES}
+          value={values.scale}
+          onChange={(scale) => set({ scale })}
+        />
+      </Step>
+
+      {values.scale === CUSTOM_SCALE && (
+        <Step name="custom-scale" title="custom scale" question="paste the rating scale as JSON">
+          <TextField
+            label="rating scale"
+            help="either a numerical or a categorical list of rungs, not both"
+            example='{"numerical": [{"value": 1, "label": "Bad", "definition": "…"}, {"value": 2, "label": "Good", "definition": "…"}]}'
+            value={values.customScale}
+            onChange={(customScale) => set({ customScale })}
+            required
+            json
+            schema={RatingScaleSchema}
+          />
+        </Step>
+      )}
+
+      <Step name="description" question="what does this evaluator measure? (optional)">
+        <TextField
+          label="description"
+          placeholder="how helpful the final answer was"
+          value={values.description}
+          onChange={(description) => set({ description })}
+        />
+      </Step>
+
+      <Step name="review" question="this evaluator will be added to agentcore.json">
+        <Summary items={summaryOf(values)} />
+      </Step>
+    </Wizard>
+  );
+}

--- a/src/handlers/project/add/gateway-connector/gatewayConnector.screen.test.tsx
+++ b/src/handlers/project/add/gateway-connector/gatewayConnector.screen.test.tsx
@@ -1,0 +1,135 @@
+import { test, expect, describe, afterEach } from "bun:test";
+import {
+  renderScreen,
+  waitForText,
+  waitForFlatText,
+  flatFrame,
+  cleanupScreens,
+} from "../../../../testing";
+import { createGatewayProjectTestHarness } from "../gateway-test-support";
+
+const { addGateway, cleanup, inProject, projectSpec, writeProjectSpec } =
+  createGatewayProjectTestHarness("add-gateway-connector-wizard");
+
+afterEach(cleanup);
+afterEach(cleanupScreens);
+
+describe("project add gateway-connector wizard", () => {
+  test("names the missing Gateway when the project has none", async () => {
+    await inProject();
+    const r = renderScreen("/agentcore/project/add/gateway-connector");
+
+    await waitForText(r.lastFrame, "has no Gateways yet");
+    expect(r.lastFrame()).toContain("agentcore project add gateway");
+    r.unmount();
+  });
+
+  test("web-search asks nothing beyond a name and writes the curated configuration", async () => {
+    const projectRoot = await inProject();
+    await addGateway("tools");
+    const r = renderScreen("/agentcore/project/add/gateway-connector");
+
+    await waitForText(r.lastFrame, "which Gateway should expose this connector?");
+    expect(r.lastFrame()).toContain("● tools");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "which connector?");
+    expect(r.lastFrame()).not.toContain("knowledge base");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "what should this Target be called?");
+    await r.write("web");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "this Target will be added to agentcore.json");
+    expect(flatFrame(r.lastFrame)).toContain("connector web-search");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "added Connector Target 'web' to Gateway 'tools'");
+
+    const targets = (await projectSpec(projectRoot)).agentCoreGateways[0].targets;
+    expect(targets).toEqual([
+      {
+        name: "web",
+        targetType: "connector",
+        connectorId: "web-search",
+        configurations: [{ name: "WebSearch", parameterValues: { maxResults: 10 } }],
+      },
+    ]);
+    r.unmount();
+  });
+
+  test("bedrock-knowledge-bases asks for an ID when the project has no Knowledge Bases", async () => {
+    const projectRoot = await inProject();
+    await addGateway("tools");
+    const r = renderScreen("/agentcore/project/add/gateway-connector");
+
+    await waitForText(r.lastFrame, "which Gateway should expose this connector?");
+    await r.press("return");
+    await waitForText(r.lastFrame, "which connector?");
+    await r.press("down");
+    await r.press("return");
+
+    // No project Knowledge Bases, so the picker is skipped for the text step.
+    await waitForText(r.lastFrame, "which Knowledge Base should it retrieve from?");
+    await r.write("not valid!");
+    await r.press("return");
+    await waitForFlatText(r.lastFrame, "ten-character Knowledge Base ID");
+    r.unmount();
+
+    // Start over with a valid ID to confirm the shape written.
+    const again = renderScreen("/agentcore/project/add/gateway-connector");
+    await waitForText(again.lastFrame, "which Gateway should expose this connector?");
+    await again.press("return");
+    await waitForText(again.lastFrame, "which connector?");
+    await again.press("down");
+    await again.press("return");
+    await waitForText(again.lastFrame, "which Knowledge Base should it retrieve from?");
+    await again.write("ABCDEFGHIJ");
+    await again.press("return");
+    await waitForText(again.lastFrame, "what should this Target be called?");
+    await again.write("knowledge");
+    await again.press("return");
+    await waitForText(again.lastFrame, "this Target will be added to agentcore.json");
+    expect(flatFrame(again.lastFrame)).toContain("knowledge base ABCDEFGHIJ");
+    await again.press("return");
+    await waitForText(again.lastFrame, "added Connector Target 'knowledge'");
+
+    const targets = (await projectSpec(projectRoot)).agentCoreGateways[0].targets;
+    expect(targets[0]).toMatchObject({
+      connectorId: "bedrock-knowledge-bases",
+      configurations: [{ name: "Retrieve", parameterValues: { knowledgeBaseId: "ABCDEFGHIJ" } }],
+    });
+    again.unmount();
+  });
+
+  test("offers the project's Knowledge Bases before asking for an ID", async () => {
+    const projectRoot = await inProject();
+    await addGateway("tools");
+    const spec = await projectSpec(projectRoot);
+    spec.knowledgeBases = [
+      { name: "docs", dataSources: [{ type: "S3", uri: "s3://bucket/docs" }] },
+    ];
+    await writeProjectSpec(projectRoot, spec);
+
+    const r = renderScreen("/agentcore/project/add/gateway-connector");
+    await waitForText(r.lastFrame, "which Gateway should expose this connector?");
+    await r.press("return");
+    await waitForText(r.lastFrame, "which connector?");
+    await r.press("down");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "which Knowledge Base?");
+    expect(r.lastFrame()).toContain("● docs");
+    expect(r.lastFrame()).toContain("another Knowledge Base");
+    await r.press("return");
+
+    // A project Knowledge Base was picked, so no ID step follows.
+    await waitForText(r.lastFrame, "what should this Target be called?");
+    await r.write("knowledge");
+    await r.press("return");
+    await waitForText(r.lastFrame, "this Target will be added to agentcore.json");
+    expect(flatFrame(r.lastFrame)).toContain("knowledge base docs");
+    r.unmount();
+  });
+});

--- a/src/handlers/project/add/gateway-connector/index.ts
+++ b/src/handlers/project/add/gateway-connector/index.ts
@@ -7,8 +7,90 @@ import {
   type ConnectorId,
 } from "../../../../projectSchemas/gateway";
 import { createHandler, flag, ProjectKey } from "../../../../router";
-import { parseJsonFlagWithSchema } from "../../../utils";
+import { formatZodError } from "../../../../router/schema";
+import { parseJsonFlag } from "../../../utils";
+import type { AddResourceInput } from "../../types";
 import type { AddProjectResourceConfig } from "../types";
+
+type AddGatewayTargetInput = Extract<AddResourceInput, { resourceType: "gateway-target" }>;
+
+/**
+ * GatewayConnectorInput is what every entry point — the flag handler, the
+ * wizard — resolves its own inputs to before a connector Target is built. A
+ * Target is either a curated shortcut (a connector ID plus the one value it
+ * needs) or a complete Target object supplied as parsed JSON.
+ */
+export interface GatewayConnectorInput {
+  gatewayName: string;
+  target:
+    | { kind: "shortcut"; name: string; connectorId: ConnectorId; knowledgeBase?: string }
+    | { kind: "configuration"; configuration: unknown };
+}
+
+/**
+ * toAddGatewayConnectorInput is the one place a connector Target is assembled
+ * from user input: the curated shortcuts' default configurations, the
+ * Knowledge Base rule, the shape a complete configuration must have. Both the
+ * flag handler and the wizard call it.
+ */
+export function toAddGatewayConnectorInput(input: GatewayConnectorInput): AddGatewayTargetInput {
+  const target =
+    input.target.kind === "configuration"
+      ? connectorTargetFromConfiguration(input.target.configuration)
+      : connectorTargetFromShortcut(
+          input.target.name,
+          input.target.connectorId,
+          input.target.knowledgeBase,
+        );
+  return { resourceType: "gateway-target", gatewayName: input.gatewayName, resourceConfig: target };
+}
+
+function connectorTargetFromConfiguration(configuration: unknown): AgentCoreGatewayTarget {
+  const parsed = AgentCoreGatewayTargetSchema.safeParse(configuration);
+  if (!parsed.success) {
+    throw new InputValidationError(
+      `Invalid value for option '--connector-configuration': ${formatZodError(parsed.error)}`,
+      { cause: parsed.error },
+    );
+  }
+  if (parsed.data.targetType !== "connector") {
+    throw new InputValidationError('--connector-configuration must have targetType: "connector"');
+  }
+  return parsed.data;
+}
+
+function connectorTargetFromShortcut(
+  name: string,
+  connectorId: ConnectorId,
+  knowledgeBase?: string,
+): AgentCoreGatewayTarget {
+  switch (connectorId) {
+    case "web-search":
+      if (knowledgeBase !== undefined) {
+        throw new InputValidationError(
+          "--knowledge-base requires --connector bedrock-knowledge-bases",
+        );
+      }
+      return {
+        name,
+        targetType: "connector",
+        connectorId,
+        configurations: [{ name: "WebSearch", parameterValues: { maxResults: 10 } }],
+      };
+    case "bedrock-knowledge-bases":
+      if (!knowledgeBase) {
+        throw new InputValidationError(
+          "--connector bedrock-knowledge-bases requires --knowledge-base",
+        );
+      }
+      return {
+        name,
+        targetType: "connector",
+        connectorId,
+        configurations: [{ name: "Retrieve", parameterValues: { knowledgeBaseId: knowledgeBase } }],
+      };
+  }
+}
 
 export const createAddGatewayConnectorHandler = (config: AddProjectResourceConfig) =>
   createHandler({
@@ -33,6 +115,9 @@ export const createAddGatewayConnectorHandler = (config: AddProjectResourceConfi
         z.string().optional(),
       ),
     ],
+    // handle only turns flags into a GatewayConnectorInput — deciding which of
+    // the two forms was given and reading the configuration from its source.
+    // What a connector Target is belongs to toAddGatewayConnectorInput.
     handle: async (ctx, flags) => {
       if (!flags.gateway) {
         throw new InputValidationError("required option '--gateway <gateway>' not specified");
@@ -57,71 +142,35 @@ export const createAddGatewayConnectorHandler = (config: AddProjectResourceConfi
       if (!usesConfiguration && !flags.name) {
         throw new InputValidationError("required option '--name <name>' not specified");
       }
-      if (flags["knowledge-base"] !== undefined && flags.connector !== "bedrock-knowledge-bases") {
-        throw new InputValidationError(
-          "--knowledge-base requires --connector bedrock-knowledge-bases",
-        );
-      }
 
       const project = ctx.require(ProjectKey);
-      let target: AgentCoreGatewayTarget;
+      let input: AddGatewayTargetInput;
       if (usesConfiguration) {
         const source = new SourceResolver({ stdin: config.io.stdin });
-        target = parseJsonFlagWithSchema(
+        const configuration = parseJsonFlag<unknown>(
           "connector-configuration",
           await source.resolveText("connector-configuration", flags["connector-configuration"]),
-          AgentCoreGatewayTargetSchema,
-        )!;
-        if (target.targetType !== "connector") {
-          throw new InputValidationError(
-            '--connector-configuration must have targetType: "connector"',
-          );
-        }
-      } else {
-        target = connectorTargetFromShortcut(
-          flags.name!,
-          flags.connector!,
-          flags["knowledge-base"],
         );
+        input = toAddGatewayConnectorInput({
+          gatewayName: flags.gateway,
+          target: { kind: "configuration", configuration },
+        });
+      } else {
+        input = toAddGatewayConnectorInput({
+          gatewayName: flags.gateway,
+          target: {
+            kind: "shortcut",
+            name: flags.name!,
+            connectorId: flags.connector!,
+            knowledgeBase: flags["knowledge-base"],
+          },
+        });
       }
-
-      for await (const event of config.projectManager.addResource(project, {
-        resourceType: "gateway-target",
-        gatewayName: flags.gateway,
-        resourceConfig: target,
-      })) {
+      for await (const event of config.projectManager.addResource(project, input)) {
         config.io.stderr.write(`${event.message}\n`);
       }
       config.io.stderr.write(
-        `added Connector Target '${target.name}' to Gateway '${flags.gateway}' in '${project.name}'\n`,
+        `added Connector Target '${input.resourceConfig.name}' to Gateway '${flags.gateway}' in '${project.name}'\n`,
       );
     },
   });
-
-function connectorTargetFromShortcut(
-  name: string,
-  connectorId: ConnectorId,
-  knowledgeBase?: string,
-): AgentCoreGatewayTarget {
-  switch (connectorId) {
-    case "web-search":
-      return {
-        name,
-        targetType: "connector",
-        connectorId,
-        configurations: [{ name: "WebSearch", parameterValues: { maxResults: 10 } }],
-      };
-    case "bedrock-knowledge-bases":
-      if (!knowledgeBase) {
-        throw new InputValidationError(
-          "--connector bedrock-knowledge-bases requires --knowledge-base",
-        );
-      }
-      return {
-        name,
-        targetType: "connector",
-        connectorId,
-        configurations: [{ name: "Retrieve", parameterValues: { knowledgeBaseId: knowledgeBase } }],
-      };
-  }
-}

--- a/src/handlers/project/add/gateway-connector/screen.tsx
+++ b/src/handlers/project/add/gateway-connector/screen.tsx
@@ -1,0 +1,238 @@
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router";
+import z from "zod";
+import { ProjectKey } from "../../../../router";
+import { REAL_KB_ID_PATTERN, type ConnectorId } from "../../../../projectSchemas/gateway";
+import type { ScreenProps } from "../../../types";
+import type { Project } from "../../types";
+import { ProjectGate } from "../../ProjectGate";
+import {
+  Wizard,
+  Step,
+  TextField,
+  ChoiceField,
+  Summary,
+  Prerequisite,
+} from "../../../../components/wizard";
+import { toAddGatewayConnectorInput, type GatewayConnectorInput } from "./index";
+
+const BREADCRUMB = ["agentcore", "project", "add", "gateway-connector"];
+const DESCRIPTION = "adds a connector-backed Target to a project Gateway";
+const ADD_MENU = "/agentcore/project/add";
+
+const CONNECTOR_CHOICES = [
+  {
+    value: "web-search" as ConnectorId,
+    label: "web-search",
+    description: "search the web · no configuration needed",
+  },
+  {
+    value: "bedrock-knowledge-bases" as ConnectorId,
+    label: "bedrock-knowledge-bases",
+    description: "retrieve from a Knowledge Base · asks which one",
+  },
+];
+
+// OTHER_KB is the picker entry that opens the free-text step, for a Knowledge
+// Base that lives outside this project.
+const OTHER_KB = "\u0000other";
+
+// A Knowledge Base is named either by a project Knowledge Base or by the
+// service's ten-character ID; the flag accepts both and so does this step.
+const KnowledgeBaseRefSchema = z
+  .string()
+  .refine((value) => REAL_KB_ID_PATTERN.test(value) || /^[A-Za-z][A-Za-z0-9_-]*$/.test(value), {
+    message: "enter a project Knowledge Base name or a ten-character Knowledge Base ID",
+  });
+
+interface GatewayConnectorFormValues {
+  gatewayName: string;
+  connectorId: ConnectorId;
+  // knowledgeBasePick is the picker's answer; OTHER_KB defers to knowledgeBaseId.
+  knowledgeBasePick: string;
+  knowledgeBaseId: string;
+  name: string;
+}
+
+// toGatewayConnectorInput reads the form into the shortcut form of
+// GatewayConnectorInput. The Knowledge Base is passed only for the connector
+// that takes one, so a value typed before switching connectors is dropped.
+export function toGatewayConnectorInput(values: GatewayConnectorFormValues): GatewayConnectorInput {
+  const usesKnowledgeBase = values.connectorId === "bedrock-knowledge-bases";
+  const knowledgeBase =
+    values.knowledgeBasePick === OTHER_KB
+      ? values.knowledgeBaseId.trim()
+      : values.knowledgeBasePick;
+  return {
+    gatewayName: values.gatewayName,
+    target: {
+      kind: "shortcut",
+      name: values.name.trim(),
+      connectorId: values.connectorId,
+      knowledgeBase: usesKnowledgeBase ? knowledgeBase : undefined,
+    },
+  };
+}
+
+function summaryOf(values: GatewayConnectorFormValues): Record<string, string> {
+  const input = toGatewayConnectorInput(values);
+  const target = input.target as Extract<GatewayConnectorInput["target"], { kind: "shortcut" }>;
+  return {
+    target: target.name,
+    gateway: input.gatewayName,
+    connector: target.connectorId,
+    ...(target.knowledgeBase === undefined ? {} : { "knowledge base": target.knowledgeBase }),
+  };
+}
+
+export function AddGatewayConnectorScreen({ ctx, core }: ScreenProps) {
+  return (
+    <ProjectGate
+      core={core}
+      breadcrumb={BREADCRUMB}
+      description={DESCRIPTION}
+      seed={ctx.value(ProjectKey)}
+    >
+      {(project) => <AddGatewayConnectorWizard project={project} core={core} />}
+    </ProjectGate>
+  );
+}
+
+function AddGatewayConnectorWizard({
+  project,
+  core,
+}: {
+  project: Project;
+  core: ScreenProps["core"];
+}) {
+  const navigate = useNavigate();
+
+  const gatewayChoices = useMemo(
+    () =>
+      (project.spec.agentCoreGateways ?? []).map((gateway) => ({
+        value: gateway.name,
+        label: gateway.name,
+        description: gateway.description ?? `${gateway.targets.length} targets`,
+      })),
+    [project.spec.agentCoreGateways],
+  );
+
+  // Project Knowledge Bases are offered first; OTHER_KB opens a text step for
+  // an external one, so a project with none goes straight to the text step.
+  const knowledgeBaseChoices = useMemo(
+    () => [
+      ...(project.spec.knowledgeBases ?? []).map((kb) => ({
+        value: kb.name,
+        label: kb.name,
+        description: kb.description ?? "project Knowledge Base",
+      })),
+      {
+        value: OTHER_KB,
+        label: "another Knowledge Base",
+        description: "enter its ten-character ID",
+      },
+    ],
+    [project.spec.knowledgeBases],
+  );
+  const hasProjectKnowledgeBases = knowledgeBaseChoices.length > 1;
+
+  const [values, setValues] = useState<GatewayConnectorFormValues>({
+    gatewayName: gatewayChoices[0]?.value ?? "",
+    connectorId: "web-search",
+    knowledgeBasePick: hasProjectKnowledgeBases ? knowledgeBaseChoices[0]!.value : OTHER_KB,
+    knowledgeBaseId: "",
+    name: "",
+  });
+  const set = (update: Partial<GatewayConnectorFormValues>) =>
+    setValues((current) => ({ ...current, ...update }));
+
+  if (gatewayChoices.length === 0) {
+    return (
+      <Prerequisite
+        breadcrumb={BREADCRUMB}
+        description={DESCRIPTION}
+        message={`'${project.name}' has no Gateways yet; a connector Target needs one to attach to`}
+        command="agentcore project add gateway"
+        onBack={() => navigate(ADD_MENU)}
+      />
+    );
+  }
+
+  const usesKnowledgeBase = values.connectorId === "bedrock-knowledge-bases";
+  const asksForId = usesKnowledgeBase && values.knowledgeBasePick === OTHER_KB;
+
+  return (
+    <Wizard
+      breadcrumb={BREADCRUMB}
+      description={DESCRIPTION}
+      onCancel={() => navigate(ADD_MENU)}
+      onSubmit={() =>
+        core.projectManager.addResource(
+          project,
+          toAddGatewayConnectorInput(toGatewayConnectorInput(values)),
+        )
+      }
+      runningLabel={`adding Connector Target ${values.name.trim()}…`}
+      successLabel={`added Connector Target '${values.name.trim()}' to Gateway '${values.gatewayName}' in '${project.name}'`}
+      successHint="enter exits"
+    >
+      <Step name="gateway" question="which Gateway should expose this connector?">
+        <ChoiceField
+          choices={gatewayChoices}
+          value={values.gatewayName}
+          onChange={(gatewayName) => set({ gatewayName })}
+        />
+      </Step>
+
+      <Step name="connector" question="which connector?">
+        <ChoiceField
+          choices={CONNECTOR_CHOICES}
+          value={values.connectorId}
+          onChange={(connectorId) => set({ connectorId })}
+        />
+      </Step>
+
+      {usesKnowledgeBase && hasProjectKnowledgeBases && (
+        <Step name="knowledge-base" title="knowledge base" question="which Knowledge Base?">
+          <ChoiceField
+            choices={knowledgeBaseChoices}
+            value={values.knowledgeBasePick}
+            onChange={(knowledgeBasePick) => set({ knowledgeBasePick })}
+          />
+        </Step>
+      )}
+
+      {asksForId && (
+        <Step
+          name="knowledge-base-id"
+          title="knowledge base"
+          question="which Knowledge Base should it retrieve from?"
+        >
+          <TextField
+            label="knowledge base"
+            help="a project Knowledge Base name, or the service's ten-character ID"
+            placeholder="ABCDEFGHIJ"
+            value={values.knowledgeBaseId}
+            onChange={(knowledgeBaseId) => set({ knowledgeBaseId })}
+            required
+            schema={KnowledgeBaseRefSchema}
+          />
+        </Step>
+      )}
+
+      <Step name="name" question="what should this Target be called?">
+        <TextField
+          label="target name"
+          placeholder={values.connectorId === "web-search" ? "web" : "knowledge"}
+          value={values.name}
+          onChange={(name) => set({ name })}
+          required
+        />
+      </Step>
+
+      <Step name="review" question="this Target will be added to agentcore.json">
+        <Summary items={summaryOf(values)} />
+      </Step>
+    </Wizard>
+  );
+}

--- a/src/handlers/project/add/gateway/gateway.screen.test.tsx
+++ b/src/handlers/project/add/gateway/gateway.screen.test.tsx
@@ -121,6 +121,33 @@ describe("project add gateway wizard", () => {
     r.unmount();
   });
 
+  test("the JWT step rejects the SDK authorizer shape, as the flag path does", async () => {
+    await inProject();
+    const r = renderScreen("/agentcore/project/add/gateway");
+
+    await waitForText(r.lastFrame, "what should this Gateway be called?");
+    await r.write("jwt");
+    await r.press("return");
+    await waitForText(r.lastFrame, "which Target types should this Gateway accept?");
+    await r.press("return");
+    await waitForText(r.lastFrame, "how should inbound callers be authorized?");
+    await r.press("down");
+    await r.press("down");
+    await r.press("return");
+    await waitForText(r.lastFrame, "paste the authorizerConfiguration for your JWT issuer");
+
+    // The SDK's casing is well-formed JSON of the wrong shape. The step must
+    // name the stray key rather than accept it: the project schema would only
+    // reject it later, at submit, as a missing customJwtAuthorizer.
+    await r.write(
+      '{"customJWTAuthorizer":{"discoveryUrl":"https://idp.example.com/.well-known/openid-configuration"}}',
+    );
+    await r.write("\x04");
+    await waitForFlatText(r.lastFrame, "customJWTAuthorizer");
+    expect(r.lastFrame()).toContain("paste the authorizerConfiguration");
+    r.unmount();
+  });
+
   test("a name that would exceed the service limit is rejected", async () => {
     await inProject();
     const r = renderScreen("/agentcore/project/add/gateway");

--- a/src/handlers/project/add/gateway/gateway.screen.test.tsx
+++ b/src/handlers/project/add/gateway/gateway.screen.test.tsx
@@ -1,0 +1,137 @@
+import { test, expect, describe, afterEach } from "bun:test";
+import {
+  renderScreen,
+  waitForText,
+  waitForFlatText,
+  flatFrame,
+  cleanupScreens,
+} from "../../../../testing";
+import { createGatewayProjectTestHarness } from "../gateway-test-support";
+
+const { cleanup, inProject, projectSpec } = createGatewayProjectTestHarness("add-gateway-wizard");
+
+afterEach(cleanup);
+afterEach(cleanupScreens);
+
+describe("project add gateway wizard", () => {
+  test("default flow writes the same defaults the flag-driven path writes", async () => {
+    const projectRoot = await inProject();
+    const r = renderScreen("/agentcore/project/add/gateway");
+
+    await waitForText(r.lastFrame, "what should this Gateway be called?");
+    await r.write("tools");
+    await r.press("return");
+
+    // Protocol: None is the preselected default.
+    await waitForText(r.lastFrame, "which Target types should this Gateway accept?");
+    expect(r.lastFrame()).toContain("● None (default)");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "how should inbound callers be authorized?");
+    expect(r.lastFrame()).toContain("● NONE (default)");
+    await r.press("return");
+
+    // Neither the JWT step nor the semantic-search step applies to these answers.
+    await waitForText(r.lastFrame, "what is this Gateway for?");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "this Gateway will be added to agentcore.json");
+    const review = flatFrame(r.lastFrame);
+    expect(review).toContain("gateway tools");
+    expect(review).toContain("protocol None");
+    expect(review).toContain("authorizer NONE");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "added Gateway 'tools' to 'TestProject'");
+
+    const gateways = (await projectSpec(projectRoot)).agentCoreGateways;
+    expect(gateways).toHaveLength(1);
+    expect(gateways[0]).toMatchObject({
+      name: "tools",
+      protocolType: "None",
+      authorizerType: "NONE",
+      targets: [],
+      enableSemanticSearch: false,
+      exceptionLevel: "NONE",
+    });
+    r.unmount();
+  });
+
+  test("the semantic-search step appears only for MCP", async () => {
+    const projectRoot = await inProject();
+    const r = renderScreen("/agentcore/project/add/gateway");
+
+    await waitForText(r.lastFrame, "what should this Gateway be called?");
+    await r.write("mcp");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "which Target types should this Gateway accept?");
+    await r.press("down");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "how should inbound callers be authorized?");
+    await r.press("return");
+
+    // The MCP-only step is now in the flow.
+    await waitForText(r.lastFrame, "should tools be searchable by meaning?");
+    await r.press("down");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "what is this Gateway for?");
+    await r.press("return");
+    await waitForText(r.lastFrame, "this Gateway will be added to agentcore.json");
+    const review = flatFrame(r.lastFrame);
+    expect(review).toContain("protocol MCP");
+    expect(review).toContain("semantic search on");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "added Gateway 'mcp'");
+    expect((await projectSpec(projectRoot)).agentCoreGateways[0]).toMatchObject({
+      protocolType: "MCP",
+      enableSemanticSearch: true,
+    });
+    r.unmount();
+  });
+
+  test("CUSTOM_JWT adds a configuration step and validates its JSON", async () => {
+    await inProject();
+    const r = renderScreen("/agentcore/project/add/gateway");
+
+    await waitForText(r.lastFrame, "what should this Gateway be called?");
+    await r.write("jwt");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "which Target types should this Gateway accept?");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "how should inbound callers be authorized?");
+    await r.press("down");
+    await r.press("down");
+    await r.press("return");
+
+    // The branch step only exists for CUSTOM_JWT.
+    await waitForText(r.lastFrame, "paste the authorizerConfiguration for your JWT issuer");
+
+    // Malformed JSON is refused before the wizard advances.
+    await r.write("{ not json");
+    await r.write("\x04"); // ctrl+d attempts to continue
+    await waitForText(r.lastFrame, "is not valid JSON");
+    // Still on the configuration step.
+    expect(r.lastFrame()).toContain("paste the authorizerConfiguration");
+    r.unmount();
+  });
+
+  test("a name that would exceed the service limit is rejected", async () => {
+    await inProject();
+    const r = renderScreen("/agentcore/project/add/gateway");
+
+    await waitForText(r.lastFrame, "what should this Gateway be called?");
+    // TestProject- prefix plus this name passes 48 characters.
+    await r.write("a".repeat(40));
+    await r.press("return");
+
+    await waitForFlatText(r.lastFrame, "exceeds the service limit of 48 characters");
+    expect(flatFrame(r.lastFrame)).toContain("what should this Gateway be called?");
+    r.unmount();
+  });
+});

--- a/src/handlers/project/add/gateway/index.ts
+++ b/src/handlers/project/add/gateway/index.ts
@@ -1,13 +1,31 @@
 import z from "zod";
 import { InputValidationError } from "../../../../errors";
 import { SourceResolver } from "../../../../io";
-import { GatewayAuthorizerConfigSchema } from "../../../../projectSchemas/auth";
-import type { AgentCoreGateway } from "../../../../projectSchemas/gateway";
+import {
+  GatewayAuthorizerConfigSchema,
+  type GatewayAuthorizerType,
+} from "../../../../projectSchemas/auth";
+import type {
+  AgentCoreGateway,
+  GatewayExceptionLevel,
+  GatewayProtocolType,
+  PolicyEngineMode,
+} from "../../../../projectSchemas/gateway";
 import { createHandler, flag, ProjectKey } from "../../../../router";
-import { parseJsonFlagWithSchema, parseTags } from "../../../utils";
+import { formatZodError } from "../../../../router/schema";
+import { parseJsonFlag, parseTags } from "../../../utils";
+import type { AddResourceInput, Project } from "../../types";
 import type { AddProjectResourceConfig } from "../types";
 
-const GatewayAuthorizerConfigurationInputSchema = GatewayAuthorizerConfigSchema.strict();
+/**
+ * The authorizerConfiguration shape both entry points accept. Strict, so the
+ * SDK's casing (`customJWTAuthorizer`) is reported as an unknown key rather than
+ * silently dropped and then rejected later as a missing `customJwtAuthorizer`.
+ */
+export const GatewayAuthorizerConfigurationInputSchema = GatewayAuthorizerConfigSchema.strict();
+
+/** The service limit on a Gateway's deployed name. */
+export const MAX_GATEWAY_RESOURCE_NAME_LENGTH = 48;
 
 /**
  The deployed service name of a gateway; mirrors the L3 Gateway construct's rule.
@@ -17,6 +35,93 @@ export function gatewayResourceName(
   gateway: { name: string; resourceName?: string },
 ): string {
   return gateway.resourceName ?? `${projectName}-${gateway.name}`;
+}
+
+/**
+ * GatewayInput is what every entry point — the flag handler, the wizard —
+ * resolves its own inputs to before a Gateway is built. Values are already
+ * typed: flag text has been read from file/stdin, JSON has been parsed, tags
+ * have been split. Anything optional is a field toAddGatewayInput defaults.
+ */
+export interface GatewayInput {
+  name: string;
+  protocolType?: GatewayProtocolType;
+  authorizerType?: GatewayAuthorizerType;
+  /** Parsed JSON; validated against GatewayAuthorizerConfigurationInputSchema here. */
+  authorizerConfiguration?: unknown;
+  enableSemanticSearch?: boolean;
+  description?: string;
+  exceptionLevel?: GatewayExceptionLevel;
+  executionRoleArn?: string;
+  policyEngine?: { name: string; mode: PolicyEngineMode };
+  tags?: Record<string, string>;
+}
+
+/**
+ * toAddGatewayInput is the one place a Gateway is assembled from user input:
+ * the defaults for what was not said, the rules that span fields, and the
+ * schema the authorizer configuration must satisfy. Both the flag handler and
+ * the wizard call it, so they cannot disagree about what a Gateway is.
+ */
+export function toAddGatewayInput(project: Project, input: GatewayInput): AddResourceInput {
+  const resourceName = gatewayResourceName(project.name, { name: input.name });
+  if (resourceName.length > MAX_GATEWAY_RESOURCE_NAME_LENGTH) {
+    throw new InputValidationError(
+      `Gateway resource name '${resourceName}' exceeds the service limit of ` +
+        `${MAX_GATEWAY_RESOURCE_NAME_LENGTH} characters`,
+    );
+  }
+  if (
+    input.policyEngine &&
+    !project.spec.policyEngines.some((engine) => engine.name === input.policyEngine?.name)
+  ) {
+    throw new InputValidationError(
+      `policy engine '${input.policyEngine.name}' does not exist in policyEngines[]`,
+    );
+  }
+
+  const authorizerType = input.authorizerType ?? "NONE";
+  if (authorizerType === "CUSTOM_JWT" && input.authorizerConfiguration === undefined) {
+    throw new InputValidationError("CUSTOM_JWT requires --authorizer-configuration");
+  }
+  if (authorizerType !== "CUSTOM_JWT" && input.authorizerConfiguration !== undefined) {
+    throw new InputValidationError("--authorizer-configuration is valid only with CUSTOM_JWT");
+  }
+  const protocolType = input.protocolType ?? "None";
+  if (input.enableSemanticSearch && protocolType !== "MCP") {
+    throw new InputValidationError("--enable-semantic-search requires --protocol-type MCP");
+  }
+
+  let authorizerConfiguration: AgentCoreGateway["authorizerConfiguration"];
+  if (input.authorizerConfiguration !== undefined) {
+    const parsed = GatewayAuthorizerConfigurationInputSchema.safeParse(
+      input.authorizerConfiguration,
+    );
+    if (!parsed.success) {
+      throw new InputValidationError(
+        `Invalid value for option '--authorizer-configuration': ${formatZodError(parsed.error)}`,
+        { cause: parsed.error },
+      );
+    }
+    authorizerConfiguration = parsed.data;
+  }
+
+  const gateway: AgentCoreGateway = {
+    name: input.name,
+    protocolType,
+    authorizerType,
+    authorizerConfiguration,
+    description: input.description,
+    targets: [],
+    enableSemanticSearch: input.enableSemanticSearch ?? false,
+    exceptionLevel: input.exceptionLevel ?? "NONE",
+    executionRoleArn: input.executionRoleArn,
+    policyEngineConfiguration: input.policyEngine
+      ? { policyEngineName: input.policyEngine.name, mode: input.policyEngine.mode }
+      : undefined,
+    tags: input.tags,
+  };
+  return { resourceType: "gateway", resourceConfig: gateway };
 }
 
 export const createAddGatewayHandler = (config: AddProjectResourceConfig) =>
@@ -60,16 +165,12 @@ export const createAddGatewayHandler = (config: AddProjectResourceConfig) =>
       flag("exception-level", "exception detail level: debug", z.enum(["debug"]).optional()),
       flag("tags", "tags as repeated key=value or a JSON object", z.array(z.string()).optional()),
     ],
+    // handle only turns flags into a GatewayInput — resolving sources, parsing
+    // JSON, pairing flags that only make sense together. What a Gateway is
+    // belongs to toAddGatewayInput.
     handle: async (ctx, flags) => {
       if (!flags.name) {
         throw new InputValidationError("required option '--name <name>' not specified");
-      }
-      const project = ctx.require(ProjectKey);
-      const resourceName = gatewayResourceName(project.name, { name: flags.name });
-      if (resourceName.length > 48) {
-        throw new InputValidationError(
-          `Gateway resource name '${resourceName}' exceeds the service limit of 48 characters`,
-        );
       }
       if (
         (flags["policy-engine-name"] === undefined) !==
@@ -79,56 +180,34 @@ export const createAddGatewayHandler = (config: AddProjectResourceConfig) =>
           "--policy-engine-name and --policy-engine-mode must be supplied together",
         );
       }
-      if (
-        flags["policy-engine-name"] &&
-        !project.spec.policyEngines.some((engine) => engine.name === flags["policy-engine-name"])
-      ) {
-        throw new InputValidationError(
-          `policy engine '${flags["policy-engine-name"]}' does not exist in policyEngines[]`,
-        );
-      }
 
-      const authorizerType = flags["authorizer-type"] ?? "NONE";
-      if (authorizerType === "CUSTOM_JWT" && flags["authorizer-configuration"] === undefined) {
-        throw new InputValidationError("CUSTOM_JWT requires --authorizer-configuration");
-      }
-      if (authorizerType !== "CUSTOM_JWT" && flags["authorizer-configuration"] !== undefined) {
-        throw new InputValidationError("--authorizer-configuration is valid only with CUSTOM_JWT");
-      }
-      if (flags["enable-semantic-search"] && flags["protocol-type"] !== "MCP") {
-        throw new InputValidationError("--enable-semantic-search requires --protocol-type MCP");
-      }
       const source = new SourceResolver({ stdin: config.io.stdin });
-      const authorizerConfiguration = parseJsonFlagWithSchema(
+      const authorizerConfiguration = parseJsonFlag<unknown>(
         "authorizer-configuration",
         await source.resolveText("authorizer-configuration", flags["authorizer-configuration"]),
-        GatewayAuthorizerConfigurationInputSchema,
       );
 
-      const gateway: AgentCoreGateway = {
+      const project = ctx.require(ProjectKey);
+      const input = toAddGatewayInput(project, {
         name: flags.name,
-        protocolType: flags["protocol-type"] ?? "None",
-        authorizerType,
+        protocolType: flags["protocol-type"],
+        authorizerType: flags["authorizer-type"],
         authorizerConfiguration,
+        enableSemanticSearch: flags["enable-semantic-search"],
         description: flags.description,
-        targets: [],
-        enableSemanticSearch: flags["enable-semantic-search"] ?? false,
-        exceptionLevel: flags["exception-level"] ? "DEBUG" : "NONE",
+        exceptionLevel: flags["exception-level"] ? "DEBUG" : undefined,
         executionRoleArn: flags["role-arn"],
-        policyEngineConfiguration:
+        policyEngine:
           flags["policy-engine-name"] && flags["policy-engine-mode"]
             ? {
-                policyEngineName: flags["policy-engine-name"],
+                name: flags["policy-engine-name"],
                 mode: flags["policy-engine-mode"] === "enforce" ? "ENFORCE" : "LOG_ONLY",
               }
             : undefined,
         tags: parseTags(flags.tags),
-      };
+      });
 
-      for await (const event of config.projectManager.addResource(project, {
-        resourceType: "gateway",
-        resourceConfig: gateway,
-      })) {
+      for await (const event of config.projectManager.addResource(project, input)) {
         config.io.stderr.write(`${event.message}\n`);
       }
       config.io.stderr.write(`added Gateway '${flags.name}' to '${project.name}'\n`);

--- a/src/handlers/project/add/gateway/screen.tsx
+++ b/src/handlers/project/add/gateway/screen.tsx
@@ -1,0 +1,236 @@
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router";
+import z from "zod";
+import { ProjectKey } from "../../../../router";
+import { GatewayAuthorizerConfigSchema } from "../../../../projectSchemas/auth";
+import type { AgentCoreGateway } from "../../../../projectSchemas/gateway";
+import type { ScreenProps } from "../../../types";
+import type { AddResourceInput, Project } from "../../types";
+import { ProjectGate } from "../../ProjectGate";
+import {
+  Wizard,
+  Step,
+  TextField,
+  ChoiceField,
+  TextAreaField,
+  Summary,
+} from "../../../../components/wizard";
+import { gatewayResourceName } from "./index";
+
+const BREADCRUMB = ["agentcore", "project", "add", "gateway"];
+const DESCRIPTION = "adds a Gateway to the current project";
+
+// The service limit the handler enforces on the deployed Gateway name.
+const MAX_RESOURCE_NAME_LENGTH = 48;
+
+// The two protocols --protocol-type resolves to: "MCP" when passed, "None" when
+// omitted. The wizard always states one, so `undefined` is not a choice here.
+type ProtocolType = "MCP" | "None";
+type AuthorizerType = "NONE" | "AWS_IAM" | "CUSTOM_JWT";
+
+const PROTOCOL_CHOICES = [
+  {
+    value: "None" as ProtocolType,
+    label: "None (default)",
+    description: "any Target type",
+  },
+  {
+    value: "MCP" as ProtocolType,
+    label: "MCP",
+    description: "restrict to MCP Targets · required for semantic tool search",
+  },
+];
+
+const AUTHORIZER_CHOICES = [
+  {
+    value: "NONE" as AuthorizerType,
+    label: "NONE (default)",
+    description: "no inbound authorizer",
+  },
+  { value: "AWS_IAM" as AuthorizerType, label: "AWS_IAM", description: "SigV4-signed callers" },
+  {
+    value: "CUSTOM_JWT" as AuthorizerType,
+    label: "CUSTOM_JWT",
+    description: "your own JWT issuer · needs a configuration below",
+  },
+];
+
+const SEMANTIC_SEARCH_CHOICES = [
+  { value: false, label: "off (default)", description: "list tools exactly as the Targets expose" },
+  { value: true, label: "on", description: "let callers search tools by meaning" },
+];
+
+interface GatewayFormValues {
+  name: string;
+  protocolType: ProtocolType;
+  authorizerType: AuthorizerType;
+  authorizerConfiguration: string;
+  enableSemanticSearch: boolean;
+  description: string;
+}
+
+// buildAddGatewayInput mirrors the flag-driven handler's construction, including
+// the defaults it applies for the flags this wizard does not ask about.
+export function buildAddGatewayInput(values: GatewayFormValues): AddResourceInput {
+  const isCustomJwt = values.authorizerType === "CUSTOM_JWT";
+  const gateway: AgentCoreGateway = {
+    name: values.name.trim(),
+    protocolType: values.protocolType,
+    authorizerType: values.authorizerType,
+    authorizerConfiguration: isCustomJwt
+      ? GatewayAuthorizerConfigSchema.parse(JSON.parse(values.authorizerConfiguration))
+      : undefined,
+    description: values.description.trim() === "" ? undefined : values.description.trim(),
+    targets: [],
+    // Semantic search is an MCP-only setting; the handler rejects it otherwise,
+    // so a protocol change away from MCP must not leave it on.
+    enableSemanticSearch: values.protocolType === "MCP" ? values.enableSemanticSearch : false,
+    exceptionLevel: "NONE",
+  };
+  return { resourceType: "gateway", resourceConfig: gateway };
+}
+
+function summaryOf(values: GatewayFormValues): Record<string, string> {
+  return {
+    gateway: values.name.trim(),
+    protocol: values.protocolType,
+    authorizer: values.authorizerType,
+    ...(values.protocolType === "MCP"
+      ? { "semantic search": values.enableSemanticSearch ? "on" : "off" }
+      : {}),
+    ...(values.description.trim() === "" ? {} : { description: values.description.trim() }),
+  };
+}
+
+export function AddGatewayScreen({ ctx, core }: ScreenProps) {
+  return (
+    <ProjectGate
+      core={core}
+      breadcrumb={BREADCRUMB}
+      description={DESCRIPTION}
+      seed={ctx.value(ProjectKey)}
+    >
+      {(project) => <AddGatewayWizard project={project} core={core} />}
+    </ProjectGate>
+  );
+}
+
+function AddGatewayWizard({ project, core }: { project: Project; core: ScreenProps["core"] }) {
+  const navigate = useNavigate();
+  const [values, setValues] = useState<GatewayFormValues>({
+    name: "",
+    protocolType: "None",
+    authorizerType: "NONE",
+    authorizerConfiguration: "",
+    enableSemanticSearch: false,
+    description: "",
+  });
+  const set = (update: Partial<GatewayFormValues>) =>
+    setValues((current) => ({ ...current, ...update }));
+
+  // The deployed name is derived from the project name, so the length limit can
+  // only be checked here — and it is checked with the handler's own helper.
+  const nameSchema = useMemo(
+    () =>
+      z.string().superRefine((name, ctx) => {
+        const resourceName = gatewayResourceName(project.name, { name });
+        if (resourceName.length > MAX_RESOURCE_NAME_LENGTH) {
+          ctx.addIssue({
+            code: "custom",
+            message:
+              `Gateway resource name '${resourceName}' exceeds the service limit of ` +
+              `${MAX_RESOURCE_NAME_LENGTH} characters`,
+          });
+        }
+      }),
+    [project.name],
+  );
+
+  const isCustomJwt = values.authorizerType === "CUSTOM_JWT";
+  const isMcp = values.protocolType === "MCP";
+
+  return (
+    <Wizard
+      breadcrumb={BREADCRUMB}
+      description={DESCRIPTION}
+      onCancel={() => navigate("/agentcore/project/add")}
+      onSubmit={() => core.projectManager.addResource(project, buildAddGatewayInput(values))}
+      runningLabel={`adding Gateway ${values.name.trim()}…`}
+      successLabel={`added Gateway '${values.name.trim()}' to '${project.name}'`}
+      successHint="enter exits"
+    >
+      <Step name="name" question="what should this Gateway be called?">
+        <TextField
+          label="gateway name"
+          help={`deployed as ${project.name}-<name>, up to ${MAX_RESOURCE_NAME_LENGTH} characters`}
+          placeholder="tools"
+          value={values.name}
+          onChange={(name) => set({ name })}
+          required
+          schema={nameSchema}
+        />
+      </Step>
+
+      <Step name="protocol" question="which Target types should this Gateway accept?">
+        <ChoiceField
+          choices={PROTOCOL_CHOICES}
+          value={values.protocolType}
+          onChange={(protocolType) => set({ protocolType })}
+        />
+      </Step>
+
+      <Step name="authorizer" question="how should inbound callers be authorized?">
+        <ChoiceField
+          choices={AUTHORIZER_CHOICES}
+          value={values.authorizerType}
+          onChange={(authorizerType) => set({ authorizerType })}
+        />
+      </Step>
+
+      {isCustomJwt && (
+        <Step
+          name="authorizer-configuration"
+          title="jwt config"
+          question="paste the authorizerConfiguration for your JWT issuer"
+        >
+          <TextAreaField
+            label="authorizer configuration"
+            placeholder='{ "customJWTAuthorizer": { "discoveryUrl": "…" } }'
+            value={values.authorizerConfiguration}
+            onChange={(authorizerConfiguration) => set({ authorizerConfiguration })}
+            required
+            json
+            schema={GatewayAuthorizerConfigSchema}
+          />
+        </Step>
+      )}
+
+      {isMcp && (
+        <Step
+          name="semantic-search"
+          title="search"
+          question="should tools be searchable by meaning?"
+        >
+          <ChoiceField
+            choices={SEMANTIC_SEARCH_CHOICES}
+            value={values.enableSemanticSearch}
+            onChange={(enableSemanticSearch) => set({ enableSemanticSearch })}
+          />
+        </Step>
+      )}
+
+      <Step name="description" question="what is this Gateway for? (optional)">
+        <TextField
+          label="description"
+          placeholder="internal tool gateway"
+          value={values.description}
+          onChange={(description) => set({ description })}
+        />
+      </Step>
+
+      <Step name="review" question="this Gateway will be added to agentcore.json">
+        <Summary items={summaryOf(values)} />
+      </Step>
+    </Wizard>
+  );
+}

--- a/src/handlers/project/add/gateway/screen.tsx
+++ b/src/handlers/project/add/gateway/screen.tsx
@@ -2,10 +2,8 @@ import { useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 import z from "zod";
 import { ProjectKey } from "../../../../router";
-import { GatewayAuthorizerConfigSchema } from "../../../../projectSchemas/auth";
-import type { AgentCoreGateway } from "../../../../projectSchemas/gateway";
 import type { ScreenProps } from "../../../types";
-import type { AddResourceInput, Project } from "../../types";
+import type { Project } from "../../types";
 import { ProjectGate } from "../../ProjectGate";
 import {
   Wizard,
@@ -15,13 +13,16 @@ import {
   TextAreaField,
   Summary,
 } from "../../../../components/wizard";
-import { gatewayResourceName } from "./index";
+import {
+  GatewayAuthorizerConfigurationInputSchema,
+  MAX_GATEWAY_RESOURCE_NAME_LENGTH,
+  gatewayResourceName,
+  toAddGatewayInput,
+  type GatewayInput,
+} from "./index";
 
 const BREADCRUMB = ["agentcore", "project", "add", "gateway"];
 const DESCRIPTION = "adds a Gateway to the current project";
-
-// The service limit the handler enforces on the deployed Gateway name.
-const MAX_RESOURCE_NAME_LENGTH = 48;
 
 // The two protocols --protocol-type resolves to: "MCP" when passed, "None" when
 // omitted. The wizard always states one, so `undefined` is not a choice here.
@@ -69,25 +70,24 @@ interface GatewayFormValues {
   description: string;
 }
 
-// buildAddGatewayInput mirrors the flag-driven handler's construction, including
-// the defaults it applies for the flags this wizard does not ask about.
-export function buildAddGatewayInput(values: GatewayFormValues): AddResourceInput {
+// toGatewayInput reads the form into the GatewayInput the handler's
+// toAddGatewayInput builds a Gateway from. It carries no defaults and no rules
+// of its own: it trims, parses, and drops the answers to steps the user never
+// saw — a JWT configuration typed before switching the authorizer to NONE, a
+// semantic-search choice made before switching the protocol away from MCP —
+// so the shared builder sees exactly what was asked.
+export function toGatewayInput(values: GatewayFormValues): GatewayInput {
   const isCustomJwt = values.authorizerType === "CUSTOM_JWT";
-  const gateway: AgentCoreGateway = {
+  const isMcp = values.protocolType === "MCP";
+  const description = values.description.trim();
+  return {
     name: values.name.trim(),
     protocolType: values.protocolType,
     authorizerType: values.authorizerType,
-    authorizerConfiguration: isCustomJwt
-      ? GatewayAuthorizerConfigSchema.parse(JSON.parse(values.authorizerConfiguration))
-      : undefined,
-    description: values.description.trim() === "" ? undefined : values.description.trim(),
-    targets: [],
-    // Semantic search is an MCP-only setting; the handler rejects it otherwise,
-    // so a protocol change away from MCP must not leave it on.
-    enableSemanticSearch: values.protocolType === "MCP" ? values.enableSemanticSearch : false,
-    exceptionLevel: "NONE",
+    authorizerConfiguration: isCustomJwt ? JSON.parse(values.authorizerConfiguration) : undefined,
+    enableSemanticSearch: isMcp ? values.enableSemanticSearch : undefined,
+    description: description === "" ? undefined : description,
   };
-  return { resourceType: "gateway", resourceConfig: gateway };
 }
 
 function summaryOf(values: GatewayFormValues): Record<string, string> {
@@ -134,12 +134,12 @@ function AddGatewayWizard({ project, core }: { project: Project; core: ScreenPro
     () =>
       z.string().superRefine((name, ctx) => {
         const resourceName = gatewayResourceName(project.name, { name });
-        if (resourceName.length > MAX_RESOURCE_NAME_LENGTH) {
+        if (resourceName.length > MAX_GATEWAY_RESOURCE_NAME_LENGTH) {
           ctx.addIssue({
             code: "custom",
             message:
               `Gateway resource name '${resourceName}' exceeds the service limit of ` +
-              `${MAX_RESOURCE_NAME_LENGTH} characters`,
+              `${MAX_GATEWAY_RESOURCE_NAME_LENGTH} characters`,
           });
         }
       }),
@@ -154,7 +154,9 @@ function AddGatewayWizard({ project, core }: { project: Project; core: ScreenPro
       breadcrumb={BREADCRUMB}
       description={DESCRIPTION}
       onCancel={() => navigate("/agentcore/project/add")}
-      onSubmit={() => core.projectManager.addResource(project, buildAddGatewayInput(values))}
+      onSubmit={() =>
+        core.projectManager.addResource(project, toAddGatewayInput(project, toGatewayInput(values)))
+      }
       runningLabel={`adding Gateway ${values.name.trim()}…`}
       successLabel={`added Gateway '${values.name.trim()}' to '${project.name}'`}
       successHint="enter exits"
@@ -162,7 +164,7 @@ function AddGatewayWizard({ project, core }: { project: Project; core: ScreenPro
       <Step name="name" question="what should this Gateway be called?">
         <TextField
           label="gateway name"
-          help={`deployed as ${project.name}-<name>, up to ${MAX_RESOURCE_NAME_LENGTH} characters`}
+          help={`deployed as ${project.name}-<name>, up to ${MAX_GATEWAY_RESOURCE_NAME_LENGTH} characters`}
           placeholder="tools"
           value={values.name}
           onChange={(name) => set({ name })}
@@ -200,7 +202,7 @@ function AddGatewayWizard({ project, core }: { project: Project; core: ScreenPro
             onChange={(authorizerConfiguration) => set({ authorizerConfiguration })}
             required
             json
-            schema={GatewayAuthorizerConfigSchema}
+            schema={GatewayAuthorizerConfigurationInputSchema}
           />
         </Step>
       )}

--- a/src/handlers/project/add/memory/index.ts
+++ b/src/handlers/project/add/memory/index.ts
@@ -10,9 +10,11 @@ import {
   MemoryStrategySchema,
   MemoryStrategyTypeSchema,
   StreamContentLevelSchema,
+  type MemorySchema,
   type MemoryStrategy,
 } from "../../../../projectSchemas/memory";
 import { TagsSchema } from "../../../../projectSchemas/tags";
+import type { AddResourceInput } from "../../types";
 
 // The service default for raw event retention
 export const DEFAULT_EVENT_EXPIRY_DURATION = 30;
@@ -22,6 +24,46 @@ export const DEFAULT_EVENT_EXPIRY_DURATION = 30;
  * retention step enforces the same range rather than a copy of it.
  */
 export const EventExpiryDurationSchema = z.number().int().min(3).max(365);
+
+type MemoryResourceConfig = z.input<typeof MemorySchema>;
+
+/**
+ * MemoryInput is what every entry point — the flag handler, the wizard —
+ * resolves its own inputs to before a memory is built. Values are already
+ * typed: JSON flags have been parsed and validated, shorthand strategies have
+ * been expanded. Anything optional is a field toAddMemoryInput defaults.
+ */
+export interface MemoryInput {
+  name: string;
+  description?: string;
+  eventExpiryDuration?: number;
+  strategies?: MemoryStrategy[];
+  indexedKeys?: MemoryResourceConfig["indexedKeys"];
+  streamDeliveryResources?: MemoryResourceConfig["streamDeliveryResources"];
+  encryptionKeyArn?: string;
+  executionRoleArn?: string;
+  tags?: Record<string, string>;
+}
+
+/**
+ * toAddMemoryInput is the one place a memory is assembled from user input.
+ * Both the flag handler and the wizard call it, so they cannot disagree about
+ * what a memory is or what it defaults to.
+ */
+export function toAddMemoryInput(input: MemoryInput): AddResourceInput {
+  const resourceConfig: MemoryResourceConfig = {
+    name: input.name,
+    description: input.description,
+    eventExpiryDuration: input.eventExpiryDuration ?? DEFAULT_EVENT_EXPIRY_DURATION,
+    strategies: input.strategies,
+    indexedKeys: input.indexedKeys,
+    streamDeliveryResources: input.streamDeliveryResources,
+    encryptionKeyArn: input.encryptionKeyArn,
+    executionRoleArn: input.executionRoleArn,
+    tags: input.tags,
+  };
+  return { resourceType: "memory", resourceConfig };
+}
 
 function projectMemoryObject<T extends z.ZodRawShape>(shape: T, label: string) {
   const supportedFields = new Set(Object.keys(shape));
@@ -150,38 +192,34 @@ export const createAddMemoryHandler = (config: AddProjectResourceConfig) =>
       ),
       flag("tags", "tags to apply (JSON object of key/value strings)", z.string().optional()),
     ],
+    // handle only turns flags into a MemoryInput — parsing JSON, expanding the
+    // strategies shorthand. What a memory is belongs to toAddMemoryInput.
     handle: async (ctx, flags) => {
       if (!flags.name)
         throw new InputValidationError("required option '--name <name>' not specified");
 
-      const inputIndexedKeys = parseJsonFlagWithSchema(
-        "indexed-keys",
-        flags["indexed-keys"],
-        z.array(IndexedKeyInputSchema),
-      );
-      const inputStreamDelivery = parseJsonFlagWithSchema(
-        "stream-delivery-resources",
-        flags["stream-delivery-resources"],
-        StreamDeliveryResourcesInputSchema,
-      );
-
-      const memoryConfig = {
+      const input = toAddMemoryInput({
         name: flags.name,
         description: flags["description"],
         eventExpiryDuration: flags["event-expiry-duration"],
         strategies: flags["strategies"] ? toStrategies(flags["strategies"]) : undefined,
-        indexedKeys: inputIndexedKeys,
+        indexedKeys: parseJsonFlagWithSchema(
+          "indexed-keys",
+          flags["indexed-keys"],
+          z.array(IndexedKeyInputSchema),
+        ),
+        streamDeliveryResources: parseJsonFlagWithSchema(
+          "stream-delivery-resources",
+          flags["stream-delivery-resources"],
+          StreamDeliveryResourcesInputSchema,
+        ),
         encryptionKeyArn: flags["encryption-key-arn"],
         executionRoleArn: flags["execution-role-arn"],
-        streamDeliveryResources: inputStreamDelivery,
         tags: parseJsonFlagWithSchema("tags", flags["tags"], TagsSchema),
-      };
+      });
 
       const project = ctx.require(ProjectKey);
-      for await (const event of config.projectManager.addResource(project, {
-        resourceType: "memory",
-        resourceConfig: memoryConfig,
-      })) {
+      for await (const event of config.projectManager.addResource(project, input)) {
         config.io.stderr.write(`${event.message}\n`);
       }
 

--- a/src/handlers/project/add/memory/index.ts
+++ b/src/handlers/project/add/memory/index.ts
@@ -15,7 +15,13 @@ import {
 import { TagsSchema } from "../../../../projectSchemas/tags";
 
 // The service default for raw event retention
-const DEFAULT_EVENT_EXPIRY_DURATION = 30;
+export const DEFAULT_EVENT_EXPIRY_DURATION = 30;
+
+/**
+ * The bounds --event-expiry-duration accepts. Exported so the wizard's
+ * retention step enforces the same range rather than a copy of it.
+ */
+export const EventExpiryDurationSchema = z.number().int().min(3).max(365);
 
 function projectMemoryObject<T extends z.ZodRawShape>(shape: T, label: string) {
   const supportedFields = new Set(Object.keys(shape));
@@ -114,7 +120,7 @@ export const createAddMemoryHandler = (config: AddProjectResourceConfig) =>
       flag(
         "event-expiry-duration",
         "how long raw events are retained, in days (3-365)",
-        z.number().int().min(3).max(365).default(DEFAULT_EVENT_EXPIRY_DURATION),
+        EventExpiryDurationSchema.default(DEFAULT_EVENT_EXPIRY_DURATION),
       ),
       flag(
         "strategies",
@@ -200,8 +206,12 @@ function toStrategies(raw: string): MemoryStrategy[] {
   return entries.map(toDefaultStrategy);
 }
 
-/** Expands a bare strategy type into a strategy carrying its default namespaces. */
-function toDefaultStrategy(type: string): MemoryStrategy {
+/**
+ * Expands a bare strategy type into a strategy carrying its default namespaces.
+ * Exported so the wizard's strategy picker produces exactly what
+ * `--strategies SEMANTIC,EPISODIC` produces.
+ */
+export function toDefaultStrategy(type: string): MemoryStrategy {
   const parsed = MemoryStrategyTypeSchema.safeParse(type);
   if (!parsed.success)
     throw new InputValidationError(

--- a/src/handlers/project/add/memory/memory.screen.test.tsx
+++ b/src/handlers/project/add/memory/memory.screen.test.tsx
@@ -1,0 +1,173 @@
+import { test, expect, describe, afterEach } from "bun:test";
+import { renderScreen, waitForText, flatFrame, cleanupScreens } from "../../../../testing";
+import { createGatewayProjectTestHarness } from "../gateway-test-support";
+import {
+  DEFAULT_STRATEGY_NAMESPACE_TEMPLATES,
+  DEFAULT_EPISODIC_REFLECTION_NAMESPACE_TEMPLATES,
+} from "../../../../projectSchemas/memory";
+
+// The wizard resolves the project from process.cwd(), exactly as the
+// flag-driven path does, so the tests run inside a real scaffolded project.
+const { cleanup, inProject, projectSpec } = createGatewayProjectTestHarness("add-memory-wizard");
+
+afterEach(cleanup);
+afterEach(cleanupScreens);
+
+describe("project add memory wizard", () => {
+  test("default flow: name → strategies → retention → description → review", async () => {
+    const projectRoot = await inProject();
+    const r = renderScreen("/agentcore/project/add/memory");
+
+    await waitForText(r.lastFrame, "what should this memory be called?");
+    await r.write("conversations");
+    await r.press("return");
+
+    // SEMANTIC is checked by default; enter accepts the selection.
+    await waitForText(r.lastFrame, "what should be extracted from raw events?");
+    expect(r.lastFrame()).toContain("SEMANTIC");
+    await r.press("return");
+
+    // Retention is prefilled with the service default.
+    await waitForText(r.lastFrame, "how long should raw events be kept?");
+    expect(r.lastFrame()).toContain("30");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "what does this memory store?");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "this memory will be added to agentcore.json");
+    // The review table reports every answer the wizard collected.
+    const review = flatFrame(r.lastFrame);
+    expect(review).toContain("memory conversations");
+    expect(review).toContain("strategies SEMANTIC");
+    expect(review).toContain("event expiry 30 days");
+
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "added memory 'conversations' to 'TestProject'");
+
+    // A picked strategy expands to the same namespaces the shorthand expands to.
+    expect((await projectSpec(projectRoot)).memories).toEqual([
+      {
+        name: "conversations",
+        eventExpiryDuration: 30,
+        strategies: [
+          {
+            type: "SEMANTIC",
+            namespaceTemplates: DEFAULT_STRATEGY_NAMESPACE_TEMPLATES.SEMANTIC,
+          },
+        ],
+      },
+    ]);
+    r.unmount();
+  });
+
+  test("toggling strategies writes each one's default namespaces", async () => {
+    const projectRoot = await inProject();
+    const r = renderScreen("/agentcore/project/add/memory");
+
+    await waitForText(r.lastFrame, "what should this memory be called?");
+    await r.write("episodes");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "what should be extracted from raw events?");
+    // Uncheck SEMANTIC (cursor starts on it), then check EPISODIC.
+    await r.write(" ");
+    await r.press("down");
+    await r.press("down");
+    await r.press("down");
+    await r.write(" ");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "how long should raw events be kept?");
+    await r.press("return");
+    await waitForText(r.lastFrame, "what does this memory store?");
+    await r.press("return");
+    await waitForText(r.lastFrame, "this memory will be added to agentcore.json");
+    expect(flatFrame(r.lastFrame)).toContain("strategies EPISODIC");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "added memory 'episodes'");
+
+    // EPISODIC additionally carries reflection namespaces, as its schema demands.
+    expect((await projectSpec(projectRoot)).memories[0].strategies).toEqual([
+      {
+        type: "EPISODIC",
+        namespaceTemplates: DEFAULT_STRATEGY_NAMESPACE_TEMPLATES.EPISODIC,
+        reflectionNamespaceTemplates: DEFAULT_EPISODIC_REFLECTION_NAMESPACE_TEMPLATES,
+      },
+    ]);
+    r.unmount();
+  });
+
+  test("a blank name does not advance", async () => {
+    await inProject();
+    const r = renderScreen("/agentcore/project/add/memory");
+
+    await waitForText(r.lastFrame, "what should this memory be called?");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "memory name is required");
+    // Still on the name step.
+    expect(r.lastFrame()).toContain("what should this memory be called?");
+    r.unmount();
+  });
+
+  test("retention outside 3-365 reports the flag's own bounds", async () => {
+    await inProject();
+    const r = renderScreen("/agentcore/project/add/memory");
+
+    await waitForText(r.lastFrame, "what should this memory be called?");
+    await r.write("shortlived");
+    await r.press("return");
+    await waitForText(r.lastFrame, "what should be extracted from raw events?");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "how long should raw events be kept?");
+    // Clear the prefilled 30 and enter something out of range.
+    for (let i = 0; i < 2; i++) await r.write("\u007F");
+    await r.write("400");
+    await r.press("return");
+
+    // The schema's own message, not a copy of the bounds.
+    await waitForText(r.lastFrame, "Too big: expected number to be <=365");
+    expect(r.lastFrame()).toContain("how long should raw events be kept?");
+    r.unmount();
+  });
+
+  test("esc on the first step returns to the add menu", async () => {
+    await inProject();
+    const r = renderScreen("/agentcore/project/add/memory");
+
+    await waitForText(r.lastFrame, "what should this memory be called?");
+    await r.press("escape");
+
+    await waitForText(r.lastFrame, "add project resources");
+    r.unmount();
+  });
+
+  test("esc on a later step goes back a question", async () => {
+    await inProject();
+    const r = renderScreen("/agentcore/project/add/memory");
+
+    await waitForText(r.lastFrame, "what should this memory be called?");
+    await r.write("conversations");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "what should be extracted from raw events?");
+    await r.press("escape");
+
+    await waitForText(r.lastFrame, "what should this memory be called?");
+    // The answer survives the round trip.
+    expect(r.lastFrame()).toContain("conversations");
+    r.unmount();
+  });
+
+  test("reports the CLI's own guidance outside a project", async () => {
+    const r = renderScreen("/agentcore/project/add/memory");
+
+    await waitForText(r.lastFrame, "No AgentCore project found");
+    expect(r.lastFrame()).toContain("agentcore project create");
+    r.unmount();
+  });
+});

--- a/src/handlers/project/add/memory/screen.tsx
+++ b/src/handlers/project/add/memory/screen.tsx
@@ -4,18 +4,19 @@ import z from "zod";
 import { ProjectKey } from "../../../../router";
 import {
   MemoryNameSchema,
-  MemorySchema,
   MemoryStrategyTypeSchema,
   type MemoryStrategyType,
 } from "../../../../projectSchemas/memory";
 import type { ScreenProps } from "../../../types";
-import type { AddResourceInput, Project } from "../../types";
+import type { Project } from "../../types";
 import { ProjectGate } from "../../ProjectGate";
 import { Wizard, Step, TextField, MultiChoiceField, Summary } from "../../../../components/wizard";
 import {
   DEFAULT_EVENT_EXPIRY_DURATION,
   EventExpiryDurationSchema,
+  toAddMemoryInput,
   toDefaultStrategy,
+  type MemoryInput,
 } from "./index";
 
 // The retention step collects text, so the flag's numeric bounds are reached
@@ -52,18 +53,19 @@ interface MemoryFormValues {
   description: string;
 }
 
-// buildAddMemoryInput translates the form into the AddResourceInput the
-// flag-driven handler builds, reusing its own toDefaultStrategy so a picked
-// strategy expands to the same namespaces `--strategies SEMANTIC` expands to.
-export function buildAddMemoryInput(values: MemoryFormValues): AddResourceInput {
-  const resourceConfig: z.input<typeof MemorySchema> = {
+// toMemoryInput reads the form into the MemoryInput the handler's
+// toAddMemoryInput builds a memory from. It trims and converts; the one piece
+// of handler logic it reaches for, toDefaultStrategy, is the handler's own, so
+// a picked strategy expands to the same namespaces `--strategies SEMANTIC` does.
+export function toMemoryInput(values: MemoryFormValues): MemoryInput {
+  const description = values.description.trim();
+  return {
     name: values.name.trim(),
-    description: values.description.trim() === "" ? undefined : values.description.trim(),
+    description: description === "" ? undefined : description,
     eventExpiryDuration: Number(values.expiry),
     strategies:
       values.strategies.length === 0 ? undefined : values.strategies.map(toDefaultStrategy),
   };
-  return { resourceType: "memory", resourceConfig };
 }
 
 function summaryOf(values: MemoryFormValues): Record<string, string> {
@@ -104,7 +106,9 @@ function AddMemoryWizard({ project, core }: { project: Project; core: ScreenProp
       breadcrumb={BREADCRUMB}
       description={DESCRIPTION}
       onCancel={() => navigate("/agentcore/project/add")}
-      onSubmit={() => core.projectManager.addResource(project, buildAddMemoryInput(values))}
+      onSubmit={() =>
+        core.projectManager.addResource(project, toAddMemoryInput(toMemoryInput(values)))
+      }
       runningLabel={`adding memory ${values.name.trim()}…`}
       successLabel={`added memory '${values.name.trim()}' to '${project.name}'`}
       successHint="enter exits"

--- a/src/handlers/project/add/memory/screen.tsx
+++ b/src/handlers/project/add/memory/screen.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { useNavigate } from "react-router";
-import z from "zod";
 import { ProjectKey } from "../../../../router";
 import {
   MemoryNameSchema,
@@ -10,7 +9,15 @@ import {
 import type { ScreenProps } from "../../../types";
 import type { Project } from "../../types";
 import { ProjectGate } from "../../ProjectGate";
-import { Wizard, Step, TextField, MultiChoiceField, Summary } from "../../../../components/wizard";
+import {
+  Wizard,
+  Step,
+  TextField,
+  MultiChoiceField,
+  Summary,
+  blankToUndefined,
+  numberSchema,
+} from "../../../../components/wizard";
 import {
   DEFAULT_EVENT_EXPIRY_DURATION,
   EventExpiryDurationSchema,
@@ -20,12 +27,8 @@ import {
 } from "./index";
 
 // The retention step collects text, so the flag's numeric bounds are reached
-// through a coercion. Anything unparseable becomes NaN, which the bounds reject.
-const ExpiryInputSchema = z
-  .string()
-  .transform((raw) => Number(raw))
-  .refine((parsed) => Number.isFinite(parsed), { message: "enter a number of days" })
-  .pipe(EventExpiryDurationSchema);
+// through a coercion; the bounds themselves are the flag's.
+const ExpiryInputSchema = numberSchema(EventExpiryDurationSchema, "enter a number of days");
 
 const BREADCRUMB = ["agentcore", "project", "add", "memory"];
 const DESCRIPTION = "adds a memory to the current project";
@@ -58,10 +61,9 @@ interface MemoryFormValues {
 // of handler logic it reaches for, toDefaultStrategy, is the handler's own, so
 // a picked strategy expands to the same namespaces `--strategies SEMANTIC` does.
 export function toMemoryInput(values: MemoryFormValues): MemoryInput {
-  const description = values.description.trim();
   return {
     name: values.name.trim(),
-    description: description === "" ? undefined : description,
+    description: blankToUndefined(values.description),
     eventExpiryDuration: Number(values.expiry),
     strategies:
       values.strategies.length === 0 ? undefined : values.strategies.map(toDefaultStrategy),

--- a/src/handlers/project/add/memory/screen.tsx
+++ b/src/handlers/project/add/memory/screen.tsx
@@ -1,0 +1,159 @@
+import { useState } from "react";
+import { useNavigate } from "react-router";
+import z from "zod";
+import { ProjectKey } from "../../../../router";
+import {
+  MemoryNameSchema,
+  MemorySchema,
+  MemoryStrategyTypeSchema,
+  type MemoryStrategyType,
+} from "../../../../projectSchemas/memory";
+import type { ScreenProps } from "../../../types";
+import type { AddResourceInput, Project } from "../../types";
+import { ProjectGate } from "../../ProjectGate";
+import { Wizard, Step, TextField, MultiChoiceField, Summary } from "../../../../components/wizard";
+import {
+  DEFAULT_EVENT_EXPIRY_DURATION,
+  EventExpiryDurationSchema,
+  toDefaultStrategy,
+} from "./index";
+
+// The retention step collects text, so the flag's numeric bounds are reached
+// through a coercion. Anything unparseable becomes NaN, which the bounds reject.
+const ExpiryInputSchema = z
+  .string()
+  .transform((raw) => Number(raw))
+  .refine((parsed) => Number.isFinite(parsed), { message: "enter a number of days" })
+  .pipe(EventExpiryDurationSchema);
+
+const BREADCRUMB = ["agentcore", "project", "add", "memory"];
+const DESCRIPTION = "adds a memory to the current project";
+
+// STRATEGY_CHOICES mirrors --strategies' comma-separated shorthand, which is
+// the form the flag documents first. The enum is read from the schema so the
+// picker cannot drift from what the flag accepts.
+const STRATEGY_DESCRIPTIONS: Record<MemoryStrategyType, string> = {
+  SEMANTIC: "durable facts extracted from conversations",
+  SUMMARIZATION: "running summaries of each session",
+  USER_PREFERENCE: "preferences the user states or implies",
+  EPISODIC: "past episodes, plus reflections over them",
+};
+
+const STRATEGY_CHOICES = MemoryStrategyTypeSchema.options.map((type) => ({
+  value: type,
+  label: type,
+  description: STRATEGY_DESCRIPTIONS[type],
+}));
+
+interface MemoryFormValues {
+  name: string;
+  strategies: MemoryStrategyType[];
+  expiry: string;
+  description: string;
+}
+
+// buildAddMemoryInput translates the form into the AddResourceInput the
+// flag-driven handler builds, reusing its own toDefaultStrategy so a picked
+// strategy expands to the same namespaces `--strategies SEMANTIC` expands to.
+export function buildAddMemoryInput(values: MemoryFormValues): AddResourceInput {
+  const resourceConfig: z.input<typeof MemorySchema> = {
+    name: values.name.trim(),
+    description: values.description.trim() === "" ? undefined : values.description.trim(),
+    eventExpiryDuration: Number(values.expiry),
+    strategies:
+      values.strategies.length === 0 ? undefined : values.strategies.map(toDefaultStrategy),
+  };
+  return { resourceType: "memory", resourceConfig };
+}
+
+function summaryOf(values: MemoryFormValues): Record<string, string> {
+  return {
+    memory: values.name.trim(),
+    strategies: values.strategies.length === 0 ? "none" : values.strategies.join(", "),
+    "event expiry": `${values.expiry} days`,
+    ...(values.description.trim() === "" ? {} : { description: values.description.trim() }),
+  };
+}
+
+export function AddMemoryScreen({ ctx, core }: ScreenProps) {
+  return (
+    <ProjectGate
+      core={core}
+      breadcrumb={BREADCRUMB}
+      description={DESCRIPTION}
+      seed={ctx.value(ProjectKey)}
+    >
+      {(project) => <AddMemoryWizard project={project} core={core} />}
+    </ProjectGate>
+  );
+}
+
+function AddMemoryWizard({ project, core }: { project: Project; core: ScreenProps["core"] }) {
+  const navigate = useNavigate();
+  const [values, setValues] = useState<MemoryFormValues>({
+    name: "",
+    strategies: ["SEMANTIC"],
+    expiry: String(DEFAULT_EVENT_EXPIRY_DURATION),
+    description: "",
+  });
+  const set = (update: Partial<MemoryFormValues>) =>
+    setValues((current) => ({ ...current, ...update }));
+
+  return (
+    <Wizard
+      breadcrumb={BREADCRUMB}
+      description={DESCRIPTION}
+      onCancel={() => navigate("/agentcore/project/add")}
+      onSubmit={() => core.projectManager.addResource(project, buildAddMemoryInput(values))}
+      runningLabel={`adding memory ${values.name.trim()}…`}
+      successLabel={`added memory '${values.name.trim()}' to '${project.name}'`}
+      successHint="enter exits"
+    >
+      <Step name="name" question="what should this memory be called?">
+        <TextField
+          label="memory name"
+          placeholder="conversations"
+          value={values.name}
+          onChange={(name) => set({ name })}
+          required
+          schema={MemoryNameSchema}
+        />
+      </Step>
+
+      <Step name="strategies" question="what should be extracted from raw events?">
+        <MultiChoiceField
+          label="long-term memory strategies"
+          help="selecting none keeps short-term events only"
+          choices={STRATEGY_CHOICES}
+          value={values.strategies}
+          onChange={(strategies) => set({ strategies })}
+        />
+      </Step>
+
+      <Step name="retention" title="retention" question="how long should raw events be kept?">
+        <TextField
+          label="event expiry, in days"
+          help="3-365 · the service default is 30"
+          placeholder={String(DEFAULT_EVENT_EXPIRY_DURATION)}
+          value={values.expiry}
+          onChange={(expiry) => set({ expiry })}
+          required
+          schema={ExpiryInputSchema}
+        />
+      </Step>
+
+      <Step name="description" question="what does this memory store? (optional)">
+        <TextField
+          label="description"
+          placeholder="user facts and session summaries"
+          value={values.description}
+          onChange={(description) => set({ description })}
+        />
+      </Step>
+
+      <Step name="review" question="this memory will be added to agentcore.json">
+        <Summary items={summaryOf(values)} />
+      </Step>
+    </Wizard>
+  );
+}

--- a/src/handlers/project/add/monitoring-steps.tsx
+++ b/src/handlers/project/add/monitoring-steps.tsx
@@ -1,0 +1,247 @@
+import { useMemo } from "react";
+import z from "zod";
+import { LogGroupNamesSchema } from "../../../projectSchemas/online-eval-config";
+import type { Project } from "../types";
+import {
+  Step,
+  TextField,
+  ChoiceField,
+  blankToUndefined,
+  splitList,
+  numberSchema,
+} from "../../../components/wizard";
+
+// The online-eval and online-insight configs monitor the same two kinds of
+// source — a project agent's traffic, or CloudWatch log groups — and share the
+// name, sampling-rate and enable-on-create questions. Both wizards use these
+// steps, so the two say the same things and produce the same shapes.
+
+export type MonitoringSourceKind = "agent" | "log-groups";
+
+export interface MonitoringFormValues {
+  name: string;
+  source: MonitoringSourceKind;
+  agent: string;
+  endpoint: string;
+  logGroupNames: string;
+  serviceNames: string;
+  samplingRate: string;
+  enableOnCreate: boolean;
+  description: string;
+}
+
+// The fields OnlineEvalConfigSchema takes that describe the source and the
+// sampling, as the wizards' input builders expect them.
+export interface MonitoringInput {
+  name: string;
+  agent?: string;
+  endpoint?: string;
+  logGroupNames?: string[];
+  serviceNames?: string[];
+  samplingRate: number;
+  enableOnCreate?: boolean;
+  description?: string;
+}
+
+export function emptyMonitoringValues(project: Project): MonitoringFormValues {
+  const firstAgent = project.spec.runtimes[0]?.name;
+  return {
+    name: "",
+    source: firstAgent === undefined ? "log-groups" : "agent",
+    agent: firstAgent ?? "",
+    endpoint: "",
+    logGroupNames: "",
+    serviceNames: "",
+    samplingRate: "",
+    enableOnCreate: true,
+    description: "",
+  };
+}
+
+// toMonitoringInput passes only the answers of the source branch the user saw,
+// so a log group typed before switching to an agent is dropped rather than
+// tripping the schema's "mutually exclusive" rule.
+export function toMonitoringInput(values: MonitoringFormValues): MonitoringInput {
+  const fromAgent = values.source === "agent";
+  return {
+    name: values.name.trim(),
+    agent: fromAgent ? values.agent : undefined,
+    endpoint: fromAgent ? blankToUndefined(values.endpoint) : undefined,
+    logGroupNames: fromAgent ? undefined : splitList(values.logGroupNames),
+    serviceNames: fromAgent ? undefined : splitList(values.serviceNames),
+    samplingRate: Number(values.samplingRate),
+    enableOnCreate: values.enableOnCreate,
+    description: blankToUndefined(values.description),
+  };
+}
+
+export function monitoringSummary(values: MonitoringFormValues): Record<string, string> {
+  const input = toMonitoringInput(values);
+  return {
+    ...(input.agent === undefined
+      ? { "log groups": input.logGroupNames?.join(", ") ?? "" }
+      : { agent: input.agent + (input.endpoint === undefined ? "" : ` (${input.endpoint})`) }),
+    ...(input.serviceNames === undefined ? {} : { services: input.serviceNames.join(", ") }),
+    "sampling rate": `${input.samplingRate}%`,
+    "on deploy": input.enableOnCreate ? "enabled" : "paused",
+    ...(input.description === undefined ? {} : { description: input.description }),
+  };
+}
+
+const SOURCE_CHOICES = [
+  {
+    value: "agent" as MonitoringSourceKind,
+    label: "a project agent",
+    description: "sample the traffic of a runtime declared in this project",
+  },
+  {
+    value: "log-groups" as MonitoringSourceKind,
+    label: "CloudWatch log groups",
+    description: "sample traces from up to five log groups you name",
+  },
+];
+
+const ENABLE_CHOICES = [
+  { value: true, label: "enabled (default)", description: "start sampling as soon as it deploys" },
+  { value: false, label: "paused", description: "deploy it, but leave it off until resumed" },
+];
+
+// The schema's own bounds for --sampling-rate, reached through a text field.
+const SamplingRateInputSchema = numberSchema(
+  z.number().min(0.01).max(100),
+  "enter a percentage between 0.01 and 100",
+);
+
+// LogGroupsInputSchema reads a comma-separated answer as the 1-5 log groups the
+// schema allows, so the step reports the same limit the flag path reports.
+const LogGroupsInputSchema = z
+  .string()
+  .transform((raw) => splitList(raw) ?? [])
+  .pipe(LogGroupNamesSchema);
+
+export function useMonitoringSteps(
+  project: Project,
+  values: MonitoringFormValues,
+  set: (update: Partial<MonitoringFormValues>) => void,
+  // noun is what the config is called in questions: "evaluation" or "insight".
+  noun: string,
+) {
+  const agentChoices = useMemo(
+    () =>
+      project.spec.runtimes.map((runtime) => ({
+        value: runtime.name,
+        label: runtime.name,
+        description: runtime.description ?? "",
+      })),
+    [project.spec.runtimes],
+  );
+  const hasAgents = agentChoices.length > 0;
+  const fromAgent = hasAgents && values.source === "agent";
+
+  // sourceSteps go after the name; trailingSteps go after the config-specific
+  // questions. Arrays, because React.Children.toArray flattens them into the
+  // Wizard's step list.
+  const sourceSteps = [
+    hasAgents && (
+      <Step key="source" name="source" question={`what should this ${noun} config monitor?`}>
+        <ChoiceField
+          choices={SOURCE_CHOICES}
+          value={values.source}
+          onChange={(source) => set({ source })}
+        />
+      </Step>
+    ),
+
+    fromAgent && (
+      <Step key="agent" name="agent" question="which agent's traffic should be sampled?">
+        <ChoiceField
+          choices={agentChoices}
+          value={values.agent}
+          onChange={(agent) => set({ agent })}
+        />
+      </Step>
+    ),
+
+    fromAgent && (
+      <Step key="endpoint" name="endpoint" question="scope to one endpoint? (optional)">
+        <TextField
+          label="endpoint"
+          help="an endpoint qualifier such as DEFAULT; blank monitors every endpoint"
+          placeholder="DEFAULT"
+          value={values.endpoint}
+          onChange={(endpoint) => set({ endpoint })}
+        />
+      </Step>
+    ),
+
+    !fromAgent && (
+      <Step
+        key="log-groups"
+        name="log-groups"
+        title="log groups"
+        question="which CloudWatch log groups?"
+      >
+        <TextField
+          label="log groups"
+          help="one to five, comma-separated"
+          placeholder="/aws/bedrock-agentcore/runtimes/my-agent"
+          value={values.logGroupNames}
+          onChange={(logGroupNames) => set({ logGroupNames })}
+          required
+          schema={LogGroupsInputSchema}
+        />
+      </Step>
+    ),
+
+    !fromAgent && (
+      <Step
+        key="services"
+        name="services"
+        question="filter traces to particular services? (optional)"
+      >
+        <TextField
+          label="service names"
+          help="comma-separated; blank keeps every service in the log groups"
+          placeholder="checkout-agent"
+          value={values.serviceNames}
+          onChange={(serviceNames) => set({ serviceNames })}
+        />
+      </Step>
+    ),
+  ];
+
+  const trailingSteps = [
+    <Step key="sampling" name="sampling" question="what share of sessions should be sampled?">
+      <TextField
+        label="sampling rate"
+        help="a percentage, 0.01-100"
+        placeholder="10"
+        value={values.samplingRate}
+        onChange={(samplingRate) => set({ samplingRate })}
+        required
+        schema={SamplingRateInputSchema}
+      />
+    </Step>,
+
+    <Step key="enabled" name="enabled" question={`should ${noun} start when this deploys?`}>
+      <ChoiceField
+        choices={ENABLE_CHOICES}
+        value={values.enableOnCreate}
+        onChange={(enableOnCreate) => set({ enableOnCreate })}
+      />
+    </Step>,
+
+    <Step key="description" name="description" question="what is this config for? (optional)">
+      <TextField
+        label="description"
+        help="up to 200 characters"
+        placeholder="production quality monitoring"
+        value={values.description}
+        onChange={(description) => set({ description })}
+        schema={z.string().max(200)}
+      />
+    </Step>,
+  ];
+
+  return { sourceSteps, trailingSteps };
+}

--- a/src/handlers/project/add/online-eval/index.ts
+++ b/src/handlers/project/add/online-eval/index.ts
@@ -3,7 +3,38 @@ import { createHandler, flag, ProjectKey } from "../../../../router";
 import { InputValidationError } from "../../../../errors";
 import { OnlineEvalConfigSchema } from "../../../../projectSchemas/online-eval-config";
 import { parseJsonFlag } from "../../../utils";
+import type { AddResourceInput } from "../../types";
 import type { AddProjectResourceConfig } from "../types";
+
+/**
+ * OnlineEvalInput is what every entry point — the flag handler, the wizard —
+ * resolves its own inputs to before an online-eval config is built. It is the
+ * schema's own shape less the defaults the schema applies; the source rules
+ * (agent or log groups, never both; endpoint needs agent) are the schema's too,
+ * and toAddOnlineEvalInput reports them in the schema's words.
+ */
+export interface OnlineEvalInput {
+  name: string;
+  agent?: string;
+  endpoint?: string;
+  logGroupNames?: string[];
+  serviceNames?: string[];
+  evaluators?: string[];
+  samplingRate: number;
+  description?: string;
+  enableOnCreate?: boolean;
+  tags?: Record<string, string>;
+}
+
+/**
+ * toAddOnlineEvalInput is the one place an online-eval config is assembled and
+ * checked. Both the flag handler and the wizard call it.
+ */
+export function toAddOnlineEvalInput(input: OnlineEvalInput): AddResourceInput {
+  const parsed = OnlineEvalConfigSchema.safeParse(input);
+  if (!parsed.success) throw new InputValidationError(z.prettifyError(parsed.error));
+  return { resourceType: "online-eval", resourceConfig: parsed.data };
+}
 
 export const createAddOnlineEvalHandler = (config: AddProjectResourceConfig) =>
   createHandler({
@@ -53,6 +84,8 @@ export const createAddOnlineEvalHandler = (config: AddProjectResourceConfig) =>
       ),
       flag("tags", "tags to apply (JSON object of key/value strings)", z.string().optional()),
     ],
+    // handle only turns flags into an OnlineEvalInput. What a config is, and
+    // which combinations are allowed, belongs to toAddOnlineEvalInput.
     handle: async (ctx, flags) => {
       if (!flags["name"])
         throw new InputValidationError("required option '--name <name>' not specified");
@@ -61,7 +94,7 @@ export const createAddOnlineEvalHandler = (config: AddProjectResourceConfig) =>
           "required option '--sampling-rate <sampling-rate>' not specified",
         );
 
-      const candidate = {
+      const input = toAddOnlineEvalInput({
         name: flags["name"],
         agent: flags["agent"],
         endpoint: flags["endpoint"],
@@ -75,16 +108,10 @@ export const createAddOnlineEvalHandler = (config: AddProjectResourceConfig) =>
             ? undefined
             : flags["enable-on-create"] === "true",
         tags: parseJsonFlag<Record<string, string>>("tags", flags["tags"]),
-      };
-
-      const parsed = OnlineEvalConfigSchema.safeParse(candidate);
-      if (!parsed.success) throw new InputValidationError(z.prettifyError(parsed.error));
+      });
 
       const project = ctx.require(ProjectKey);
-      for await (const event of config.projectManager.addResource(project, {
-        resourceType: "online-eval",
-        resourceConfig: parsed.data,
-      })) {
+      for await (const event of config.projectManager.addResource(project, input)) {
         config.io.stderr.write(`${event.message}\n`);
       }
 

--- a/src/handlers/project/add/online-eval/onlineEval.screen.test.tsx
+++ b/src/handlers/project/add/online-eval/onlineEval.screen.test.tsx
@@ -1,0 +1,177 @@
+import { test, expect, describe, afterEach } from "bun:test";
+import {
+  renderScreen,
+  waitForText,
+  waitForFlatText,
+  flatFrame,
+  cleanupScreens,
+} from "../../../../testing";
+import { createGatewayProjectTestHarness } from "../gateway-test-support";
+
+const { cleanup, inProject, projectSpec, run } =
+  createGatewayProjectTestHarness("add-online-eval-wizard");
+
+afterEach(cleanup);
+afterEach(cleanupScreens);
+
+// The scaffolded project declares one runtime, hello_world, so the agent
+// source is offered and preselected.
+describe("project add online-eval wizard", () => {
+  test("agent source: writes the same config the flag path writes", async () => {
+    const projectRoot = await inProject();
+    const r = renderScreen("/agentcore/project/add/online-eval");
+
+    await waitForText(r.lastFrame, "what should this online evaluation config be called?");
+    await r.write("prod_quality");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "what should this evaluation config monitor?");
+    expect(r.lastFrame()).toContain("● a project agent");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "which agent's traffic should be sampled?");
+    expect(r.lastFrame()).toContain("● hello_world");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "scope to one endpoint?");
+    await r.press("return");
+
+    // No project evaluators, so the built-in step is the only one and required.
+    await waitForText(r.lastFrame, "which evaluators should score the sessions?");
+    await r.press("return");
+    await waitForText(r.lastFrame, "evaluators is required");
+    await r.write("Builtin.Helpfulness, Builtin.Correctness");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "what share of sessions should be sampled?");
+    await r.write("200");
+    await r.press("return");
+    await waitForFlatText(r.lastFrame, "<=100");
+    // Backspaces one at a time: a multi-character chunk reads as a paste.
+    for (let i = 0; i < 3; i++) await r.write("\x7f");
+    await r.write("25");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "should evaluation start when this deploys?");
+    await r.press("return");
+    await waitForText(r.lastFrame, "what is this config for?");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "this config will be added to agentcore.json");
+    const review = flatFrame(r.lastFrame);
+    expect(review).toContain("agent hello_world");
+    expect(review).toContain("sampling rate 25%");
+    expect(review).toContain("evaluators Builtin.Helpfulness, Builtin.Correctness");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "added online-eval config 'prod_quality'");
+
+    const configs = (await projectSpec(projectRoot)).onlineEvalConfigs;
+    expect(configs).toEqual([
+      {
+        name: "prod_quality",
+        agent: "hello_world",
+        evaluators: ["Builtin.Helpfulness", "Builtin.Correctness"],
+        samplingRate: 25,
+        enableOnCreate: true,
+      },
+    ]);
+    r.unmount();
+  });
+
+  test("log-group source: asks for log groups instead of an agent", async () => {
+    const projectRoot = await inProject();
+    const r = renderScreen("/agentcore/project/add/online-eval");
+
+    await waitForText(r.lastFrame, "what should this online evaluation config be called?");
+    await r.write("custom_logs");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "what should this evaluation config monitor?");
+    await r.press("down");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "which CloudWatch log groups?");
+    expect(r.lastFrame()).not.toContain("which agent");
+    await r.write("/aws/one, /aws/two");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "filter traces to particular services?");
+    await r.write("checkout");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "which evaluators should score the sessions?");
+    await r.write("Builtin.Helpfulness");
+    await r.press("return");
+    await waitForText(r.lastFrame, "what share of sessions should be sampled?");
+    await r.write("5");
+    await r.press("return");
+    await waitForText(r.lastFrame, "should evaluation start when this deploys?");
+    await r.press("down");
+    await r.press("return");
+    await waitForText(r.lastFrame, "what is this config for?");
+    await r.press("return");
+    await waitForText(r.lastFrame, "this config will be added to agentcore.json");
+    expect(flatFrame(r.lastFrame)).toContain("on deploy paused");
+    await r.press("return");
+    await waitForText(r.lastFrame, "added online-eval config 'custom_logs'");
+
+    expect((await projectSpec(projectRoot)).onlineEvalConfigs[0]).toMatchObject({
+      logGroupNames: ["/aws/one", "/aws/two"],
+      serviceNames: ["checkout"],
+      enableOnCreate: false,
+    });
+    r.unmount();
+  });
+
+  test("offers the project's evaluators, making the built-in step optional", async () => {
+    const projectRoot = await inProject();
+    await run([
+      "add",
+      "evaluator",
+      "llm-as-a-judge",
+      "--name",
+      "judge",
+      "--level",
+      "SESSION",
+      "--model",
+      "anthropic.claude-3-5-sonnet-20240620-v1:0",
+      "--instructions",
+      "Score {context}.",
+      "--rating-scale",
+      "1-5-quality",
+    ]);
+    const r = renderScreen("/agentcore/project/add/online-eval");
+
+    await waitForText(r.lastFrame, "what should this online evaluation config be called?");
+    await r.write("judged");
+    await r.press("return");
+    await waitForText(r.lastFrame, "what should this evaluation config monitor?");
+    await r.press("return");
+    await waitForText(r.lastFrame, "which agent's traffic should be sampled?");
+    await r.press("return");
+    await waitForText(r.lastFrame, "scope to one endpoint?");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "which of this project's evaluators should score the sessions?");
+    await r.write(" ");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "any built-in evaluators as well?");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "what share of sessions should be sampled?");
+    await r.write("10");
+    await r.press("return");
+    await waitForText(r.lastFrame, "should evaluation start when this deploys?");
+    await r.press("return");
+    await waitForText(r.lastFrame, "what is this config for?");
+    await r.press("return");
+    await waitForText(r.lastFrame, "this config will be added to agentcore.json");
+    await r.press("return");
+    await waitForText(r.lastFrame, "added online-eval config 'judged'");
+
+    expect((await projectSpec(projectRoot)).onlineEvalConfigs[0].evaluators).toEqual(["judge"]);
+    r.unmount();
+  });
+});

--- a/src/handlers/project/add/online-eval/screen.tsx
+++ b/src/handlers/project/add/online-eval/screen.tsx
@@ -1,0 +1,156 @@
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router";
+import { ProjectKey } from "../../../../router";
+import { OnlineEvalConfigNameSchema } from "../../../../projectSchemas/online-eval-config";
+import type { ScreenProps } from "../../../types";
+import type { Project } from "../../types";
+import { ProjectGate } from "../../ProjectGate";
+import {
+  Wizard,
+  Step,
+  TextField,
+  MultiChoiceField,
+  Summary,
+  splitList,
+} from "../../../../components/wizard";
+import {
+  emptyMonitoringValues,
+  monitoringSummary,
+  toMonitoringInput,
+  useMonitoringSteps,
+  type MonitoringFormValues,
+} from "../monitoring-steps";
+import { toAddOnlineEvalInput, type OnlineEvalInput } from "./index";
+
+const BREADCRUMB = ["agentcore", "project", "add", "online-eval"];
+const DESCRIPTION = "adds an online evaluation config to the current project";
+const ADD_MENU = "/agentcore/project/add";
+
+interface OnlineEvalFormValues extends MonitoringFormValues {
+  // projectEvaluators are picked from the project's own; otherEvaluators are
+  // typed — Builtin.* IDs or ARNs — so both routes to --evaluator are open.
+  projectEvaluators: string[];
+  otherEvaluators: string;
+}
+
+export function toOnlineEvalInput(values: OnlineEvalFormValues): OnlineEvalInput {
+  const evaluators = [...values.projectEvaluators, ...(splitList(values.otherEvaluators) ?? [])];
+  return {
+    ...toMonitoringInput(values),
+    evaluators: evaluators.length === 0 ? undefined : evaluators,
+  };
+}
+
+function summaryOf(values: OnlineEvalFormValues): Record<string, string> {
+  return {
+    "online eval": values.name.trim(),
+    ...monitoringSummary(values),
+    evaluators: toOnlineEvalInput(values).evaluators?.join(", ") ?? "",
+  };
+}
+
+export function AddOnlineEvalScreen({ ctx, core }: ScreenProps) {
+  return (
+    <ProjectGate
+      core={core}
+      breadcrumb={BREADCRUMB}
+      description={DESCRIPTION}
+      seed={ctx.value(ProjectKey)}
+    >
+      {(project) => <AddOnlineEvalWizard project={project} core={core} />}
+    </ProjectGate>
+  );
+}
+
+function AddOnlineEvalWizard({ project, core }: { project: Project; core: ScreenProps["core"] }) {
+  const navigate = useNavigate();
+  const [values, setValues] = useState<OnlineEvalFormValues>(() => ({
+    ...emptyMonitoringValues(project),
+    projectEvaluators: [],
+    otherEvaluators: "",
+  }));
+  const set = (update: Partial<OnlineEvalFormValues>) =>
+    setValues((current) => ({ ...current, ...update }));
+
+  const { sourceSteps, trailingSteps } = useMonitoringSteps(project, values, set, "evaluation");
+
+  const evaluatorChoices = useMemo(
+    () =>
+      project.spec.evaluators.map((evaluator) => ({
+        value: evaluator.name,
+        label: evaluator.name,
+        description: evaluator.description ?? evaluator.level,
+      })),
+    [project.spec.evaluators],
+  );
+  const hasProjectEvaluators = evaluatorChoices.length > 0;
+
+  return (
+    <Wizard
+      breadcrumb={BREADCRUMB}
+      description={DESCRIPTION}
+      onCancel={() => navigate(ADD_MENU)}
+      onSubmit={() =>
+        core.projectManager.addResource(project, toAddOnlineEvalInput(toOnlineEvalInput(values)))
+      }
+      runningLabel={`adding online-eval config ${values.name.trim()}…`}
+      successLabel={`added online-eval config '${values.name.trim()}' to '${project.name}'`}
+      successHint="enter exits"
+    >
+      <Step name="name" question="what should this online evaluation config be called?">
+        <TextField
+          label="config name"
+          placeholder="prod_quality"
+          value={values.name}
+          onChange={(name) => set({ name })}
+          required
+          schema={OnlineEvalConfigNameSchema}
+        />
+      </Step>
+
+      {sourceSteps}
+
+      {hasProjectEvaluators && (
+        <Step
+          name="project-evaluators"
+          title="evaluators"
+          question="which of this project's evaluators should score the sessions?"
+        >
+          <MultiChoiceField
+            label="evaluator"
+            help="built-in evaluators can be added on the next step"
+            choices={evaluatorChoices}
+            value={values.projectEvaluators}
+            onChange={(projectEvaluators) => set({ projectEvaluators })}
+          />
+        </Step>
+      )}
+
+      <Step
+        name="other-evaluators"
+        title={hasProjectEvaluators ? "built-in" : "evaluators"}
+        question={
+          hasProjectEvaluators
+            ? "any built-in evaluators as well? (optional)"
+            : "which evaluators should score the sessions?"
+        }
+      >
+        <TextField
+          label="evaluators"
+          help="Builtin.* IDs or evaluator ARNs, comma-separated"
+          placeholder="Builtin.Helpfulness, Builtin.Correctness"
+          value={values.otherEvaluators}
+          onChange={(otherEvaluators) => set({ otherEvaluators })}
+          // The schema wants at least one evaluator; this is the last chance.
+          required={values.projectEvaluators.length === 0}
+        />
+      </Step>
+
+      {trailingSteps}
+
+      <Step name="review" question="this config will be added to agentcore.json">
+        <Summary items={summaryOf(values)} />
+      </Step>
+    </Wizard>
+  );
+}

--- a/src/handlers/project/add/online-insight/index.ts
+++ b/src/handlers/project/add/online-insight/index.ts
@@ -1,12 +1,71 @@
 import z from "zod";
 import { createHandler, flag, ProjectKey } from "../../../../router";
 import { InputValidationError } from "../../../../errors";
-import { OnlineEvalConfigSchema } from "../../../../projectSchemas/online-eval-config";
+import {
+  OnlineEvalConfigSchema,
+  type ClusteringConfig,
+} from "../../../../projectSchemas/online-eval-config";
 import { parseJsonFlag } from "../../../utils";
+import type { AddResourceInput } from "../../types";
 import type { AddProjectResourceConfig } from "../types";
 
-const BUILTIN_INSIGHT_PREFIX = "Builtin.Insight.";
+export const BUILTIN_INSIGHT_PREFIX = "Builtin.Insight.";
 const ARN_PREFIX = "arn:";
+
+export type ClusteringFrequency = ClusteringConfig["frequencies"][number];
+
+/**
+ * InsightIdSchema is what one --insight value must look like. Exported so the
+ * wizard's insights step refuses the same values the flag path refuses.
+ */
+export const InsightIdSchema = z
+  .string()
+  .refine((id) => id.startsWith(BUILTIN_INSIGHT_PREFIX) || id.startsWith(ARN_PREFIX), {
+    message: `must be a ${BUILTIN_INSIGHT_PREFIX}* identifier or a full ARN`,
+  });
+
+/**
+ * OnlineInsightInput is what every entry point — the flag handler, the wizard —
+ * resolves its own inputs to before an online-insight config is built. The
+ * source rules are the schema's; the insight-ID shape is checked here.
+ */
+export interface OnlineInsightInput {
+  name: string;
+  agent?: string;
+  endpoint?: string;
+  logGroupNames?: string[];
+  serviceNames?: string[];
+  insights?: string[];
+  clusteringFrequencies?: ClusteringFrequency[];
+  samplingRate: number;
+  description?: string;
+  enableOnCreate?: boolean;
+  tags?: Record<string, string>;
+}
+
+/**
+ * toAddOnlineInsightInput is the one place an online-insight config is
+ * assembled and checked. Both the flag handler and the wizard call it.
+ */
+export function toAddOnlineInsightInput(input: OnlineInsightInput): AddResourceInput {
+  for (const id of input.insights ?? []) {
+    if (!InsightIdSchema.safeParse(id).success)
+      throw new InputValidationError(
+        `invalid insight "${id}": must be a ${BUILTIN_INSIGHT_PREFIX}* identifier or a full ARN`,
+      );
+  }
+
+  const { clusteringFrequencies, ...rest } = input;
+  const parsed = OnlineEvalConfigSchema.safeParse({
+    ...rest,
+    clusteringConfig:
+      clusteringFrequencies && clusteringFrequencies.length > 0
+        ? { frequencies: clusteringFrequencies }
+        : undefined,
+  });
+  if (!parsed.success) throw new InputValidationError(z.prettifyError(parsed.error));
+  return { resourceType: "online-insight", resourceConfig: parsed.data };
+}
 
 export const createAddOnlineInsightHandler = (config: AddProjectResourceConfig) =>
   createHandler({
@@ -61,6 +120,8 @@ export const createAddOnlineInsightHandler = (config: AddProjectResourceConfig) 
       ),
       flag("tags", "tags to apply (JSON object of key/value strings)", z.string().optional()),
     ],
+    // handle only turns flags into an OnlineInsightInput. What a config is, and
+    // which combinations are allowed, belongs to toAddOnlineInsightInput.
     handle: async (ctx, flags) => {
       if (!flags["name"])
         throw new InputValidationError("required option '--name <name>' not specified");
@@ -69,22 +130,14 @@ export const createAddOnlineInsightHandler = (config: AddProjectResourceConfig) 
           "required option '--sampling-rate <sampling-rate>' not specified",
         );
 
-      for (const id of flags["insight"] ?? []) {
-        if (!id.startsWith(BUILTIN_INSIGHT_PREFIX) && !id.startsWith(ARN_PREFIX))
-          throw new InputValidationError(
-            `invalid insight "${id}": must be a ${BUILTIN_INSIGHT_PREFIX}* identifier or a full ARN`,
-          );
-      }
-
-      const frequencies = flags["clustering-frequency"];
-      const candidate = {
+      const input = toAddOnlineInsightInput({
         name: flags["name"],
         agent: flags["agent"],
         endpoint: flags["endpoint"],
         logGroupNames: flags["log-group-name"],
         serviceNames: flags["service-name"],
         insights: flags["insight"],
-        clusteringConfig: frequencies ? { frequencies } : undefined,
+        clusteringFrequencies: flags["clustering-frequency"],
         samplingRate: flags["sampling-rate"],
         description: flags["description"],
         enableOnCreate:
@@ -92,16 +145,10 @@ export const createAddOnlineInsightHandler = (config: AddProjectResourceConfig) 
             ? undefined
             : flags["enable-on-create"] === "true",
         tags: parseJsonFlag<Record<string, string>>("tags", flags["tags"]),
-      };
-
-      const parsed = OnlineEvalConfigSchema.safeParse(candidate);
-      if (!parsed.success) throw new InputValidationError(z.prettifyError(parsed.error));
+      });
 
       const project = ctx.require(ProjectKey);
-      for await (const event of config.projectManager.addResource(project, {
-        resourceType: "online-insight",
-        resourceConfig: parsed.data,
-      })) {
+      for await (const event of config.projectManager.addResource(project, input)) {
         config.io.stderr.write(`${event.message}\n`);
       }
 

--- a/src/handlers/project/add/online-insight/onlineInsight.screen.test.tsx
+++ b/src/handlers/project/add/online-insight/onlineInsight.screen.test.tsx
@@ -1,0 +1,100 @@
+import { test, expect, describe, afterEach } from "bun:test";
+import {
+  renderScreen,
+  waitForText,
+  waitForFlatText,
+  flatFrame,
+  cleanupScreens,
+} from "../../../../testing";
+import { createGatewayProjectTestHarness } from "../gateway-test-support";
+
+const { cleanup, inProject, projectSpec } = createGatewayProjectTestHarness(
+  "add-online-insight-wizard",
+);
+
+afterEach(cleanup);
+afterEach(cleanupScreens);
+
+describe("project add online-insight wizard", () => {
+  test("writes the same config the flag path writes, with clustering", async () => {
+    const projectRoot = await inProject();
+    const r = renderScreen("/agentcore/project/add/online-insight");
+
+    await waitForText(r.lastFrame, "what should this online insight config be called?");
+    await r.write("prod_failures");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "what should this insight config monitor?");
+    await r.press("return");
+    await waitForText(r.lastFrame, "which agent's traffic should be sampled?");
+    await r.press("return");
+    await waitForText(r.lastFrame, "scope to one endpoint?");
+    await r.write("PROD");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "which insights should be generated?");
+    await r.write("Builtin.Insight.FailureAnalysis");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "how often should sessions be clustered?");
+    await r.write(" ");
+    await r.press("down");
+    await r.press("down");
+    await r.write(" ");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "what share of sessions should be sampled?");
+    await r.write("50");
+    await r.press("return");
+    await waitForText(r.lastFrame, "should insight start when this deploys?");
+    await r.press("return");
+    await waitForText(r.lastFrame, "what is this config for?");
+    await r.write("watch for failures");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "this config will be added to agentcore.json");
+    const review = flatFrame(r.lastFrame);
+    expect(review).toContain("agent hello_world (PROD)");
+    expect(review).toContain("clustering DAILY, MONTHLY");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "added online-insight config 'prod_failures'");
+
+    expect((await projectSpec(projectRoot)).onlineEvalConfigs).toEqual([
+      {
+        name: "prod_failures",
+        agent: "hello_world",
+        endpoint: "PROD",
+        insights: ["Builtin.Insight.FailureAnalysis"],
+        clusteringConfig: { frequencies: ["DAILY", "MONTHLY"] },
+        samplingRate: 50,
+        description: "watch for failures",
+        enableOnCreate: true,
+      },
+    ]);
+    r.unmount();
+  });
+
+  test("an insight that is neither Builtin.Insight.* nor an ARN is refused", async () => {
+    await inProject();
+    const r = renderScreen("/agentcore/project/add/online-insight");
+
+    await waitForText(r.lastFrame, "what should this online insight config be called?");
+    await r.write("x");
+    await r.press("return");
+    await waitForText(r.lastFrame, "what should this insight config monitor?");
+    await r.press("return");
+    await waitForText(r.lastFrame, "which agent's traffic should be sampled?");
+    await r.press("return");
+    await waitForText(r.lastFrame, "scope to one endpoint?");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "which insights should be generated?");
+    await r.write("Builtin.Helpfulness");
+    await r.press("return");
+
+    await waitForFlatText(r.lastFrame, "must be a Builtin.Insight.* identifier or a full ARN");
+    expect(r.lastFrame()).toContain("which insights should be generated?");
+    r.unmount();
+  });
+});

--- a/src/handlers/project/add/online-insight/screen.tsx
+++ b/src/handlers/project/add/online-insight/screen.tsx
@@ -1,0 +1,163 @@
+import { useState } from "react";
+import { useNavigate } from "react-router";
+import z from "zod";
+import { ProjectKey } from "../../../../router";
+import { OnlineEvalConfigNameSchema } from "../../../../projectSchemas/online-eval-config";
+import type { ScreenProps } from "../../../types";
+import type { Project } from "../../types";
+import { ProjectGate } from "../../ProjectGate";
+import {
+  Wizard,
+  Step,
+  TextField,
+  MultiChoiceField,
+  Summary,
+  splitList,
+} from "../../../../components/wizard";
+import {
+  emptyMonitoringValues,
+  monitoringSummary,
+  toMonitoringInput,
+  useMonitoringSteps,
+  type MonitoringFormValues,
+} from "../monitoring-steps";
+import {
+  BUILTIN_INSIGHT_PREFIX,
+  InsightIdSchema,
+  toAddOnlineInsightInput,
+  type ClusteringFrequency,
+  type OnlineInsightInput,
+} from "./index";
+
+const BREADCRUMB = ["agentcore", "project", "add", "online-insight"];
+const DESCRIPTION = "adds an online insight config to the current project";
+const ADD_MENU = "/agentcore/project/add";
+
+const FREQUENCY_CHOICES = [
+  { value: "DAILY" as ClusteringFrequency, label: "DAILY", description: "cluster every day" },
+  { value: "WEEKLY" as ClusteringFrequency, label: "WEEKLY", description: "cluster every week" },
+  { value: "MONTHLY" as ClusteringFrequency, label: "MONTHLY", description: "cluster every month" },
+];
+
+// The insights step collects a comma-separated list, each entry checked with
+// the handler's own InsightIdSchema so the wizard refuses what the flag refuses.
+const InsightsInputSchema = z
+  .string()
+  .transform((raw) => splitList(raw) ?? [])
+  .pipe(z.array(InsightIdSchema).min(1, "enter at least one insight"));
+
+interface OnlineInsightFormValues extends MonitoringFormValues {
+  insights: string;
+  clusteringFrequencies: ClusteringFrequency[];
+}
+
+export function toOnlineInsightInput(values: OnlineInsightFormValues): OnlineInsightInput {
+  return {
+    ...toMonitoringInput(values),
+    insights: splitList(values.insights),
+    clusteringFrequencies:
+      values.clusteringFrequencies.length === 0 ? undefined : values.clusteringFrequencies,
+  };
+}
+
+function summaryOf(values: OnlineInsightFormValues): Record<string, string> {
+  const input = toOnlineInsightInput(values);
+  return {
+    "online insight": values.name.trim(),
+    ...monitoringSummary(values),
+    insights: input.insights?.join(", ") ?? "",
+    ...(input.clusteringFrequencies === undefined
+      ? {}
+      : { clustering: input.clusteringFrequencies.join(", ") }),
+  };
+}
+
+export function AddOnlineInsightScreen({ ctx, core }: ScreenProps) {
+  return (
+    <ProjectGate
+      core={core}
+      breadcrumb={BREADCRUMB}
+      description={DESCRIPTION}
+      seed={ctx.value(ProjectKey)}
+    >
+      {(project) => <AddOnlineInsightWizard project={project} core={core} />}
+    </ProjectGate>
+  );
+}
+
+function AddOnlineInsightWizard({
+  project,
+  core,
+}: {
+  project: Project;
+  core: ScreenProps["core"];
+}) {
+  const navigate = useNavigate();
+  const [values, setValues] = useState<OnlineInsightFormValues>(() => ({
+    ...emptyMonitoringValues(project),
+    insights: "",
+    clusteringFrequencies: [],
+  }));
+  const set = (update: Partial<OnlineInsightFormValues>) =>
+    setValues((current) => ({ ...current, ...update }));
+
+  const { sourceSteps, trailingSteps } = useMonitoringSteps(project, values, set, "insight");
+
+  return (
+    <Wizard
+      breadcrumb={BREADCRUMB}
+      description={DESCRIPTION}
+      onCancel={() => navigate(ADD_MENU)}
+      onSubmit={() =>
+        core.projectManager.addResource(
+          project,
+          toAddOnlineInsightInput(toOnlineInsightInput(values)),
+        )
+      }
+      runningLabel={`adding online-insight config ${values.name.trim()}…`}
+      successLabel={`added online-insight config '${values.name.trim()}' to '${project.name}'`}
+      successHint="enter exits"
+    >
+      <Step name="name" question="what should this online insight config be called?">
+        <TextField
+          label="config name"
+          placeholder="prod_failures"
+          value={values.name}
+          onChange={(name) => set({ name })}
+          required
+          schema={OnlineEvalConfigNameSchema}
+        />
+      </Step>
+
+      {sourceSteps}
+
+      <Step name="insights" question="which insights should be generated?">
+        <TextField
+          label="insights"
+          help={`${BUILTIN_INSIGHT_PREFIX}* IDs or insight ARNs, comma-separated`}
+          placeholder={`${BUILTIN_INSIGHT_PREFIX}FailureAnalysis`}
+          value={values.insights}
+          onChange={(insights) => set({ insights })}
+          required
+          schema={InsightsInputSchema}
+        />
+      </Step>
+
+      <Step name="clustering" question="how often should sessions be clustered? (optional)">
+        <MultiChoiceField
+          label="clustering frequency"
+          help="leave empty to accept the service default"
+          choices={FREQUENCY_CHOICES}
+          value={values.clusteringFrequencies}
+          onChange={(clusteringFrequencies) => set({ clusteringFrequencies })}
+        />
+      </Step>
+
+      {trailingSteps}
+
+      <Step name="review" question="this config will be added to agentcore.json">
+        <Summary items={summaryOf(values)} />
+      </Step>
+    </Wizard>
+  );
+}

--- a/src/handlers/project/add/payment-manager/index.ts
+++ b/src/handlers/project/add/payment-manager/index.ts
@@ -5,9 +5,88 @@ import {
   DEFAULT_SPEND_LIMIT,
   PaymentAuthorizerTypeSchema,
   PaymentSpendLimitSchema,
+  type PaymentAuthorizerType,
+  type PaymentManagerSchema,
 } from "../../../../projectSchemas/payment";
 import { createHandler, flag, ProjectKey } from "../../../../router";
+import type { AddResourceInput } from "../../types";
 import type { AddProjectResourceConfig } from "../types";
+
+/**
+ * PaymentManagerInput is what every entry point — the flag handler, the wizard —
+ * resolves its own inputs to before a payment manager is built. The JWT fields
+ * are grouped, since they mean nothing apart from CUSTOM_JWT. Anything optional
+ * is a field toAddPaymentManagerInput defaults.
+ */
+export interface PaymentManagerInput {
+  name: string;
+  authorizerType?: PaymentAuthorizerType;
+  jwt?: {
+    discoveryUrl?: string;
+    allowedClients?: string[];
+    allowedAudience?: string[];
+    allowedScopes?: string[];
+  };
+  description?: string;
+  autoPayment?: boolean;
+  defaultSpendLimit?: string;
+  paymentToolAllowlist?: string[];
+  networkPreferences?: string[];
+}
+
+/**
+ * toAddPaymentManagerInput is the one place a payment manager is assembled from
+ * user input: the authorizer defaults, the rule that JWT settings belong to
+ * CUSTOM_JWT alone. Both the flag handler and the wizard call it.
+ */
+export function toAddPaymentManagerInput(input: PaymentManagerInput): AddResourceInput {
+  const authorizerType = input.authorizerType ?? "AWS_IAM";
+  const jwt = input.jwt ?? {};
+  const hasJwtSettings = Object.values(jwt).some((value) => value !== undefined);
+
+  if (authorizerType === "CUSTOM_JWT" && !jwt.discoveryUrl) {
+    throw new InputValidationError("CUSTOM_JWT requires --discovery-url");
+  }
+  if (authorizerType !== "CUSTOM_JWT" && hasJwtSettings) {
+    throw new InputValidationError("JWT authorization flags are valid only with CUSTOM_JWT");
+  }
+
+  const resourceConfig: z.input<typeof PaymentManagerSchema> = {
+    name: input.name,
+    authorizerType,
+    authorizerConfiguration:
+      authorizerType === "CUSTOM_JWT"
+        ? {
+            customJWTAuthorizer: {
+              discoveryUrl: jwt.discoveryUrl!,
+              allowedClients: jwt.allowedClients,
+              allowedAudience: jwt.allowedAudience,
+              allowedScopes: jwt.allowedScopes,
+            },
+          }
+        : undefined,
+    connectors: [],
+    description: input.description,
+    autoPayment: input.autoPayment ?? DEFAULT_AUTO_PAYMENT,
+    defaultSpendLimit: input.defaultSpendLimit ?? DEFAULT_SPEND_LIMIT,
+    paymentToolAllowlist: input.paymentToolAllowlist,
+    networkPreferences: input.networkPreferences,
+  };
+  return { resourceType: "payment-manager", resourceConfig };
+}
+
+/** The warning both entry points print when a manager settles payments on its own. */
+export function autoPaymentWarning(name: string): string {
+  return (
+    `Warning: auto-payment is ENABLED for manager '${name}'. Agents can automatically settle ` +
+    "402 responses without human approval. Use --no-auto-payment to require manual approval."
+  );
+}
+
+/** The warning both entry points print when the project has runtimes to configure. */
+export const RUNTIME_SOURCE_WARNING =
+  "Warning: project add payment-manager does not modify runtime source code. " +
+  "Configure the Payments SDK or plugin in supported runtimes before invoking payment-enabled agents.";
 
 export const createAddPaymentManagerHandler = (config: AddProjectResourceConfig) =>
   createHandler({
@@ -46,66 +125,39 @@ export const createAddPaymentManagerHandler = (config: AddProjectResourceConfig)
       ),
       flag("network-preferences", "preferred payment networks", z.array(z.string()).optional()),
     ],
+    // handle only turns flags into a PaymentManagerInput. What a manager is,
+    // and when JWT settings apply, belongs to toAddPaymentManagerInput.
     handle: async (ctx, flags) => {
       if (!flags.name) {
         throw new InputValidationError("required option '--name <name>' not specified");
       }
 
-      const jwtFlags = [
-        flags["discovery-url"],
-        flags["allowed-clients"],
-        flags["allowed-audience"],
-        flags["allowed-scopes"],
-      ];
-      if (flags["authorizer-type"] === "CUSTOM_JWT" && !flags["discovery-url"]) {
-        throw new InputValidationError("CUSTOM_JWT requires --discovery-url");
-      }
-      if (
-        flags["authorizer-type"] !== "CUSTOM_JWT" &&
-        jwtFlags.some((value) => value !== undefined)
-      ) {
-        throw new InputValidationError("JWT authorization flags are valid only with CUSTOM_JWT");
-      }
+      const input = toAddPaymentManagerInput({
+        name: flags.name,
+        authorizerType: flags["authorizer-type"],
+        jwt: {
+          discoveryUrl: flags["discovery-url"],
+          allowedClients: flags["allowed-clients"],
+          allowedAudience: flags["allowed-audience"],
+          allowedScopes: flags["allowed-scopes"],
+        },
+        description: flags.description,
+        autoPayment: flags["auto-payment"],
+        defaultSpendLimit: flags["default-spend-limit"],
+        paymentToolAllowlist: flags["tool-allowlist"],
+        networkPreferences: flags["network-preferences"],
+      });
 
       const project = ctx.require(ProjectKey);
-      for await (const event of config.projectManager.addResource(project, {
-        resourceType: "payment-manager",
-        resourceConfig: {
-          name: flags.name,
-          authorizerType: flags["authorizer-type"],
-          authorizerConfiguration:
-            flags["authorizer-type"] === "CUSTOM_JWT"
-              ? {
-                  customJWTAuthorizer: {
-                    discoveryUrl: flags["discovery-url"]!,
-                    allowedClients: flags["allowed-clients"],
-                    allowedAudience: flags["allowed-audience"],
-                    allowedScopes: flags["allowed-scopes"],
-                  },
-                }
-              : undefined,
-          connectors: [],
-          description: flags.description,
-          autoPayment: flags["auto-payment"],
-          defaultSpendLimit: flags["default-spend-limit"],
-          paymentToolAllowlist: flags["tool-allowlist"],
-          networkPreferences: flags["network-preferences"],
-        },
-      })) {
+      for await (const event of config.projectManager.addResource(project, input)) {
         config.io.stderr.write(`${event.message}\n`);
       }
       config.io.stderr.write(`added payment manager '${flags.name}' to '${project.name}'\n`);
       if (flags["auto-payment"]) {
-        config.io.stderr.write(
-          `Warning: auto-payment is ENABLED for manager '${flags.name}'. Agents can automatically settle ` +
-            "402 responses without human approval. Use --no-auto-payment to require manual approval.\n",
-        );
+        config.io.stderr.write(`${autoPaymentWarning(flags.name)}\n`);
       }
       if (project.spec.runtimes.length > 0) {
-        config.io.stderr.write(
-          "Warning: project add payment-manager does not modify runtime source code. " +
-            "Configure the Payments SDK or plugin in supported runtimes before invoking payment-enabled agents.\n",
-        );
+        config.io.stderr.write(`${RUNTIME_SOURCE_WARNING}\n`);
       }
     },
   });

--- a/src/handlers/project/add/payment-manager/paymentManager.screen.test.tsx
+++ b/src/handlers/project/add/payment-manager/paymentManager.screen.test.tsx
@@ -1,0 +1,131 @@
+import { test, expect, describe, afterEach } from "bun:test";
+import {
+  renderScreen,
+  waitForText,
+  waitForFlatText,
+  flatFrame,
+  cleanupScreens,
+} from "../../../../testing";
+import { createGatewayProjectTestHarness } from "../gateway-test-support";
+
+const { cleanup, inProject, projectSpec } = createGatewayProjectTestHarness(
+  "add-payment-manager-wizard",
+);
+
+afterEach(cleanup);
+afterEach(cleanupScreens);
+
+describe("project add payment-manager wizard", () => {
+  test("default flow writes the same defaults the flag path writes, and warns the same way", async () => {
+    const projectRoot = await inProject();
+    const r = renderScreen("/agentcore/project/add/payment-manager");
+
+    await waitForText(r.lastFrame, "what should this payment manager be called?");
+    await r.write("payments");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "how should payment requests be authorized?");
+    expect(r.lastFrame()).toContain("● AWS_IAM (default)");
+    await r.press("return");
+
+    // AWS_IAM asks nothing about JWT issuers.
+    await waitForText(r.lastFrame, "should agents settle payments on their own?");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "how much may one payment session spend?");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "what is this payment manager for?");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "this payment manager will be added to agentcore.json");
+    const review = flatFrame(r.lastFrame);
+    expect(review).toContain("authorizer AWS_IAM");
+    expect(review).toContain("auto-payment on");
+    expect(review).toContain("spend limit 10.00");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "added payment manager 'payments'");
+    // The flag path's post-success warnings are shown too: the scaffolded
+    // project has a runtime, and auto-payment defaults on.
+    expect(r.lastFrame()).toContain("auto-payment is ENABLED");
+    expect(r.lastFrame()).toContain("does not modify runtime source code");
+
+    const managers = (await projectSpec(projectRoot)).payments;
+    expect(managers).toEqual([
+      {
+        name: "payments",
+        authorizerType: "AWS_IAM",
+        connectors: [],
+        autoPayment: true,
+        defaultSpendLimit: "10.00",
+      },
+    ]);
+    r.unmount();
+  });
+
+  test("CUSTOM_JWT adds the issuer steps and validates the discovery URL", async () => {
+    const projectRoot = await inProject();
+    const r = renderScreen("/agentcore/project/add/payment-manager");
+
+    await waitForText(r.lastFrame, "what should this payment manager be called?");
+    await r.write("jwtPayments");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "how should payment requests be authorized?");
+    await r.press("down");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "where is your JWT issuer's OIDC discovery document?");
+    await r.write("http://idp.example.com");
+    await r.press("return");
+    await waitForFlatText(r.lastFrame, "HTTPS");
+    for (let i = 0; i < "http://idp.example.com".length; i++) await r.write("\x7f");
+    await r.write("https://idp.example.com/.well-known/openid-configuration");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "which client IDs may pay?");
+    await r.write("client-a, client-b");
+    await r.press("return");
+    await waitForText(r.lastFrame, "which audiences may pay?");
+    await r.press("return");
+    await waitForText(r.lastFrame, "which scopes may pay?");
+    await r.write("pay");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "should agents settle payments on their own?");
+    await r.press("down");
+    await r.press("return");
+    await waitForText(r.lastFrame, "how much may one payment session spend?");
+    for (let i = 0; i < "10.00".length; i++) await r.write("\x7f");
+    await r.write("-5");
+    await r.press("return");
+    await waitForFlatText(r.lastFrame, "non-negative");
+    await r.write("\x7f");
+    await r.write("\x7f");
+    await r.write("2.50");
+    await r.press("return");
+    await waitForText(r.lastFrame, "what is this payment manager for?");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "this payment manager will be added to agentcore.json");
+    expect(flatFrame(r.lastFrame)).toContain("clients client-a, client-b");
+    await r.press("return");
+    await waitForText(r.lastFrame, "added payment manager 'jwtPayments'");
+    expect(r.lastFrame()).not.toContain("auto-payment is ENABLED");
+
+    expect((await projectSpec(projectRoot)).payments[0]).toMatchObject({
+      authorizerType: "CUSTOM_JWT",
+      authorizerConfiguration: {
+        customJWTAuthorizer: {
+          discoveryUrl: "https://idp.example.com/.well-known/openid-configuration",
+          allowedClients: ["client-a", "client-b"],
+          allowedScopes: ["pay"],
+        },
+      },
+      autoPayment: false,
+      defaultSpendLimit: "2.50",
+    });
+    r.unmount();
+  });
+});

--- a/src/handlers/project/add/payment-manager/screen.tsx
+++ b/src/handlers/project/add/payment-manager/screen.tsx
@@ -1,0 +1,292 @@
+import { useState } from "react";
+import { useNavigate } from "react-router";
+import { ProjectKey } from "../../../../router";
+import { OidcDiscoveryUrlSchema } from "../../../../projectSchemas/auth";
+import {
+  DEFAULT_SPEND_LIMIT,
+  PaymentManagerNameSchema,
+  PaymentSpendLimitSchema,
+  type PaymentAuthorizerType,
+} from "../../../../projectSchemas/payment";
+import type { ScreenProps } from "../../../types";
+import type { Project } from "../../types";
+import { ProjectGate } from "../../ProjectGate";
+import {
+  Wizard,
+  Step,
+  TextField,
+  ChoiceField,
+  Summary,
+  blankToUndefined,
+  splitList,
+} from "../../../../components/wizard";
+import {
+  RUNTIME_SOURCE_WARNING,
+  autoPaymentWarning,
+  toAddPaymentManagerInput,
+  type PaymentManagerInput,
+} from "./index";
+
+const BREADCRUMB = ["agentcore", "project", "add", "payment-manager"];
+const DESCRIPTION = "adds a payment manager to the current project";
+const ADD_MENU = "/agentcore/project/add";
+
+const AUTHORIZER_CHOICES = [
+  {
+    value: "AWS_IAM" as PaymentAuthorizerType,
+    label: "AWS_IAM (default)",
+    description: "SigV4-signed callers",
+  },
+  {
+    value: "CUSTOM_JWT" as PaymentAuthorizerType,
+    label: "CUSTOM_JWT",
+    description: "your own JWT issuer · asks for its discovery URL",
+  },
+];
+
+const AUTO_PAYMENT_CHOICES = [
+  {
+    value: true,
+    label: "on (default)",
+    description: "agents settle 402 responses themselves, without human approval",
+  },
+  { value: false, label: "off", description: "every payment waits for manual approval" },
+];
+
+interface PaymentManagerFormValues {
+  name: string;
+  authorizerType: PaymentAuthorizerType;
+  discoveryUrl: string;
+  allowedClients: string;
+  allowedAudience: string;
+  allowedScopes: string;
+  autoPayment: boolean;
+  defaultSpendLimit: string;
+  description: string;
+}
+
+// toPaymentManagerInput reads the form into the PaymentManagerInput the
+// handler's builder expects. JWT answers are passed only under CUSTOM_JWT, so
+// a discovery URL typed before switching back to AWS_IAM is dropped rather
+// than tripping the "valid only with CUSTOM_JWT" rule.
+export function toPaymentManagerInput(values: PaymentManagerFormValues): PaymentManagerInput {
+  const isJwt = values.authorizerType === "CUSTOM_JWT";
+  return {
+    name: values.name.trim(),
+    authorizerType: values.authorizerType,
+    jwt: isJwt
+      ? {
+          discoveryUrl: values.discoveryUrl.trim(),
+          allowedClients: splitList(values.allowedClients),
+          allowedAudience: splitList(values.allowedAudience),
+          allowedScopes: splitList(values.allowedScopes),
+        }
+      : undefined,
+    autoPayment: values.autoPayment,
+    defaultSpendLimit: blankToUndefined(values.defaultSpendLimit),
+    description: blankToUndefined(values.description),
+  };
+}
+
+function summaryOf(values: PaymentManagerFormValues): Record<string, string> {
+  const input = toPaymentManagerInput(values);
+  return {
+    "payment manager": input.name,
+    authorizer: values.authorizerType,
+    ...(input.jwt === undefined ? {} : { "discovery url": input.jwt.discoveryUrl ?? "" }),
+    ...(input.jwt?.allowedClients === undefined
+      ? {}
+      : { clients: input.jwt.allowedClients.join(", ") }),
+    ...(input.jwt?.allowedAudience === undefined
+      ? {}
+      : { audience: input.jwt.allowedAudience.join(", ") }),
+    ...(input.jwt?.allowedScopes === undefined
+      ? {}
+      : { scopes: input.jwt.allowedScopes.join(", ") }),
+    "auto-payment": values.autoPayment ? "on" : "off",
+    "spend limit": input.defaultSpendLimit ?? DEFAULT_SPEND_LIMIT,
+    ...(input.description === undefined ? {} : { description: input.description }),
+  };
+}
+
+// successHintFor carries the warnings the flag path prints after success, so
+// the wizard's user is told the same things.
+function successHintFor(values: PaymentManagerFormValues, project: Project): string {
+  const warnings = [
+    ...(values.autoPayment ? [autoPaymentWarning(values.name.trim())] : []),
+    ...(project.spec.runtimes.length > 0 ? [RUNTIME_SOURCE_WARNING] : []),
+  ];
+  return [...warnings, "enter exits"].join("\n");
+}
+
+export function AddPaymentManagerScreen({ ctx, core }: ScreenProps) {
+  return (
+    <ProjectGate
+      core={core}
+      breadcrumb={BREADCRUMB}
+      description={DESCRIPTION}
+      seed={ctx.value(ProjectKey)}
+    >
+      {(project) => <AddPaymentManagerWizard project={project} core={core} />}
+    </ProjectGate>
+  );
+}
+
+function AddPaymentManagerWizard({
+  project,
+  core,
+}: {
+  project: Project;
+  core: ScreenProps["core"];
+}) {
+  const navigate = useNavigate();
+  const [values, setValues] = useState<PaymentManagerFormValues>({
+    name: "",
+    authorizerType: "AWS_IAM",
+    discoveryUrl: "",
+    allowedClients: "",
+    allowedAudience: "",
+    allowedScopes: "",
+    autoPayment: true,
+    defaultSpendLimit: DEFAULT_SPEND_LIMIT,
+    description: "",
+  });
+  const set = (update: Partial<PaymentManagerFormValues>) =>
+    setValues((current) => ({ ...current, ...update }));
+
+  const isJwt = values.authorizerType === "CUSTOM_JWT";
+
+  return (
+    <Wizard
+      breadcrumb={BREADCRUMB}
+      description={DESCRIPTION}
+      onCancel={() => navigate(ADD_MENU)}
+      onSubmit={() =>
+        core.projectManager.addResource(
+          project,
+          toAddPaymentManagerInput(toPaymentManagerInput(values)),
+        )
+      }
+      runningLabel={`adding payment manager ${values.name.trim()}…`}
+      successLabel={`added payment manager '${values.name.trim()}' to '${project.name}'`}
+      successHint={successHintFor(values, project)}
+    >
+      <Step name="name" question="what should this payment manager be called?">
+        <TextField
+          label="payment manager name"
+          placeholder="payments"
+          value={values.name}
+          onChange={(name) => set({ name })}
+          required
+          schema={PaymentManagerNameSchema}
+        />
+      </Step>
+
+      <Step name="authorizer" question="how should payment requests be authorized?">
+        <ChoiceField
+          choices={AUTHORIZER_CHOICES}
+          value={values.authorizerType}
+          onChange={(authorizerType) => set({ authorizerType })}
+        />
+      </Step>
+
+      {isJwt && (
+        <Step
+          name="discovery-url"
+          title="issuer"
+          question="where is your JWT issuer's OIDC discovery document?"
+        >
+          <TextField
+            label="discovery URL"
+            placeholder="https://idp.example.com/.well-known/openid-configuration"
+            value={values.discoveryUrl}
+            onChange={(discoveryUrl) => set({ discoveryUrl })}
+            required
+            schema={OidcDiscoveryUrlSchema}
+          />
+        </Step>
+      )}
+
+      {isJwt && (
+        <Step
+          name="allowed-clients"
+          title="clients"
+          question="which client IDs may pay? (optional)"
+        >
+          <TextField
+            label="allowed clients"
+            help="comma-separated; blank accepts any client"
+            value={values.allowedClients}
+            onChange={(allowedClients) => set({ allowedClients })}
+          />
+        </Step>
+      )}
+
+      {isJwt && (
+        <Step
+          name="allowed-audience"
+          title="audience"
+          question="which audiences may pay? (optional)"
+        >
+          <TextField
+            label="allowed audience"
+            help="comma-separated; blank accepts any audience"
+            value={values.allowedAudience}
+            onChange={(allowedAudience) => set({ allowedAudience })}
+          />
+        </Step>
+      )}
+
+      {isJwt && (
+        <Step name="allowed-scopes" title="scopes" question="which scopes may pay? (optional)">
+          <TextField
+            label="allowed scopes"
+            help="comma-separated; blank accepts any scope"
+            value={values.allowedScopes}
+            onChange={(allowedScopes) => set({ allowedScopes })}
+          />
+        </Step>
+      )}
+
+      <Step
+        name="auto-payment"
+        title="auto-payment"
+        question="should agents settle payments on their own?"
+      >
+        <ChoiceField
+          choices={AUTO_PAYMENT_CHOICES}
+          value={values.autoPayment}
+          onChange={(autoPayment) => set({ autoPayment })}
+        />
+      </Step>
+
+      <Step
+        name="spend-limit"
+        title="spend limit"
+        question="how much may one payment session spend?"
+      >
+        <TextField
+          label="default spend limit"
+          help={`a non-negative amount; blank keeps the default of ${DEFAULT_SPEND_LIMIT}`}
+          placeholder={DEFAULT_SPEND_LIMIT}
+          value={values.defaultSpendLimit}
+          onChange={(defaultSpendLimit) => set({ defaultSpendLimit })}
+          schema={PaymentSpendLimitSchema}
+        />
+      </Step>
+
+      <Step name="description" question="what is this payment manager for? (optional)">
+        <TextField
+          label="description"
+          placeholder="pays for premium data APIs"
+          value={values.description}
+          onChange={(description) => set({ description })}
+        />
+      </Step>
+
+      <Step name="review" question="this payment manager will be added to agentcore.json">
+        <Summary items={summaryOf(values)} />
+      </Step>
+    </Wizard>
+  );
+}

--- a/src/handlers/project/add/policy-engine/index.ts
+++ b/src/handlers/project/add/policy-engine/index.ts
@@ -1,15 +1,67 @@
 import z from "zod";
 import { InputValidationError } from "../../../../errors";
+import type { PolicyEngineMode } from "../../../../projectSchemas/gateway";
 import type { PolicyEngineSchema } from "../../../../projectSchemas/policy";
 import { createHandler, flag, ProjectKey } from "../../../../router";
 import { parseTags } from "../../../utils";
+import type { AddResourceInput, Project } from "../../types";
 import type { AddProjectResourceConfig } from "../types";
+
+/** The service limit on a Policy Engine's deployed name. */
+export const MAX_POLICY_ENGINE_RESOURCE_NAME_LENGTH = 48;
 
 /**
  The deployed service name of a policy engine; mirrors the L3 AgentCorePolicyEngine construct's rule.
 **/
 export function policyEngineResourceName(projectName: string, engineName: string): string {
   return `${projectName}_${engineName}`;
+}
+
+/**
+ * PolicyEngineInput is what every entry point — the flag handler, the wizard —
+ * resolves its own inputs to before an engine is built. `attachToGateways`
+ * absent means attach to nothing; `attachMode` is only read alongside it.
+ */
+export interface PolicyEngineInput {
+  name: string;
+  description?: string;
+  encryptionKeyArn?: string;
+  tags?: Record<string, string>;
+  attachToGateways?: string[];
+  attachMode?: PolicyEngineMode;
+}
+
+/**
+ * toAddPolicyEngineInput is the one place a Policy Engine is assembled from
+ * user input: the name limit, the attach default. Both the flag handler and the
+ * wizard call it, so they cannot disagree about what an engine is.
+ */
+export function toAddPolicyEngineInput(
+  project: Project,
+  input: PolicyEngineInput,
+): AddResourceInput {
+  const resourceName = policyEngineResourceName(project.name, input.name);
+  if (resourceName.length > MAX_POLICY_ENGINE_RESOURCE_NAME_LENGTH) {
+    throw new InputValidationError(
+      `Policy Engine resource name '${resourceName}' exceeds the service limit of ` +
+        `${MAX_POLICY_ENGINE_RESOURCE_NAME_LENGTH} characters`,
+    );
+  }
+
+  const engine: z.input<typeof PolicyEngineSchema> = {
+    name: input.name,
+    description: input.description,
+    encryptionKeyArn: input.encryptionKeyArn,
+    tags: input.tags,
+  };
+  return {
+    resourceType: "policy-engine",
+    resourceConfig: engine,
+    attachGateways:
+      input.attachToGateways && input.attachToGateways.length > 0
+        ? { names: input.attachToGateways, mode: input.attachMode ?? "ENFORCE" }
+        : undefined,
+  };
 }
 
 export const createAddPolicyEngineHandler = (config: AddProjectResourceConfig) =>
@@ -32,6 +84,9 @@ export const createAddPolicyEngineHandler = (config: AddProjectResourceConfig) =
         z.enum(["log-only", "enforce"]).optional(),
       ),
     ],
+    // handle only turns flags into a PolicyEngineInput — splitting tags,
+    // pairing flags that only make sense together. What an engine is belongs
+    // to toAddPolicyEngineInput.
     handle: async (ctx, flags) => {
       if (!flags.name) {
         throw new InputValidationError("required option '--name <name>' not specified");
@@ -39,31 +94,23 @@ export const createAddPolicyEngineHandler = (config: AddProjectResourceConfig) =
       if (flags["attach-mode"] !== undefined && flags["attach-to-gateways"] === undefined) {
         throw new InputValidationError("--attach-mode requires --attach-to-gateways");
       }
-      const project = ctx.require(ProjectKey);
-      const resourceName = policyEngineResourceName(project.name, flags.name);
-      if (resourceName.length > 48) {
-        throw new InputValidationError(
-          `Policy Engine resource name '${resourceName}' exceeds the service limit of 48 characters`,
-        );
-      }
 
-      const engine: z.input<typeof PolicyEngineSchema> = {
+      const project = ctx.require(ProjectKey);
+      const input = toAddPolicyEngineInput(project, {
         name: flags.name,
         description: flags.description,
         encryptionKeyArn: flags["encryption-key-arn"],
         tags: parseTags(flags.tags),
-      };
+        attachToGateways: flags["attach-to-gateways"],
+        attachMode:
+          flags["attach-mode"] === undefined
+            ? undefined
+            : flags["attach-mode"] === "log-only"
+              ? "LOG_ONLY"
+              : "ENFORCE",
+      });
 
-      for await (const event of config.projectManager.addResource(project, {
-        resourceType: "policy-engine",
-        resourceConfig: engine,
-        attachGateways: flags["attach-to-gateways"]
-          ? {
-              names: flags["attach-to-gateways"],
-              mode: flags["attach-mode"] === "log-only" ? "LOG_ONLY" : "ENFORCE",
-            }
-          : undefined,
-      })) {
+      for await (const event of config.projectManager.addResource(project, input)) {
         config.io.stderr.write(`${event.message}\n`);
       }
       config.io.stderr.write(`added Policy Engine '${flags.name}' to '${project.name}'\n`);

--- a/src/handlers/project/add/policy-engine/policyEngine.screen.test.tsx
+++ b/src/handlers/project/add/policy-engine/policyEngine.screen.test.tsx
@@ -1,0 +1,103 @@
+import { test, expect, describe, afterEach } from "bun:test";
+import {
+  renderScreen,
+  waitForText,
+  waitForFlatText,
+  flatFrame,
+  cleanupScreens,
+} from "../../../../testing";
+import { createGatewayProjectTestHarness } from "../gateway-test-support";
+
+const { addGateway, cleanup, inProject, projectSpec } = createGatewayProjectTestHarness(
+  "add-policy-engine-wizard",
+);
+
+afterEach(cleanup);
+afterEach(cleanupScreens);
+
+describe("project add policy-engine wizard", () => {
+  test("skips the attach step when the project has no Gateways", async () => {
+    const projectRoot = await inProject();
+    const r = renderScreen("/agentcore/project/add/policy-engine");
+
+    await waitForText(r.lastFrame, "what should this Policy Engine be called?");
+    // Nothing to attach to, so the stepper offers name → description → review.
+    expect(r.lastFrame()).toContain("○ review");
+    expect(r.lastFrame()).not.toContain("attach");
+    await r.write("Guardrails");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "what does this engine govern?");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "this Policy Engine will be added to agentcore.json");
+    expect(r.lastFrame()).toContain("none");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "added Policy Engine 'Guardrails' to 'TestProject'");
+
+    const engines = (await projectSpec(projectRoot)).policyEngines;
+    expect(engines).toHaveLength(1);
+    expect(engines[0]).toMatchObject({ name: "Guardrails" });
+    r.unmount();
+  });
+
+  test("offers the project's Gateways, and the mode step only once one is picked", async () => {
+    const projectRoot = await inProject();
+    await addGateway("tools");
+    const r = renderScreen("/agentcore/project/add/policy-engine");
+
+    await waitForText(r.lastFrame, "what should this Policy Engine be called?");
+    await r.write("Guardrails");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "what does this engine govern?");
+    await r.press("return");
+
+    // The attach step lists the Gateway the project already declares.
+    await waitForText(r.lastFrame, "which Gateways should this engine govern?");
+    expect(r.lastFrame()).toContain("tools");
+    // Nothing is selected yet, so the mode step is not in the flow.
+    expect(r.lastFrame()).not.toContain("○ mode");
+
+    await r.write(" ");
+    await waitForText(r.lastFrame, "○ mode");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "how should the attached Gateways enforce this engine?");
+    expect(r.lastFrame()).toContain("● enforce (default)");
+    // log-only is the second row.
+    await r.press("down");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "this Policy Engine will be added to agentcore.json");
+    const review = flatFrame(r.lastFrame);
+    expect(review).toContain("attached gateways tools");
+    expect(review).toContain("mode log-only");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "added Policy Engine 'Guardrails'");
+
+    const spec = await projectSpec(projectRoot);
+    expect(spec.policyEngines[0]).toMatchObject({ name: "Guardrails" });
+    // The attachment is recorded on the Gateway, as the handler records it.
+    expect(spec.agentCoreGateways[0].policyEngineConfiguration).toEqual({
+      policyEngineName: "Guardrails",
+      mode: "LOG_ONLY",
+    });
+    r.unmount();
+  });
+
+  test("a name that would exceed the service limit is rejected", async () => {
+    await inProject();
+    const r = renderScreen("/agentcore/project/add/policy-engine");
+
+    await waitForText(r.lastFrame, "what should this Policy Engine be called?");
+    await r.write("a".repeat(40));
+    await r.press("return");
+
+    await waitForFlatText(r.lastFrame, "exceeds the service limit of 48 characters");
+    expect(flatFrame(r.lastFrame)).toContain("what should this Policy Engine be called?");
+    r.unmount();
+  });
+});

--- a/src/handlers/project/add/policy-engine/screen.tsx
+++ b/src/handlers/project/add/policy-engine/screen.tsx
@@ -2,9 +2,8 @@ import { useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 import z from "zod";
 import { ProjectKey } from "../../../../router";
-import type { PolicyEngineSchema } from "../../../../projectSchemas/policy";
 import type { ScreenProps } from "../../../types";
-import type { AddResourceInput, Project } from "../../types";
+import type { Project } from "../../types";
 import { ProjectGate } from "../../ProjectGate";
 import {
   Wizard,
@@ -14,13 +13,15 @@ import {
   MultiChoiceField,
   Summary,
 } from "../../../../components/wizard";
-import { policyEngineResourceName } from "./index";
+import {
+  MAX_POLICY_ENGINE_RESOURCE_NAME_LENGTH,
+  policyEngineResourceName,
+  toAddPolicyEngineInput,
+  type PolicyEngineInput,
+} from "./index";
 
 const BREADCRUMB = ["agentcore", "project", "add", "policy-engine"];
 const DESCRIPTION = "adds a Policy Engine to the current project";
-
-// The service limit the handler enforces on the deployed engine name.
-const MAX_RESOURCE_NAME_LENGTH = 48;
 
 type AttachMode = "enforce" | "log-only";
 
@@ -44,23 +45,21 @@ interface PolicyEngineFormValues {
   attachMode: AttachMode;
 }
 
-export function buildAddPolicyEngineInput(values: PolicyEngineFormValues): AddResourceInput {
-  const engine: z.input<typeof PolicyEngineSchema> = {
-    name: values.name.trim(),
-    description: values.description.trim() === "" ? undefined : values.description.trim(),
-  };
+// toPolicyEngineInput reads the form into the PolicyEngineInput the handler's
+// toAddPolicyEngineInput builds an engine from. It trims and converts, and
+// drops the mode when no Gateway was picked — that step was never shown.
+export function toPolicyEngineInput(values: PolicyEngineFormValues): PolicyEngineInput {
+  const description = values.description.trim();
+  const isAttaching = values.attachToGateways.length > 0;
   return {
-    resourceType: "policy-engine",
-    resourceConfig: engine,
-    // The handler treats an absent --attach-to-gateways as "attach to nothing",
-    // and --attach-mode is meaningless without it.
-    attachGateways:
-      values.attachToGateways.length === 0
-        ? undefined
-        : {
-            names: values.attachToGateways,
-            mode: values.attachMode === "log-only" ? "LOG_ONLY" : "ENFORCE",
-          },
+    name: values.name.trim(),
+    description: description === "" ? undefined : description,
+    attachToGateways: isAttaching ? values.attachToGateways : undefined,
+    attachMode: isAttaching
+      ? values.attachMode === "log-only"
+        ? "LOG_ONLY"
+        : "ENFORCE"
+      : undefined,
   };
 }
 
@@ -102,12 +101,12 @@ function AddPolicyEngineWizard({ project, core }: { project: Project; core: Scre
     () =>
       z.string().superRefine((name, ctx) => {
         const resourceName = policyEngineResourceName(project.name, name);
-        if (resourceName.length > MAX_RESOURCE_NAME_LENGTH) {
+        if (resourceName.length > MAX_POLICY_ENGINE_RESOURCE_NAME_LENGTH) {
           ctx.addIssue({
             code: "custom",
             message:
               `Policy Engine resource name '${resourceName}' exceeds the service limit of ` +
-              `${MAX_RESOURCE_NAME_LENGTH} characters`,
+              `${MAX_POLICY_ENGINE_RESOURCE_NAME_LENGTH} characters`,
           });
         }
       }),
@@ -134,7 +133,12 @@ function AddPolicyEngineWizard({ project, core }: { project: Project; core: Scre
       breadcrumb={BREADCRUMB}
       description={DESCRIPTION}
       onCancel={() => navigate("/agentcore/project/add")}
-      onSubmit={() => core.projectManager.addResource(project, buildAddPolicyEngineInput(values))}
+      onSubmit={() =>
+        core.projectManager.addResource(
+          project,
+          toAddPolicyEngineInput(project, toPolicyEngineInput(values)),
+        )
+      }
       runningLabel={`adding Policy Engine ${values.name.trim()}…`}
       successLabel={`added Policy Engine '${values.name.trim()}' to '${project.name}'`}
       successHint="enter exits"
@@ -142,7 +146,7 @@ function AddPolicyEngineWizard({ project, core }: { project: Project; core: Scre
       <Step name="name" question="what should this Policy Engine be called?">
         <TextField
           label="policy engine name"
-          help={`deployed as ${project.name}_<name>, up to ${MAX_RESOURCE_NAME_LENGTH} characters`}
+          help={`deployed as ${project.name}_<name>, up to ${MAX_POLICY_ENGINE_RESOURCE_NAME_LENGTH} characters`}
           placeholder="access"
           value={values.name}
           onChange={(name) => set({ name })}

--- a/src/handlers/project/add/policy-engine/screen.tsx
+++ b/src/handlers/project/add/policy-engine/screen.tsx
@@ -1,0 +1,190 @@
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router";
+import z from "zod";
+import { ProjectKey } from "../../../../router";
+import type { PolicyEngineSchema } from "../../../../projectSchemas/policy";
+import type { ScreenProps } from "../../../types";
+import type { AddResourceInput, Project } from "../../types";
+import { ProjectGate } from "../../ProjectGate";
+import {
+  Wizard,
+  Step,
+  TextField,
+  ChoiceField,
+  MultiChoiceField,
+  Summary,
+} from "../../../../components/wizard";
+import { policyEngineResourceName } from "./index";
+
+const BREADCRUMB = ["agentcore", "project", "add", "policy-engine"];
+const DESCRIPTION = "adds a Policy Engine to the current project";
+
+// The service limit the handler enforces on the deployed engine name.
+const MAX_RESOURCE_NAME_LENGTH = 48;
+
+type AttachMode = "enforce" | "log-only";
+
+const ATTACH_MODE_CHOICES = [
+  {
+    value: "enforce" as AttachMode,
+    label: "enforce (default)",
+    description: "deny requests the policies reject",
+  },
+  {
+    value: "log-only" as AttachMode,
+    label: "log-only",
+    description: "record decisions without blocking anything",
+  },
+];
+
+interface PolicyEngineFormValues {
+  name: string;
+  description: string;
+  attachToGateways: string[];
+  attachMode: AttachMode;
+}
+
+export function buildAddPolicyEngineInput(values: PolicyEngineFormValues): AddResourceInput {
+  const engine: z.input<typeof PolicyEngineSchema> = {
+    name: values.name.trim(),
+    description: values.description.trim() === "" ? undefined : values.description.trim(),
+  };
+  return {
+    resourceType: "policy-engine",
+    resourceConfig: engine,
+    // The handler treats an absent --attach-to-gateways as "attach to nothing",
+    // and --attach-mode is meaningless without it.
+    attachGateways:
+      values.attachToGateways.length === 0
+        ? undefined
+        : {
+            names: values.attachToGateways,
+            mode: values.attachMode === "log-only" ? "LOG_ONLY" : "ENFORCE",
+          },
+  };
+}
+
+function summaryOf(values: PolicyEngineFormValues): Record<string, string> {
+  return {
+    "policy engine": values.name.trim(),
+    ...(values.description.trim() === "" ? {} : { description: values.description.trim() }),
+    "attached gateways":
+      values.attachToGateways.length === 0 ? "none" : values.attachToGateways.join(", "),
+    ...(values.attachToGateways.length === 0 ? {} : { mode: values.attachMode }),
+  };
+}
+
+export function AddPolicyEngineScreen({ ctx, core }: ScreenProps) {
+  return (
+    <ProjectGate
+      core={core}
+      breadcrumb={BREADCRUMB}
+      description={DESCRIPTION}
+      seed={ctx.value(ProjectKey)}
+    >
+      {(project) => <AddPolicyEngineWizard project={project} core={core} />}
+    </ProjectGate>
+  );
+}
+
+function AddPolicyEngineWizard({ project, core }: { project: Project; core: ScreenProps["core"] }) {
+  const navigate = useNavigate();
+  const [values, setValues] = useState<PolicyEngineFormValues>({
+    name: "",
+    description: "",
+    attachToGateways: [],
+    attachMode: "enforce",
+  });
+  const set = (update: Partial<PolicyEngineFormValues>) =>
+    setValues((current) => ({ ...current, ...update }));
+
+  const nameSchema = useMemo(
+    () =>
+      z.string().superRefine((name, ctx) => {
+        const resourceName = policyEngineResourceName(project.name, name);
+        if (resourceName.length > MAX_RESOURCE_NAME_LENGTH) {
+          ctx.addIssue({
+            code: "custom",
+            message:
+              `Policy Engine resource name '${resourceName}' exceeds the service limit of ` +
+              `${MAX_RESOURCE_NAME_LENGTH} characters`,
+          });
+        }
+      }),
+    [project.name],
+  );
+
+  // Attachment targets are the Gateways this project already declares, so the
+  // step is offered only when there is something to attach to.
+  const gatewayChoices = useMemo(
+    () =>
+      (project.spec.agentCoreGateways ?? []).map((gateway) => ({
+        value: gateway.name,
+        label: gateway.name,
+        description: gateway.description ?? gateway.protocolType,
+      })),
+    [project.spec.agentCoreGateways],
+  );
+
+  const hasGateways = gatewayChoices.length > 0;
+  const isAttaching = values.attachToGateways.length > 0;
+
+  return (
+    <Wizard
+      breadcrumb={BREADCRUMB}
+      description={DESCRIPTION}
+      onCancel={() => navigate("/agentcore/project/add")}
+      onSubmit={() => core.projectManager.addResource(project, buildAddPolicyEngineInput(values))}
+      runningLabel={`adding Policy Engine ${values.name.trim()}…`}
+      successLabel={`added Policy Engine '${values.name.trim()}' to '${project.name}'`}
+      successHint="enter exits"
+    >
+      <Step name="name" question="what should this Policy Engine be called?">
+        <TextField
+          label="policy engine name"
+          help={`deployed as ${project.name}_<name>, up to ${MAX_RESOURCE_NAME_LENGTH} characters`}
+          placeholder="access"
+          value={values.name}
+          onChange={(name) => set({ name })}
+          required
+          schema={nameSchema}
+        />
+      </Step>
+
+      <Step name="description" question="what does this engine govern? (optional)">
+        <TextField
+          label="description"
+          placeholder="tool access rules"
+          value={values.description}
+          onChange={(description) => set({ description })}
+        />
+      </Step>
+
+      {hasGateways && (
+        <Step name="attach" title="attach" question="which Gateways should this engine govern?">
+          <MultiChoiceField
+            label="project gateways"
+            help="leave empty to attach nothing for now"
+            choices={gatewayChoices}
+            value={values.attachToGateways}
+            onChange={(attachToGateways) => set({ attachToGateways })}
+          />
+        </Step>
+      )}
+
+      {hasGateways && isAttaching && (
+        <Step name="mode" question="how should the attached Gateways enforce this engine?">
+          <ChoiceField
+            choices={ATTACH_MODE_CHOICES}
+            value={values.attachMode}
+            onChange={(attachMode) => set({ attachMode })}
+          />
+        </Step>
+      )}
+
+      <Step name="review" question="this Policy Engine will be added to agentcore.json">
+        <Summary items={summaryOf(values)} />
+      </Step>
+    </Wizard>
+  );
+}

--- a/src/handlers/project/add/policy/index.ts
+++ b/src/handlers/project/add/policy/index.ts
@@ -1,14 +1,20 @@
 import z from "zod";
 import { InputValidationError } from "../../../../errors";
 import { SourceResolver } from "../../../../io";
-import type { PolicySchema } from "../../../../projectSchemas/policy";
+import type {
+  AuthorizationPhase,
+  EnforcementMode,
+  PolicySchema,
+  ValidationMode,
+} from "../../../../projectSchemas/policy";
 import { createHandler, flag, ProjectKey } from "../../../../router";
+import type { AddResourceInput } from "../../types";
 import type { AddProjectResourceConfig } from "../types";
 
 /**
  A substring heuristic, not a Cedar parser; --authorization-phase overrides it.
 **/
-export function inferAuthorizationPhase(statement: string): "INITIATE" | "RETURN_OUTPUT" {
+export function inferAuthorizationPhase(statement: string): AuthorizationPhase {
   return /\bsuppressOutput\b|context\.output/.test(statement) ? "RETURN_OUTPUT" : "INITIATE";
 }
 
@@ -18,6 +24,42 @@ const VALIDATION_MODES = {
   "ignore-all-findings": "IGNORE_ALL_FINDINGS",
 } as const;
 const ENFORCEMENT_MODES = { active: "ACTIVE", "log-only": "LOG_ONLY" } as const;
+
+/**
+ * PolicyInput is what every entry point — the flag handler, the wizard —
+ * resolves its own inputs to before a Policy is built. `statement` is the Cedar
+ * text itself, already read from wherever the user kept it. Anything optional
+ * is a field toAddPolicyInput defaults, or leaves to the project schema.
+ */
+export interface PolicyInput {
+  engineName: string;
+  name: string;
+  statement: string;
+  /** Where `statement` was read from, when it was a file; recorded on the Policy. */
+  sourceFile?: string;
+  description?: string;
+  validationMode?: ValidationMode;
+  enforcementMode?: EnforcementMode;
+  /** Inferred from the statement when absent. */
+  authorizationPhase?: AuthorizationPhase;
+}
+
+/**
+ * toAddPolicyInput is the one place a Policy is assembled from user input,
+ * including the phase inference. Both the flag handler and the wizard call it.
+ */
+export function toAddPolicyInput(input: PolicyInput): AddResourceInput {
+  const policy: z.input<typeof PolicySchema> = {
+    name: input.name,
+    description: input.description,
+    statement: input.statement,
+    sourceFile: input.sourceFile,
+    validationMode: input.validationMode,
+    enforcementMode: input.enforcementMode,
+    authorizationPhase: input.authorizationPhase ?? inferAuthorizationPhase(input.statement),
+  };
+  return { resourceType: "policy", engineName: input.engineName, resourceConfig: policy };
+}
 
 export const createAddPolicyHandler = (config: AddProjectResourceConfig) =>
   createHandler({
@@ -48,6 +90,9 @@ export const createAddPolicyHandler = (config: AddProjectResourceConfig) =>
         z.enum(["initiate", "return-output"]).optional(),
       ),
     ],
+    // handle only turns flags into a PolicyInput — reading the statement from
+    // its source, mapping the kebab-case flag values. What a Policy is belongs
+    // to toAddPolicyInput.
     handle: async (ctx, flags) => {
       if (!flags.engine) {
         throw new InputValidationError("required option '--engine <engine>' not specified");
@@ -66,25 +111,18 @@ export const createAddPolicyHandler = (config: AddProjectResourceConfig) =>
         ? flags.statement.slice("file://".length)
         : undefined;
 
-      const authorizationPhase = flags["authorization-phase"]
-        ? PHASES[flags["authorization-phase"]]
-        : inferAuthorizationPhase(statement);
-
-      const policy: z.input<typeof PolicySchema> = {
+      const input = toAddPolicyInput({
+        engineName: flags.engine,
         name: flags.name,
-        description: flags.description,
         statement,
         sourceFile,
+        description: flags.description,
         validationMode: flags["validation-mode"] && VALIDATION_MODES[flags["validation-mode"]],
         enforcementMode: flags["enforcement-mode"] && ENFORCEMENT_MODES[flags["enforcement-mode"]],
-        authorizationPhase,
-      };
+        authorizationPhase: flags["authorization-phase"] && PHASES[flags["authorization-phase"]],
+      });
 
-      for await (const event of config.projectManager.addResource(project, {
-        resourceType: "policy",
-        engineName: flags.engine,
-        resourceConfig: policy,
-      })) {
+      for await (const event of config.projectManager.addResource(project, input)) {
         config.io.stderr.write(`${event.message}\n`);
       }
       config.io.stderr.write(

--- a/src/handlers/project/add/policy/policy.screen.test.tsx
+++ b/src/handlers/project/add/policy/policy.screen.test.tsx
@@ -1,0 +1,94 @@
+import { test, expect, describe, afterEach } from "bun:test";
+import {
+  renderScreen,
+  waitForText,
+  waitForFlatText,
+  flatFrame,
+  cleanupScreens,
+} from "../../../../testing";
+import { createGatewayProjectTestHarness } from "../gateway-test-support";
+
+const { cleanup, inProject, projectSpec, run } =
+  createGatewayProjectTestHarness("add-policy-wizard");
+
+afterEach(cleanup);
+afterEach(cleanupScreens);
+
+const FORBID_ALL = "forbid(principal, action, resource);";
+
+describe("project add policy wizard", () => {
+  test("names the missing Policy Engine when the project has none", async () => {
+    await inProject();
+    const r = renderScreen("/agentcore/project/add/policy");
+
+    await waitForText(r.lastFrame, "has no Policy Engines yet");
+    expect(r.lastFrame()).toContain("agentcore project add policy-engine");
+
+    await r.press("escape");
+    await waitForText(r.lastFrame, "add project resources");
+    r.unmount();
+  });
+
+  test("writes the same Policy the flag path writes, with the phase inferred", async () => {
+    const projectRoot = await inProject();
+    await run(["add", "policy-engine", "--name", "Guardrails"]);
+    const r = renderScreen("/agentcore/project/add/policy");
+
+    await waitForText(r.lastFrame, "which Policy Engine should hold this Policy?");
+    expect(r.lastFrame()).toContain("● Guardrails");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "what should this Policy be called?");
+    await r.write("DenyAll");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "paste the Cedar statement");
+    await r.write(FORBID_ALL);
+    await r.write("\x04");
+
+    await waitForText(r.lastFrame, "when should this Policy be evaluated?");
+    await r.press("return");
+    await waitForText(r.lastFrame, "what should happen if the validator flags the statement?");
+    await r.press("return");
+    await waitForText(r.lastFrame, "how should this Policy be enforced?");
+    await r.press("return");
+    await waitForText(r.lastFrame, "what does this Policy do?");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "this Policy will be added to agentcore.json");
+    const review = flatFrame(r.lastFrame);
+    expect(review).toContain("policy DenyAll");
+    expect(review).toContain("engine Guardrails");
+    expect(review).toContain("phase INITIATE (inferred)");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "added Policy 'DenyAll' to Policy Engine 'Guardrails'");
+
+    const policies = (await projectSpec(projectRoot)).policyEngines[0].policies;
+    expect(policies).toHaveLength(1);
+    expect(policies[0]).toMatchObject({
+      name: "DenyAll",
+      statement: FORBID_ALL,
+      authorizationPhase: "INITIATE",
+      validationMode: "FAIL_ON_ANY_FINDINGS",
+      enforcementMode: "ACTIVE",
+    });
+    r.unmount();
+  });
+
+  test("a name that breaks the schema's pattern is rejected", async () => {
+    await inProject();
+    await run(["add", "policy-engine", "--name", "Guardrails"]);
+    const r = renderScreen("/agentcore/project/add/policy");
+
+    await waitForText(r.lastFrame, "which Policy Engine should hold this Policy?");
+    await r.press("return");
+    await waitForText(r.lastFrame, "what should this Policy be called?");
+    await r.write("bad-name");
+    await r.press("return");
+
+    await waitForFlatText(r.lastFrame, "Must begin with a letter");
+    expect(r.lastFrame()).toContain("what should this Policy be called?");
+    r.unmount();
+  });
+});

--- a/src/handlers/project/add/policy/screen.tsx
+++ b/src/handlers/project/add/policy/screen.tsx
@@ -1,0 +1,240 @@
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router";
+import { ProjectKey } from "../../../../router";
+import {
+  PolicyNameSchema,
+  type AuthorizationPhase,
+  type EnforcementMode,
+  type ValidationMode,
+} from "../../../../projectSchemas/policy";
+import type { ScreenProps } from "../../../types";
+import type { Project } from "../../types";
+import { ProjectGate } from "../../ProjectGate";
+import {
+  Wizard,
+  Step,
+  TextField,
+  TextAreaField,
+  ChoiceField,
+  Summary,
+  Prerequisite,
+  blankToUndefined,
+} from "../../../../components/wizard";
+import { inferAuthorizationPhase, toAddPolicyInput, type PolicyInput } from "./index";
+
+const BREADCRUMB = ["agentcore", "project", "add", "policy"];
+const DESCRIPTION = "adds a Cedar Policy to a project Policy Engine";
+const ADD_MENU = "/agentcore/project/add";
+
+// "infer" is the wizard's stand-in for leaving --authorization-phase unset:
+// the builder reads the statement and decides.
+type PhaseChoice = AuthorizationPhase | "infer";
+
+const PHASE_CHOICES = [
+  {
+    value: "infer" as PhaseChoice,
+    label: "infer from the statement (default)",
+    description: "RETURN_OUTPUT when it mentions suppressOutput or context.output",
+  },
+  { value: "INITIATE" as PhaseChoice, label: "INITIATE", description: "evaluate before the call" },
+  {
+    value: "RETURN_OUTPUT" as PhaseChoice,
+    label: "RETURN_OUTPUT",
+    description: "evaluate against the call's output",
+  },
+];
+
+const VALIDATION_CHOICES = [
+  {
+    value: "FAIL_ON_ANY_FINDINGS" as ValidationMode,
+    label: "fail on any findings (default)",
+    description: "refuse to deploy a statement the validator flags",
+  },
+  {
+    value: "IGNORE_ALL_FINDINGS" as ValidationMode,
+    label: "ignore all findings",
+    description: "deploy regardless of validator findings",
+  },
+];
+
+const ENFORCEMENT_CHOICES = [
+  {
+    value: "ACTIVE" as EnforcementMode,
+    label: "active (default)",
+    description: "deny requests this Policy forbids",
+  },
+  {
+    value: "LOG_ONLY" as EnforcementMode,
+    label: "log-only",
+    description: "record decisions without blocking anything",
+  },
+];
+
+interface PolicyFormValues {
+  engineName: string;
+  name: string;
+  statement: string;
+  phase: PhaseChoice;
+  validationMode: ValidationMode;
+  enforcementMode: EnforcementMode;
+  description: string;
+}
+
+// toPolicyInput reads the form into the PolicyInput the handler's
+// toAddPolicyInput builds a Policy from. "infer" becomes an absent phase, so
+// the builder infers it exactly as it does when --authorization-phase is unset.
+export function toPolicyInput(values: PolicyFormValues): PolicyInput {
+  return {
+    engineName: values.engineName,
+    name: values.name.trim(),
+    statement: values.statement.trim(),
+    description: blankToUndefined(values.description),
+    validationMode: values.validationMode,
+    enforcementMode: values.enforcementMode,
+    authorizationPhase: values.phase === "infer" ? undefined : values.phase,
+  };
+}
+
+function summaryOf(values: PolicyFormValues): Record<string, string> {
+  const inferred = inferAuthorizationPhase(values.statement);
+  return {
+    policy: values.name.trim(),
+    engine: values.engineName,
+    phase: values.phase === "infer" ? `${inferred} (inferred)` : values.phase,
+    validation: values.validationMode,
+    enforcement: values.enforcementMode,
+    ...(values.description.trim() === "" ? {} : { description: values.description.trim() }),
+  };
+}
+
+export function AddPolicyScreen({ ctx, core }: ScreenProps) {
+  return (
+    <ProjectGate
+      core={core}
+      breadcrumb={BREADCRUMB}
+      description={DESCRIPTION}
+      seed={ctx.value(ProjectKey)}
+    >
+      {(project) => <AddPolicyWizard project={project} core={core} />}
+    </ProjectGate>
+  );
+}
+
+function AddPolicyWizard({ project, core }: { project: Project; core: ScreenProps["core"] }) {
+  const navigate = useNavigate();
+
+  // A Policy lives inside a Policy Engine, so the first question is which one.
+  const engineChoices = useMemo(
+    () =>
+      project.spec.policyEngines.map((engine) => ({
+        value: engine.name,
+        label: engine.name,
+        description: engine.description ?? `${engine.policies?.length ?? 0} policies`,
+      })),
+    [project.spec.policyEngines],
+  );
+
+  const [values, setValues] = useState<PolicyFormValues>({
+    engineName: engineChoices[0]?.value ?? "",
+    name: "",
+    statement: "",
+    phase: "infer",
+    validationMode: "FAIL_ON_ANY_FINDINGS",
+    enforcementMode: "ACTIVE",
+    description: "",
+  });
+  const set = (update: Partial<PolicyFormValues>) =>
+    setValues((current) => ({ ...current, ...update }));
+
+  if (engineChoices.length === 0) {
+    return (
+      <Prerequisite
+        breadcrumb={BREADCRUMB}
+        description={DESCRIPTION}
+        message={`'${project.name}' has no Policy Engines yet; a Policy needs one to live in`}
+        command="agentcore project add policy-engine"
+        onBack={() => navigate(ADD_MENU)}
+      />
+    );
+  }
+
+  return (
+    <Wizard
+      breadcrumb={BREADCRUMB}
+      description={DESCRIPTION}
+      onCancel={() => navigate(ADD_MENU)}
+      onSubmit={() =>
+        core.projectManager.addResource(project, toAddPolicyInput(toPolicyInput(values)))
+      }
+      runningLabel={`adding Policy ${values.name.trim()}…`}
+      successLabel={`added Policy '${values.name.trim()}' to Policy Engine '${values.engineName}' in '${project.name}'`}
+      successHint="enter exits"
+    >
+      <Step name="engine" question="which Policy Engine should hold this Policy?">
+        <ChoiceField
+          choices={engineChoices}
+          value={values.engineName}
+          onChange={(engineName) => set({ engineName })}
+        />
+      </Step>
+
+      <Step name="name" question="what should this Policy be called?">
+        <TextField
+          label="policy name"
+          placeholder="DenyDeletes"
+          value={values.name}
+          onChange={(name) => set({ name })}
+          required
+          schema={PolicyNameSchema}
+        />
+      </Step>
+
+      <Step name="statement" question="paste the Cedar statement">
+        <TextAreaField
+          label="Cedar statement"
+          placeholder='forbid(principal, action == Action::"delete", resource);'
+          value={values.statement}
+          onChange={(statement) => set({ statement })}
+          required
+        />
+      </Step>
+
+      <Step name="phase" question="when should this Policy be evaluated?">
+        <ChoiceField
+          choices={PHASE_CHOICES}
+          value={values.phase}
+          onChange={(phase) => set({ phase })}
+        />
+      </Step>
+
+      <Step name="validation" question="what should happen if the validator flags the statement?">
+        <ChoiceField
+          choices={VALIDATION_CHOICES}
+          value={values.validationMode}
+          onChange={(validationMode) => set({ validationMode })}
+        />
+      </Step>
+
+      <Step name="enforcement" question="how should this Policy be enforced?">
+        <ChoiceField
+          choices={ENFORCEMENT_CHOICES}
+          value={values.enforcementMode}
+          onChange={(enforcementMode) => set({ enforcementMode })}
+        />
+      </Step>
+
+      <Step name="description" question="what does this Policy do? (optional)">
+        <TextField
+          label="description"
+          placeholder="blocks destructive tool calls"
+          value={values.description}
+          onChange={(description) => set({ description })}
+        />
+      </Step>
+
+      <Step name="review" question="this Policy will be added to agentcore.json">
+        <Summary items={summaryOf(values)} />
+      </Step>
+    </Wizard>
+  );
+}

--- a/src/handlers/project/add/screen.tsx
+++ b/src/handlers/project/add/screen.tsx
@@ -1,0 +1,9 @@
+import { RouterScreen } from "../../../components/RouterScreen";
+import type { ScreenProps } from "../../types";
+
+// AddScreen is the `agentcore project add` menu. RouterScreen reads the
+// subcommands straight off the compiled Commander tree, so a new `project add`
+// resource appears here without touching this file.
+export function AddScreen(props: ScreenProps) {
+  return <RouterScreen {...props} path={["agentcore", "project", "add"]} />;
+}

--- a/src/handlers/project/project.screen.test.tsx
+++ b/src/handlers/project/project.screen.test.tsx
@@ -76,24 +76,23 @@ describe("project subcommands without a screen", () => {
   // Reading the cases off the router also guards Root's hand-written
   // PROJECT_COMMANDS: an unrouted subcommand hits the catch-all, which resolves
   // instead of rejecting. Frames can't detect that — the catch-all exits before
-  // painting, so it and this screen both render empty. `create` and `invoke`
-  // are excluded because both have real screens.
-  test.each(projectSubcommands().filter((command) => command !== "create" && command !== "invoke"))(
-    "%s tears down the TUI with NotImplementedError",
-    async (command) => {
-      const { streams } = ttyTestIO();
+  // painting, so it and this screen both render empty. `create`, `invoke` and
+  // `add` are excluded because all three have real screens.
+  test.each(
+    projectSubcommands().filter((command) => !["create", "invoke", "add"].includes(command)),
+  )("%s tears down the TUI with NotImplementedError", async (command) => {
+    const { streams } = ttyTestIO();
 
-      const rendering = renderTuiAt(
-        `/agentcore/project/${command}`,
-        ValueContext.EmptyContext(),
-        new TestCoreClient(),
-        streams.io,
-      );
+    const rendering = renderTuiAt(
+      `/agentcore/project/${command}`,
+      ValueContext.EmptyContext(),
+      new TestCoreClient(),
+      streams.io,
+    );
 
-      await expect(rendering).rejects.toThrow(NotImplementedError);
-      await expect(rendering).rejects.toThrow(`'agentcore project ${command}'`);
-    },
-  );
+    await expect(rendering).rejects.toThrow(NotImplementedError);
+    await expect(rendering).rejects.toThrow(`'agentcore project ${command}'`);
+  });
 
   test("the error names the command to run instead", async () => {
     const { streams } = ttyTestIO();

--- a/src/projectSchemas/online-eval-config.ts
+++ b/src/projectSchemas/online-eval-config.ts
@@ -15,12 +15,13 @@ export const ClusteringConfigSchema = z.object({
     .max(3),
 });
 export type ClusteringConfig = z.infer<typeof ClusteringConfigSchema>;
+export const LogGroupNamesSchema = z.array(z.string().min(1)).min(1).max(5);
 export const OnlineEvalConfigSchema = z
   .object({
     name: OnlineEvalConfigNameSchema,
     agent: z.string().min(1, "Agent name is required").optional(),
     endpoint: z.string().min(1).optional(),
-    logGroupNames: z.array(z.string().min(1)).min(1).max(5).optional(),
+    logGroupNames: LogGroupNamesSchema.optional(),
     serviceNames: z.array(z.string().min(1)).min(1).optional(),
     evaluators: z.array(z.string().min(1)).optional(),
     insights: z.array(z.string().min(1)).optional(),

--- a/src/testing/index.tsx
+++ b/src/testing/index.tsx
@@ -24,6 +24,8 @@ export {
   cleanupScreens,
   keys,
   waitForText,
+  waitForFlatText,
+  flatFrame,
   type RenderScreenOptions,
   type RenderScreenResult,
 } from "./renderScreen";

--- a/src/testing/renderScreen.tsx
+++ b/src/testing/renderScreen.tsx
@@ -170,3 +170,20 @@ export function waitForText(
 ): Promise<void> {
   return waitFor(() => (lastFrame() ?? "").includes(text), timeoutMs);
 }
+
+// flatFrame collapses a frame's line breaks and runs of spaces into single
+// spaces. Ink hard-wraps at the terminal width, so a long message — a schema's
+// validation error, say — is split across lines at an unpredictable word.
+// Asserting against the flattened frame matches the sentence the user reads.
+export function flatFrame(lastFrame: () => string | undefined): string {
+  return (lastFrame() ?? "").replace(/\s+/g, " ");
+}
+
+// waitForFlatText is waitForText against the flattened frame.
+export function waitForFlatText(
+  lastFrame: () => string | undefined,
+  text: string,
+  timeoutMs = 1000,
+): Promise<void> {
+  return waitFor(() => flatFrame(lastFrame).includes(text), timeoutMs);
+}


### PR DESCRIPTION
> **Stacked on #2166.** Review only the last commit (`64b98a77`); the rest is #2166. Once that merges, this diff collapses to it.

## What

Six more `project add` resources get a wizard, on the shell #2166 introduced: **policy**, **gateway-connector**, **online-eval**, **online-insight**, **evaluator llm-as-a-judge**, **payment-manager**. That makes ten of fifteen. The remaining five (`harness`, `runtime`, `credentials`, `gateway-target`, `payment-connector`) keep the not-implemented screen.

| resource | steps (*italic* = conditional) |
|---|---|
| `policy` | engine → name → statement → phase → validation → enforcement → description → review |
| `gateway-connector` | gateway → connector → *knowledge base* → *knowledge base ID* → name → review |
| `online-eval` | name → *source* → *agent* → *endpoint* / *log groups* → *services* → *project evaluators* → evaluators → sampling → enabled → description → review |
| `online-insight` | name → *source* → … → insights → clustering → sampling → enabled → description → review |
| `evaluator` | a menu; `llm-as-a-judge`: name → level → model → instructions → scale → *custom scale* → description → review |
| `payment-manager` | name → authorizer → *issuer* → *clients* → *audience* → *scopes* → auto-payment → spend limit → description → review |

Where a project resource can answer a question, it is offered: `policy` picks from the project's Policy Engines, `gateway-connector` from its Gateways and Knowledge Bases, `online-eval` from its runtimes and evaluators. Where the project has none and the wizard cannot proceed without one, a `Prerequisite` screen names what is missing and the command that adds it.

## Design

Each resource follows the recipe #2166 established, unchanged:

```
flags ──(resolve file://, parse JSON, pair flags)──┐
                                                    ├──► toAddXxxInput(input) ──► projectManager.addResource
form  ──(trim, split lists, drop hidden-step answers)┘
```

The handler exports `XxxInput` + `toAddXxxInput`; `handle` reduces to flag conversion; the screen's `onSubmit` reduces to form conversion. Every existing flag test now exercises the shared builder, and the screen tests exercise the same builder from the form side — so the two paths write byte-identical `agentcore.json` entries, which the tests assert with `toEqual` against the full object.

Two things moved *into* builders that had been handler-body-only: online-insight's `Builtin.Insight.*`/ARN check (now `InsightIdSchema`, also used by the wizard step), and llm-as-a-judge's model-ID check (now `JudgeModelSchema`, likewise). gateway-connector's builder takes a discriminated `target` — shortcut or complete configuration — so the JSON path goes through it too rather than around it.

## Shell additions

Both small, both driven by these six:

- **`Prerequisite`** — for a wizard whose first question has no possible answer. esc returns to the add menu.
- **`values.ts`** — `blankToUndefined`, `splitList`, `numberSchema`. Text answers → the typed values builders take. memory's retention step now uses `numberSchema` instead of its own copy.

`online-eval` and `online-insight` share their source/sampling/enable steps through `monitoring-steps.tsx` — a hook returning arrays of `<Step>`s, which `React.Children.toArray` flattens into the wizard's step list. The two wizards ask the same questions in the same words and produce the same shapes.

`evaluator` is a command group, so `agentcore/project/add/evaluator` is a `RouterScreen` menu like `add` itself, reading its kinds off the Commander tree.

## Decisions worth a reviewer's attention

- **Curation.** The wizards don't ask everything the flags accept. Skipped: `--tags`, `--kms-key-arn`, `--encryption-key-arn` (all six); payment-manager's `--tool-allowlist` and `--network-preferences`; gateway-connector's `--connector-configuration` JSON path. All remain available on the command line and pass through the same builder.
- **Builtin IDs are typed, not picked.** There's no list of `Builtin.*` evaluators or insights in the codebase, so those steps are comma-separated text. Project evaluators are offered as a multi-select first, and the text step is `required` only when nothing was picked there — the schema's "at least one evaluator" rule is never reached at submit.
- **`LogGroupNamesSchema`** is extracted from `OnlineEvalConfigSchema` (same definition, now named) so the log-groups step validates against the schema's own 1–5 bound.
- **Warnings carry over.** payment-manager's post-success stderr warnings (auto-payment enabled; runtimes need SDK config) are shown in the wizard's success hint from the same exported strings.

## Testing

`bun test`: **2656 pass, 0 fail**. `tsc --noEmit`, `oxlint` (1.74 and 1.80), `prettier --check` clean.

17 new screen tests. Each resource has a "same as the flag path" test asserting the written spec with `toEqual`, plus its branch behaviour (prerequisite screens, conditional steps, picker vs. text) and one field-validation case using the schema's own message.
