### PR TITLE
fix(create): default the LiteLLM harness model to a keyless bedrock model

### DIFF
--- a/src/handlers/project/create/create.screen.test.tsx
+++ b/src/handlers/project/create/create.screen.test.tsx
@@ -22,6 +22,7 @@ import { InputValidationError } from "../../../errors";
 import type { AppIO } from "../../../io";
 import { resolveRuntimeTemplateShortcut } from "../shortcuts";
 import type { CreateProjectInput } from "../types";
+import { HARNESS_DEFAULT_MODEL_IDS } from "./index";
 
 afterEach(cleanupScreens);
 
@@ -217,6 +218,47 @@ describe("project create wizard", () => {
       modelId: "gpt-5",
       apiKeyArn,
     });
+    r.unmount();
+  }, 10000);
+
+  // The wizard pre-fills a model id, so pressing through it deploys that value.
+  // It must therefore match the flag path's default rather than a second literal
+  // — a keyless bedrock/ id, not one that needs an Anthropic key it never asks for.
+  test("the litellm default offered by the wizard matches the flag path", async () => {
+    const core = new TestCoreClient();
+    const inputs = spyOnCreate(core);
+    const r = renderScreen("/agentcore/project/create", { core });
+    await inTempDirectory();
+
+    await waitForText(r.lastFrame, "name your project");
+    await r.write("LiteLlmDefaultApp");
+    await r.press("return");
+    await waitForText(r.lastFrame, "what should the project be built around?");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "choose a model");
+    await r.press("down");
+    await r.press("down");
+    await r.press("down");
+    expect(r.lastFrame()).toContain("● litellm");
+
+    await r.press("return"); // focus model id, pre-filled with the shared default
+    expect(r.lastFrame()).toContain(HARNESS_DEFAULT_MODEL_IDS.lite_llm);
+    await r.press("return"); // accept it; api key arn and api base are optional
+    await r.press("return");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "this project will be created");
+    await r.press("return");
+    await waitForText(r.lastFrame, "project created in ./LiteLlmDefaultApp", 5000);
+
+    expect(inputs[0]?.scaffoldHarnessInput?.model).toEqual({
+      provider: "lite_llm",
+      modelId: HARNESS_DEFAULT_MODEL_IDS.lite_llm,
+    });
+    // bedrock/ is the property that makes the default keyless; an anthropic/ id
+    // would deploy READY and then fail its first invoke.
+    expect(HARNESS_DEFAULT_MODEL_IDS.lite_llm).toStartWith("bedrock/");
     r.unmount();
   }, 10000);
 

--- a/src/handlers/project/create/create.screen.test.tsx
+++ b/src/handlers/project/create/create.screen.test.tsx
@@ -22,7 +22,6 @@ import { InputValidationError } from "../../../errors";
 import type { AppIO } from "../../../io";
 import { resolveRuntimeTemplateShortcut } from "../shortcuts";
 import type { CreateProjectInput } from "../types";
-import { HARNESS_DEFAULT_MODEL_IDS } from "./index";
 
 afterEach(cleanupScreens);
 
@@ -218,47 +217,6 @@ describe("project create wizard", () => {
       modelId: "gpt-5",
       apiKeyArn,
     });
-    r.unmount();
-  }, 10000);
-
-  // The wizard pre-fills a model id, so pressing through it deploys that value.
-  // It must therefore match the flag path's default rather than a second literal
-  // — a keyless bedrock/ id, not one that needs an Anthropic key it never asks for.
-  test("the litellm default offered by the wizard matches the flag path", async () => {
-    const core = new TestCoreClient();
-    const inputs = spyOnCreate(core);
-    const r = renderScreen("/agentcore/project/create", { core });
-    await inTempDirectory();
-
-    await waitForText(r.lastFrame, "name your project");
-    await r.write("LiteLlmDefaultApp");
-    await r.press("return");
-    await waitForText(r.lastFrame, "what should the project be built around?");
-    await r.press("return");
-
-    await waitForText(r.lastFrame, "choose a model");
-    await r.press("down");
-    await r.press("down");
-    await r.press("down");
-    expect(r.lastFrame()).toContain("● litellm");
-
-    await r.press("return"); // focus model id, pre-filled with the shared default
-    expect(r.lastFrame()).toContain(HARNESS_DEFAULT_MODEL_IDS.lite_llm);
-    await r.press("return"); // accept it; api key arn and api base are optional
-    await r.press("return");
-    await r.press("return");
-
-    await waitForText(r.lastFrame, "this project will be created");
-    await r.press("return");
-    await waitForText(r.lastFrame, "project created in ./LiteLlmDefaultApp", 5000);
-
-    expect(inputs[0]?.scaffoldHarnessInput?.model).toEqual({
-      provider: "lite_llm",
-      modelId: HARNESS_DEFAULT_MODEL_IDS.lite_llm,
-    });
-    // bedrock/ is the property that makes the default keyless; an anthropic/ id
-    // would deploy READY and then fail its first invoke.
-    expect(HARNESS_DEFAULT_MODEL_IDS.lite_llm).toStartWith("bedrock/");
     r.unmount();
   }, 10000);
 

--- a/src/handlers/project/create/index.ts
+++ b/src/handlers/project/create/index.ts
@@ -76,7 +76,7 @@ const HARNESS_DEFAULT_MODEL_IDS: Record<HarnessModelProvider, string> = {
   bedrock: DEFAULT_HARNESS_MODEL.modelId,
   open_ai: "gpt-5",
   gemini: "gemini-2.5-flash",
-  lite_llm: "anthropic/claude-sonnet-4-5",
+  lite_llm: `bedrock/${DEFAULT_HARNESS_MODEL.modelId}`,
 };
 
 export const createCreateProjectHandler = (config: CreateProjectHandlerConfig) =>

--- a/src/handlers/project/create/index.ts
+++ b/src/handlers/project/create/index.ts
@@ -72,7 +72,7 @@ const HARNESS_ONLY_FLAGS = [
 const ModelProviderFlagSchema = z.union([z.literal("Bedrock"), HarnessModelProviderSchema]);
 type ModelProviderFlag = z.infer<typeof ModelProviderFlagSchema>;
 
-const HARNESS_DEFAULT_MODEL_IDS: Record<HarnessModelProvider, string> = {
+export const HARNESS_DEFAULT_MODEL_IDS: Record<HarnessModelProvider, string> = {
   bedrock: DEFAULT_HARNESS_MODEL.modelId,
   open_ai: "gpt-5",
   gemini: "gemini-2.5-flash",

--- a/src/handlers/project/create/screen.tsx
+++ b/src/handlers/project/create/screen.tsx
@@ -6,13 +6,12 @@ import { ProjectNameSchema } from "../../../projectSchemas/project";
 import type { HarnessModelProvider } from "../../../projectSchemas/harness";
 import type { ScreenProps } from "../../types";
 import type { CreateProjectInput } from "../types";
-import { DEFAULT_HARNESS_MODEL } from "../add/harness";
 import {
   resolveRuntimeTemplateShortcut,
   type MemoryShortcutName,
   type RuntimeTemplateShortcutName,
 } from "../shortcuts";
-import { resolveScaffoldHarnessInput } from "./index";
+import { HARNESS_DEFAULT_MODEL_IDS, resolveScaffoldHarnessInput } from "./index";
 import { Layout } from "../../../components/Layout";
 import { FormTextInput } from "../../../components/FormTextInput";
 import { FormRadioGroup, type FormRadioOption } from "../../../components/FormRadioGroup";
@@ -50,35 +49,32 @@ interface CreateProjectFormValues {
   memory: MemoryShortcutName;
 }
 
+// defaultModelId is not declared here: the wizard and the flag path must offer
+// the same default, so both read HARNESS_DEFAULT_MODEL_IDS.
 const MODEL_PROVIDERS: {
   provider: HarnessModelProvider;
   label: string;
   description: string;
-  defaultModelId: string;
 }[] = [
   {
     provider: "bedrock",
     label: "bedrock (recommended)",
     description: "an Amazon Bedrock model or inference profile",
-    defaultModelId: DEFAULT_HARNESS_MODEL.modelId,
   },
   {
     provider: "open_ai",
     label: "openai",
     description: "an OpenAI model using an API-key credential ARN",
-    defaultModelId: "gpt-5",
   },
   {
     provider: "gemini",
     label: "gemini",
     description: "a Google Gemini model using an API-key credential ARN",
-    defaultModelId: "gemini-2.5-flash",
   },
   {
     provider: "lite_llm",
     label: "litellm",
     description: "a third-party provider through LiteLLM",
-    defaultModelId: "anthropic/claude-sonnet-4-5",
   },
 ];
 
@@ -86,9 +82,9 @@ function emptyProjectModel(): ProjectModelValues {
   return {
     provider: "bedrock",
     configs: Object.fromEntries(
-      MODEL_PROVIDERS.map(({ provider, defaultModelId }) => [
+      MODEL_PROVIDERS.map(({ provider }) => [
         provider,
-        { modelId: defaultModelId, apiKeyArn: "", apiBase: "" },
+        { modelId: HARNESS_DEFAULT_MODEL_IDS[provider], apiKeyArn: "", apiBase: "" },
       ]),
     ) as Record<HarnessModelProvider, ProjectModelConfig>,
   };
@@ -553,7 +549,6 @@ interface ModelField {
 }
 
 function modelFields(provider: HarnessModelProvider): ModelField[] {
-  const option = MODEL_PROVIDERS.find((candidate) => candidate.provider === provider)!;
   const fields: ModelField[] = [
     {
       key: "modelId",
@@ -562,7 +557,7 @@ function modelFields(provider: HarnessModelProvider): ModelField[] {
         provider === "bedrock"
           ? "a Bedrock model or inference profile id"
           : `the ${providerLabel(provider)} model to use`,
-      placeholder: option.defaultModelId,
+      placeholder: HARNESS_DEFAULT_MODEL_IDS[provider],
       required: true,
       requiredError: `enter a model id for ${providerLabel(provider)}`,
     },

--- a/src/handlers/project/project.test.ts
+++ b/src/handlers/project/project.test.ts
@@ -185,7 +185,7 @@ describe("project create", () => {
     ).json();
     expect(harness.model).toEqual({
       provider: "lite_llm",
-      modelId: "anthropic/claude-sonnet-4-5",
+      modelId: "bedrock/global.anthropic.claude-sonnet-4-6",
       apiBase: "https://litellm.example.com/v1",
       additionalParams: { max_retries: 2 },
     });


### PR DESCRIPTION
Follow-up to #2150, which fixed the harness-first create defects the #2146 bug bash turned up. This one fixes the LiteLLM default that same bug bash surfaced.

## The default LiteLLM model required a key the CLI never asks for

**Before:** `HARNESS_DEFAULT_MODEL_IDS.lite_llm` was `anthropic/claude-sonnet-4-5`. That prefix routes LiteLLM at Anthropic directly, which needs an Anthropic API key — but `apiKeyArn` is optional for LiteLLM, so nothing stopped you. A default `project create --model-provider lite_llm` deployed to `READY` and then failed its first invoke with `litellm.AuthenticationError: Missing Anthropic API Key`.

**After:** the default derives from `DEFAULT_HARNESS_MODEL`, giving `bedrock/global.anthropic.claude-sonnet-4-6`. A `bedrock/` prefix routes LiteLLM at Bedrock, which it signs with SigV4 from the harness execution role — no API key, no `apiKeyArn`. Deriving rather than hardcoding also stops the `bedrock` and `lite_llm` defaults drifting apart.

Confirmed live in us-east-1:

| model id | `apiKeyArn` | result |
| --- | --- | --- |
| `anthropic/claude-sonnet-4-5` | omitted | LiteLLM `AuthenticationError` |
| `bedrock/global.anthropic.claude-sonnet-4-6` | omitted | authenticated via IAM, `end_turn`, nonzero `outputTokens` |
| `bedrock/us.amazon.nova-lite-v1:0` | omitted | authenticated via IAM, `end_turn`, nonzero `outputTokens` |

This matches the documented contract — the [Harness models guide](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/harness-models.html) states LiteLLM models using the `bedrock/` prefix use the execution role and need no API key, while direct providers require `apiKeyArn`. `anthropic/...` keeps requiring a key; only `bedrock/...` is keyless.

## The wizard shipped its own copy of that default

Found while fixing the above, and it would have silently undone it for TUI users.

`create/screen.tsx` declared `defaultModelId` per provider, duplicating all four values including `lite_llm: "anthropic/claude-sonnet-4-5"`. Fixing the flag path alone left the wizard pre-filling the broken id — and that value is form state, not placeholder text, so pressing enter through the wizard deployed it:

```
 model id
 the litellm model to use
 ╭──────────────────────────────────────────╮
 │❯ anthropic/claude-sonnet-4-5             │
 ╰──────────────────────────────────────────╯
```

`HARNESS_DEFAULT_MODEL_IDS` is now exported and supplies both the pre-filled value and the placeholder; `MODEL_PROVIDERS` describes only labels. The flag path and the wizard read one table, so they cannot disagree again.

## Testing

- `bun test`: 2735 pass, 0 fail. `typecheck`, `lint:check`, `format:check` clean.
- `project.test.ts` already pins the flag path's litellm default, and after this change the wizard reads the same table, so that one assertion covers both paths. No new wizard test: `MODEL_PROVIDERS` no longer declares a per-provider default, so there is no second literal left to drift.
- Live: `project create --model-provider lite_llm` writes `"modelId": "bedrock/global.anthropic.claude-sonnet-4-6"`, and that harness authenticates and completes. All AWS test resources were deleted.

## Note on the empty transcript, for anyone who tested this earlier

Until today, `agentcore harness invoke` rendered no assistant text for a `lite_llm` harness — the call
succeeded with `end_turn` and nonzero `outputTokens`, but nothing appeared. That was a harness-side
contract bug, not a CLI one: the LiteLLM provider path omitted `contentBlockIndex`, which
`invokeHarness.smithy` marks `@required` on all three content-block events, and the CLI correctly
rejects events that lack it.

The harness team had already fixed it (`LoopyRuntimeArtifacts`, "Emit contentBlockIndex as it is part
of the invoke harness contract") on 2026-08-27. It reached us-east-1 on 2026-09-02 at 16:37Z. Our
capture was taken on 2026-09-01, before the wave arrived, which is why we saw it.

No CLI change is needed for that, and this branch carries none. Mentioning it only because a reviewer
who tried a LiteLLM harness in the last few days may remember an empty transcript.
