### PR TITLE
feat(templates): support agui for python

### DIFF
--- a/src/assets/templates/agui-python-strands/Dockerfile.template
+++ b/src/assets/templates/agui-python-strands/Dockerfile.template
@@ -1,0 +1,40 @@
+FROM public.ecr.aws/docker/library/python:3.12-slim-trixie
+
+RUN pip install --no-cache-dir uv
+
+ARG UV_DEFAULT_INDEX
+ARG UV_INDEX
+
+WORKDIR /app
+
+ENV UV_SYSTEM_PYTHON=1 \
+    UV_COMPILE_BYTECODE=1 \
+    UV_NO_PROGRESS=1 \
+    PYTHONUNBUFFERED=1 \
+    DOCKER_CONTAINER=1 \
+    UV_DEFAULT_INDEX=${UV_DEFAULT_INDEX} \
+    UV_INDEX=${UV_INDEX} \
+    PATH="/app/.venv/bin:$PATH"
+
+RUN useradd -m -u 1000 bedrock_agentcore
+
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-dev --no-install-project
+
+COPY --chown=bedrock_agentcore:bedrock_agentcore . .
+RUN uv sync --frozen --no-dev
+
+USER bedrock_agentcore
+
+# AgentCore Runtime service contract ports
+# https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-service-contract.html
+# 8080: HTTP Mode
+# 8000: MCP Mode
+# 9000: A2A Mode
+EXPOSE 8080 8000 9000
+
+{{#if enableOtel}}
+CMD ["opentelemetry-instrument", "python", "-m", "{{entrypoint}}"]
+{{else}}
+CMD ["python", "-m", "{{entrypoint}}"]
+{{/if}}

--- a/src/assets/templates/agui-python-strands/README.md
+++ b/src/assets/templates/agui-python-strands/README.md
@@ -28,5 +28,12 @@ health at `http://127.0.0.1:8080/ping`.
 
 ## Deployment
 
-`agentcore project deploy` deploys the agent into Amazon Bedrock AgentCore. Invoke it with
-the AWS CLI (`bedrock-agentcore invoke-agent-runtime`) using an AG-UI `RunAgentInput` payload.
+`agentcore project deploy` deploys the agent into Amazon Bedrock AgentCore. Invoke the deployed
+runtime with an AG-UI `RunAgentInput` payload:
+
+```bash
+agentcore project invoke runtime --name agui_python_strands \
+  --payload '{"threadId":"t1","runId":"r1","state":{},"messages":[{"id":"m1","role":"user","content":"Hello!"}],"tools":[],"context":[],"forwardedProps":{}}'
+```
+
+The response streams back as AG-UI server-sent events.

--- a/src/assets/templates/agui-python-strands/README.md
+++ b/src/assets/templates/agui-python-strands/README.md
@@ -1,0 +1,32 @@
+# {{ name }}
+
+An AG-UI agent deployed on Amazon Bedrock AgentCore using the Strands SDK.
+
+## Overview
+
+This agent speaks the [AG-UI protocol](https://docs.ag-ui.com/introduction), which
+streams agent-to-UI events over HTTP. It exposes an `/invocations` endpoint that accepts
+an AG-UI `RunAgentInput` body and streams the response back as AG-UI server-sent events,
+matching the AgentCore Runtime HTTP service contract.
+
+## Adding Tools
+
+Define tools with the `@tool` decorator in `main.py` and add them to the agent's `tools` list:
+
+```python
+@tool
+def my_tool(param: str) -> str:
+    """Description of what the tool does."""
+    return f"Result: {param}"
+```
+
+## Developing locally
+
+`agentcore project dev` starts the agent locally on `0.0.0.0:8080`. Post an AG-UI
+`RunAgentInput` body to `http://127.0.0.1:8080/invocations` to invoke it, and check its
+health at `http://127.0.0.1:8080/ping`.
+
+## Deployment
+
+`agentcore project deploy` deploys the agent into Amazon Bedrock AgentCore. Invoke it with
+the AWS CLI (`bedrock-agentcore invoke-agent-runtime`) using an AG-UI `RunAgentInput` payload.

--- a/src/assets/templates/agui-python-strands/dockerignore.template
+++ b/src/assets/templates/agui-python-strands/dockerignore.template
@@ -1,0 +1,27 @@
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+dist/
+build/
+
+# IDE
+.vscode/
+.idea/
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Secrets and environment files
+.env
+.env.*
+
+# Version control
+.git/
+
+# AgentCore build artifacts
+.agentcore/artifacts/
+*.zip

--- a/src/assets/templates/agui-python-strands/gitignore.template
+++ b/src/assets/templates/agui-python-strands/gitignore.template
@@ -1,0 +1,41 @@
+# Environment variables
+.env
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environments
+.venv/
+venv/
+ENV/
+env/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db

--- a/src/assets/templates/agui-python-strands/main.py
+++ b/src/assets/templates/agui-python-strands/main.py
@@ -1,0 +1,46 @@
+import os
+
+import uvicorn
+from strands import Agent, tool
+from ag_ui_strands import StrandsAgent, StrandsAgentConfig, create_strands_app
+from model.load import load_model
+{{#if hasMemory}}
+from memory.session import get_memory_session_manager
+{{/if}}
+
+
+@tool
+def add_numbers(a: int, b: int) -> int:
+    """Return the sum of two numbers."""
+    return a + b
+
+
+agent = Agent(
+    model=load_model(),
+    system_prompt="You are a helpful assistant. Use tools when appropriate.",
+    tools=[add_numbers],
+)
+
+{{#if hasMemory}}
+# The AG-UI protocol carries a per-conversation thread_id; each thread gets its
+# own session manager so history is scoped to the conversation. Returns None
+# (in-process history only) until the deployed MEMORY_ID env var is set.
+def session_manager_provider(input_data):
+    return get_memory_session_manager(input_data.thread_id, "default-user")
+
+
+config = StrandsAgentConfig(session_manager_provider=session_manager_provider)
+{{else}}
+config = StrandsAgentConfig()
+{{/if}}
+
+agui_agent = StrandsAgent(
+    agent=agent, name="{{ name }}", description="A helpful assistant", config=config
+)
+
+# create_strands_app publishes the AG-UI endpoint at /invocations and a health
+# check at /ping, matching the AgentCore Runtime HTTP service contract on 8080.
+app = create_strands_app(agui_agent, path="/invocations", ping_path="/ping")
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=int(os.environ.get("PORT", "8080")))

--- a/src/assets/templates/agui-python-strands/memory/session.py
+++ b/src/assets/templates/agui-python-strands/memory/session.py
@@ -1,0 +1,47 @@
+import os
+import uuid
+from typing import Optional
+
+from bedrock_agentcore.memory.integrations.strands.config import AgentCoreMemoryConfig{{#if memoryStrategies.length}}, RetrievalConfig{{/if}}
+from bedrock_agentcore.memory.integrations.strands.session_manager import AgentCoreMemorySessionManager
+
+MEMORY_ID = os.getenv("{{memoryEnvVarName}}")
+REGION = os.getenv("AWS_REGION")
+
+
+def get_memory_session_manager(
+    session_id: Optional[str], actor_id: str
+) -> Optional[AgentCoreMemorySessionManager]:
+    if not MEMORY_ID:
+        return None
+
+    session_id = session_id or uuid.uuid4().hex
+
+{{#if memoryStrategies.length}}
+    retrieval_config = {
+{{#if (includes memoryStrategies "SEMANTIC")}}
+        f"/users/{actor_id}/facts": RetrievalConfig(top_k=3, relevance_score=0.5),
+{{/if}}
+{{#if (includes memoryStrategies "USER_PREFERENCE")}}
+        f"/users/{actor_id}/preferences": RetrievalConfig(top_k=3, relevance_score=0.5),
+{{/if}}
+{{#if (includes memoryStrategies "EPISODIC")}}
+        f"/episodes/{actor_id}/{session_id}": RetrievalConfig(top_k=5, relevance_score=0.5),
+{{/if}}
+{{#if (includes memoryStrategies "SUMMARIZATION")}}
+        f"/summaries/{actor_id}": RetrievalConfig(top_k=3, relevance_score=0.5),
+{{/if}}
+    }
+{{/if}}
+
+    return AgentCoreMemorySessionManager(
+        AgentCoreMemoryConfig(
+            memory_id=MEMORY_ID,
+            session_id=session_id,
+            actor_id=actor_id,
+{{#if memoryStrategies.length}}
+            retrieval_config=retrieval_config,
+{{/if}}
+        ),
+        REGION,
+    )

--- a/src/assets/templates/agui-python-strands/model/__init__.py
+++ b/src/assets/templates/agui-python-strands/model/__init__.py
@@ -1,0 +1,1 @@
+# Package marker

--- a/src/assets/templates/agui-python-strands/model/load.py
+++ b/src/assets/templates/agui-python-strands/model/load.py
@@ -1,0 +1,6 @@
+from strands.models.bedrock import BedrockModel
+
+
+def load_model() -> BedrockModel:
+    """Get Bedrock model client using IAM credentials."""
+    return BedrockModel(model_id="global.anthropic.claude-sonnet-4-5-20250929-v1:0")

--- a/src/assets/templates/agui-python-strands/pyproject.toml
+++ b/src/assets/templates/agui-python-strands/pyproject.toml
@@ -9,8 +9,8 @@ description = "AgentCore AG-UI Agent using Strands SDK"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "ag-ui-strands >= 0.1.7, < 0.2.0",
-    "ag-ui-protocol >= 0.1.10, < 0.2.0",
+    "ag-ui-strands >= 0.3.0, < 0.4.0",
+    "ag-ui-protocol >= 0.1.19, < 0.2.0",
     "aws-opentelemetry-distro ~= 0.17.0",
     "bedrock-agentcore ~= 1.9.1",
     "botocore[crt] ~= 1.43.0",

--- a/src/assets/templates/agui-python-strands/pyproject.toml
+++ b/src/assets/templates/agui-python-strands/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["hatchling ~= 1.27.0"]
+build-backend = "hatchling.build"
+
+[project]
+name = "{{ name }}"
+version = "0.1.0"
+description = "AgentCore AG-UI Agent using Strands SDK"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "ag-ui-strands >= 0.1.7, < 0.2.0",
+    "ag-ui-protocol >= 0.1.10, < 0.2.0",
+    "aws-opentelemetry-distro ~= 0.17.0",
+    "bedrock-agentcore ~= 1.9.1",
+    "botocore[crt] ~= 1.43.0",
+    "strands-agents ~= 1.15.0",
+    "uvicorn >= 0.34.3, < 1.0.0",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]

--- a/src/core/project/__snapshots__/manager.test.ts.snap
+++ b/src/core/project/__snapshots__/manager.test.ts.snap
@@ -251,3 +251,78 @@ exports[`FsProjectManager.create snapshots the Strands A2A project manifest and 
   ],
 }
 `;
+
+exports[`FsProjectManager.create snapshots the Strands AG-UI project manifest and runtime spec 1`] = `
+{
+  "manifest": [
+    ".gitignore",
+    "agentcore/.env.local",
+    "agentcore/agentcore.json",
+    "agentcore/aws-targets.json",
+    "agentcore/cdk/.gitignore",
+    "agentcore/cdk/.npmignore",
+    "agentcore/cdk/.prettierrc",
+    "agentcore/cdk/README.md",
+    "agentcore/cdk/bin/cdk.ts",
+    "agentcore/cdk/cdk.json",
+    "agentcore/cdk/jest.config.js",
+    "agentcore/cdk/lib/cdk-stack.ts",
+    "agentcore/cdk/package.json",
+    "agentcore/cdk/test/cdk.test.ts",
+    "agentcore/cdk/tsconfig.json",
+    "app/agui_python_strands/.gitignore",
+    "app/agui_python_strands/README.md",
+    "app/agui_python_strands/main.py",
+    "app/agui_python_strands/memory/__init__.py",
+    "app/agui_python_strands/memory/session.py",
+    "app/agui_python_strands/model/__init__.py",
+    "app/agui_python_strands/model/load.py",
+    "app/agui_python_strands/pyproject.toml",
+  ],
+  "memories": [
+    {
+      "eventExpiryDuration": 30,
+      "name": "agui_python_strandsMemory",
+      "strategies": [
+        {
+          "namespaceTemplates": [
+            "/users/{actorId}/facts",
+          ],
+          "type": "SEMANTIC",
+        },
+        {
+          "namespaceTemplates": [
+            "/users/{actorId}/preferences",
+          ],
+          "type": "USER_PREFERENCE",
+        },
+        {
+          "namespaceTemplates": [
+            "/summaries/{actorId}/{sessionId}",
+          ],
+          "type": "SUMMARIZATION",
+        },
+        {
+          "namespaceTemplates": [
+            "/episodes/{actorId}/{sessionId}",
+          ],
+          "reflectionNamespaceTemplates": [
+            "/episodes/{actorId}",
+          ],
+          "type": "EPISODIC",
+        },
+      ],
+    },
+  ],
+  "runtimes": [
+    {
+      "build": "CodeZip",
+      "codeLocation": "app/agui_python_strands",
+      "entrypoint": "main.py",
+      "name": "agui_python_strands",
+      "protocol": "AGUI",
+      "runtimeVersion": "PYTHON_3_14",
+    },
+  ],
+}
+`;

--- a/src/core/project/manager.test.ts
+++ b/src/core/project/manager.test.ts
@@ -35,6 +35,10 @@ const A2A_PYTHON_STRANDS = resolveRuntimeTemplateShortcut("a2a-python-strands");
 const A2A_PYTHON_STRANDS_CONTAINER = resolveRuntimeTemplateShortcut("a2a-python-strands", {
   build: "Container",
 });
+const AGUI_PYTHON_STRANDS = resolveRuntimeTemplateShortcut("agui-python-strands");
+const AGUI_PYTHON_STRANDS_CONTAINER = resolveRuntimeTemplateShortcut("agui-python-strands", {
+  build: "Container",
+});
 
 const originalCwd = process.cwd();
 const tempDirectories: string[] = [];
@@ -187,6 +191,58 @@ describe("FsProjectManager.create", () => {
       build: "Container",
       dockerfile: "Dockerfile",
       protocol: "A2A",
+    });
+  });
+
+  test("snapshots the Strands AG-UI project manifest and runtime spec", async () => {
+    const directory = await inTempDirectory();
+    await runCreate(manager().manager, {
+      name: "example",
+      scaffoldRuntimeInput: AGUI_PYTHON_STRANDS,
+    });
+
+    const projectRoot = join(directory, "example");
+    const spec = await Bun.file(join(projectRoot, "agentcore", "agentcore.json")).json();
+    expect({
+      manifest: await projectManifest(projectRoot),
+      runtimes: spec.runtimes,
+      memories: spec.memories,
+    }).toMatchSnapshot();
+  });
+
+  test("scaffolds the Strands AG-UI runtime with the AGUI protocol", async () => {
+    const directory = await inTempDirectory();
+    await runCreate(manager().manager, {
+      name: "example",
+      scaffoldRuntimeInput: AGUI_PYTHON_STRANDS,
+    });
+
+    const spec = await Bun.file(join(directory, "example", "agentcore", "agentcore.json")).json();
+    expect(spec.runtimes[0]).toMatchObject({
+      name: "agui_python_strands",
+      build: "CodeZip",
+      protocol: "AGUI",
+      entrypoint: "main.py",
+    });
+    expect(spec.memories).toMatchObject([{ name: "agui_python_strandsMemory" }]);
+  });
+
+  test("scaffolds the Strands AG-UI runtime as a container with --build Container", async () => {
+    const directory = await inTempDirectory();
+    await runCreate(manager().manager, {
+      name: "example",
+      scaffoldRuntimeInput: AGUI_PYTHON_STRANDS_CONTAINER,
+    });
+
+    const appDir = join(directory, "example", "app", "agui_python_strands");
+    expect(await Bun.file(join(appDir, "Dockerfile")).exists()).toBe(true);
+    expect(await Bun.file(join(appDir, ".dockerignore")).exists()).toBe(true);
+
+    const spec = await Bun.file(join(directory, "example", "agentcore", "agentcore.json")).json();
+    expect(spec.runtimes[0]).toMatchObject({
+      build: "Container",
+      dockerfile: "Dockerfile",
+      protocol: "AGUI",
     });
   });
 

--- a/src/core/project/templates/runtime.ts
+++ b/src/core/project/templates/runtime.ts
@@ -313,6 +313,42 @@ const getTemplateResolvers = (assetSource: AssetSource, templateRenderer: Templa
       },
     };
   },
+  [buildResolverKey("strands", "Python", "AGUI")]: async (input: RuntimeResourceConfig) => {
+    const memory = input.scaffoldRuntimeInput.memory;
+    const context = {
+      name: toPythonPackageName(input.name),
+      hasMemory: memory !== undefined,
+      // the CDK injects this env var corresponding to the actual ID once its resolved on deployment.
+      memoryEnvVarName: memory ? `MEMORY_${memory.name.toUpperCase()}_ID` : undefined,
+      memoryStrategies: memory?.strategies.map(({ type }) => type) ?? [],
+      // The AgentCore Runtime requires OTEL dependencies to be present; the
+      // container launches main.py as the `main` module under
+      // opentelemetry-instrument, and the AG-UI app binds uvicorn on port 8080.
+      enableOtel: true,
+      entrypoint: "main",
+    };
+    const isContainer = input.scaffoldRuntimeInput.build === "Container";
+    const tree = await FsTreeNode.fromAssetSource(
+      { assetSource },
+      { assetDir: "templates/agui-python-strands" },
+      {
+        rootDirName: input.name,
+        transformContent: (raw) => templateRenderer.render(raw, context),
+        filter: (name, isDir) => {
+          if (isDir && name === "memory") return memory !== undefined;
+          if (name === "Dockerfile" || name === ".dockerignore") return isContainer;
+          return true;
+        },
+      },
+    );
+    return {
+      tree,
+      spec: {
+        runtimes: [{ ...buildRuntimeSpec(input), protocol: "AGUI" as const }],
+        ...(memory && { memories: [memory] }),
+      },
+    };
+  },
 });
 
 type GetRuntimeTemplateResolverConfig = {

--- a/src/handlers/project/add/runtime/index.test.ts
+++ b/src/handlers/project/add/runtime/index.test.ts
@@ -155,6 +155,15 @@ describe("project add runtime", () => {
       build: "CodeZip",
       protocol: "A2A",
     },
+    "agui-python-strands template preset": {
+      build: "CodeZip",
+      protocol: "AGUI",
+    },
+    "agui-python-strands overrides to Container": {
+      build: "Container",
+      dockerfile: "Dockerfile",
+      protocol: "AGUI",
+    },
     "all infrastructure flags": {
       description: "Configured runtime",
       executionRoleArn: "arn:aws:iam::123456789012:role/MyRole",
@@ -241,6 +250,14 @@ describe("project add runtime", () => {
         "--memory",
         "none",
       ],
+    ],
+    [
+      "agui-python-strands template preset",
+      ["--name", "my_agui", "--template", "agui-python-strands"],
+    ],
+    [
+      "agui-python-strands overrides to Container",
+      ["--name", "my_agui", "--template", "agui-python-strands", "--build", "Container"],
     ],
     [
       "agent-python-strands with session, EFS, and S3 mounts",
@@ -537,6 +554,37 @@ describe("project add runtime", () => {
       (candidate: { name: string }) => candidate.name === "my_a2aMemory",
     );
     const memoryDir = join(projectRoot, "app", "my_a2a", "memory", "session.py");
+
+    if (expectedStrategies.length === 0) {
+      expect(memory).toBeUndefined();
+      expect(await Bun.file(memoryDir).exists()).toBe(false);
+      return;
+    }
+
+    expect(memory.strategies.map(({ type }: { type: string }) => type)).toEqual(expectedStrategies);
+    expect(await Bun.file(memoryDir).exists()).toBe(true);
+  });
+
+  test.each<[string, string[], string[]]>([
+    [
+      "template preset defaults to long and short-term memory",
+      ["--name", "my_agui", "--template", "agui-python-strands"],
+      ["SEMANTIC", "USER_PREFERENCE", "SUMMARIZATION", "EPISODIC"],
+    ],
+    [
+      "template preset with --memory none",
+      ["--name", "my_agui", "--template", "agui-python-strands", "--memory", "none"],
+      [],
+    ],
+  ])("agui-python-strands %s", async (_label, flags, expectedStrategies) => {
+    const projectRoot = await inProject();
+    await run(["add", "runtime", ...flags]);
+
+    const spec = await Bun.file(join(projectRoot, "agentcore", "agentcore.json")).json();
+    const memory = (spec.memories ?? []).find(
+      (candidate: { name: string }) => candidate.name === "my_aguiMemory",
+    );
+    const memoryDir = join(projectRoot, "app", "my_agui", "memory", "session.py");
 
     if (expectedStrategies.length === 0) {
       expect(memory).toBeUndefined();

--- a/src/handlers/project/create/screen.tsx
+++ b/src/handlers/project/create/screen.tsx
@@ -142,6 +142,11 @@ const TEMPLATE_OPTIONS: {
     label: "a2a-python-strands",
     description: "Strands agent speaking the A2A protocol on Bedrock (CodeZip build)",
   },
+  {
+    template: "agui-python-strands",
+    label: "agui-python-strands",
+    description: "Strands agent speaking the AG-UI protocol on Bedrock (CodeZip build)",
+  },
 ];
 
 const MEMORY_OPTIONS: { memory: MemoryShortcutName; label: string; description: string }[] = [

--- a/src/handlers/project/shortcuts.ts
+++ b/src/handlers/project/shortcuts.ts
@@ -97,6 +97,16 @@ export const RUNTIME_TEMPLATE_SHORTCUTS = {
     memory: "longAndShortTerm",
     runtimeVersion: "PYTHON_3_14",
   },
+  "agui-python-strands": {
+    runtimeName: "agui_python_strands",
+    build: "CodeZip",
+    language: "Python",
+    framework: "strands",
+    protocol: "AGUI",
+    modelProvider: "Bedrock",
+    memory: "longAndShortTerm",
+    runtimeVersion: "PYTHON_3_14",
+  },
 } as const satisfies Record<string, RuntimeTemplateShortcut>;
 
 export type RuntimeTemplateShortcutName = keyof typeof RUNTIME_TEMPLATE_SHORTCUTS;


### PR DESCRIPTION
### Problem 
AGUI Python templates are not supported. 

### Solution 
- pull in the assets from mainline. 
- add a new template resolver entry. 

### Verification
```
$ agentcore project create --name aguiTest --template agui-python-strands
...
$ agentcore project dev --mode headless --port 8090 &
...
$ curl -N -X POST localhost:8090/invocations \
    -H 'Content-Type: application/json' \
    -d '{"threadId":"t1","runId":"r1","state":{},"messages":[{"id":"m1","role":"user","content":"Reply with exactly: hello from agui"}],"tools":[],"context":[],"forwardedProps":{}}'

data: {"type":"RUN_STARTED","threadId":"t1","runId":"r1"}

data: {"type":"STATE_SNAPSHOT","snapshot":{}}

data: {"type":"MESSAGES_SNAPSHOT","messages":[{"id":"m1","role":"user","content":"Reply with exactly: hello from agui"}]}

data: {"type":"TEXT_MESSAGE_START","messageId":"95e19696-c0cc-4ce2-b296-25148b277efd","role":"assistant"}

data: {"type":"TEXT_MESSAGE_CONTENT","messageId":"95e19696-c0cc-4ce2-b296-25148b277efd","delta":"hello"}

data: {"type":"TEXT_MESSAGE_CONTENT","messageId":"95e19696-c0cc-4ce2-b296-25148b277efd","delta":" from agui"}

data: {"type":"TEXT_MESSAGE_END","messageId":"95e19696-c0cc-4ce2-b296-25148b277efd"}

data: {"type":"MESSAGES_SNAPSHOT","messages":[{"id":"m1","role":"user","content":"Reply with exactly: hello from agui"},{"id":"95e19696-c0cc-4ce2-b296-25148b277efd","role":"assistant","content":"hello from agui"}]}

data: {"type":"STATE_SNAPSHOT","snapshot":{}}

data: {"type":"RUN_FINISHED","threadId":"t1","runId":"r1"}

$ agentcore project deploy
...
$ agentcore project invoke runtime --name agui_python_strands --payload '{"threadId":"t1","runId":"r1","state":{},"messages":[{"id":"m1","role":"user","content":"Reply with exactly: hello from agui"}],"tools":[],"context":[],"forwardedProps":{}}'

data: {"type":"RUN_STARTED","threadId":"t1","runId":"r1"}

data: {"type":"STATE_SNAPSHOT","snapshot":{}}

data: {"type":"MESSAGES_SNAPSHOT","messages":[{"id":"m1","role":"user","content":"Reply with exactly: hello from agui"}]}

data: {"type":"TEXT_MESSAGE_START","messageId":"1e667fda-81ba-42c6-8648-a694f3a3d5b5","role":"assistant"}

data: {"type":"TEXT_MESSAGE_CONTENT","messageId":"1e667fda-81ba-42c6-8648-a694f3a3d5b5","delta":"hello"}

data: {"type":"TEXT_MESSAGE_CONTENT","messageId":"1e667fda-81ba-42c6-8648-a694f3a3d5b5","delta":" from agui"}

data: {"type":"TEXT_MESSAGE_END","messageId":"1e667fda-81ba-42c6-8648-a694f3a3d5b5"}

data: {"type":"MESSAGES_SNAPSHOT","messages":[{"id":"m1","role":"user","content":"Reply with exactly: hello from agui"},{"id":"1e667fda-81ba-42c6-8648-a694f3a3d5b5","role":"assistant","content":"hello from agui"}]}

data: {"type":"STATE_SNAPSHOT","snapshot":{}}

data: {"type":"RUN_FINISHED","threadId":"t1","runId":"r1"}

status=200 content-type=text/event-stream; charset=utf-8 runtime-session-id=356d5ae7-a9c6-408c-94f6-51622588103e mcp-session-id=- mcp-protocol-version=- trace-id=- trace-parent=- trace-state=- baggage=- complete=true bytes=962
```

had my agent verify the same flow for container, memory/no-memory, and with gemini. 
