### PR TITLE
feat(project): build and deploy TUI screens render the CLI's own progress steps

### DIFF
--- a/src/components/ConfirmAction.test.tsx
+++ b/src/components/ConfirmAction.test.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { afterEach, expect, test } from "bun:test";
+import { cleanup, render } from "ink-testing-library";
+import { MemoryRouter } from "react-router";
+import { waitForText } from "../testing";
+import { ConfirmAction, type ActionTrigger } from "./ConfirmAction";
+
+afterEach(cleanup);
+
+test("resolves the trigger after loading and does not skip a late confirmation", async () => {
+  let calls = 0;
+  const action = async () => {
+    calls += 1;
+    return { rows: {} };
+  };
+  const view = (isPending: boolean, trigger: ActionTrigger) => (
+    <MemoryRouter>
+      <ConfirmAction
+        breadcrumb={["agentcore", "test"]}
+        trigger={trigger}
+        isPending={isPending}
+        error={null}
+        action={action}
+        successTitle="Done"
+        runningLabel="running…"
+        onDone={() => {}}
+      />
+    </MemoryRouter>
+  );
+
+  const screen = render(view(true, { kind: "immediate" }));
+  screen.rerender(view(false, { kind: "confirm", message: "Delete everything?" }));
+
+  await waitForText(screen.lastFrame, "Delete everything?");
+  expect(calls).toBe(0);
+});

--- a/src/components/ConfirmAction.tsx
+++ b/src/components/ConfirmAction.tsx
@@ -5,8 +5,9 @@ import { Layout } from "./Layout";
 import { Spinner } from "./ui/spinner";
 import { Confirm } from "./ui/confirm";
 import { TaskList, type Task } from "./ui/task-list";
+import { KeyValueTable } from "./KeyValueTable";
 import { darkTheme } from "./ui/_core.js";
-import { applyProgressEvent, settleProgress, type ProgressEvent } from "../tui/progress";
+import { driveProgress, type ProgressEvent } from "../tui/progress";
 
 const theme = darkTheme;
 
@@ -14,6 +15,8 @@ export interface SummaryRow {
   label: string;
   value: string;
 }
+
+export type ActionResult = SummaryRow[] | { title: string; rows: SummaryRow[] };
 
 export interface ConfirmActionProps {
   // breadcrumb labels the screen.
@@ -30,13 +33,16 @@ export interface ConfirmActionProps {
   // isPending / error reflect the summary fetch backing the overlay.
   isPending: boolean;
   error: Error | null;
-  // action performs the confirmed operation and resolves to result rows shown
-  // on the success panel. A long-running operation may instead return a
-  // progress generator — the same AsyncGenerator<ProgressEvent> runWithProgress
-  // drives for the headless command — and its steps render as a live task list
-  // while it runs, exactly as they do on the command line.
-  action: () => Promise<SummaryRow[]> | AsyncGenerator<ProgressEvent, SummaryRow[]>;
-  // successTitle heads the success panel (e.g. "Harness deleted").
+  // action performs the confirmed operation and resolves to what the success
+  // panel shows: result rows, optionally under a title that replaces
+  // successTitle — for an outcome only known once the action has run. A
+  // long-running operation may instead return a progress generator — the same
+  // AsyncGenerator<ProgressEvent> runWithProgress drives for the headless
+  // command — and its steps render as a live task list while it runs, exactly
+  // as they do on the command line.
+  action: () => Promise<ActionResult> | AsyncGenerator<ProgressEvent, ActionResult>;
+  // successTitle heads the success panel (e.g. "Harness deleted") unless the
+  // action's result carries its own.
   successTitle: string;
   // runningLabel is the spinner label while the action runs, shown until the
   // action's first progress step arrives (or throughout, for a plain promise).
@@ -51,7 +57,7 @@ export interface ConfirmActionProps {
 type Phase =
   | { kind: "confirm" }
   | { kind: "running" }
-  | { kind: "success"; rows: SummaryRow[] }
+  | { kind: "success"; title: string; rows: SummaryRow[] }
   | { kind: "error"; message: string };
 
 // ConfirmAction is the shared destructive-action screen body: a summary overlay
@@ -84,22 +90,14 @@ export function ConfirmAction({
     setTasks([]);
     try {
       const result = action();
-      let rows: SummaryRow[];
-      if (isProgressGenerator(result)) {
-        let next = await result.next();
-        while (!next.done) {
-          const event = next.value;
-          setTasks((current) => applyProgressEvent(current, event));
-          next = await result.next();
-        }
-        rows = next.value;
-      } else {
-        rows = await result;
-      }
-      setTasks((current) => settleProgress(current, "done"));
-      setPhase({ kind: "success", rows });
+      const outcome = isProgressGenerator(result)
+        ? await driveProgress(result, setTasks)
+        : await result;
+      const { title, rows } = Array.isArray(outcome)
+        ? { title: successTitle, rows: outcome }
+        : outcome;
+      setPhase({ kind: "success", title, rows });
     } catch (err) {
-      setTasks((current) => settleProgress(current, "failed"));
       setPhase({ kind: "error", message: err instanceof Error ? err.message : String(err) });
     }
   };
@@ -113,10 +111,14 @@ export function ConfirmAction({
         ]
       : phase.kind === "success"
         ? [{ key: "enter", label: "continue" }]
-        : [
-            { key: "esc", label: "back" },
-            { key: "ctl+c", label: "quit" },
-          ];
+        : phase.kind === "running"
+          ? // Nothing listens for esc mid-action: an operation in flight is
+            // not abandoned by leaving the screen.
+            [{ key: "ctl+c", label: "quit" }]
+          : [
+              { key: "esc", label: "back" },
+              { key: "ctl+c", label: "quit" },
+            ];
 
   return (
     <Layout breadcrumb={breadcrumb} description={description} keyHints={hints}>
@@ -134,7 +136,7 @@ export function ConfirmAction({
             marginBottom={1}
           >
             <Text bold>{title}</Text>
-            <SummaryRows rows={rows} />
+            <KeyValueTable items={toItems(rows)} />
           </Box>
 
           {phase.kind === "confirm" && (
@@ -147,7 +149,7 @@ export function ConfirmAction({
           )}
           {phase.kind === "running" && tasks.length === 0 && <Spinner label={runningLabel} />}
           {phase.kind === "success" && (
-            <SuccessBody title={successTitle} rows={phase.rows} onDone={onDone} />
+            <SuccessBody title={phase.title} rows={phase.rows} onDone={onDone} />
           )}
           {phase.kind === "error" && (
             <ErrorBody message={phase.message} onBack={() => setPhase({ kind: "confirm" })} />
@@ -160,29 +162,18 @@ export function ConfirmAction({
 
 // A promise has no Symbol.asyncIterator, so this is a safe discriminator.
 function isProgressGenerator(
-  result: Promise<SummaryRow[]> | AsyncGenerator<ProgressEvent, SummaryRow[]>,
-): result is AsyncGenerator<ProgressEvent, SummaryRow[]> {
+  result: Promise<ActionResult> | AsyncGenerator<ProgressEvent, ActionResult>,
+): result is AsyncGenerator<ProgressEvent, ActionResult> {
   return (
-    typeof (result as AsyncGenerator<ProgressEvent, SummaryRow[]>)[Symbol.asyncIterator] ===
+    typeof (result as AsyncGenerator<ProgressEvent, ActionResult>)[Symbol.asyncIterator] ===
     "function"
   );
 }
 
-// SummaryRows aligns values on a column one past the longest label, so a
-// label longer than the old fixed width (a stack output name, say) still has a
-// gap before its value.
-function SummaryRows({ rows }: { rows: SummaryRow[] }) {
-  const width = rows.reduce((max, row) => Math.max(max, row.label.length), 0) + 2;
-  return (
-    <>
-      {rows.map((row) => (
-        <Text key={row.label}>
-          <Text color={theme.colors.muted}>{row.label.padEnd(width)}</Text>
-          {row.value}
-        </Text>
-      ))}
-    </>
-  );
+// KeyValueTable takes a record; rows are kept as a list here so callers can
+// order them.
+function toItems(rows: SummaryRow[]): Record<string, string> {
+  return Object.fromEntries(rows.map((row) => [row.label, row.value]));
 }
 
 function SuccessBody({
@@ -204,7 +195,7 @@ function SuccessBody({
         ✔ {title}
       </Text>
       <Box flexDirection="column" marginTop={1} marginLeft={2}>
-        <SummaryRows rows={rows} />
+        <KeyValueTable items={toItems(rows)} />
       </Box>
       <Box marginTop={1}>
         <Text color={theme.colors.muted}>

--- a/src/components/ConfirmAction.tsx
+++ b/src/components/ConfirmAction.tsx
@@ -18,6 +18,11 @@ export interface SummaryRow {
 
 export type ActionResult = SummaryRow[] | { title: string; rows: SummaryRow[] };
 
+// ActionTrigger says what starts the action: a y/N question the user answers
+// (destructive actions default to No), or nothing — it runs as soon as the
+// summary has loaded, for an operation that is safe to start unasked.
+export type ActionTrigger = { kind: "confirm"; message: string } | { kind: "immediate" };
+
 export interface ConfirmActionProps {
   // breadcrumb labels the screen.
   breadcrumb: string[];
@@ -28,9 +33,7 @@ export interface ConfirmActionProps {
   // rows describe the resource the action applies to. With neither title nor
   // rows the overlay is omitted.
   rows?: SummaryRow[];
-  // message is the yes/no question (destructive actions default to No). Omit it
-  // to skip the confirmation and run as soon as the summary loads.
-  message?: string;
+  trigger: ActionTrigger;
   // isPending / error reflect the summary fetch backing the overlay.
   isPending: boolean;
   error: Error | null;
@@ -56,8 +59,11 @@ export interface ConfirmActionProps {
   onCancel?: () => void;
 }
 
+// "confirm" waits on the question; "idle" waits on the summary for an immediate
+// trigger. Neither survives the first run.
 type Phase =
   | { kind: "confirm" }
+  | { kind: "idle" }
   | { kind: "running" }
   | { kind: "success"; title: string; rows: SummaryRow[] }
   | { kind: "error"; message: string };
@@ -70,7 +76,7 @@ export function ConfirmAction({
   description,
   title,
   rows = [],
-  message,
+  trigger,
   isPending,
   error,
   action,
@@ -83,8 +89,9 @@ export function ConfirmAction({
 }: ConfirmActionProps) {
   const navigate = useNavigate();
   const cancel = onCancel ?? (() => navigate(-1));
-  const [phase, setPhase] = useState<Phase>({ kind: "confirm" });
-  const confirms = message !== undefined;
+  const [phase, setPhase] = useState<Phase>({
+    kind: trigger.kind === "confirm" ? "confirm" : "idle",
+  });
   // tasks is the step list a progress-reporting action builds up; it stays on
   // screen through success and error.
   const [tasks, setTasks] = useState<Task[]>([]);
@@ -106,11 +113,11 @@ export function ConfirmAction({
     }
   };
 
-  // Without a question, run once the summary is ready.
+  // An immediate trigger runs once the summary is ready.
   useEffect(() => {
-    if (!confirms && !isPending && !error && phase.kind === "confirm") void run();
+    if (phase.kind === "idle" && !isPending && !error) void run();
     // eslint-disable-next-line react-hooks/exhaustive-deps -- the phase guard makes this run once
-  }, [confirms, isPending, error, phase.kind]);
+  }, [phase.kind, isPending, error]);
 
   const hints =
     phase.kind === "confirm"
@@ -121,14 +128,14 @@ export function ConfirmAction({
         ]
       : phase.kind === "success"
         ? [{ key: "enter", label: doneLabel }]
-        : phase.kind === "running"
-          ? // Nothing listens for esc mid-action: an operation in flight is
-            // not abandoned by leaving the screen.
-            [{ key: "ctl+c", label: "quit" }]
-          : [
+        : phase.kind === "error"
+          ? [
               { key: "esc", label: "back" },
               { key: "ctl+c", label: "quit" },
-            ];
+            ]
+          : // Nothing listens for esc while the action runs (or is about to):
+            // an operation in flight is not abandoned by leaving the screen.
+            [{ key: "ctl+c", label: "quit" }];
 
   return (
     <Layout breadcrumb={breadcrumb} description={description} keyHints={hints}>
@@ -151,8 +158,13 @@ export function ConfirmAction({
             </Box>
           )}
 
-          {phase.kind === "confirm" && confirms && (
-            <Confirm message={message} defaultValue={false} onConfirm={run} onCancel={cancel} />
+          {phase.kind === "confirm" && trigger.kind === "confirm" && (
+            <Confirm
+              message={trigger.message}
+              defaultValue={false}
+              onConfirm={run}
+              onCancel={cancel}
+            />
           )}
           {phase.kind !== "confirm" && tasks.length > 0 && (
             <Box marginBottom={phase.kind === "running" ? 0 : 1}>
@@ -170,10 +182,10 @@ export function ConfirmAction({
             />
           )}
           {phase.kind === "error" && (
-            // Without a confirmation, returning to it would run again.
+            // Without a question to return to, returning would run again.
             <ErrorBody
               message={phase.message}
-              onBack={confirms ? () => setPhase({ kind: "confirm" }) : cancel}
+              onBack={trigger.kind === "confirm" ? () => setPhase({ kind: "confirm" }) : cancel}
             />
           )}
         </Box>

--- a/src/components/ConfirmAction.tsx
+++ b/src/components/ConfirmAction.tsx
@@ -21,45 +21,38 @@ export type ActionResult = SummaryRow[] | { title: string; rows: SummaryRow[] };
 export interface ConfirmActionProps {
   // breadcrumb labels the screen.
   breadcrumb: string[];
-  // description is shown dimmed after the breadcrumb, e.g. the command's own
-  // description so the header matches `--help`.
+  // description is shown dimmed after the breadcrumb.
   description?: string;
   // title heads the summary overlay (usually the resource name).
   title?: string;
   // rows describe the resource the action applies to. With neither title nor
-  // rows the overlay is omitted, for an action whose breadcrumb says it all.
+  // rows the overlay is omitted.
   rows?: SummaryRow[];
   // message is the yes/no question (destructive actions default to No). Omit it
-  // to skip the confirmation and run the action as soon as the summary loads —
-  // for an operation that is safe to start without asking, like a build.
+  // to skip the confirmation and run as soon as the summary loads.
   message?: string;
   // isPending / error reflect the summary fetch backing the overlay.
   isPending: boolean;
   error: Error | null;
-  // action performs the confirmed operation and resolves to what the success
-  // panel shows: result rows, optionally under a title that replaces
-  // successTitle — for an outcome only known once the action has run. A
-  // long-running operation may instead return a progress generator — the same
-  // AsyncGenerator<ProgressEvent> runWithProgress drives for the headless
-  // command — and its steps render as a live task list while it runs, exactly
-  // as they do on the command line.
+  // action performs the confirmed operation and resolves to the result rows,
+  // optionally with a title overriding successTitle for an outcome only known
+  // afterwards. A progress generator (what runWithProgress drives) may be
+  // returned instead; its steps render as a live TaskList while it runs.
   action: () => Promise<ActionResult> | AsyncGenerator<ProgressEvent, ActionResult>;
   // successTitle heads the success panel (e.g. "Harness deleted") unless the
   // action's result carries its own.
   successTitle: string;
-  // runningLabel is the spinner label while the action runs, shown until the
-  // action's first progress step arrives (or throughout, for a plain promise).
+  // runningLabel is the spinner label while the action runs, until its first
+  // progress step arrives.
   runningLabel: string;
-  // nextSteps are commands suggested under the success panel, as the create
-  // wizard suggests `agentcore project deploy`.
+  // nextSteps are commands suggested under the success panel.
   nextSteps?: string[];
   // onDone is called when the user acknowledges the success panel; doneLabel
-  // says where that leads ("continue" by default, "go back" for a screen that
-  // returns to a menu).
+  // is the footer's word for it ("continue" by default).
   onDone: () => void;
   doneLabel?: string;
   // onCancel runs when the confirmation is declined or esc is pressed; defaults
-  // to popping the router history, which suits a screen reached from a picker.
+  // to popping the router history.
   onCancel?: () => void;
 }
 
@@ -92,9 +85,8 @@ export function ConfirmAction({
   const cancel = onCancel ?? (() => navigate(-1));
   const [phase, setPhase] = useState<Phase>({ kind: "confirm" });
   const confirms = message !== undefined;
-  // tasks is the step list a progress-reporting action builds up. It stays on
-  // screen through success and error, as the headless command leaves its
-  // completed steps in scrollback above the final line.
+  // tasks is the step list a progress-reporting action builds up; it stays on
+  // screen through success and error.
   const [tasks, setTasks] = useState<Task[]>([]);
 
   const run = async () => {
@@ -114,11 +106,10 @@ export function ConfirmAction({
     }
   };
 
-  // Without a question there is nothing to wait for: run once the summary is
-  // ready. Keyed on isPending/error so it fires exactly once, when they settle.
+  // Without a question, run once the summary is ready.
   useEffect(() => {
     if (!confirms && !isPending && !error && phase.kind === "confirm") void run();
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- run is recreated each render; the phase guard makes this idempotent
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- the phase guard makes this run once
   }, [confirms, isPending, error, phase.kind]);
 
   const hints =
@@ -179,8 +170,7 @@ export function ConfirmAction({
             />
           )}
           {phase.kind === "error" && (
-            // With a confirmation, esc returns to the question to try again;
-            // without one, returning would run again, so it leaves instead.
+            // Without a confirmation, returning to it would run again.
             <ErrorBody
               message={phase.message}
               onBack={confirms ? () => setPhase({ kind: "confirm" }) : cancel}
@@ -202,8 +192,6 @@ function isProgressGenerator(
   );
 }
 
-// KeyValueTable takes a record; rows are kept as a list here so callers can
-// order them.
 function toItems(rows: SummaryRow[]): Record<string, string> {
   return Object.fromEntries(rows.map((row) => [row.label, row.value]));
 }

--- a/src/components/ConfirmAction.tsx
+++ b/src/components/ConfirmAction.tsx
@@ -11,12 +11,12 @@ import { driveProgress, type ProgressEvent } from "../tui/progress";
 
 const theme = darkTheme;
 
-export interface SummaryRow {
-  label: string;
-  value: string;
-}
+export type SummaryRows = Record<string, string>;
 
-export type ActionResult = SummaryRow[] | { title: string; rows: SummaryRow[] };
+export interface ActionResult {
+  title?: string;
+  rows: SummaryRows;
+}
 
 // ActionTrigger says what starts the action: a y/N question the user answers
 // (destructive actions default to No), or nothing — it runs as soon as the
@@ -32,7 +32,7 @@ export interface ConfirmActionProps {
   title?: string;
   // rows describe the resource the action applies to. With neither title nor
   // rows the overlay is omitted.
-  rows?: SummaryRow[];
+  rows?: SummaryRows;
   trigger: ActionTrigger;
   // isPending / error reflect the summary fetch backing the overlay.
   isPending: boolean;
@@ -59,14 +59,14 @@ export interface ConfirmActionProps {
   onCancel?: () => void;
 }
 
-// "confirm" waits on the question; "idle" waits on the summary for an immediate
-// trigger. Neither survives the first run.
+// "waiting" snapshots the trigger once the summary is ready. A confirmation's
+// message then stays fixed through retries, even if a caller's props change.
 type Phase =
-  | { kind: "confirm" }
-  | { kind: "idle" }
+  | { kind: "waiting" }
+  | { kind: "confirm"; message: string }
   | { kind: "running" }
-  | { kind: "success"; title: string; rows: SummaryRow[] }
-  | { kind: "error"; message: string };
+  | { kind: "success"; title: string; rows: SummaryRows }
+  | { kind: "error"; message: string; retryMessage?: string };
 
 // ConfirmAction is the shared destructive-action screen body: a summary overlay
 // of the target resource, a y/N confirmation (defaulting to No), a spinner
@@ -75,7 +75,7 @@ export function ConfirmAction({
   breadcrumb,
   description,
   title,
-  rows = [],
+  rows = {},
   trigger,
   isPending,
   error,
@@ -89,14 +89,12 @@ export function ConfirmAction({
 }: ConfirmActionProps) {
   const navigate = useNavigate();
   const cancel = onCancel ?? (() => navigate(-1));
-  const [phase, setPhase] = useState<Phase>({
-    kind: trigger.kind === "confirm" ? "confirm" : "idle",
-  });
+  const [phase, setPhase] = useState<Phase>({ kind: "waiting" });
   // tasks is the step list a progress-reporting action builds up; it stays on
   // screen through success and error.
   const [tasks, setTasks] = useState<Task[]>([]);
 
-  const run = async () => {
+  const run = async (retryMessage?: string) => {
     setPhase({ kind: "running" });
     setTasks([]);
     try {
@@ -104,20 +102,25 @@ export function ConfirmAction({
       const outcome = isProgressGenerator(result)
         ? await driveProgress(result, setTasks)
         : await result;
-      const { title, rows } = Array.isArray(outcome)
-        ? { title: successTitle, rows: outcome }
-        : outcome;
-      setPhase({ kind: "success", title, rows });
+      setPhase({ kind: "success", title: outcome.title ?? successTitle, rows: outcome.rows });
     } catch (err) {
-      setPhase({ kind: "error", message: err instanceof Error ? err.message : String(err) });
+      setPhase({
+        kind: "error",
+        message: err instanceof Error ? err.message : String(err),
+        retryMessage,
+      });
     }
   };
 
-  // An immediate trigger runs once the summary is ready.
+  // Resolve the latest trigger only after the summary is ready. This prevents a
+  // destructive action from inheriting an earlier immediate trigger while its
+  // data was still loading.
   useEffect(() => {
-    if (phase.kind === "idle" && !isPending && !error) void run();
+    if (phase.kind !== "waiting" || isPending || error) return;
+    if (trigger.kind === "confirm") setPhase({ kind: "confirm", message: trigger.message });
+    else void run();
     // eslint-disable-next-line react-hooks/exhaustive-deps -- the phase guard makes this run once
-  }, [phase.kind, isPending, error]);
+  }, [phase.kind, isPending, error, trigger.kind]);
 
   const hints =
     phase.kind === "confirm"
@@ -145,7 +148,7 @@ export function ConfirmAction({
         <ErrorBody message={error.message} onBack={cancel} />
       ) : (
         <Box flexDirection="column" paddingX={1}>
-          {(title !== undefined || rows.length > 0) && (
+          {(title !== undefined || Object.keys(rows).length > 0) && (
             <Box
               flexDirection="column"
               borderStyle="round"
@@ -154,15 +157,15 @@ export function ConfirmAction({
               marginBottom={1}
             >
               {title !== undefined && <Text bold>{title}</Text>}
-              {rows.length > 0 && <KeyValueTable items={toItems(rows)} />}
+              {Object.keys(rows).length > 0 && <KeyValueTable items={rows} />}
             </Box>
           )}
 
-          {phase.kind === "confirm" && trigger.kind === "confirm" && (
+          {phase.kind === "confirm" && (
             <Confirm
-              message={trigger.message}
+              message={phase.message}
               defaultValue={false}
-              onConfirm={run}
+              onConfirm={() => run(phase.message)}
               onCancel={cancel}
             />
           )}
@@ -185,7 +188,11 @@ export function ConfirmAction({
             // Without a question to return to, returning would run again.
             <ErrorBody
               message={phase.message}
-              onBack={trigger.kind === "confirm" ? () => setPhase({ kind: "confirm" }) : cancel}
+              onBack={
+                phase.retryMessage !== undefined
+                  ? () => setPhase({ kind: "confirm", message: phase.retryMessage! })
+                  : cancel
+              }
             />
           )}
         </Box>
@@ -204,10 +211,6 @@ function isProgressGenerator(
   );
 }
 
-function toItems(rows: SummaryRow[]): Record<string, string> {
-  return Object.fromEntries(rows.map((row) => [row.label, row.value]));
-}
-
 function SuccessBody({
   title,
   rows,
@@ -216,7 +219,7 @@ function SuccessBody({
   doneLabel,
 }: {
   title: string;
-  rows: SummaryRow[];
+  rows: SummaryRows;
   nextSteps?: string[];
   onDone: () => void;
   doneLabel: string;
@@ -230,9 +233,9 @@ function SuccessBody({
       <Text color={theme.colors.success} bold>
         ✔ {title}
       </Text>
-      {rows.length > 0 && (
+      {Object.keys(rows).length > 0 && (
         <Box flexDirection="column" marginTop={1} marginLeft={2}>
-          <KeyValueTable items={toItems(rows)} />
+          <KeyValueTable items={rows} />
         </Box>
       )}
       {nextSteps !== undefined && nextSteps.length > 0 && (

--- a/src/components/ConfirmAction.tsx
+++ b/src/components/ConfirmAction.tsx
@@ -4,7 +4,9 @@ import { useNavigate } from "react-router";
 import { Layout } from "./Layout";
 import { Spinner } from "./ui/spinner";
 import { Confirm } from "./ui/confirm";
+import { TaskList, type Task } from "./ui/task-list";
 import { darkTheme } from "./ui/_core.js";
+import { applyProgressEvent, settleProgress, type ProgressEvent } from "../tui/progress";
 
 const theme = darkTheme;
 
@@ -16,6 +18,9 @@ export interface SummaryRow {
 export interface ConfirmActionProps {
   // breadcrumb labels the screen.
   breadcrumb: string[];
+  // description is shown dimmed after the breadcrumb, e.g. the command's own
+  // description so the header matches `--help`.
+  description?: string;
   // title heads the summary overlay (usually the resource name).
   title: string;
   // rows describe the resource the action applies to.
@@ -26,14 +31,21 @@ export interface ConfirmActionProps {
   isPending: boolean;
   error: Error | null;
   // action performs the confirmed operation and resolves to result rows shown
-  // on the success panel.
-  action: () => Promise<SummaryRow[]>;
+  // on the success panel. A long-running operation may instead return a
+  // progress generator — the same AsyncGenerator<ProgressEvent> runWithProgress
+  // drives for the headless command — and its steps render as a live task list
+  // while it runs, exactly as they do on the command line.
+  action: () => Promise<SummaryRow[]> | AsyncGenerator<ProgressEvent, SummaryRow[]>;
   // successTitle heads the success panel (e.g. "Harness deleted").
   successTitle: string;
-  // runningLabel is the spinner label while the action runs.
+  // runningLabel is the spinner label while the action runs, shown until the
+  // action's first progress step arrives (or throughout, for a plain promise).
   runningLabel: string;
   // onDone is called when the user acknowledges the success panel.
   onDone: () => void;
+  // onCancel runs when the confirmation is declined or esc is pressed; defaults
+  // to popping the router history, which suits a screen reached from a picker.
+  onCancel?: () => void;
 }
 
 type Phase =
@@ -47,6 +59,7 @@ type Phase =
 // while the action runs, and a success/error panel. Cancel and esc pop back.
 export function ConfirmAction({
   breadcrumb,
+  description,
   title,
   rows,
   message,
@@ -56,15 +69,37 @@ export function ConfirmAction({
   successTitle,
   runningLabel,
   onDone,
+  onCancel,
 }: ConfirmActionProps) {
   const navigate = useNavigate();
+  const cancel = onCancel ?? (() => navigate(-1));
   const [phase, setPhase] = useState<Phase>({ kind: "confirm" });
+  // tasks is the step list a progress-reporting action builds up. It stays on
+  // screen through success and error, as the headless command leaves its
+  // completed steps in scrollback above the final line.
+  const [tasks, setTasks] = useState<Task[]>([]);
 
   const run = async () => {
     setPhase({ kind: "running" });
+    setTasks([]);
     try {
-      setPhase({ kind: "success", rows: await action() });
+      const result = action();
+      let rows: SummaryRow[];
+      if (isProgressGenerator(result)) {
+        let next = await result.next();
+        while (!next.done) {
+          const event = next.value;
+          setTasks((current) => applyProgressEvent(current, event));
+          next = await result.next();
+        }
+        rows = next.value;
+      } else {
+        rows = await result;
+      }
+      setTasks((current) => settleProgress(current, "done"));
+      setPhase({ kind: "success", rows });
     } catch (err) {
+      setTasks((current) => settleProgress(current, "failed"));
       setPhase({ kind: "error", message: err instanceof Error ? err.message : String(err) });
     }
   };
@@ -84,11 +119,11 @@ export function ConfirmAction({
           ];
 
   return (
-    <Layout breadcrumb={breadcrumb} keyHints={hints}>
+    <Layout breadcrumb={breadcrumb} description={description} keyHints={hints}>
       {isPending ? (
         <Spinner label="Loading…" />
       ) : error ? (
-        <ErrorBody message={error.message} onBack={() => navigate(-1)} />
+        <ErrorBody message={error.message} onBack={cancel} />
       ) : (
         <Box flexDirection="column" paddingX={1}>
           <Box
@@ -99,23 +134,18 @@ export function ConfirmAction({
             marginBottom={1}
           >
             <Text bold>{title}</Text>
-            {rows.map((row) => (
-              <Text key={row.label}>
-                <Text color={theme.colors.muted}>{row.label.padEnd(8)}</Text>
-                {row.value}
-              </Text>
-            ))}
+            <SummaryRows rows={rows} />
           </Box>
 
           {phase.kind === "confirm" && (
-            <Confirm
-              message={message}
-              defaultValue={false}
-              onConfirm={run}
-              onCancel={() => navigate(-1)}
-            />
+            <Confirm message={message} defaultValue={false} onConfirm={run} onCancel={cancel} />
           )}
-          {phase.kind === "running" && <Spinner label={runningLabel} />}
+          {phase.kind !== "confirm" && tasks.length > 0 && (
+            <Box marginBottom={phase.kind === "running" ? 0 : 1}>
+              <TaskList tasks={tasks} />
+            </Box>
+          )}
+          {phase.kind === "running" && tasks.length === 0 && <Spinner label={runningLabel} />}
           {phase.kind === "success" && (
             <SuccessBody title={successTitle} rows={phase.rows} onDone={onDone} />
           )}
@@ -125,6 +155,33 @@ export function ConfirmAction({
         </Box>
       )}
     </Layout>
+  );
+}
+
+// A promise has no Symbol.asyncIterator, so this is a safe discriminator.
+function isProgressGenerator(
+  result: Promise<SummaryRow[]> | AsyncGenerator<ProgressEvent, SummaryRow[]>,
+): result is AsyncGenerator<ProgressEvent, SummaryRow[]> {
+  return (
+    typeof (result as AsyncGenerator<ProgressEvent, SummaryRow[]>)[Symbol.asyncIterator] ===
+    "function"
+  );
+}
+
+// SummaryRows aligns values on a column one past the longest label, so a
+// label longer than the old fixed width (a stack output name, say) still has a
+// gap before its value.
+function SummaryRows({ rows }: { rows: SummaryRow[] }) {
+  const width = rows.reduce((max, row) => Math.max(max, row.label.length), 0) + 2;
+  return (
+    <>
+      {rows.map((row) => (
+        <Text key={row.label}>
+          <Text color={theme.colors.muted}>{row.label.padEnd(width)}</Text>
+          {row.value}
+        </Text>
+      ))}
+    </>
   );
 }
 
@@ -147,12 +204,7 @@ function SuccessBody({
         ✔ {title}
       </Text>
       <Box flexDirection="column" marginTop={1} marginLeft={2}>
-        {rows.map((row) => (
-          <Text key={row.label}>
-            <Text color={theme.colors.muted}>{row.label.padEnd(8)}</Text>
-            {row.value}
-          </Text>
-        ))}
+        <SummaryRows rows={rows} />
       </Box>
       <Box marginTop={1}>
         <Text color={theme.colors.muted}>

--- a/src/components/ConfirmAction.tsx
+++ b/src/components/ConfirmAction.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Box, Text, useInput } from "ink";
 import { useNavigate } from "react-router";
 import { Layout } from "./Layout";
@@ -25,11 +25,14 @@ export interface ConfirmActionProps {
   // description so the header matches `--help`.
   description?: string;
   // title heads the summary overlay (usually the resource name).
-  title: string;
-  // rows describe the resource the action applies to.
-  rows: SummaryRow[];
-  // message is the yes/no question (destructive actions default to No).
-  message: string;
+  title?: string;
+  // rows describe the resource the action applies to. With neither title nor
+  // rows the overlay is omitted, for an action whose breadcrumb says it all.
+  rows?: SummaryRow[];
+  // message is the yes/no question (destructive actions default to No). Omit it
+  // to skip the confirmation and run the action as soon as the summary loads —
+  // for an operation that is safe to start without asking, like a build.
+  message?: string;
   // isPending / error reflect the summary fetch backing the overlay.
   isPending: boolean;
   error: Error | null;
@@ -47,8 +50,14 @@ export interface ConfirmActionProps {
   // runningLabel is the spinner label while the action runs, shown until the
   // action's first progress step arrives (or throughout, for a plain promise).
   runningLabel: string;
-  // onDone is called when the user acknowledges the success panel.
+  // nextSteps are commands suggested under the success panel, as the create
+  // wizard suggests `agentcore project deploy`.
+  nextSteps?: string[];
+  // onDone is called when the user acknowledges the success panel; doneLabel
+  // says where that leads ("continue" by default, "go back" for a screen that
+  // returns to a menu).
   onDone: () => void;
+  doneLabel?: string;
   // onCancel runs when the confirmation is declined or esc is pressed; defaults
   // to popping the router history, which suits a screen reached from a picker.
   onCancel?: () => void;
@@ -67,19 +76,22 @@ export function ConfirmAction({
   breadcrumb,
   description,
   title,
-  rows,
+  rows = [],
   message,
   isPending,
   error,
   action,
   successTitle,
   runningLabel,
+  nextSteps,
   onDone,
+  doneLabel = "continue",
   onCancel,
 }: ConfirmActionProps) {
   const navigate = useNavigate();
   const cancel = onCancel ?? (() => navigate(-1));
   const [phase, setPhase] = useState<Phase>({ kind: "confirm" });
+  const confirms = message !== undefined;
   // tasks is the step list a progress-reporting action builds up. It stays on
   // screen through success and error, as the headless command leaves its
   // completed steps in scrollback above the final line.
@@ -102,6 +114,13 @@ export function ConfirmAction({
     }
   };
 
+  // Without a question there is nothing to wait for: run once the summary is
+  // ready. Keyed on isPending/error so it fires exactly once, when they settle.
+  useEffect(() => {
+    if (!confirms && !isPending && !error && phase.kind === "confirm") void run();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- run is recreated each render; the phase guard makes this idempotent
+  }, [confirms, isPending, error, phase.kind]);
+
   const hints =
     phase.kind === "confirm"
       ? [
@@ -110,7 +129,7 @@ export function ConfirmAction({
           { key: "ctl+c", label: "quit" },
         ]
       : phase.kind === "success"
-        ? [{ key: "enter", label: "continue" }]
+        ? [{ key: "enter", label: doneLabel }]
         : phase.kind === "running"
           ? // Nothing listens for esc mid-action: an operation in flight is
             // not abandoned by leaving the screen.
@@ -128,18 +147,20 @@ export function ConfirmAction({
         <ErrorBody message={error.message} onBack={cancel} />
       ) : (
         <Box flexDirection="column" paddingX={1}>
-          <Box
-            flexDirection="column"
-            borderStyle="round"
-            borderColor={theme.colors.border}
-            paddingX={1}
-            marginBottom={1}
-          >
-            <Text bold>{title}</Text>
-            <KeyValueTable items={toItems(rows)} />
-          </Box>
+          {(title !== undefined || rows.length > 0) && (
+            <Box
+              flexDirection="column"
+              borderStyle="round"
+              borderColor={theme.colors.border}
+              paddingX={1}
+              marginBottom={1}
+            >
+              {title !== undefined && <Text bold>{title}</Text>}
+              {rows.length > 0 && <KeyValueTable items={toItems(rows)} />}
+            </Box>
+          )}
 
-          {phase.kind === "confirm" && (
+          {phase.kind === "confirm" && confirms && (
             <Confirm message={message} defaultValue={false} onConfirm={run} onCancel={cancel} />
           )}
           {phase.kind !== "confirm" && tasks.length > 0 && (
@@ -149,10 +170,21 @@ export function ConfirmAction({
           )}
           {phase.kind === "running" && tasks.length === 0 && <Spinner label={runningLabel} />}
           {phase.kind === "success" && (
-            <SuccessBody title={phase.title} rows={phase.rows} onDone={onDone} />
+            <SuccessBody
+              title={phase.title}
+              rows={phase.rows}
+              nextSteps={nextSteps}
+              onDone={onDone}
+              doneLabel={doneLabel}
+            />
           )}
           {phase.kind === "error" && (
-            <ErrorBody message={phase.message} onBack={() => setPhase({ kind: "confirm" })} />
+            // With a confirmation, esc returns to the question to try again;
+            // without one, returning would run again, so it leaves instead.
+            <ErrorBody
+              message={phase.message}
+              onBack={confirms ? () => setPhase({ kind: "confirm" }) : cancel}
+            />
           )}
         </Box>
       )}
@@ -179,11 +211,15 @@ function toItems(rows: SummaryRow[]): Record<string, string> {
 function SuccessBody({
   title,
   rows,
+  nextSteps,
   onDone,
+  doneLabel,
 }: {
   title: string;
   rows: SummaryRow[];
+  nextSteps?: string[];
   onDone: () => void;
+  doneLabel: string;
 }) {
   useInput((_input, key) => {
     if (key.return || key.escape) onDone();
@@ -194,12 +230,22 @@ function SuccessBody({
       <Text color={theme.colors.success} bold>
         ✔ {title}
       </Text>
-      <Box flexDirection="column" marginTop={1} marginLeft={2}>
-        <KeyValueTable items={toItems(rows)} />
-      </Box>
+      {rows.length > 0 && (
+        <Box flexDirection="column" marginTop={1} marginLeft={2}>
+          <KeyValueTable items={toItems(rows)} />
+        </Box>
+      )}
+      {nextSteps !== undefined && nextSteps.length > 0 && (
+        <Box flexDirection="column" marginTop={1}>
+          <Text color={theme.colors.text}>next steps</Text>
+          {nextSteps.map((step) => (
+            <Text key={step} color={theme.colors.primary}>{`  ${step}`}</Text>
+          ))}
+        </Box>
+      )}
       <Box marginTop={1}>
         <Text color={theme.colors.muted}>
-          press <Text color={theme.colors.focus}>enter</Text> to continue
+          press <Text color={theme.colors.focus}>enter</Text> to {doneLabel}
         </Text>
       </Box>
     </Box>

--- a/src/components/Root.tsx
+++ b/src/components/Root.tsx
@@ -108,6 +108,8 @@ import { GatewayRuleListScreen } from "../handlers/gateway/rule/list/screen.tsx"
 import { GatewayRuleGetScreen } from "../handlers/gateway/rule/get/screen.tsx";
 import { GatewayInvokeScreen } from "../handlers/gateway/invoke/screen.tsx";
 import { ProjectScreen, ProjectCommandNotImplementedScreen } from "../handlers/project/screen.tsx";
+import { BuildProjectScreen } from "../handlers/project/build/screen.tsx";
+import { DeployProjectScreen } from "../handlers/project/deploy/screen.tsx";
 import { ProjectCreateScreen } from "../handlers/project/create/screen.tsx";
 import { ProjectInvokePickerScreen } from "../handlers/project/invoke/screen.tsx";
 import { RootScreen, HelpScreen } from "../handlers/screen.tsx";
@@ -116,7 +118,7 @@ import type { Context } from "../router";
 // PROJECT_COMMANDS are the `agentcore project` subcommands that are listed in
 // the menu but have no screen of their own yet (`create` has the wizard). Each
 // is routed explicitly so selecting it reports "not implemented" error
-const PROJECT_COMMANDS = ["add", "export", "remove", "dev", "deploy", "status", "build"] as const;
+const PROJECT_COMMANDS = ["add", "export", "remove", "dev", "status"] as const;
 
 export interface RootProps {
   // path is the command path to the executing node (e.g. "/agentcore").
@@ -749,6 +751,14 @@ export function Root({ path, ctx, core, queryClient }: RootProps) {
             element={<Oauth2CredentialProviderGetJsonScreen ctx={ctx} core={core} />}
           />
           <Route path="agentcore/project" element={<ProjectScreen ctx={ctx} core={core} />} />
+          <Route
+            path="agentcore/project/build"
+            element={<BuildProjectScreen ctx={ctx} core={core} />}
+          />
+          <Route
+            path="agentcore/project/deploy"
+            element={<DeployProjectScreen ctx={ctx} core={core} />}
+          />
           <Route
             path="agentcore/project/create"
             element={<ProjectCreateScreen ctx={ctx} core={core} />}

--- a/src/core/project/manager.tsx
+++ b/src/core/project/manager.tsx
@@ -919,13 +919,17 @@ export class FsProjectManager implements ProjectManager {
   // A read-only lookup, so callers (e.g. the deploy handler's up-front teardown
   // confirmation) can name the target's account and region without triggering
   // the default-target provisioning deploy performs.
+  public async listTargets(project: Project): Promise<AwsDeploymentTarget[]> {
+    const targetsPath = join(project.rootPath, "agentcore", "aws-targets.json");
+    if (!existsSync(targetsPath)) return [];
+    return this.json.read(targetsPath, AwsDeploymentTargetsSchema);
+  }
+
   public async resolveTarget(
     project: Project,
     input: ResolveTargetInput,
   ): Promise<AwsDeploymentTarget | undefined> {
-    const targetsPath = join(project.rootPath, "agentcore", "aws-targets.json");
-    if (!existsSync(targetsPath)) return undefined;
-    const targets = await this.json.read(targetsPath, AwsDeploymentTargetsSchema);
+    const targets = await this.listTargets(project);
     return targets.find((candidate) => candidate.name === input.target);
   }
 

--- a/src/core/project/manager.tsx
+++ b/src/core/project/manager.tsx
@@ -873,7 +873,7 @@ export class FsProjectManager implements ProjectManager {
   ): AsyncGenerator<ProjectEvent, DeployResult> {
     const targetsPath = join(project.rootPath, "agentcore", "aws-targets.json");
     const fileExists = existsSync(targetsPath);
-    const targets = fileExists ? await this.json.read(targetsPath, AwsDeploymentTargetsSchema) : [];
+    const targets = await this.listTargets(project);
 
     let target = targets.find((candidate) => candidate.name === input.target);
 

--- a/src/handlers/harness/delete/screen.tsx
+++ b/src/handlers/harness/delete/screen.tsx
@@ -39,11 +39,11 @@ function DeleteConfirm({ ctx, core, harnessId }: ScreenProps & { harnessId: stri
     <ConfirmAction
       breadcrumb={["agentcore", "harness", "delete", harnessId]}
       title={harness?.harnessName ?? harnessId}
-      rows={[
-        { label: "arn", value: harness?.arn ?? "-" },
-        { label: "status", value: harness?.status ?? "-" },
-        { label: "version", value: harness?.harnessVersion ?? "-" },
-      ]}
+      rows={{
+        arn: harness?.arn ?? "-",
+        status: harness?.status ?? "-",
+        version: harness?.harnessVersion ?? "-",
+      }}
       trigger={{
         kind: "confirm",
         message: `Delete harness ${harness?.harnessName ?? harnessId}? This permanently removes the harness, its versions, and its endpoints.`,
@@ -52,10 +52,12 @@ function DeleteConfirm({ ctx, core, harnessId }: ScreenProps & { harnessId: stri
       error={detail.isError ? (detail.error as Error) : null}
       action={async () => {
         const response = await core.harness.deleteHarness({ harnessId }, opts);
-        return [
-          { label: "id", value: response.harness?.harnessId ?? harnessId },
-          { label: "status", value: response.harness?.status ?? "DELETING" },
-        ];
+        return {
+          rows: {
+            id: response.harness?.harnessId ?? harnessId,
+            status: response.harness?.status ?? "DELETING",
+          },
+        };
       }}
       successTitle="Harness deletion started"
       runningLabel="Deleting harness…"

--- a/src/handlers/harness/delete/screen.tsx
+++ b/src/handlers/harness/delete/screen.tsx
@@ -44,7 +44,10 @@ function DeleteConfirm({ ctx, core, harnessId }: ScreenProps & { harnessId: stri
         { label: "status", value: harness?.status ?? "-" },
         { label: "version", value: harness?.harnessVersion ?? "-" },
       ]}
-      message={`Delete harness ${harness?.harnessName ?? harnessId}? This permanently removes the harness, its versions, and its endpoints.`}
+      trigger={{
+        kind: "confirm",
+        message: `Delete harness ${harness?.harnessName ?? harnessId}? This permanently removes the harness, its versions, and its endpoints.`,
+      }}
       isPending={detail.isPending}
       error={detail.isError ? (detail.error as Error) : null}
       action={async () => {

--- a/src/handlers/harness/endpoint/delete/screen.tsx
+++ b/src/handlers/harness/endpoint/delete/screen.tsx
@@ -57,11 +57,11 @@ function DeleteConfirm({
     <ConfirmAction
       breadcrumb={["agentcore", "harness", "endpoint", "delete", harnessId, endpointName]}
       title={endpoint?.endpointName ?? endpointName}
-      rows={[
-        { label: "arn", value: endpoint?.arn ?? "-" },
-        { label: "status", value: endpoint?.status ?? "-" },
-        { label: "target", value: endpoint?.targetVersion ?? "-" },
-      ]}
+      rows={{
+        arn: endpoint?.arn ?? "-",
+        status: endpoint?.status ?? "-",
+        target: endpoint?.targetVersion ?? "-",
+      }}
       trigger={{
         kind: "confirm",
         message: `Delete endpoint ${endpointName}? Callers using it will lose access.`,
@@ -73,10 +73,12 @@ function DeleteConfirm({
           { harnessId, endpointName },
           opts,
         );
-        return [
-          { label: "name", value: response.endpoint?.endpointName ?? endpointName },
-          { label: "status", value: response.endpoint?.status ?? "DELETING" },
-        ];
+        return {
+          rows: {
+            name: response.endpoint?.endpointName ?? endpointName,
+            status: response.endpoint?.status ?? "DELETING",
+          },
+        };
       }}
       successTitle="Endpoint deletion started"
       runningLabel="Deleting endpoint…"

--- a/src/handlers/harness/endpoint/delete/screen.tsx
+++ b/src/handlers/harness/endpoint/delete/screen.tsx
@@ -62,7 +62,10 @@ function DeleteConfirm({
         { label: "status", value: endpoint?.status ?? "-" },
         { label: "target", value: endpoint?.targetVersion ?? "-" },
       ]}
-      message={`Delete endpoint ${endpointName}? Callers using it will lose access.`}
+      trigger={{
+        kind: "confirm",
+        message: `Delete endpoint ${endpointName}? Callers using it will lose access.`,
+      }}
       isPending={detail.isPending}
       error={detail.isError ? (detail.error as Error) : null}
       action={async () => {

--- a/src/handlers/project/ProjectGate.tsx
+++ b/src/handlers/project/ProjectGate.tsx
@@ -24,6 +24,7 @@ export function useProject(core: Core, seed?: Project): UseQueryResult<Project> 
       if (!project) throw new ProjectStateError(projectNotFoundMessage(from));
       return project;
     },
+    gcTime: 0,
     // A seeded project is authoritative — it is what the launching command ran
     // against — so it is never refetched from the cwd.
     ...(seed && { initialData: seed, staleTime: Infinity }),

--- a/src/handlers/project/ProjectGate.tsx
+++ b/src/handlers/project/ProjectGate.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Box, Text } from "ink";
+import { Box, Text, useInput } from "ink";
 import { Layout } from "../../components/Layout";
 import { Spinner } from "../../components/ui/spinner";
 import { darkTheme } from "../../components/ui/_core.js";
@@ -56,6 +56,9 @@ export interface ProjectGateProps {
   // seed is the project already pinned on the launch context, when the command
   // that opened the TUI was itself a project command.
   seed?: Project;
+  // onBack runs on esc when resolution fails, so the user is not left with quit
+  // as the only way off the error.
+  onBack: () => void;
   // children receives the resolved project and returns the screen. It must
   // return an element rather than call hooks itself — the gate renders a
   // spinner on the first paint, so a hook called here would change order.
@@ -64,11 +67,31 @@ export interface ProjectGateProps {
 
 // ProjectGate resolves the project before rendering a project screen, showing
 // the same not-found guidance the CLI prints when there is none.
-export function ProjectGate({ core, breadcrumb, description, seed, children }: ProjectGateProps) {
+export function ProjectGate({
+  core,
+  breadcrumb,
+  description,
+  seed,
+  onBack,
+  children,
+}: ProjectGateProps) {
   const { project, error } = useProject(core, seed);
 
   if (project !== undefined) return children(project);
-
+  if (error !== undefined) {
+    return (
+      <Layout
+        breadcrumb={breadcrumb}
+        description={description}
+        keyHints={[
+          { key: "esc", label: "back" },
+          { key: "ctl+c", label: "quit" },
+        ]}
+      >
+        <ResolutionError message={error} onBack={onBack} />
+      </Layout>
+    );
+  }
   return (
     <Layout
       breadcrumb={breadcrumb}
@@ -76,12 +99,19 @@ export function ProjectGate({ core, breadcrumb, description, seed, children }: P
       keyHints={[{ key: "ctl+c", label: "quit" }]}
     >
       <Box paddingX={1}>
-        {error === undefined ? (
-          <Spinner label="loading project…" />
-        ) : (
-          <Text color={theme.colors.error}>✗ {error}</Text>
-        )}
+        <Spinner label="loading project…" />
       </Box>
     </Layout>
+  );
+}
+
+function ResolutionError({ message, onBack }: { message: string; onBack: () => void }) {
+  useInput((_input, key) => {
+    if (key.escape) onBack();
+  });
+  return (
+    <Box paddingX={1}>
+      <Text color={theme.colors.error}>✗ {message}</Text>
+    </Box>
   );
 }

--- a/src/handlers/project/ProjectGate.tsx
+++ b/src/handlers/project/ProjectGate.tsx
@@ -1,0 +1,87 @@
+import React, { useEffect, useState } from "react";
+import { Box, Text } from "ink";
+import { Layout } from "../../components/Layout";
+import { Spinner } from "../../components/ui/spinner";
+import { darkTheme } from "../../components/ui/_core.js";
+import { projectNotFoundMessage } from "../../middleware/withProject";
+import type { Core } from "../types";
+import type { Project } from "./types";
+
+const theme = darkTheme;
+
+export interface UseProjectResult {
+  project?: Project;
+  error?: string;
+}
+
+// useProject resolves the project enclosing the working directory for a TUI
+// screen. Screens need their own resolution because withProject wraps `handle`
+// only: middleware runs when a command executes, and navigating between TUI
+// screens never executes one, so ProjectKey is set only when the launching
+// command happened to be a project command. When it was, pass it as `seed` and
+// no resolution happens. The not-found guidance is withProject's own.
+export function useProject(core: Core, seed?: Project): UseProjectResult {
+  const [project, setProject] = useState<Project | undefined>(seed);
+  const [error, setError] = useState<string>();
+
+  useEffect(() => {
+    if (project !== undefined) return;
+    let active = true;
+    const from = process.cwd();
+    void core.projectManager
+      .resolve({ filePath: from })
+      .then((resolved) => {
+        if (!active) return;
+        if (!resolved) {
+          setError(projectNotFoundMessage(from));
+          return;
+        }
+        setProject(resolved);
+      })
+      .catch((cause: unknown) => {
+        if (active) setError(cause instanceof Error ? cause.message : String(cause));
+      });
+    return () => {
+      active = false;
+    };
+  }, [core.projectManager, project]);
+
+  return { project, error };
+}
+
+export interface ProjectGateProps {
+  core: Core;
+  breadcrumb: string[];
+  description?: string;
+  // seed is the project already pinned on the launch context, when the command
+  // that opened the TUI was itself a project command.
+  seed?: Project;
+  // children receives the resolved project and returns the screen. It must
+  // return an element rather than call hooks itself — the gate renders a
+  // spinner on the first paint, so a hook called here would change order.
+  children: (project: Project) => React.ReactElement;
+}
+
+// ProjectGate resolves the project before rendering a project screen, showing
+// the same not-found guidance the CLI prints when there is none.
+export function ProjectGate({ core, breadcrumb, description, seed, children }: ProjectGateProps) {
+  const { project, error } = useProject(core, seed);
+
+  if (project !== undefined) return children(project);
+
+  return (
+    <Layout
+      breadcrumb={breadcrumb}
+      description={description}
+      keyHints={[{ key: "ctl+c", label: "quit" }]}
+    >
+      <Box paddingX={1}>
+        {error === undefined ? (
+          <Spinner label="loading project…" />
+        ) : (
+          <Text color={theme.colors.error}>✗ {error}</Text>
+        )}
+      </Box>
+    </Layout>
+  );
+}

--- a/src/handlers/project/ProjectGate.tsx
+++ b/src/handlers/project/ProjectGate.tsx
@@ -14,12 +14,10 @@ export interface UseProjectResult {
   error?: string;
 }
 
-// useProject resolves the project enclosing the working directory for a TUI
-// screen. Screens need their own resolution because withProject wraps `handle`
-// only: middleware runs when a command executes, and navigating between TUI
-// screens never executes one, so ProjectKey is set only when the launching
-// command happened to be a project command. When it was, pass it as `seed` and
-// no resolution happens. The not-found guidance is withProject's own.
+// useProject resolves the project enclosing the cwd for a TUI screen. Screens
+// resolve it themselves because withProject wraps `handle` only, and navigating
+// between screens never executes a command — ProjectKey is set only when the
+// launching command was a project command, in which case pass it as `seed`.
 export function useProject(core: Core, seed?: Project): UseProjectResult {
   const [project, setProject] = useState<Project | undefined>(seed);
   const [error, setError] = useState<string>();
@@ -56,8 +54,7 @@ export interface ProjectGateProps {
   // seed is the project already pinned on the launch context, when the command
   // that opened the TUI was itself a project command.
   seed?: Project;
-  // onBack runs on esc when resolution fails, so the user is not left with quit
-  // as the only way off the error.
+  // onBack runs on esc when resolution fails.
   onBack: () => void;
   // children receives the resolved project and returns the screen. It must
   // return an element rather than call hooks itself — the gate renders a

--- a/src/handlers/project/ProjectGate.tsx
+++ b/src/handlers/project/ProjectGate.tsx
@@ -1,50 +1,77 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 import { Box, Text, useInput } from "ink";
 import { Layout } from "../../components/Layout";
 import { Spinner } from "../../components/ui/spinner";
 import { darkTheme } from "../../components/ui/_core.js";
+import { ProjectStateError } from "../../errors/errors";
 import { projectNotFoundMessage } from "../../middleware/withProject";
 import type { Core } from "../types";
 import type { Project } from "./types";
 
 const theme = darkTheme;
 
-export interface UseProjectResult {
-  project?: Project;
-  error?: string;
-}
-
 // useProject resolves the project enclosing the cwd for a TUI screen. Screens
 // resolve it themselves because withProject wraps `handle` only, and navigating
 // between screens never executes a command — ProjectKey is set only when the
 // launching command was a project command, in which case pass it as `seed`.
-export function useProject(core: Core, seed?: Project): UseProjectResult {
-  const [project, setProject] = useState<Project | undefined>(seed);
-  const [error, setError] = useState<string>();
+export function useProject(core: Core, seed?: Project): UseQueryResult<Project> {
+  const from = process.cwd();
+  return useQuery({
+    queryKey: ["project", from],
+    queryFn: async () => {
+      const project = await core.projectManager.resolve({ filePath: from });
+      if (!project) throw new ProjectStateError(projectNotFoundMessage(from));
+      return project;
+    },
+    // A seeded project is authoritative — it is what the launching command ran
+    // against — so it is never refetched from the cwd.
+    ...(seed && { initialData: seed, staleTime: Infinity }),
+  });
+}
 
-  useEffect(() => {
-    if (project !== undefined) return;
-    let active = true;
-    const from = process.cwd();
-    void core.projectManager
-      .resolve({ filePath: from })
-      .then((resolved) => {
-        if (!active) return;
-        if (!resolved) {
-          setError(projectNotFoundMessage(from));
-          return;
-        }
-        setProject(resolved);
-      })
-      .catch((cause: unknown) => {
-        if (active) setError(cause instanceof Error ? cause.message : String(cause));
-      });
-    return () => {
-      active = false;
-    };
-  }, [core.projectManager, project]);
+export interface LoadingFrameProps {
+  breadcrumb: string[];
+  description?: string;
+  // query is whatever the screen is waiting on.
+  query: Pick<UseQueryResult, "isError" | "error" | "refetch">;
+  loadingLabel: string;
+  onBack: () => void;
+}
 
-  return { project, error };
+// LoadingFrame is the spinner-or-error a screen shows before its data arrives:
+// esc leaves, and on an error `r` tries again — the PaginatedTablePicker keys.
+export function LoadingFrame({
+  breadcrumb,
+  description,
+  query,
+  loadingLabel,
+  onBack,
+}: LoadingFrameProps) {
+  useInput((input, key) => {
+    if (key.escape) onBack();
+    if (query.isError && input === "r") void query.refetch();
+  });
+
+  return (
+    <Layout
+      breadcrumb={breadcrumb}
+      description={description}
+      keyHints={[
+        ...(query.isError ? [{ key: "r", label: "retry" }] : []),
+        { key: "esc", label: "back" },
+        { key: "ctl+c", label: "quit" },
+      ]}
+    >
+      <Box paddingX={1}>
+        {query.isError ? (
+          <Text color={theme.colors.error}>✗ {(query.error as Error).message}</Text>
+        ) : (
+          <Spinner label={loadingLabel} />
+        )}
+      </Box>
+    </Layout>
+  );
 }
 
 export interface ProjectGateProps {
@@ -54,7 +81,6 @@ export interface ProjectGateProps {
   // seed is the project already pinned on the launch context, when the command
   // that opened the TUI was itself a project command.
   seed?: Project;
-  // onBack runs on esc when resolution fails.
   onBack: () => void;
   // children receives the resolved project and returns the screen. It must
   // return an element rather than call hooks itself — the gate renders a
@@ -72,43 +98,15 @@ export function ProjectGate({
   onBack,
   children,
 }: ProjectGateProps) {
-  const { project, error } = useProject(core, seed);
-
-  if (project !== undefined) return children(project);
-  if (error !== undefined) {
-    return (
-      <Layout
-        breadcrumb={breadcrumb}
-        description={description}
-        keyHints={[
-          { key: "esc", label: "back" },
-          { key: "ctl+c", label: "quit" },
-        ]}
-      >
-        <ResolutionError message={error} onBack={onBack} />
-      </Layout>
-    );
-  }
+  const project = useProject(core, seed);
+  if (project.data !== undefined) return children(project.data);
   return (
-    <Layout
+    <LoadingFrame
       breadcrumb={breadcrumb}
       description={description}
-      keyHints={[{ key: "ctl+c", label: "quit" }]}
-    >
-      <Box paddingX={1}>
-        <Spinner label="loading project…" />
-      </Box>
-    </Layout>
-  );
-}
-
-function ResolutionError({ message, onBack }: { message: string; onBack: () => void }) {
-  useInput((_input, key) => {
-    if (key.escape) onBack();
-  });
-  return (
-    <Box paddingX={1}>
-      <Text color={theme.colors.error}>✗ {message}</Text>
-    </Box>
+      query={project}
+      loadingLabel="loading project…"
+      onBack={onBack}
+    />
   );
 }

--- a/src/handlers/project/build/index.ts
+++ b/src/handlers/project/build/index.ts
@@ -4,12 +4,17 @@ import { JsonRendererKey } from "../../../tui";
 import { runWithProgress } from "../../../tui/progress";
 import { JsonKey } from "../../keys";
 import { renderJsonError } from "../../utils";
-import type { ProjectManager } from "../types";
+import type { Project, ProjectManager } from "../types";
 
 type BuildProjectHandlerConfig = {
   projectManager: ProjectManager;
   io: AppIO;
 };
+
+/** The line both entry points print once a build finishes. */
+export function builtMessage(project: Project): string {
+  return `Built project '${project.name}'`;
+}
 
 export const createBuildProjectHandler = (config: BuildProjectHandlerConfig) =>
   createHandler({
@@ -35,7 +40,7 @@ export const createBuildProjectHandler = (config: BuildProjectHandlerConfig) =>
         throw error;
       }
 
-      const message = `Built project '${project.name}'`;
+      const message = builtMessage(project);
       config.io.stderr.write(`${message}\n`);
       if (jsonOutput) ctx.require(JsonRendererKey).renderJson({ message });
     },

--- a/src/handlers/project/build/screen.tsx
+++ b/src/handlers/project/build/screen.tsx
@@ -1,5 +1,4 @@
 import { useNavigate } from "react-router";
-import { useApp } from "ink";
 import { ConfirmAction } from "../../../components/ConfirmAction";
 import { ProjectKey } from "../../../router";
 import type { ScreenProps } from "../../types";
@@ -15,7 +14,7 @@ const PROJECT_MENU = "/agentcore/project";
 // same projectManager.build generator the command runs, and ConfirmAction
 // renders its steps through the same TaskList runWithProgress renders on the
 // command line — the TUI is a frame around the CLI's own progress, not a
-// second progress UI.
+// second progress UI. Once done, enter returns to the project menu.
 export function BuildProjectScreen({ ctx, core }: ScreenProps) {
   const navigate = useNavigate();
   return (
@@ -33,18 +32,13 @@ export function BuildProjectScreen({ ctx, core }: ScreenProps) {
 
 function BuildConfirm({ project, core }: { project: Project; core: ScreenProps["core"] }) {
   const navigate = useNavigate();
-  const { exit } = useApp();
 
+  // No confirmation: a build changes nothing outside the project directory,
+  // so it starts as soon as the screen opens, as the command does.
   return (
     <ConfirmAction
       breadcrumb={BREADCRUMB}
       description={DESCRIPTION}
-      title={project.name}
-      rows={[
-        { label: "root", value: project.rootPath },
-        { label: "agents", value: String(project.spec.runtimes.length) },
-      ]}
-      message={`Build project '${project.name}'?`}
       isPending={false}
       error={null}
       action={async function* () {
@@ -53,7 +47,9 @@ function BuildConfirm({ project, core }: { project: Project; core: ScreenProps["
       }}
       successTitle={builtMessage(project)}
       runningLabel="building…"
-      onDone={() => exit()}
+      nextSteps={["agentcore project deploy"]}
+      onDone={() => navigate(PROJECT_MENU)}
+      doneLabel="go back"
       onCancel={() => navigate(PROJECT_MENU)}
     />
   );

--- a/src/handlers/project/build/screen.tsx
+++ b/src/handlers/project/build/screen.tsx
@@ -35,6 +35,7 @@ function BuildConfirm({ project, core }: { project: Project; core: ScreenProps["
     <ConfirmAction
       breadcrumb={BREADCRUMB}
       description={DESCRIPTION}
+      trigger={{ kind: "immediate" }}
       isPending={false}
       error={null}
       action={async function* () {

--- a/src/handlers/project/build/screen.tsx
+++ b/src/handlers/project/build/screen.tsx
@@ -1,0 +1,57 @@
+import { useNavigate } from "react-router";
+import { useApp } from "ink";
+import { ConfirmAction } from "../../../components/ConfirmAction";
+import { ProjectKey } from "../../../router";
+import type { ScreenProps } from "../../types";
+import { ProjectGate } from "../ProjectGate";
+import type { Project } from "../types";
+import { builtMessage } from "./index";
+
+const BREADCRUMB = ["agentcore", "project", "build"];
+const DESCRIPTION = "build the project's deployable artifacts";
+
+// BuildProjectScreen is `agentcore project build` from the menu. It runs the
+// same projectManager.build generator the command runs, and ConfirmAction
+// renders its steps through the same TaskList runWithProgress renders on the
+// command line — the TUI is a frame around the CLI's own progress, not a
+// second progress UI.
+export function BuildProjectScreen({ ctx, core }: ScreenProps) {
+  return (
+    <ProjectGate
+      core={core}
+      breadcrumb={BREADCRUMB}
+      description={DESCRIPTION}
+      seed={ctx.value(ProjectKey)}
+    >
+      {(project) => <BuildConfirm project={project} core={core} />}
+    </ProjectGate>
+  );
+}
+
+function BuildConfirm({ project, core }: { project: Project; core: ScreenProps["core"] }) {
+  const navigate = useNavigate();
+  const { exit } = useApp();
+
+  return (
+    <ConfirmAction
+      breadcrumb={BREADCRUMB}
+      description={DESCRIPTION}
+      title={project.name}
+      rows={[
+        { label: "root", value: project.rootPath },
+        { label: "agents", value: String(project.spec.runtimes.length) },
+      ]}
+      message={`Build project '${project.name}'?`}
+      isPending={false}
+      error={null}
+      action={async function* () {
+        yield* core.projectManager.build(project);
+        return [{ label: "result", value: builtMessage(project) }];
+      }}
+      successTitle={builtMessage(project)}
+      runningLabel="building…"
+      onDone={() => exit()}
+      onCancel={() => navigate("/agentcore/project")}
+    />
+  );
+}

--- a/src/handlers/project/build/screen.tsx
+++ b/src/handlers/project/build/screen.tsx
@@ -9,6 +9,7 @@ import { builtMessage } from "./index";
 
 const BREADCRUMB = ["agentcore", "project", "build"];
 const DESCRIPTION = "build the project's deployable artifacts";
+const PROJECT_MENU = "/agentcore/project";
 
 // BuildProjectScreen is `agentcore project build` from the menu. It runs the
 // same projectManager.build generator the command runs, and ConfirmAction
@@ -16,12 +17,14 @@ const DESCRIPTION = "build the project's deployable artifacts";
 // command line — the TUI is a frame around the CLI's own progress, not a
 // second progress UI.
 export function BuildProjectScreen({ ctx, core }: ScreenProps) {
+  const navigate = useNavigate();
   return (
     <ProjectGate
       core={core}
       breadcrumb={BREADCRUMB}
       description={DESCRIPTION}
       seed={ctx.value(ProjectKey)}
+      onBack={() => navigate(PROJECT_MENU)}
     >
       {(project) => <BuildConfirm project={project} core={core} />}
     </ProjectGate>
@@ -46,12 +49,12 @@ function BuildConfirm({ project, core }: { project: Project; core: ScreenProps["
       error={null}
       action={async function* () {
         yield* core.projectManager.build(project);
-        return [{ label: "result", value: builtMessage(project) }];
+        return [];
       }}
       successTitle={builtMessage(project)}
       runningLabel="building…"
       onDone={() => exit()}
-      onCancel={() => navigate("/agentcore/project")}
+      onCancel={() => navigate(PROJECT_MENU)}
     />
   );
 }

--- a/src/handlers/project/build/screen.tsx
+++ b/src/handlers/project/build/screen.tsx
@@ -10,11 +10,8 @@ const BREADCRUMB = ["agentcore", "project", "build"];
 const DESCRIPTION = "build the project's deployable artifacts";
 const PROJECT_MENU = "/agentcore/project";
 
-// BuildProjectScreen is `agentcore project build` from the menu. It runs the
-// same projectManager.build generator the command runs, and ConfirmAction
-// renders its steps through the same TaskList runWithProgress renders on the
-// command line — the TUI is a frame around the CLI's own progress, not a
-// second progress UI. Once done, enter returns to the project menu.
+// BuildProjectScreen runs the same projectManager.build generator the command
+// runs; ConfirmAction renders its steps through the same TaskList.
 export function BuildProjectScreen({ ctx, core }: ScreenProps) {
   const navigate = useNavigate();
   return (
@@ -33,8 +30,7 @@ export function BuildProjectScreen({ ctx, core }: ScreenProps) {
 function BuildConfirm({ project, core }: { project: Project; core: ScreenProps["core"] }) {
   const navigate = useNavigate();
 
-  // No confirmation: a build changes nothing outside the project directory,
-  // so it starts as soon as the screen opens, as the command does.
+  // No confirmation: a build changes nothing outside the project directory.
   return (
     <ConfirmAction
       breadcrumb={BREADCRUMB}

--- a/src/handlers/project/build/screen.tsx
+++ b/src/handlers/project/build/screen.tsx
@@ -40,7 +40,7 @@ function BuildConfirm({ project, core }: { project: Project; core: ScreenProps["
       error={null}
       action={async function* () {
         yield* core.projectManager.build(project);
-        return [];
+        return { rows: {} };
       }}
       successTitle={builtMessage(project)}
       runningLabel="building…"

--- a/src/handlers/project/buildDeploy.screen.test.tsx
+++ b/src/handlers/project/buildDeploy.screen.test.tsx
@@ -1,0 +1,230 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { DeployBackendInput, ProjectBackend } from "../../core/project";
+import { createRootHandler } from "../index";
+import {
+  cleanupScreens,
+  createSilentLogger,
+  flatFrame,
+  renderScreen,
+  TestCoreClient,
+  TestGlobalConfigAccessor,
+  testIO,
+  waitForFlatText,
+  waitForText,
+} from "../../testing";
+import type { DeployResult, Project, ProjectEvent } from "./types";
+
+// The build and deploy screens run the same ProjectManager generators the
+// commands run, so these tests stub the backend exactly as the handler tests
+// do and assert the same steps come out — through the TaskList this time.
+
+const EVENTS: ProjectEvent[] = [
+  { type: "step", message: "Synthesizing CloudFormation templates" },
+  { type: "output", line: "cdk synth: 3 stacks" },
+  { type: "step", message: "Deploying stack" },
+  { type: "output", line: "CREATE_IN_PROGRESS | AWS::IAM::Role" },
+];
+
+type FakeBackendOptions = {
+  events?: ProjectEvent[];
+  failure?: Error;
+  result?: DeployResult;
+};
+
+function fakeBackend(options: FakeBackendOptions = {}) {
+  const deploys: { project: Project; input: DeployBackendInput; confirmed?: boolean }[] = [];
+  const backend: ProjectBackend = {
+    async *build() {
+      yield* options.events ?? EVENTS;
+      if (options.failure) throw options.failure;
+    },
+    async *deploy(project, input) {
+      const call: (typeof deploys)[number] = { project, input };
+      deploys.push(call);
+      call.confirmed = await input.confirmTeardown({
+        projectName: project.name,
+        targetName: input.target.name,
+        resourceDescription: "the stack",
+        account: input.target.account,
+        region: input.target.region,
+      });
+      yield* options.events ?? EVENTS;
+      if (options.failure) throw options.failure;
+      return options.result ?? { outputs: { RuntimeArn: "arn:runtime" } };
+    },
+    async resolveDeployedResources() {
+      return [];
+    },
+  };
+  return { backend, deploys };
+}
+
+const originalCwd = process.cwd();
+const tempDirectories: string[] = [];
+
+afterEach(cleanupScreens);
+afterEach(async () => {
+  process.chdir(originalCwd);
+  await Promise.all(
+    tempDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+/** Scaffolds project 'orders' with a default target and cds into it. */
+async function inProject(core: TestCoreClient, options: { empty?: boolean } = {}): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "agentcore-build-deploy-screen-"));
+  tempDirectories.push(directory);
+  process.chdir(directory);
+  const root = createRootHandler(core, {
+    io: testIO().io,
+    globalConfigAccessor: new TestGlobalConfigAccessor(),
+    logger: createSilentLogger(),
+  });
+  await root.route([
+    "node",
+    "agentcore",
+    "project",
+    "create",
+    "--name",
+    "orders",
+    "--skip-install",
+    "--skip-git",
+  ]);
+  const projectRoot = join(process.cwd(), "orders");
+  await writeFile(
+    join(projectRoot, "agentcore", "aws-targets.json"),
+    JSON.stringify([{ name: "default", account: "111122223333", region: "us-east-1" }]),
+  );
+  if (options.empty) {
+    // What `remove --all` leaves: the up-front signal the deploy asks about.
+    await writeFile(
+      join(projectRoot, "agentcore", "agentcore.json"),
+      JSON.stringify({ name: "orders", version: 1 }),
+    );
+  }
+  process.chdir(projectRoot);
+  return projectRoot;
+}
+
+describe("project build screen", () => {
+  test("confirms, then renders the backend's steps as the CLI does, then the CLI's own success line", async () => {
+    const { backend } = fakeBackend();
+    const core = new TestCoreClient({ backends: { CDK: backend } });
+    await inProject(core);
+    const r = renderScreen("/agentcore/project/build", { core });
+
+    await waitForText(r.lastFrame, "Build project 'orders'?");
+    expect(r.lastFrame()).toContain("agentcore → project → build");
+    await r.write("y");
+
+    // Both steps settle to ✓, as the inline TaskList leaves them on the
+    // command line; the finished steps' output tails collapse.
+    await waitForText(r.lastFrame, "✔ Built project 'orders'");
+    const frame = r.lastFrame()!;
+    expect(frame).toContain("✓ Synthesizing CloudFormation templates");
+    expect(frame).toContain("✓ Deploying stack");
+    expect(frame).not.toContain("cdk synth");
+    r.unmount();
+  });
+
+  test("a failing step is marked ✕ with its output kept, above the error", async () => {
+    const { backend } = fakeBackend({ failure: new Error("synth exploded") });
+    const core = new TestCoreClient({ backends: { CDK: backend } });
+    await inProject(core);
+    const r = renderScreen("/agentcore/project/build", { core });
+
+    await waitForText(r.lastFrame, "Build project 'orders'?");
+    await r.write("y");
+
+    await waitForText(r.lastFrame, "✗ synth exploded");
+    const frame = r.lastFrame()!;
+    expect(frame).toContain("✓ Synthesizing CloudFormation templates");
+    expect(frame).toContain("✕ Deploying stack");
+    expect(frame).toContain("CREATE_IN_PROGRESS | AWS::IAM::Role");
+    r.unmount();
+  });
+
+  test("declining returns to the project menu", async () => {
+    const core = new TestCoreClient({ backends: { CDK: fakeBackend().backend } });
+    await inProject(core);
+    const r = renderScreen("/agentcore/project/build", { core });
+
+    await waitForText(r.lastFrame, "Build project 'orders'?");
+    await r.write("n");
+    await waitForText(r.lastFrame, "manage an AgentCore project");
+    r.unmount();
+  });
+
+  test("reports the CLI's own guidance outside a project", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "agentcore-no-project-"));
+    tempDirectories.push(directory);
+    process.chdir(directory);
+    const r = renderScreen("/agentcore/project/build");
+
+    await waitForFlatText(r.lastFrame, "No AgentCore project found");
+    expect(flatFrame(r.lastFrame)).toContain("agentcore project create");
+    r.unmount();
+  });
+});
+
+describe("project deploy screen", () => {
+  test("shows the target, then the backend's steps, then the CLI's own success line and outputs", async () => {
+    const { backend, deploys } = fakeBackend();
+    const core = new TestCoreClient({ backends: { CDK: backend } });
+    await inProject(core);
+    const r = renderScreen("/agentcore/project/deploy", { core });
+
+    await waitForText(r.lastFrame, "Deploy project 'orders' to target 'default'?");
+    expect(flatFrame(r.lastFrame)).toContain("account 111122223333/us-east-1");
+    await r.write("y");
+
+    await waitForText(r.lastFrame, "✔ Project deployed");
+    const frame = flatFrame(r.lastFrame);
+    expect(frame).toContain("✓ Synthesizing CloudFormation templates");
+    expect(frame).toContain("✓ Deploying stack");
+    expect(frame).toContain("Deployed project 'orders' to target 'default'");
+    expect(frame).toContain("RuntimeArn arn:runtime");
+
+    // A project with resources never confirms a teardown, as on the command line.
+    expect(deploys).toHaveLength(1);
+    expect(deploys[0]!.confirmed).toBe(false);
+    expect(deploys[0]!.input.target.name).toBe("default");
+    r.unmount();
+  });
+
+  test("an empty project asks the CLI's teardown question and confirms it on yes", async () => {
+    const { backend, deploys } = fakeBackend({ result: { outputs: {}, tornDown: true } });
+    const core = new TestCoreClient({ backends: { CDK: backend } });
+    await inProject(core, { empty: true });
+    const r = renderScreen("/agentcore/project/deploy", { core });
+
+    await waitForFlatText(r.lastFrame, "declares no resources to deploy");
+    // Confirm lays its (y/N) inline, so the question wraps around it.
+    expect(flatFrame(r.lastFrame)).toContain(
+      "deployed to target 'default' (111122223333/us-east-1). Continue?",
+    );
+    await r.write("y");
+
+    await waitForText(r.lastFrame, "✔ Project removed");
+    expect(flatFrame(r.lastFrame)).toContain("Removed project 'orders' from target 'default'");
+    expect(deploys[0]!.confirmed).toBe(true);
+    r.unmount();
+  });
+
+  test("a failing deploy keeps the completed steps above the error", async () => {
+    const { backend } = fakeBackend({ failure: new Error("stack rolled back") });
+    const core = new TestCoreClient({ backends: { CDK: backend } });
+    await inProject(core);
+    const r = renderScreen("/agentcore/project/deploy", { core });
+
+    await waitForText(r.lastFrame, "Deploy project 'orders' to target 'default'?");
+    await r.write("y");
+
+    await waitForText(r.lastFrame, "✗ stack rolled back");
+    expect(r.lastFrame()).toContain("✕ Deploying stack");
+    r.unmount();
+  });
+});

--- a/src/handlers/project/buildDeploy.screen.test.tsx
+++ b/src/handlers/project/buildDeploy.screen.test.tsx
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { QueryClient } from "@tanstack/react-query";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -224,7 +225,8 @@ describe("project deploy screen", () => {
 
     await r.write("r");
     await waitForText(r.lastFrame, "✔ Deployed project 'orders' to target 'default'");
-    expect(attempts).toBe(2);
+    // Loading retries once, then deploy itself re-reads through listTargets.
+    expect(attempts).toBe(3);
     r.unmount();
   });
 
@@ -258,6 +260,62 @@ describe("project deploy screen", () => {
     await waitForText(r.lastFrame, "✔ Deployed project 'orders' to target 'staging'");
     expect(flatFrame(r.lastFrame)).toContain("target staging");
     expect(deploys[0]!.input.target).toEqual(STAGING);
+    r.unmount();
+  });
+
+  test("revisiting reads targets afresh before starting another deploy", async () => {
+    const { backend, deploys } = fakeBackend();
+    const core = new TestCoreClient({ backends: { CDK: backend } });
+    const projectRoot = await inProject(core);
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: Infinity, staleTime: 0 },
+      },
+    });
+    const r = renderScreen("/agentcore/project/deploy", { core, queryClient });
+
+    await waitForText(r.lastFrame, "✔ Deployed project 'orders' to target 'default'");
+    expect(deploys).toHaveLength(1);
+    await r.press("return");
+    await waitForText(r.lastFrame, "manage an AgentCore project");
+
+    await writeFile(
+      join(projectRoot, "agentcore", "aws-targets.json"),
+      JSON.stringify([{ name: "default", account: "111122223333", region: "us-east-1" }, STAGING]),
+    );
+    await r.write("deploy");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "choose a deployment target");
+    expect(deploys).toHaveLength(1);
+    r.unmount();
+  });
+
+  test("revisiting resolves the project afresh before deciding whether to confirm teardown", async () => {
+    const { backend, deploys } = fakeBackend();
+    const core = new TestCoreClient({ backends: { CDK: backend } });
+    const projectRoot = await inProject(core);
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: Infinity, staleTime: 0 },
+      },
+    });
+    const r = renderScreen("/agentcore/project/deploy", { core, queryClient });
+
+    await waitForText(r.lastFrame, "✔ Deployed project 'orders' to target 'default'");
+    expect(deploys).toHaveLength(1);
+    await r.press("return");
+    await waitForText(r.lastFrame, "manage an AgentCore project");
+
+    await writeFile(
+      join(projectRoot, "agentcore", "agentcore.json"),
+      JSON.stringify({ name: "orders", version: 1 }),
+    );
+    await r.write("deploy");
+    await r.press("return");
+
+    await waitForFlatText(r.lastFrame, "declares no resources to deploy");
+    expect(deploys).toHaveLength(1);
     r.unmount();
   });
 

--- a/src/handlers/project/buildDeploy.screen.test.tsx
+++ b/src/handlers/project/buildDeploy.screen.test.tsx
@@ -166,6 +166,9 @@ describe("project build screen", () => {
 
     await waitForFlatText(r.lastFrame, "No AgentCore project found");
     expect(flatFrame(r.lastFrame)).toContain("agentcore project create");
+    // esc is a way off the error, not just ctl+c.
+    await r.press("escape");
+    await waitForText(r.lastFrame, "manage an AgentCore project");
     r.unmount();
   });
 });
@@ -181,12 +184,13 @@ describe("project deploy screen", () => {
     expect(flatFrame(r.lastFrame)).toContain("account 111122223333/us-east-1");
     await r.write("y");
 
-    await waitForText(r.lastFrame, "✔ Project deployed");
+    await waitForText(r.lastFrame, "✔ Deployed project 'orders' to target 'default'");
     const frame = flatFrame(r.lastFrame);
     expect(frame).toContain("✓ Synthesizing CloudFormation templates");
     expect(frame).toContain("✓ Deploying stack");
-    expect(frame).toContain("Deployed project 'orders' to target 'default'");
     expect(frame).toContain("RuntimeArn arn:runtime");
+    // esc is not offered mid-action; here the action has finished.
+    expect(frame).toContain("[enter] continue");
 
     // A project with resources never confirms a teardown, as on the command line.
     expect(deploys).toHaveLength(1);
@@ -208,9 +212,25 @@ describe("project deploy screen", () => {
     );
     await r.write("y");
 
-    await waitForText(r.lastFrame, "✔ Project removed");
-    expect(flatFrame(r.lastFrame)).toContain("Removed project 'orders' from target 'default'");
+    await waitForText(r.lastFrame, "✔ Removed project 'orders' from target 'default'");
     expect(deploys[0]!.confirmed).toBe(true);
+    r.unmount();
+  });
+
+  test("the outcome follows the result, not the preflight heuristic", async () => {
+    // The spec declares resources, so no teardown is asked — yet the backend
+    // reports it tore the stack down (nothing synthesized). The title must say
+    // what happened, as the command's own line does.
+    const { backend } = fakeBackend({ result: { outputs: {}, tornDown: true } });
+    const core = new TestCoreClient({ backends: { CDK: backend } });
+    await inProject(core);
+    const r = renderScreen("/agentcore/project/deploy", { core });
+
+    await waitForText(r.lastFrame, "Deploy project 'orders' to target 'default'?");
+    await r.write("y");
+
+    await waitForText(r.lastFrame, "✔ Removed project 'orders' from target 'default'");
+    expect(r.lastFrame()).not.toContain("Deployed project");
     r.unmount();
   });
 

--- a/src/handlers/project/buildDeploy.screen.test.tsx
+++ b/src/handlers/project/buildDeploy.screen.test.tsx
@@ -131,7 +131,10 @@ describe("project build screen", () => {
     await waitForText(r.lastFrame, "✔ Built project 'orders'");
     const frame = r.lastFrame()!;
     expect(frame).toContain("agentcore → project → build");
-    expect(frame).not.toContain("(y/N)");
+    // No frame — not even the first — advertised a question.
+    expect(r.frames.some((painted) => painted.includes("(y/N)") || painted.includes("y/n"))).toBe(
+      false,
+    );
     expect(frame).toContain("✓ Synthesizing CloudFormation templates");
     expect(frame).toContain("✓ Deploying stack");
     expect(frame).not.toContain("cdk synth");
@@ -199,6 +202,43 @@ describe("project deploy screen", () => {
     expect(deploys).toHaveLength(1);
     expect(deploys[0]!.confirmed).toBe(false);
     expect(deploys[0]!.input.target.name).toBe("default");
+    r.unmount();
+  });
+
+  test("a target-loading failure offers esc back and r to retry", async () => {
+    const { backend } = fakeBackend();
+    const core = new TestCoreClient({ backends: { CDK: backend } });
+    await inProject(core);
+    let attempts = 0;
+    const listTargets = core.projectManager.listTargets.bind(core.projectManager);
+    core.projectManager.listTargets = async (project) => {
+      attempts += 1;
+      if (attempts === 1) throw new Error("aws-targets.json is unreadable");
+      return listTargets(project);
+    };
+    const r = renderScreen("/agentcore/project/deploy", { core });
+
+    await waitForText(r.lastFrame, "✗ aws-targets.json is unreadable");
+    expect(r.lastFrame()).toContain("[r] retry");
+    expect(r.lastFrame()).toContain("[esc] back");
+
+    await r.write("r");
+    await waitForText(r.lastFrame, "✔ Deployed project 'orders' to target 'default'");
+    expect(attempts).toBe(2);
+    r.unmount();
+  });
+
+  test("esc leaves a target-loading failure for the project menu", async () => {
+    const core = new TestCoreClient({ backends: { CDK: fakeBackend().backend } });
+    await inProject(core);
+    core.projectManager.listTargets = async () => {
+      throw new Error("aws-targets.json is unreadable");
+    };
+    const r = renderScreen("/agentcore/project/deploy", { core });
+
+    await waitForText(r.lastFrame, "✗ aws-targets.json is unreadable");
+    await r.press("escape");
+    await waitForText(r.lastFrame, "manage an AgentCore project");
     r.unmount();
   });
 

--- a/src/handlers/project/buildDeploy.screen.test.tsx
+++ b/src/handlers/project/buildDeploy.screen.test.tsx
@@ -74,7 +74,12 @@ afterEach(async () => {
 });
 
 /** Scaffolds project 'orders' with a default target and cds into it. */
-async function inProject(core: TestCoreClient, options: { empty?: boolean } = {}): Promise<string> {
+const STAGING = { name: "staging", account: "444455556666", region: "eu-west-1" } as const;
+
+async function inProject(
+  core: TestCoreClient,
+  options: { empty?: boolean; targets?: boolean; staging?: boolean } = {},
+): Promise<string> {
   const directory = await mkdtemp(join(tmpdir(), "agentcore-build-deploy-screen-"));
   tempDirectories.push(directory);
   process.chdir(directory);
@@ -94,10 +99,15 @@ async function inProject(core: TestCoreClient, options: { empty?: boolean } = {}
     "--skip-git",
   ]);
   const projectRoot = join(process.cwd(), "orders");
-  await writeFile(
-    join(projectRoot, "agentcore", "aws-targets.json"),
-    JSON.stringify([{ name: "default", account: "111122223333", region: "us-east-1" }]),
-  );
+  if (options.targets !== false) {
+    await writeFile(
+      join(projectRoot, "agentcore", "aws-targets.json"),
+      JSON.stringify([
+        { name: "default", account: "111122223333", region: "us-east-1" },
+        ...(options.staging ? [STAGING] : []),
+      ]),
+    );
+  }
   if (options.empty) {
     // What `remove --all` leaves: the up-front signal the deploy asks about.
     await writeFile(
@@ -110,23 +120,26 @@ async function inProject(core: TestCoreClient, options: { empty?: boolean } = {}
 }
 
 describe("project build screen", () => {
-  test("confirms, then renders the backend's steps as the CLI does, then the CLI's own success line", async () => {
+  test("starts at once, renders the backend's steps as the CLI does, then the CLI's own success line", async () => {
     const { backend } = fakeBackend();
     const core = new TestCoreClient({ backends: { CDK: backend } });
     await inProject(core);
     const r = renderScreen("/agentcore/project/build", { core });
 
-    await waitForText(r.lastFrame, "Build project 'orders'?");
-    expect(r.lastFrame()).toContain("agentcore → project → build");
-    await r.write("y");
-
     // Both steps settle to ✓, as the inline TaskList leaves them on the
     // command line; the finished steps' output tails collapse.
     await waitForText(r.lastFrame, "✔ Built project 'orders'");
     const frame = r.lastFrame()!;
+    expect(frame).toContain("agentcore → project → build");
+    expect(frame).not.toContain("(y/N)");
     expect(frame).toContain("✓ Synthesizing CloudFormation templates");
     expect(frame).toContain("✓ Deploying stack");
     expect(frame).not.toContain("cdk synth");
+    expect(frame).toContain("agentcore project deploy");
+
+    // Enter stays in the TUI: back to the project menu.
+    await r.press("return");
+    await waitForText(r.lastFrame, "manage an AgentCore project");
     r.unmount();
   });
 
@@ -136,24 +149,14 @@ describe("project build screen", () => {
     await inProject(core);
     const r = renderScreen("/agentcore/project/build", { core });
 
-    await waitForText(r.lastFrame, "Build project 'orders'?");
-    await r.write("y");
-
     await waitForText(r.lastFrame, "✗ synth exploded");
     const frame = r.lastFrame()!;
     expect(frame).toContain("✓ Synthesizing CloudFormation templates");
     expect(frame).toContain("✕ Deploying stack");
     expect(frame).toContain("CREATE_IN_PROGRESS | AWS::IAM::Role");
-    r.unmount();
-  });
-
-  test("declining returns to the project menu", async () => {
-    const core = new TestCoreClient({ backends: { CDK: fakeBackend().backend } });
-    await inProject(core);
-    const r = renderScreen("/agentcore/project/build", { core });
-
-    await waitForText(r.lastFrame, "Build project 'orders'?");
-    await r.write("n");
+    // With no confirmation to return to, esc leaves for the project menu
+    // rather than running the build again.
+    await r.press("escape");
     await waitForText(r.lastFrame, "manage an AgentCore project");
     r.unmount();
   });
@@ -174,28 +177,64 @@ describe("project build screen", () => {
 });
 
 describe("project deploy screen", () => {
-  test("shows the target, then the backend's steps, then the CLI's own success line and outputs", async () => {
+  test("one target: deploys to it at once, then the CLI's own success line", async () => {
     const { backend, deploys } = fakeBackend();
     const core = new TestCoreClient({ backends: { CDK: backend } });
     await inProject(core);
     const r = renderScreen("/agentcore/project/deploy", { core });
 
-    await waitForText(r.lastFrame, "Deploy project 'orders' to target 'default'?");
-    expect(flatFrame(r.lastFrame)).toContain("account 111122223333/us-east-1");
-    await r.write("y");
-
+    // A project with resources is not asked anything, as on the command line.
     await waitForText(r.lastFrame, "✔ Deployed project 'orders' to target 'default'");
     const frame = flatFrame(r.lastFrame);
+    expect(frame).not.toContain("(y/N)");
+    expect(frame).toContain("project orders");
+    expect(frame).toContain("target default");
     expect(frame).toContain("✓ Synthesizing CloudFormation templates");
     expect(frame).toContain("✓ Deploying stack");
-    expect(frame).toContain("RuntimeArn arn:runtime");
-    // esc is not offered mid-action; here the action has finished.
-    expect(frame).toContain("[enter] continue");
+    // Stack outputs are not listed, as the command prints them only with --json.
+    expect(frame).not.toContain("RuntimeArn");
+    expect(frame).toContain("[enter] go back");
 
-    // A project with resources never confirms a teardown, as on the command line.
+    // …and never confirms a teardown.
     expect(deploys).toHaveLength(1);
     expect(deploys[0]!.confirmed).toBe(false);
     expect(deploys[0]!.input.target.name).toBe("default");
+    r.unmount();
+  });
+
+  test("several targets: asks which, and deploys to the chosen one", async () => {
+    const { backend, deploys } = fakeBackend();
+    const core = new TestCoreClient({ backends: { CDK: backend } });
+    await inProject(core, { staging: true });
+    const r = renderScreen("/agentcore/project/deploy", { core });
+
+    await waitForText(r.lastFrame, "choose a deployment target");
+    const picker = flatFrame(r.lastFrame);
+    expect(picker).toContain("default 111122223333 us-east-1");
+    expect(picker).toContain("staging 444455556666 eu-west-1");
+    await r.press("down");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "✔ Deployed project 'orders' to target 'staging'");
+    expect(flatFrame(r.lastFrame)).toContain("target staging");
+    expect(deploys[0]!.input.target).toEqual(STAGING);
+    r.unmount();
+  });
+
+  test("a fresh project with no aws-targets.json deploys, provisioning the default target as the CLI does", async () => {
+    const { backend, deploys } = fakeBackend();
+    const core = new TestCoreClient({
+      backends: { CDK: backend },
+      resolveAccount: async () => "887863153624",
+    });
+    await inProject(core, { targets: false });
+    const r = renderScreen("/agentcore/project/deploy", { core });
+
+    await waitForText(r.lastFrame, "✔ Deployed project 'orders' to target 'default'");
+    const frame = flatFrame(r.lastFrame);
+    // The manager's own provisioning step streams through like any other.
+    expect(frame).toContain("✓ Created default deployment target: account 887863153624");
+    expect(deploys[0]!.input.target).toMatchObject({ name: "default", account: "887863153624" });
     r.unmount();
   });
 
@@ -226,9 +265,6 @@ describe("project deploy screen", () => {
     await inProject(core);
     const r = renderScreen("/agentcore/project/deploy", { core });
 
-    await waitForText(r.lastFrame, "Deploy project 'orders' to target 'default'?");
-    await r.write("y");
-
     await waitForText(r.lastFrame, "✔ Removed project 'orders' from target 'default'");
     expect(r.lastFrame()).not.toContain("Deployed project");
     r.unmount();
@@ -239,9 +275,6 @@ describe("project deploy screen", () => {
     const core = new TestCoreClient({ backends: { CDK: backend } });
     await inProject(core);
     const r = renderScreen("/agentcore/project/deploy", { core });
-
-    await waitForText(r.lastFrame, "Deploy project 'orders' to target 'default'?");
-    await r.write("y");
 
     await waitForText(r.lastFrame, "✗ stack rolled back");
     expect(r.lastFrame()).toContain("✕ Deploying stack");

--- a/src/handlers/project/create/create.screen.test.tsx
+++ b/src/handlers/project/create/create.screen.test.tsx
@@ -468,7 +468,7 @@ describe("project create wizard", () => {
     r.unmount();
   });
 
-  test("the spinner follows streamed progress without a blank row", async () => {
+  test("streamed progress renders as the CLI's step list", async () => {
     const core = new TestCoreClient();
     let release!: () => void;
     const held = new Promise<void>((resolve) => {
@@ -494,22 +494,11 @@ describe("project create wizard", () => {
     await waitForText(r.lastFrame, "this project will be created");
     await r.press("return");
 
-    await waitFor(() =>
-      r.frames.some(
-        (frame) => frame.includes("✓ syncing dependencies") && frame.includes("creating DemoApp…"),
-      ),
-    );
-    const progressFrame =
-      [...r.frames]
-        .reverse()
-        .find(
-          (frame) =>
-            frame.includes("✓ syncing dependencies") && frame.includes("creating DemoApp…"),
-        ) ?? "";
-    const lines = progressFrame.split("\n");
-    const eventLine = lines.findIndex((line) => line.includes("✓ syncing dependencies"));
-    const spinnerLine = lines.findIndex((line) => line.includes("creating DemoApp…"));
-    expect(spinnerLine).toBe(eventLine + 1);
+    // The running step is the spinner row itself, as on the command line; the
+    // generic "creating…" spinner shows only until the first step arrives.
+    await waitForText(r.lastFrame, "syncing dependencies");
+    expect(r.lastFrame()).not.toContain("creating DemoApp…");
+    expect(r.lastFrame()).not.toContain("✓ syncing dependencies");
 
     r.unmount();
     release();

--- a/src/handlers/project/create/screen.tsx
+++ b/src/handlers/project/create/screen.tsx
@@ -18,7 +18,9 @@ import { FormRadioGroup, type FormRadioOption } from "../../../components/FormRa
 import { KeyValueTable } from "../../../components/KeyValueTable";
 import { Stepper, type Step } from "../../../components/ui/stepper";
 import { Spinner } from "../../../components/ui/spinner";
+import { TaskList, type Task } from "../../../components/ui/task-list";
 import { Divider } from "../../../components/ui/divider";
+import { driveProgress } from "../../../tui/progress";
 import { darkTheme } from "../../../components/ui/_core.js";
 
 const theme = darkTheme;
@@ -244,7 +246,7 @@ export function ProjectCreateScreen({ core }: ScreenProps) {
   const [values, setValues] = useState<CreateProjectFormValues>(emptyCreateProjectForm);
   const [stepIndex, setStepIndex] = useState(0);
   const [phase, setPhase] = useState<WizardPhase>({ kind: "form" });
-  const [events, setEvents] = useState<string[]>([]);
+  const [tasks, setTasks] = useState<Task[]>([]);
 
   // The step list is dynamic: the branch chosen on the type step decides
   // whether model or template (and, for strands, memory) questions follow.
@@ -288,9 +290,7 @@ export function ProjectCreateScreen({ core }: ScreenProps) {
     }
     setPhase({ kind: "running" });
     try {
-      for await (const event of core.projectManager.create(input)) {
-        if (event.type === "step") setEvents((current) => [...current, event.message]);
-      }
+      await driveProgress(core.projectManager.create(input), setTasks);
       setPhase({ kind: "success" });
     } catch (error) {
       setPhase({ kind: "error", error: toError(error) });
@@ -322,8 +322,10 @@ export function ProjectCreateScreen({ core }: ScreenProps) {
         )}
         {phase.kind !== "form" && (
           <Box flexDirection="column" paddingX={1}>
-            <EventLog events={events} />
-            {phase.kind === "running" && <Spinner label={`creating ${values.name}…`} />}
+            <TaskList tasks={tasks} />
+            {phase.kind === "running" && tasks.length === 0 && (
+              <Spinner label={`creating ${values.name}…`} />
+            )}
             {phase.kind === "success" && (
               <SuccessPanel name={values.name} onContinue={() => exit()} />
             )}
@@ -776,18 +778,6 @@ function ReviewStep({
 }
 
 // ─── result panels ────────────────────────────────────────────────────────────
-
-function EventLog({ events }: { events: string[] }) {
-  return (
-    <Box flexDirection="column">
-      {events.map((message, index) => (
-        <Text key={`${index}-${message}`} color={theme.colors.muted}>
-          ✓ {message}
-        </Text>
-      ))}
-    </Box>
-  );
-}
 
 function SuccessPanel({ name, onContinue }: { name: string; onContinue: () => void }) {
   useInput((_input, key) => {

--- a/src/handlers/project/deploy/index.ts
+++ b/src/handlers/project/deploy/index.ts
@@ -15,6 +15,33 @@ type DeployProjectHandlerConfig = {
   io: AppIO;
 };
 
+/** The line both entry points print once a deploy finishes. */
+export function deployedMessage(
+  project: Project,
+  targetName: string,
+  result: DeployResult,
+): string {
+  return result.tornDown
+    ? `Removed project '${project.name}' from target '${targetName}'`
+    : `Deployed project '${project.name}' to target '${targetName}'`;
+}
+
+/**
+ * The teardown question both entry points ask. Asked before synthesis, so the
+ * exact stack name is not known yet; the target coordinates identify what would
+ * be deleted.
+ */
+export function teardownQuestion(
+  projectName: string,
+  target: { name: string; account: string; region: string },
+): string {
+  return (
+    `Project '${projectName}' declares no resources to deploy. ` +
+    `Deploying will delete everything deployed to target ` +
+    `'${target.name}' (${target.account}/${target.region}). Continue?`
+  );
+}
+
 export const createDeployProjectHandler = (config: DeployProjectHandlerConfig) =>
   createHandler({
     name: "deploy",
@@ -72,9 +99,7 @@ export const createDeployProjectHandler = (config: DeployProjectHandlerConfig) =
         throw error;
       }
 
-      const message = result.tornDown
-        ? `Removed project '${project.name}' from target '${flags.target}'`
-        : `Deployed project '${project.name}' to target '${flags.target}'`;
+      const message = deployedMessage(project, flags.target, result);
       config.io.stderr.write(`${message}\n`);
       if (jsonOutput) {
         ctx.require(JsonRendererKey).renderJson({ message, ...result });
@@ -91,7 +116,7 @@ export const createDeployProjectHandler = (config: DeployProjectHandlerConfig) =
  * CDK app adds one), so the backend's count stays authoritative and this only
  * decides whether to ask the user before starting.
  */
-function declaresNothingDeployable(project: Project): boolean {
+export function declaresNothingDeployable(project: Project): boolean {
   const { spec } = project;
   const collections = [
     spec.runtimes,
@@ -158,14 +183,8 @@ async function promptForTeardown(
       readline.once("SIGINT", cancel);
       readline.once("close", cancel);
     });
-    // Asked before synthesis, so the exact stack name is not known yet; the
-    // target coordinates identify what would be deleted.
     const answer = await Promise.race([
-      readline.question(
-        `Project '${projectName}' declares no resources to deploy.\n` +
-          `Deploying will delete everything deployed to target ` +
-          `'${target.name}' (${target.account}/${target.region}). Continue? (y/N) `,
-      ),
+      readline.question(`${teardownQuestion(projectName, target)} (y/N) `),
       cancelled,
     ]);
     return /^(?:y|yes)$/i.test(answer.trim());

--- a/src/handlers/project/deploy/index.ts
+++ b/src/handlers/project/deploy/index.ts
@@ -28,8 +28,7 @@ export function deployedMessage(
 
 /**
  * The teardown question both entry points ask. Asked before synthesis, so the
- * exact stack name is not known yet; the target coordinates identify what would
- * be deleted.
+ * target coordinates stand in for the stack name.
  */
 export function teardownQuestion(
   projectName: string,

--- a/src/handlers/project/deploy/screen.tsx
+++ b/src/handlers/project/deploy/screen.tsx
@@ -1,0 +1,100 @@
+import { useQuery } from "@tanstack/react-query";
+import { useNavigate } from "react-router";
+import { useApp } from "ink";
+import { ConfirmAction, type SummaryRow } from "../../../components/ConfirmAction";
+import { DEFAULT_TARGET_NAME } from "../../../projectSchemas/aws-targets";
+import { ProjectKey, type Context } from "../../../router";
+import { RegionKey } from "../../keys";
+import type { ScreenProps } from "../../types";
+import { ProjectGate } from "../ProjectGate";
+import type { Project } from "../types";
+import { declaresNothingDeployable, deployedMessage, teardownQuestion } from "./index";
+
+const BREADCRUMB = ["agentcore", "project", "deploy"];
+const DESCRIPTION = "deploy the project to AWS";
+
+// DeployProjectScreen is `agentcore project deploy` from the menu. It runs the
+// same projectManager.deploy generator the command runs, and ConfirmAction
+// renders its steps through the same TaskList runWithProgress renders on the
+// command line. The teardown question the command asks over readline is asked
+// here as the confirmation itself.
+export function DeployProjectScreen({ ctx, core }: ScreenProps) {
+  return (
+    <ProjectGate
+      core={core}
+      breadcrumb={BREADCRUMB}
+      description={DESCRIPTION}
+      seed={ctx.value(ProjectKey)}
+    >
+      {(project) => <DeployConfirm project={project} ctx={ctx} core={core} />}
+    </ProjectGate>
+  );
+}
+
+function DeployConfirm({
+  project,
+  ctx,
+  core,
+}: {
+  project: Project;
+  ctx: Context;
+  core: ScreenProps["core"];
+}) {
+  const navigate = useNavigate();
+  const { exit } = useApp();
+  const region = ctx.require(RegionKey);
+  const targetName = DEFAULT_TARGET_NAME;
+
+  // The target is resolved up front, as the command does, because the teardown
+  // question is only asked when there is a target whose stack could be removed.
+  const target = useQuery({
+    queryKey: ["project-target", project.rootPath, targetName],
+    queryFn: () => core.projectManager.resolveTarget(project, { target: targetName }),
+  });
+
+  // Once the progress UI is up nothing may block on input, so the teardown
+  // decision is settled by the confirmation the user is about to answer: when
+  // the project declares nothing deployable, confirming *is* confirming the
+  // teardown. Otherwise the backend's own zero-resource check reports the
+  // "re-run with --yes" error, as it does for a non-interactive deploy.
+  const teardown = target.data !== undefined && declaresNothingDeployable(project);
+  const message = teardown
+    ? teardownQuestion(project.name, target.data!)
+    : `Deploy project '${project.name}' to target '${targetName}'?`;
+
+  return (
+    <ConfirmAction
+      breadcrumb={BREADCRUMB}
+      description={DESCRIPTION}
+      title={project.name}
+      rows={[
+        { label: "target", value: targetName },
+        {
+          label: "account",
+          value: target.data
+            ? `${target.data.account}/${target.data.region}`
+            : `created on first deploy (${region})`,
+        },
+      ]}
+      message={message}
+      isPending={target.isPending}
+      error={target.isError ? (target.error as Error) : null}
+      action={async function* () {
+        const result = yield* core.projectManager.deploy(project, {
+          target: targetName,
+          region,
+          confirmTeardown: async () => teardown,
+        });
+        const rows: SummaryRow[] = [
+          { label: "result", value: deployedMessage(project, targetName, result) },
+        ];
+        for (const [key, value] of Object.entries(result.outputs)) rows.push({ label: key, value });
+        return rows;
+      }}
+      successTitle={teardown ? "Project removed" : "Project deployed"}
+      runningLabel="deploying…"
+      onDone={() => exit()}
+      onCancel={() => navigate("/agentcore/project")}
+    />
+  );
+}

--- a/src/handlers/project/deploy/screen.tsx
+++ b/src/handlers/project/deploy/screen.tsx
@@ -18,11 +18,9 @@ const BREADCRUMB = ["agentcore", "project", "deploy"];
 const DESCRIPTION = "deploy the project to AWS";
 const PROJECT_MENU = "/agentcore/project";
 
-// DeployProjectScreen is `agentcore project deploy` from the menu. It runs the
-// same projectManager.deploy generator the command runs, and ConfirmAction
-// renders its steps through the same TaskList runWithProgress renders on the
-// command line. With one target (or none yet) it deploys there; with several,
-// it asks which — the TUI's stand-in for --target.
+// DeployProjectScreen runs the same projectManager.deploy generator the command
+// runs; ConfirmAction renders its steps through the same TaskList. With several
+// targets it asks which first — the TUI's stand-in for --target.
 export function DeployProjectScreen({ ctx, core }: ScreenProps) {
   const navigate = useNavigate();
   return (
@@ -58,9 +56,8 @@ function DeployTarget({
   const navigate = useNavigate();
   const [chosen, setChosen] = useState<string>();
 
-  // The declared targets decide whether there is anything to choose. A fresh
-  // project has no aws-targets.json yet: the list is empty, and deploy
-  // provisions `default` on first run, as the command does.
+  // A fresh project has no aws-targets.json yet: the list is empty and deploy
+  // provisions `default` on first run.
   const targets = useQuery({
     queryKey: ["project-targets", project.rootPath],
     queryFn: () => core.projectManager.listTargets(project),
@@ -148,12 +145,10 @@ function DeployConfirm({
   const navigate = useNavigate();
   const region = ctx.require(RegionKey);
 
-  // A deploy is confirmed only when it would tear the stack down — the same
-  // rule as the command, which asks its readline question in exactly that case
-  // and otherwise just deploys. Once the progress UI is up nothing may block on
-  // input, so the answer here is the pre-answered decision the backend
-  // consults; when the backend's own count disagrees with this preflight, it
-  // reports the "re-run with --yes" error as it does for a non-interactive run.
+  // Confirmed only when the deploy would tear the stack down, the one case the
+  // command asks. Nothing may block on input once the progress UI is up, so the
+  // answer is the pre-answered decision the backend consults; if its own count
+  // disagrees with this preflight it reports the "re-run with --yes" error.
   const teardown = target !== undefined && declaresNothingDeployable(project);
 
   return (
@@ -173,10 +168,9 @@ function DeployConfirm({
           region,
           confirmTeardown: async () => teardown,
         });
-        // The outcome comes from the result, as the command's own line does:
-        // the preflight heuristic above only decides what to ask, and the
-        // backend's post-synth count can disagree with it. Stack outputs are
-        // not listed — the command prints them only with --json.
+        // The title follows the result, not the preflight heuristic, which
+        // synthesis can disagree with. Outputs are not listed: the command
+        // prints them only with --json.
         return { title: deployedMessage(project, targetName, result), rows: [] };
       }}
       successTitle="Deploy finished"

--- a/src/handlers/project/deploy/screen.tsx
+++ b/src/handlers/project/deploy/screen.tsx
@@ -12,6 +12,7 @@ import { declaresNothingDeployable, deployedMessage, teardownQuestion } from "./
 
 const BREADCRUMB = ["agentcore", "project", "deploy"];
 const DESCRIPTION = "deploy the project to AWS";
+const PROJECT_MENU = "/agentcore/project";
 
 // DeployProjectScreen is `agentcore project deploy` from the menu. It runs the
 // same projectManager.deploy generator the command runs, and ConfirmAction
@@ -19,12 +20,14 @@ const DESCRIPTION = "deploy the project to AWS";
 // command line. The teardown question the command asks over readline is asked
 // here as the confirmation itself.
 export function DeployProjectScreen({ ctx, core }: ScreenProps) {
+  const navigate = useNavigate();
   return (
     <ProjectGate
       core={core}
       breadcrumb={BREADCRUMB}
       description={DESCRIPTION}
       seed={ctx.value(ProjectKey)}
+      onBack={() => navigate(PROJECT_MENU)}
     >
       {(project) => <DeployConfirm project={project} ctx={ctx} core={core} />}
     </ProjectGate>
@@ -85,16 +88,19 @@ function DeployConfirm({
           region,
           confirmTeardown: async () => teardown,
         });
-        const rows: SummaryRow[] = [
-          { label: "result", value: deployedMessage(project, targetName, result) },
-        ];
-        for (const [key, value] of Object.entries(result.outputs)) rows.push({ label: key, value });
-        return rows;
+        // The outcome comes from the result, as the command's own line does:
+        // the preflight heuristic above only decides what to ask, and the
+        // backend's post-synth count can disagree with it.
+        const rows: SummaryRow[] = Object.entries(result.outputs).map(([label, value]) => ({
+          label,
+          value,
+        }));
+        return { title: deployedMessage(project, targetName, result), rows };
       }}
-      successTitle={teardown ? "Project removed" : "Project deployed"}
+      successTitle="Deploy finished"
       runningLabel="deploying…"
       onDone={() => exit()}
-      onCancel={() => navigate("/agentcore/project")}
+      onCancel={() => navigate(PROJECT_MENU)}
     />
   );
 }

--- a/src/handlers/project/deploy/screen.tsx
+++ b/src/handlers/project/deploy/screen.tsx
@@ -1,8 +1,12 @@
+import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { Box, Text } from "ink";
 import { useNavigate } from "react-router";
-import { useApp } from "ink";
-import { ConfirmAction, type SummaryRow } from "../../../components/ConfirmAction";
-import { DEFAULT_TARGET_NAME } from "../../../projectSchemas/aws-targets";
+import { ConfirmAction } from "../../../components/ConfirmAction";
+import { Layout } from "../../../components/Layout";
+import { DataTable, type DataTableColumn } from "../../../components/ui/data-table";
+import { Spinner } from "../../../components/ui/spinner";
+import { DEFAULT_TARGET_NAME, type AwsDeploymentTarget } from "../../../projectSchemas/aws-targets";
 import { ProjectKey, type Context } from "../../../router";
 import { RegionKey } from "../../keys";
 import type { ScreenProps } from "../../types";
@@ -17,8 +21,8 @@ const PROJECT_MENU = "/agentcore/project";
 // DeployProjectScreen is `agentcore project deploy` from the menu. It runs the
 // same projectManager.deploy generator the command runs, and ConfirmAction
 // renders its steps through the same TaskList runWithProgress renders on the
-// command line. The teardown question the command asks over readline is asked
-// here as the confirmation itself.
+// command line. With one target (or none yet) it deploys there; with several,
+// it asks which — the TUI's stand-in for --target.
 export function DeployProjectScreen({ ctx, core }: ScreenProps) {
   const navigate = useNavigate();
   return (
@@ -29,12 +33,20 @@ export function DeployProjectScreen({ ctx, core }: ScreenProps) {
       seed={ctx.value(ProjectKey)}
       onBack={() => navigate(PROJECT_MENU)}
     >
-      {(project) => <DeployConfirm project={project} ctx={ctx} core={core} />}
+      {(project) => <DeployTarget project={project} ctx={ctx} core={core} />}
     </ProjectGate>
   );
 }
 
-function DeployConfirm({
+type TargetRow = Record<string, unknown> & AwsDeploymentTarget;
+
+const TARGET_COLUMNS = [
+  { key: "name", header: "target", width: 16 },
+  { key: "account", header: "account", width: 14 },
+  { key: "region", header: "region", flex: true },
+] satisfies DataTableColumn<TargetRow>[];
+
+function DeployTarget({
   project,
   ctx,
   core,
@@ -44,44 +56,117 @@ function DeployConfirm({
   core: ScreenProps["core"];
 }) {
   const navigate = useNavigate();
-  const { exit } = useApp();
-  const region = ctx.require(RegionKey);
-  const targetName = DEFAULT_TARGET_NAME;
+  const [chosen, setChosen] = useState<string>();
 
-  // The target is resolved up front, as the command does, because the teardown
-  // question is only asked when there is a target whose stack could be removed.
-  const target = useQuery({
-    queryKey: ["project-target", project.rootPath, targetName],
-    queryFn: () => core.projectManager.resolveTarget(project, { target: targetName }),
+  // The declared targets decide whether there is anything to choose. A fresh
+  // project has no aws-targets.json yet: the list is empty, and deploy
+  // provisions `default` on first run, as the command does.
+  const targets = useQuery({
+    queryKey: ["project-targets", project.rootPath],
+    queryFn: () => core.projectManager.listTargets(project),
   });
 
-  // Once the progress UI is up nothing may block on input, so the teardown
-  // decision is settled by the confirmation the user is about to answer: when
-  // the project declares nothing deployable, confirming *is* confirming the
-  // teardown. Otherwise the backend's own zero-resource check reports the
-  // "re-run with --yes" error, as it does for a non-interactive deploy.
-  const teardown = target.data !== undefined && declaresNothingDeployable(project);
-  const message = teardown
-    ? teardownQuestion(project.name, target.data!)
-    : `Deploy project '${project.name}' to target '${targetName}'?`;
+  if (targets.isPending || targets.isError) {
+    return (
+      <Layout
+        breadcrumb={BREADCRUMB}
+        description={DESCRIPTION}
+        keyHints={[{ key: "ctl+c", label: "quit" }]}
+      >
+        <Box paddingX={1}>
+          {targets.isError ? (
+            <Text color="red">{(targets.error as Error).message}</Text>
+          ) : (
+            <Spinner label="reading deployment targets…" />
+          )}
+        </Box>
+      </Layout>
+    );
+  }
+
+  const declared = targets.data;
+  const targetName =
+    chosen ?? (declared.length <= 1 ? (declared[0]?.name ?? DEFAULT_TARGET_NAME) : undefined);
+
+  if (targetName === undefined) {
+    return (
+      <Layout
+        breadcrumb={BREADCRUMB}
+        description="choose a deployment target"
+        keyHints={[
+          { key: "↑↓", label: "navigate" },
+          { key: "enter", label: "select" },
+          { key: "esc", label: "back" },
+          { key: "ctl+c", label: "quit" },
+        ]}
+      >
+        <DataTable
+          borderStyle="none"
+          borderTop={false}
+          borderBottom={false}
+          borderRight={false}
+          showFooter={false}
+          focus
+          columns={TARGET_COLUMNS}
+          data={declared as TargetRow[]}
+          emptyMessage="No deployment targets are configured."
+          onSelect={(row) => setChosen(row.name)}
+          onEscape={() => navigate(PROJECT_MENU)}
+        />
+      </Layout>
+    );
+  }
+
+  return (
+    <DeployConfirm
+      project={project}
+      ctx={ctx}
+      core={core}
+      targetName={targetName}
+      target={declared.find((candidate) => candidate.name === targetName)}
+      // With a choice behind us, esc returns to it; otherwise to the menu.
+      onCancel={() => (declared.length > 1 ? setChosen(undefined) : navigate(PROJECT_MENU))}
+    />
+  );
+}
+
+function DeployConfirm({
+  project,
+  ctx,
+  core,
+  targetName,
+  target,
+  onCancel,
+}: {
+  project: Project;
+  ctx: Context;
+  core: ScreenProps["core"];
+  targetName: string;
+  target: AwsDeploymentTarget | undefined;
+  onCancel: () => void;
+}) {
+  const navigate = useNavigate();
+  const region = ctx.require(RegionKey);
+
+  // A deploy is confirmed only when it would tear the stack down — the same
+  // rule as the command, which asks its readline question in exactly that case
+  // and otherwise just deploys. Once the progress UI is up nothing may block on
+  // input, so the answer here is the pre-answered decision the backend
+  // consults; when the backend's own count disagrees with this preflight, it
+  // reports the "re-run with --yes" error as it does for a non-interactive run.
+  const teardown = target !== undefined && declaresNothingDeployable(project);
 
   return (
     <ConfirmAction
       breadcrumb={BREADCRUMB}
       description={DESCRIPTION}
-      title={project.name}
       rows={[
+        { label: "project", value: project.name },
         { label: "target", value: targetName },
-        {
-          label: "account",
-          value: target.data
-            ? `${target.data.account}/${target.data.region}`
-            : `created on first deploy (${region})`,
-        },
       ]}
-      message={message}
-      isPending={target.isPending}
-      error={target.isError ? (target.error as Error) : null}
+      message={teardown ? teardownQuestion(project.name, target) : undefined}
+      isPending={false}
+      error={null}
       action={async function* () {
         const result = yield* core.projectManager.deploy(project, {
           target: targetName,
@@ -90,17 +175,15 @@ function DeployConfirm({
         });
         // The outcome comes from the result, as the command's own line does:
         // the preflight heuristic above only decides what to ask, and the
-        // backend's post-synth count can disagree with it.
-        const rows: SummaryRow[] = Object.entries(result.outputs).map(([label, value]) => ({
-          label,
-          value,
-        }));
-        return { title: deployedMessage(project, targetName, result), rows };
+        // backend's post-synth count can disagree with it. Stack outputs are
+        // not listed — the command prints them only with --json.
+        return { title: deployedMessage(project, targetName, result), rows: [] };
       }}
       successTitle="Deploy finished"
       runningLabel="deploying…"
-      onDone={() => exit()}
-      onCancel={() => navigate(PROJECT_MENU)}
+      onDone={() => navigate(PROJECT_MENU)}
+      doneLabel="go back"
+      onCancel={onCancel}
     />
   );
 }

--- a/src/handlers/project/deploy/screen.tsx
+++ b/src/handlers/project/deploy/screen.tsx
@@ -1,16 +1,14 @@
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Box, Text } from "ink";
 import { useNavigate } from "react-router";
 import { ConfirmAction } from "../../../components/ConfirmAction";
 import { Layout } from "../../../components/Layout";
 import { DataTable, type DataTableColumn } from "../../../components/ui/data-table";
-import { Spinner } from "../../../components/ui/spinner";
 import { DEFAULT_TARGET_NAME, type AwsDeploymentTarget } from "../../../projectSchemas/aws-targets";
 import { ProjectKey, type Context } from "../../../router";
 import { RegionKey } from "../../keys";
 import type { ScreenProps } from "../../types";
-import { ProjectGate } from "../ProjectGate";
+import { LoadingFrame, ProjectGate } from "../ProjectGate";
 import type { Project } from "../types";
 import { declaresNothingDeployable, deployedMessage, teardownQuestion } from "./index";
 
@@ -63,21 +61,15 @@ function DeployTarget({
     queryFn: () => core.projectManager.listTargets(project),
   });
 
-  if (targets.isPending || targets.isError) {
+  if (targets.data === undefined) {
     return (
-      <Layout
+      <LoadingFrame
         breadcrumb={BREADCRUMB}
         description={DESCRIPTION}
-        keyHints={[{ key: "ctl+c", label: "quit" }]}
-      >
-        <Box paddingX={1}>
-          {targets.isError ? (
-            <Text color="red">{(targets.error as Error).message}</Text>
-          ) : (
-            <Spinner label="reading deployment targets…" />
-          )}
-        </Box>
-      </Layout>
+        query={targets}
+        loadingLabel="reading deployment targets…"
+        onBack={() => navigate(PROJECT_MENU)}
+      />
     );
   }
 
@@ -159,7 +151,11 @@ function DeployConfirm({
         { label: "project", value: project.name },
         { label: "target", value: targetName },
       ]}
-      message={teardown ? teardownQuestion(project.name, target) : undefined}
+      trigger={
+        teardown
+          ? { kind: "confirm", message: teardownQuestion(project.name, target) }
+          : { kind: "immediate" }
+      }
       isPending={false}
       error={null}
       action={async function* () {

--- a/src/handlers/project/deploy/screen.tsx
+++ b/src/handlers/project/deploy/screen.tsx
@@ -59,9 +59,10 @@ function DeployTarget({
   const targets = useQuery({
     queryKey: ["project-targets", project.rootPath],
     queryFn: () => core.projectManager.listTargets(project),
+    gcTime: 0,
   });
 
-  if (targets.data === undefined) {
+  if (targets.data === undefined || targets.isFetching || targets.isError) {
     return (
       <LoadingFrame
         breadcrumb={BREADCRUMB}
@@ -147,10 +148,7 @@ function DeployConfirm({
     <ConfirmAction
       breadcrumb={BREADCRUMB}
       description={DESCRIPTION}
-      rows={[
-        { label: "project", value: project.name },
-        { label: "target", value: targetName },
-      ]}
+      rows={{ project: project.name, target: targetName }}
       trigger={
         teardown
           ? { kind: "confirm", message: teardownQuestion(project.name, target) }
@@ -167,7 +165,7 @@ function DeployConfirm({
         // The title follows the result, not the preflight heuristic, which
         // synthesis can disagree with. Outputs are not listed: the command
         // prints them only with --json.
-        return { title: deployedMessage(project, targetName, result), rows: [] };
+        return { title: deployedMessage(project, targetName, result), rows: {} };
       }}
       successTitle="Deploy finished"
       runningLabel="deploying…"

--- a/src/handlers/project/invoke/screen.tsx
+++ b/src/handlers/project/invoke/screen.tsx
@@ -37,11 +37,11 @@ export function ProjectInvokePickerScreen({ ctx, core }: ScreenProps) {
   const navigate = useNavigate();
   // The project comes from the launch context when a project command opened
   // the TUI, and is resolved from the cwd otherwise.
-  const { project, error: projectError } = useProject(core, ctx.value(ProjectKey));
+  const { data: project, error: projectError } = useProject(core, ctx.value(ProjectKey));
   const [deployed, setDeployed] = useState<ResolvedDeployedResources>();
   const [destination, setDestination] = useState<Destination>();
   const [deployedError, setDeployedError] = useState<string>();
-  const error = projectError ?? deployedError;
+  const error = projectError?.message ?? deployedError;
 
   useEffect(() => {
     if (!project) return;

--- a/src/handlers/project/invoke/screen.tsx
+++ b/src/handlers/project/invoke/screen.tsx
@@ -10,7 +10,8 @@ import { HarnessChat } from "../../harness/invoke/screen";
 import { RegionKey } from "../../keys";
 import { RuntimeInvokeConsole } from "../../runtime/invoke/screen";
 import type { ScreenProps } from "../../types";
-import type { Project, ResolvedDeployedResources } from "../types";
+import type { ResolvedDeployedResources } from "../types";
+import { useProject } from "../ProjectGate";
 
 type ProjectInvokableRow = Record<string, unknown> & {
   resourceType: "runtime" | "harness";
@@ -34,36 +35,13 @@ type Destination =
 
 export function ProjectInvokePickerScreen({ ctx, core }: ScreenProps) {
   const navigate = useNavigate();
-  const [project, setProject] = useState<Project | undefined>(() => ctx.value(ProjectKey));
+  // The project comes from the launch context when a project command opened
+  // the TUI, and is resolved from the cwd otherwise.
+  const { project, error: projectError } = useProject(core, ctx.value(ProjectKey));
   const [deployed, setDeployed] = useState<ResolvedDeployedResources>();
   const [destination, setDestination] = useState<Destination>();
-  const [error, setError] = useState<string>();
-
-  useEffect(() => {
-    if (project) return;
-    let active = true;
-    const from = process.cwd();
-    void core.projectManager
-      .resolve({ filePath: from })
-      .then((resolved) => {
-        if (!active) return;
-        if (!resolved) {
-          setError(
-            `No AgentCore project found at ${from} or any parent directory ` +
-              `(looked for agentcore/agentcore.json). ` +
-              `Run 'agentcore project create' to scaffold one.`,
-          );
-          return;
-        }
-        setProject(resolved);
-      })
-      .catch((cause: unknown) => {
-        if (active) setError(cause instanceof Error ? cause.message : String(cause));
-      });
-    return () => {
-      active = false;
-    };
-  }, [core.projectManager, project]);
+  const [deployedError, setDeployedError] = useState<string>();
+  const error = projectError ?? deployedError;
 
   useEffect(() => {
     if (!project) return;
@@ -74,7 +52,7 @@ export function ProjectInvokePickerScreen({ ctx, core }: ScreenProps) {
         if (active) setDeployed(resolved);
       })
       .catch((cause: unknown) => {
-        if (active) setError(cause instanceof Error ? cause.message : String(cause));
+        if (active) setDeployedError(cause instanceof Error ? cause.message : String(cause));
       });
     return () => {
       active = false;

--- a/src/handlers/project/project.screen.test.tsx
+++ b/src/handlers/project/project.screen.test.tsx
@@ -76,9 +76,10 @@ describe("project subcommands without a screen", () => {
   // Reading the cases off the router also guards Root's hand-written
   // PROJECT_COMMANDS: an unrouted subcommand hits the catch-all, which resolves
   // instead of rejecting. Frames can't detect that — the catch-all exits before
-  // painting, so it and this screen both render empty. `create` and `invoke`
-  // are excluded because both have real screens.
-  test.each(projectSubcommands().filter((command) => command !== "create" && command !== "invoke"))(
+  // painting, so it and this screen both render empty. Subcommands with a real
+  // screen are excluded.
+  const WITH_SCREENS = ["create", "invoke", "build", "deploy"];
+  test.each(projectSubcommands().filter((command) => !WITH_SCREENS.includes(command)))(
     "%s tears down the TUI with NotImplementedError",
     async (command) => {
       const { streams } = ttyTestIO();
@@ -99,7 +100,7 @@ describe("project subcommands without a screen", () => {
     const { streams } = ttyTestIO();
 
     const caught: unknown = await renderTuiAt(
-      "/agentcore/project/deploy",
+      "/agentcore/project/status",
       ValueContext.EmptyContext(),
       new TestCoreClient(),
       streams.io,
@@ -110,7 +111,7 @@ describe("project subcommands without a screen", () => {
 
     expect(caught).toBeInstanceOf(NotImplementedError);
     const error = caught as NotImplementedError;
-    expect(error.message).toContain("agentcore project deploy --help");
+    expect(error.message).toContain("agentcore project status --help");
     // Surfaces as a plain CLI failure, not a crash.
     expect(error.exitCode).toBe(1);
   });

--- a/src/handlers/project/types.ts
+++ b/src/handlers/project/types.ts
@@ -350,6 +350,12 @@ export interface ProjectManager {
   deploy(project: Project, input: DeployProjectInput): AsyncGenerator<ProjectEvent, DeployResult>;
 
   /**
+   * The targets aws-targets.json declares, in file order; empty when the file
+   * is absent (deploy then synthesizes the default target on demand).
+   */
+  listTargets(project: Project): Promise<AwsDeploymentTarget[]>;
+
+  /**
    * Look up a target in aws-targets.json without provisioning or requiring it.
    * Returns undefined when the file or the named entry is absent — unlike
    * deploy, which synthesizes the default target on demand.

--- a/src/middleware/withProject.tsx
+++ b/src/middleware/withProject.tsx
@@ -15,6 +15,18 @@ interface WithProjectConfig {
  *
  * @param config - Contains the {@link ProjectManager} and an optional `cwd` to search from.
  */
+/**
+ * The guidance printed when no project encloses `from`. Exported so TUI screens
+ * that resolve the project themselves (see useProject) say the same thing.
+ */
+export function projectNotFoundMessage(from: string): string {
+  return (
+    `No AgentCore project found at ${from} or any parent directory ` +
+    `(looked for agentcore/agentcore.json). ` +
+    `Run 'agentcore project create' to scaffold one.`
+  );
+}
+
 export function withProject(config: WithProjectConfig): Middleware {
   return (h) => ({
     name: () => h.name(),
@@ -29,11 +41,7 @@ export function withProject(config: WithProjectConfig): Middleware {
       const from = config.cwd ?? process.cwd();
       const project = await config.projectManager.resolve({ filePath: from });
       if (!project) {
-        throw new ProjectStateError(
-          `No AgentCore project found at ${from} or any parent directory ` +
-            `(looked for agentcore/agentcore.json). ` +
-            `Run 'agentcore project create' to scaffold one.`,
-        );
+        throw new ProjectStateError(projectNotFoundMessage(from));
       }
       await h.handle(ctx.withValue<Project>(ProjectKey, project), flags, args);
     },

--- a/src/middleware/withProject.tsx
+++ b/src/middleware/withProject.tsx
@@ -15,10 +15,7 @@ interface WithProjectConfig {
  *
  * @param config - Contains the {@link ProjectManager} and an optional `cwd` to search from.
  */
-/**
- * The guidance printed when no project encloses `from`. Exported so TUI screens
- * that resolve the project themselves (see useProject) say the same thing.
- */
+/** The guidance printed when no project encloses `from`; TUI screens reuse it. */
 export function projectNotFoundMessage(from: string): string {
   return (
     `No AgentCore project found at ${from} or any parent directory ` +

--- a/src/testing/index.tsx
+++ b/src/testing/index.tsx
@@ -25,6 +25,8 @@ export {
   cleanupScreens,
   keys,
   waitForText,
+  flatFrame,
+  waitForFlatText,
   type RenderScreenOptions,
   type RenderScreenResult,
 } from "./renderScreen";

--- a/src/testing/renderScreen.tsx
+++ b/src/testing/renderScreen.tsx
@@ -170,3 +170,19 @@ export function waitForText(
 ): Promise<void> {
   return waitFor(() => (lastFrame() ?? "").includes(text), timeoutMs);
 }
+
+// flatFrame collapses a frame's whitespace so text that Ink lays out across
+// columns or lines (a key/value table, a wrapped sentence) can be matched as a
+// single string.
+export function flatFrame(lastFrame: () => string | undefined): string {
+  return (lastFrame() ?? "").replace(/\s+/g, " ");
+}
+
+// waitForFlatText is waitForText against the flattened frame.
+export function waitForFlatText(
+  lastFrame: () => string | undefined,
+  text: string,
+  timeoutMs = 1000,
+): Promise<void> {
+  return waitFor(() => flatFrame(lastFrame).includes(text), timeoutMs);
+}

--- a/src/tui/progress.test.tsx
+++ b/src/tui/progress.test.tsx
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import { testIO } from "../testing";
-import { runWithProgress, type ProgressEvent } from "./progress";
+import {
+  applyProgressEvent,
+  runWithProgress,
+  settleProgress,
+  type ProgressEvent,
+} from "./progress";
 
 // Ink writes cursor/erase sequences around each frame; the assertions here
 // care about frame text, not terminal control. Built without a control-char
@@ -133,5 +138,42 @@ describe("runWithProgress interactive path", () => {
 
     expect(result).toBe(1);
     expect(stripAnsi(io.stderr())).toContain("✓ Only step");
+  });
+});
+
+describe("applyProgressEvent / settleProgress", () => {
+  test("a step completes the running task and starts the next", () => {
+    let tasks = applyProgressEvent([], { type: "step", message: "synth" });
+    expect(tasks).toEqual([{ title: "synth", state: "running", tail: [] }]);
+
+    tasks = applyProgressEvent(tasks, { type: "output", line: "one" });
+    tasks = applyProgressEvent(tasks, { type: "step", message: "deploy" });
+    expect(tasks).toEqual([
+      { title: "synth", state: "done", tail: [] },
+      { title: "deploy", state: "running", tail: [] },
+    ]);
+  });
+
+  test("output joins the running task's tail, bounded by tailLines", () => {
+    let tasks = applyProgressEvent([], { type: "step", message: "deploy" });
+    for (const line of ["a", "b", "c"]) {
+      tasks = applyProgressEvent(tasks, { type: "output", line }, 2);
+    }
+    expect(tasks[0]!.tail).toEqual(["b", "c"]);
+  });
+
+  test("output before any step is dropped", () => {
+    expect(applyProgressEvent([], { type: "output", line: "stray" })).toEqual([]);
+  });
+
+  test("settling keeps the tail on failure and clears it on success", () => {
+    let tasks = applyProgressEvent([], { type: "step", message: "deploy" });
+    tasks = applyProgressEvent(tasks, { type: "output", line: "boom" });
+
+    expect(settleProgress(tasks, "failed")).toEqual([
+      { title: "deploy", state: "failed", tail: ["boom"] },
+    ]);
+    expect(settleProgress(tasks, "done")).toEqual([{ title: "deploy", state: "done", tail: [] }]);
+    expect(settleProgress([], "done")).toEqual([]);
   });
 });

--- a/src/tui/progress.test.tsx
+++ b/src/tui/progress.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { testIO } from "../testing";
 import {
   applyProgressEvent,
+  driveProgress,
   runWithProgress,
   settleProgress,
   type ProgressEvent,
@@ -175,5 +176,38 @@ describe("applyProgressEvent / settleProgress", () => {
     ]);
     expect(settleProgress(tasks, "done")).toEqual([{ title: "deploy", state: "done", tail: [] }]);
     expect(settleProgress([], "done")).toEqual([]);
+  });
+});
+
+describe("driveProgress", () => {
+  test("reports the task list after each event, settles done, and resolves the return value", async () => {
+    async function* work() {
+      yield { type: "step", message: "one" } as ProgressEvent;
+      yield { type: "output", line: "detail" } as ProgressEvent;
+      return 42;
+    }
+    const frames: string[] = [];
+    const result = await driveProgress(work(), (tasks) =>
+      frames.push(
+        tasks.map((task) => `${task.state}:${task.title}:${task.tail.join(",")}`).join("|"),
+      ),
+    );
+    expect(result).toBe(42);
+    expect(frames).toEqual(["running:one:", "running:one:detail", "done:one:"]);
+  });
+
+  test("settles the running task failed and rethrows unchanged", async () => {
+    const failure = new Error("boom");
+    async function* work() {
+      yield { type: "step", message: "one" } as ProgressEvent;
+      throw failure;
+    }
+    let last: string | undefined;
+    await expect(
+      driveProgress(work(), (tasks) => {
+        last = tasks.map((task) => `${task.state}:${task.title}`).join("|");
+      }),
+    ).rejects.toBe(failure);
+    expect(last).toBe("failed:one");
   });
 });

--- a/src/tui/progress.tsx
+++ b/src/tui/progress.tsx
@@ -27,8 +27,6 @@ const DEFAULT_TAIL_LINES = 5;
 /**
  * Folds one progress event into a task list: a `step` completes the running
  * task and starts a new one; an `output` line joins the running task's tail.
- * Pure, so every renderer of progress — the inline TaskList below, a TUI
- * screen's running phase — reads events the same way and shows the same steps.
  */
 export function applyProgressEvent(
   tasks: readonly Task[],
@@ -64,10 +62,8 @@ export function settleProgress(tasks: readonly Task[], state: "done" | "failed")
 
 /**
  * Drains a progress generator, reporting the task list after every change, and
- * resolves with the generator's return value. On failure the running task is
- * marked failed and the error rethrown unchanged. This is the one place a
- * generator becomes tasks; every renderer — the inline TaskList below, a TUI
- * screen — supplies only how to draw them.
+ * resolves with its return value. On failure the running task is marked failed
+ * and the error rethrown unchanged. Renderers supply only how to draw the tasks.
  */
 export async function driveProgress<T>(
   generator: AsyncGenerator<ProgressEvent, T>,
@@ -136,8 +132,8 @@ export async function runWithProgress<T>(
     patchConsole: false,
   });
 
-  // On failure the failed step keeps its tail: the last frame stays in
-  // scrollback above the error message runWithExitCode prints after the rethrow.
+  // A failed step keeps its tail: the last frame stays in scrollback above the
+  // error runWithExitCode prints after the rethrow.
   try {
     return await driveProgress(
       generator,

--- a/src/tui/progress.tsx
+++ b/src/tui/progress.tsx
@@ -63,6 +63,34 @@ export function settleProgress(tasks: readonly Task[], state: "done" | "failed")
 }
 
 /**
+ * Drains a progress generator, reporting the task list after every change, and
+ * resolves with the generator's return value. On failure the running task is
+ * marked failed and the error rethrown unchanged. This is the one place a
+ * generator becomes tasks; every renderer — the inline TaskList below, a TUI
+ * screen — supplies only how to draw them.
+ */
+export async function driveProgress<T>(
+  generator: AsyncGenerator<ProgressEvent, T>,
+  onChange: (tasks: Task[]) => void,
+  tailLines = DEFAULT_TAIL_LINES,
+): Promise<T> {
+  let tasks: Task[] = [];
+  try {
+    let next = await generator.next();
+    while (!next.done) {
+      tasks = applyProgressEvent(tasks, next.value, tailLines);
+      onChange(tasks);
+      next = await generator.next();
+    }
+    onChange(settleProgress(tasks, "done"));
+    return next.value;
+  } catch (error) {
+    onChange(settleProgress(tasks, "failed"));
+    throw error;
+  }
+}
+
+/**
  * Drains a progress generator into a live step list and resolves with the
  * generator's return value.
  *
@@ -95,7 +123,6 @@ export async function runWithProgress<T>(
   }
 
   const tailLines = options.tailLines ?? DEFAULT_TAIL_LINES;
-  let tasks: Task[] = [];
   // Ink renders onto its `stdout` option; handing it io.stderr keeps progress
   // off the machine-readable stream, same as the plain path.
   const instance = render(<TaskList tasks={[]} tailLines={tailLines} />, {
@@ -108,24 +135,15 @@ export async function runWithProgress<T>(
     exitOnCtrlC: false,
     patchConsole: false,
   });
-  const draw = () => instance.rerender(<TaskList tasks={tasks} tailLines={tailLines} />);
 
+  // On failure the failed step keeps its tail: the last frame stays in
+  // scrollback above the error message runWithExitCode prints after the rethrow.
   try {
-    let next = await generator.next();
-    while (!next.done) {
-      tasks = applyProgressEvent(tasks, next.value, tailLines);
-      draw();
-      next = await generator.next();
-    }
-    tasks = settleProgress(tasks, "done");
-    draw();
-    return next.value;
-  } catch (error) {
-    // The failed step keeps its tail: the last frame stays in scrollback above
-    // the error message runWithExitCode prints after the rethrow.
-    tasks = settleProgress(tasks, "failed");
-    draw();
-    throw error;
+    return await driveProgress(
+      generator,
+      (tasks) => instance.rerender(<TaskList tasks={tasks} tailLines={tailLines} />),
+      tailLines,
+    );
   } finally {
     instance.unmount();
     await instance.waitUntilExit();

--- a/src/tui/progress.tsx
+++ b/src/tui/progress.tsx
@@ -25,6 +25,44 @@ export type RunWithProgressOptions = {
 const DEFAULT_TAIL_LINES = 5;
 
 /**
+ * Folds one progress event into a task list: a `step` completes the running
+ * task and starts a new one; an `output` line joins the running task's tail.
+ * Pure, so every renderer of progress — the inline TaskList below, a TUI
+ * screen's running phase — reads events the same way and shows the same steps.
+ */
+export function applyProgressEvent(
+  tasks: readonly Task[],
+  event: ProgressEvent,
+  tailLines = DEFAULT_TAIL_LINES,
+): Task[] {
+  const current = tasks[tasks.length - 1];
+  if (event.type === "step") {
+    const settled = current
+      ? [...tasks.slice(0, -1), { ...current, state: "done" as const, tail: [] }]
+      : [];
+    return [...settled, { title: event.message, state: "running", tail: [] }];
+  }
+  // An output line before the first step has nowhere to render; the debug log
+  // still has it.
+  if (!current) return [...tasks];
+  return [
+    ...tasks.slice(0, -1),
+    { ...current, tail: [...current.tail, event.line].slice(-tailLines) },
+  ];
+}
+
+/**
+ * Marks the running task finished: `done` when the generator returned (its
+ * tail collapses), `failed` when it threw (the tail stays, so the last output
+ * is visible above the error).
+ */
+export function settleProgress(tasks: readonly Task[], state: "done" | "failed"): Task[] {
+  const current = tasks[tasks.length - 1];
+  if (!current) return [...tasks];
+  return [...tasks.slice(0, -1), { ...current, state, tail: state === "done" ? [] : current.tail }];
+}
+
+/**
  * Drains a progress generator into a live step list and resolves with the
  * generator's return value.
  *
@@ -57,7 +95,7 @@ export async function runWithProgress<T>(
   }
 
   const tailLines = options.tailLines ?? DEFAULT_TAIL_LINES;
-  const tasks: Task[] = [];
+  let tasks: Task[] = [];
   // Ink renders onto its `stdout` option; handing it io.stderr keeps progress
   // off the machine-readable stream, same as the plain path.
   const instance = render(<TaskList tasks={[]} tailLines={tailLines} />, {
@@ -70,41 +108,22 @@ export async function runWithProgress<T>(
     exitOnCtrlC: false,
     patchConsole: false,
   });
-  const draw = () => instance.rerender(<TaskList tasks={[...tasks]} tailLines={tailLines} />);
-  const current = () => tasks[tasks.length - 1];
+  const draw = () => instance.rerender(<TaskList tasks={tasks} tailLines={tailLines} />);
 
   try {
     let next = await generator.next();
     while (!next.done) {
-      const event = next.value;
-      if (event.type === "step") {
-        const previous = current();
-        if (previous) {
-          previous.state = "done";
-          previous.tail = [];
-        }
-        tasks.push({ title: event.message, state: "running", tail: [] });
-      } else {
-        // An output line before the first step has nowhere to render; the
-        // debug log still has it.
-        const task = current();
-        if (task) task.tail = [...task.tail, event.line].slice(-tailLines);
-      }
+      tasks = applyProgressEvent(tasks, next.value, tailLines);
       draw();
       next = await generator.next();
     }
-    const last = current();
-    if (last) {
-      last.state = "done";
-      last.tail = [];
-    }
+    tasks = settleProgress(tasks, "done");
     draw();
     return next.value;
   } catch (error) {
     // The failed step keeps its tail: the last frame stays in scrollback above
     // the error message runWithExitCode prints after the rethrow.
-    const task = current();
-    if (task) task.state = "failed";
+    tasks = settleProgress(tasks, "failed");
     draw();
     throw error;
   } finally {


### PR DESCRIPTION
## What

`project build` and `project deploy` open from the TUI menu instead of reporting "not implemented", and show **exactly the progress the command shows** — same steps, same ✓/✕/spinner glyphs, same output tail under the running step.

```
 agentcore → project → deploy → deploy the project to AWS
──────────────────────────────────────────────────────────────
 ╭────────────────────────────────────────────────────────────╮
 │ project  orders                                            │
 │ target   default                                           │
 ╰────────────────────────────────────────────────────────────╯
 ✓ Verifying AWS account 111122223333
 ⠋ Deploying AgentCore-orders-default
   │ CREATE_IN_PROGRESS | AWS::IAM::Role
──────────────────────────────────────────────────────────────
[ctl+c] quit
```

**build** starts as soon as the screen opens (nothing to confirm — it only writes inside the project). Done, it suggests `agentcore project deploy`; enter returns to the project menu.

**deploy** behaves as the command does: it deploys at once, and asks only in the one case the command asks — when `agentcore.json` declares nothing deployable, so deploying would remove the stack. Then the confirmation *is* the CLI's teardown question, and "y" is the pre-answered `--yes`. With several targets in `aws-targets.json` it first asks which (the TUI's stand-in for `--target`); with one or none it uses that or `default`, provisioning it on first deploy exactly as the command does.

## How 

Everything on screen is a CLI piece wrapped in the TUI frame:

| the command uses | the screen uses |
|---|---|
| `projectManager.build(project)` / `.deploy(project, …)` | the same generator, verbatim: the screen's action is `yield* core.projectManager.build(project)` |
| `TaskList`, rendered inline by `runWithProgress` | the same `TaskList`, rendered by `ConfirmAction` while the generator streams |
| the generator drain + event→task fold inside `runWithProgress` | extracted to `driveProgress` (over pure `applyProgressEvent` / `settleProgress`) in `src/tui/progress.tsx`; **both** renderers call it and supply only how to draw the tasks |
| `ConfirmAction` (the confirm → run → success \| error body behind `harness delete`) | the whole screen. It learns to accept an `AsyncGenerator<ProgressEvent, …>` as its `action` and shows the `TaskList` in place of the bare spinner. `message`/`title`/`rows` become optional (no question → run when ready; no header → no box). Existing callers unchanged |
| `Confirm` (y/N) | the teardown confirmation |
| the readline teardown question | `teardownQuestion()`, exported from the handler and used by both; `declaresNothingDeployable()` (now exported) decides whether it is asked |
| `Built project '…'` / `Deployed project '…' to target '…'` | `builtMessage()` / `deployedMessage()`, exported and used by both. The deploy outcome is read from `result.tornDown`, as the command does — not from the preflight heuristic, which synthesis can disagree with |
| `DataTable` (the invoke picker) | the target picker |
| `KeyValueTable` | `ConfirmAction`'s header and result rows (replacing its fixed-width renderer) |
| `withProject`'s not-found message | `projectNotFoundMessage()`, exported; `useProject` / `ProjectGate` show it for a screen the user navigated to, esc back to the menu |

Stack outputs are not listed on success, matching the command, which prints them only with `--json`. Bare `agentcore project deploy` on the command line is unchanged.

## Also

- `ProjectManager.listTargets(project)` — the declared targets, `[]` with no file; `resolveTarget` delegates to it.
- `ProjectInvokePickerScreen` drops its inline project-resolution effect and message copy for `useProject`.
- `ConfirmAction` doesn't advertise `esc` while the action runs — nothing listens for it mid-flight, by design — and gains `doneLabel` / `nextSteps` / `onCancel`.
- `flatFrame` / `waitForFlatText` test helpers.

## Testing

`bun test`: **2754 pass, 0 fail**. `tsc --noEmit`, `oxlint`, `prettier --check` clean.

9 screen tests stub the backend exactly as the handler tests do, so both paths are asserted against identical events: build happy (enter → menu) / failure (✕ step with tail kept, esc → menu) / outside a project (esc → menu); deploy one target / several targets (picker) / fresh project with no `aws-targets.json` (default provisioned, step streamed) / empty-project teardown confirm / result-vs-heuristic disagreement / failure. 6 unit tests for the extracted fold and driver.

Driven by hand against a real project as well.
