### PR TITLE
fix(tc): address failing typechecker by completing test interface

### DIFF
--- a/src/handlers/project/buildDeploy.screen.test.tsx
+++ b/src/handlers/project/buildDeploy.screen.test.tsx
@@ -56,6 +56,9 @@ function fakeBackend(options: FakeBackendOptions = {}) {
       if (options.failure) throw options.failure;
       return options.result ?? { outputs: { RuntimeArn: "arn:runtime" } };
     },
+    async resolveProjectResources() {
+      return [];
+    },
     async resolveDeployedResources() {
       return [];
     },


### PR DESCRIPTION
### Problem 
typechecker failing. https://github.com/aws/agentcore-cli/actions/runs/33786276059/job/100751718167


### Solution 
- add missing method on test interface. 

### Verification
` bun run typecheck && bun test src/core/project/backends/ ` passes. 