### PR TITLE
fix(runtime): default omitted invoke user ID

### DIFF
--- a/src/handlers/project/invoke/index.test.tsx
+++ b/src/handlers/project/invoke/index.test.tsx
@@ -162,6 +162,7 @@ describe("project invoke", () => {
       .args[0] as RuntimeInvokeRequest;
     expect(new TextDecoder().decode(request.payload)).toBe(payload);
     expect(request.contentType).toBe("application/custom+json");
+    expect(request.runtimeUserId).toBe("default");
     expect(core.runtime.calls.at(-1)!.args[1]).toEqual({ region: TARGET.region });
     expect(io.stdout()).toBe("runtime response");
     expect(resolved.calls).toEqual([{ target: TARGET }]);

--- a/src/handlers/project/invoke/runtime.tsx
+++ b/src/handlers/project/invoke/runtime.tsx
@@ -33,7 +33,7 @@ export const createProjectInvokeRuntimeHandler = (
       flag("content-type", "the payload content type", z.string().optional()),
       flag("accept", "the accepted response content type", z.string().optional()),
       flag("session-id", "the Runtime session ID", z.string().optional()),
-      flag("user-id", "the Runtime user ID", z.string().optional()),
+      flag("user-id", 'the Runtime user ID (default: "default")', z.string().optional()),
       flag("header", "an ordered application header", z.array(z.string()).optional(), {
         sensitive: true,
       }),

--- a/src/handlers/runtime/invoke/index.tsx
+++ b/src/handlers/runtime/invoke/index.tsx
@@ -30,7 +30,7 @@ export const createInvokeRuntimeHandler = (core: Core, io: AppIO) =>
       flag("content-type", "the payload content type", z.string().optional()),
       flag("accept", "the accepted response content type", z.string().optional()),
       flag("session-id", "the Runtime session ID", z.string().optional()),
-      flag("user-id", "the Runtime user ID", z.string().optional()),
+      flag("user-id", 'the Runtime user ID (default: "default")', z.string().optional()),
       flag("header", "an ordered application header", z.array(z.string()).optional(), {
         sensitive: true,
       }),

--- a/src/handlers/runtime/invoke/invoke.screen.test.tsx
+++ b/src/handlers/runtime/invoke/invoke.screen.test.tsx
@@ -808,7 +808,7 @@ describe("Runtime invoke JSON console", () => {
     await screen.write("{}");
     await screen.press("return");
     await waitFor(() => invokeRequests(core).length === 1);
-    expect(invokeRequests(core)[0]!.runtimeUserId).toBeUndefined();
+    expect(invokeRequests(core)[0]!.runtimeUserId).toBe("default");
     expect(invokeRequests(core)[0]!.applicationHeaders).toBeUndefined();
     expect(invokeRequests(core)[0]!.bearerToken).toBeUndefined();
   });

--- a/src/handlers/runtime/invoke/invoke.test.tsx
+++ b/src/handlers/runtime/invoke/invoke.test.tsx
@@ -106,6 +106,7 @@ describe("runtime invoke", () => {
       qualifier: "DEFAULT",
       payload: new TextEncoder().encode('{"prompt":"hello"}'),
       contentType: "application/json",
+      runtimeUserId: "default",
     });
     expect(invoke.args[1]).toEqual({ region: REGION });
     expect(lookup.args[2]).toBe(invoke.args[2]);

--- a/src/handlers/runtime/invoke/request.test.ts
+++ b/src/handlers/runtime/invoke/request.test.ts
@@ -212,6 +212,15 @@ describe("normalizeRuntimeInvokeRequest", () => {
     expect(request.accept).toBe("application/json, text/event-stream");
   });
 
+  test("defaults the Runtime user ID when omitted", () => {
+    const request = normalizeRuntimeInvokeRequest(detail(), {
+      runtimeId: RUNTIME_ID,
+      payload: new Uint8Array(),
+    });
+
+    expect(request.runtimeUserId).toBe("default");
+  });
+
   test("maps every request field and ordered allowed headers once", () => {
     const request = normalizeRuntimeInvokeRequest(
       detail({

--- a/src/handlers/runtime/invoke/request.ts
+++ b/src/handlers/runtime/invoke/request.ts
@@ -15,6 +15,7 @@ export type RuntimeInvokeInput = Omit<
 > &
   Partial<Pick<RuntimeInvokeRequest, "qualifier" | "contentType">>;
 
+const DEFAULT_RUNTIME_USER_ID = "default";
 const CUSTOM_HEADER_PREFIX = "x-amzn-bedrock-agentcore-runtime-custom-";
 const RESERVED_HEADERS = new Set([
   "authorization",
@@ -170,6 +171,7 @@ export function normalizeRuntimeInvokeRequest(
     payload,
     contentType: contentType || "application/json",
     ...modeled,
+    runtimeUserId: modeled.runtimeUserId ?? DEFAULT_RUNTIME_USER_ID,
     accept: modeled.accept ?? (mcp ? "application/json, text/event-stream" : undefined),
     ...(applicationHeaders.length > 0 && { applicationHeaders }),
   };


### PR DESCRIPTION
## Summary

- default omitted Runtime invoke user IDs to `default`
- apply the fallback through the shared Runtime request normalizer used by direct, project, and TUI invocation
- document the default in direct and project invoke help

## Testing

- `bun test src/handlers/runtime/invoke/request.test.ts src/handlers/runtime/invoke/invoke.test.tsx src/handlers/runtime/invoke/invoke.screen.test.tsx src/handlers/project/invoke/index.test.tsx` (`83 pass`)
- `bun test src` (`2804 pass`)
- `bun run typecheck`
- `bun run lint:check`
- `bun run format:check`
- `bun run build`
- live AWS invocation against `Issue686_Echo` returned HTTP 200 without `--user-id`
- wire capture verified the signed request sends `x-amzn-bedrock-agentcore-runtime-user-id: default`, while an explicit `--user-id` overrides it