### PR TITLE
chore: add select state to radio buttons and only show inputs on enter

### DIFF
--- a/src/components/FormRadioGroup.tsx
+++ b/src/components/FormRadioGroup.tsx
@@ -12,12 +12,21 @@ export interface FormRadioGroupProps {
   name: string;
   helpText: string;
   options: FormRadioOption[];
-  selectedIndex: number;
+  // highlighted/hovered row
+  focusedIndex: number;
+  // row that user selects / hits ENTER on
+  selectedIndex?: number;
 }
 
 // FormRadioGroup renders a column of radio rows. It is fully controlled: the
-// parent owns the selected index and the key handling that moves it.
-export function FormRadioGroup({ name, helpText, options, selectedIndex }: FormRadioGroupProps) {
+// parent owns the focused index and the key handling that moves it.
+export function FormRadioGroup({
+  name,
+  helpText,
+  options,
+  focusedIndex,
+  selectedIndex,
+}: FormRadioGroupProps) {
   const columnWidth = options.reduce((max, option) => Math.max(max, option.label.length), 0) + 2;
 
   return (
@@ -33,16 +42,23 @@ export function FormRadioGroup({ name, helpText, options, selectedIndex }: FormR
         borderColor={theme.colors.border}
       >
         {options.map((option, i) => {
+          const focused = i === focusedIndex;
           const selected = i === selectedIndex;
+          // A selected row uses the selection color; a hovered (focused) row
+          // uses the brighter focus color; everything else is neutral.
+          const accentColor = selected
+            ? theme.colors.selection
+            : focused
+              ? theme.colors.focus
+              : undefined;
+          const highlighted = focused || selected;
           return (
             <Box key={option.label} flexDirection="row">
               <Box width={2} flexShrink={0}>
-                <Text color={selected ? theme.colors.focus : theme.colors.muted}>
-                  {selected ? "●" : "○"}
-                </Text>
+                <Text color={accentColor ?? theme.colors.muted}>{highlighted ? "●" : "○"}</Text>
               </Box>
               <Box width={columnWidth} flexShrink={0}>
-                <Text bold={selected} color={selected ? theme.colors.focus : theme.colors.text}>
+                <Text bold={highlighted} color={accentColor ?? theme.colors.text}>
                   {option.label}
                 </Text>
               </Box>

--- a/src/components/HarnessWizard.tsx
+++ b/src/components/HarnessWizard.tsx
@@ -755,23 +755,25 @@ function ModelStep({
         name="choose a model"
         helpText="the provider and model that will power the harness"
         options={rows}
-        selectedIndex={index}
+        focusedIndex={index}
+        selectedIndex={focusedField !== null ? index : undefined}
       />
-      {provider.fields.map((field, i) => (
-        <FormTextInput
-          key={`${provider.kind}.${field.key}`}
-          name={field.name}
-          helpText={field.helpText}
-          placeholder={field.placeholder}
-          errorText=""
-          value={value[field.key]}
-          onChange={(next) => {
-            onChange({ ...value, [field.key]: next });
-            setError(null);
-          }}
-          focused={focusedField === i}
-        />
-      ))}
+      {focusedField !== null &&
+        provider.fields.map((field, i) => (
+          <FormTextInput
+            key={`${provider.kind}.${field.key}`}
+            name={field.name}
+            helpText={field.helpText}
+            placeholder={field.placeholder}
+            errorText=""
+            value={value[field.key]}
+            onChange={(next) => {
+              onChange({ ...value, [field.key]: next });
+              setError(null);
+            }}
+            focused={focusedField === i}
+          />
+        ))}
       {error && <Text color={theme.colors.error}>{error}</Text>}
       {index !== 0 && (
         <Text color={theme.colors.info}>
@@ -861,7 +863,7 @@ function MemoryStep({
         name="choose a memory configuration"
         helpText="how should the harness remember conversations?"
         options={MEMORY_OPTIONS}
-        selectedIndex={index}
+        focusedIndex={index}
       />
       {value.kind === "byo" && (
         <FormTextInput

--- a/src/handlers/harness/create/create.screen.test.tsx
+++ b/src/handlers/harness/create/create.screen.test.tsx
@@ -111,6 +111,27 @@ describe("harness create wizard", () => {
     r.unmount();
   });
 
+  test("reveals model fields only after enter and hides them again on escape", async () => {
+    const r = renderScreen("/agentcore/harness/create", { core: coreForCreate() });
+
+    await waitForText(r.lastFrame, "the name of your harness");
+    await r.write("my_agent");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "choose a model");
+    await r.press("down"); // bedrock
+    await waitForText(r.lastFrame, "● bedrock");
+    expect(r.lastFrame()).not.toContain("model id");
+
+    await r.press("return");
+    await waitForText(r.lastFrame, "model id");
+
+    await r.press("escape");
+    await waitFor(() => !(r.lastFrame() ?? "").includes("model id"));
+    expect(r.lastFrame()).toContain("● bedrock");
+    r.unmount();
+  });
+
   test("selecting gemini collects the model id and api key arn", async () => {
     const core = coreForCreate();
     const r = renderScreen("/agentcore/harness/create", { core });

--- a/src/handlers/harness/update/update.screen.test.tsx
+++ b/src/handlers/harness/update/update.screen.test.tsx
@@ -104,10 +104,12 @@ describe("harness update wizard", () => {
     core.harness.setGetResponse(current);
     const r = renderScreen("/agentcore/harness/update/MyHarness-abc123", { core });
 
-    // The harness's bedrock provider is preselected with its model id prefilled.
+    // The harness's bedrock provider is preselected. Its persisted model id is
+    // revealed after confirming the provider.
     await waitForText(r.lastFrame, "● bedrock");
-    expect(r.lastFrame()).toContain("us.anthropic.claude-opus-4-8");
+    expect(r.lastFrame()).not.toContain("us.anthropic.claude-opus-4-8");
     await r.press("return"); // into the model id field
+    await waitForText(r.lastFrame, "us.anthropic.claude-opus-4-8");
     await r.press("return"); // accept it unchanged
     await waitForText(r.lastFrame, "● managed");
     await r.press("return");

--- a/src/handlers/memory/record/list/screen.tsx
+++ b/src/handlers/memory/record/list/screen.tsx
@@ -66,33 +66,48 @@ interface MemoryRecordScopeScreenProps {
 
 function MemoryRecordScopeScreen({ memoryId }: MemoryRecordScopeScreenProps) {
   const navigate = useNavigate();
-  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [focusedIndex, setFocusedIndex] = useState(0);
   const [scope, setScope] = useState("");
   const [submitted, setSubmitted] = useState(false);
-
-  const submit = (value: string) => {
-    if (value.trim() === "") {
-      setSubmitted(true);
-      return;
-    }
-
-    const kind: RecordScopeKind = selectedIndex === 0 ? "namespace" : "namespace-path";
-    navigate(
-      `/agentcore/memory/record/list/${encodeURIComponent(memoryId)}/${kind}/${encodeURIComponent(value)}`,
-    );
-  };
+  // editing is true while the scope text field has focus; the radio list has
+  // focus otherwise.
+  const [editing, setEditing] = useState(false);
 
   useInput((_input, key) => {
-    if (key.escape) {
-      navigate(-1);
+    if (!editing) {
+      if (key.escape) {
+        navigate(-1);
+        return;
+      }
+      if (key.upArrow) {
+        setFocusedIndex(0);
+        return;
+      }
+      if (key.downArrow) {
+        setFocusedIndex(1);
+        return;
+      }
+      if (key.return) {
+        setEditing(true);
+      }
       return;
     }
-    if (key.upArrow) {
-      setSelectedIndex(0);
+
+    // The scope field is focused; its TextInput owns text editing.
+    if (key.escape || key.upArrow) {
+      setEditing(false);
+      setSubmitted(false);
       return;
     }
-    if (key.downArrow) {
-      setSelectedIndex(1);
+    if (key.return) {
+      if (scope.trim() === "") {
+        setSubmitted(true);
+        return;
+      }
+      const kind: RecordScopeKind = focusedIndex === 0 ? "namespace" : "namespace-path";
+      navigate(
+        `/agentcore/memory/record/list/${encodeURIComponent(memoryId)}/${kind}/${encodeURIComponent(scope)}`,
+      );
     }
   });
 
@@ -112,20 +127,22 @@ function MemoryRecordScopeScreen({ memoryId }: MemoryRecordScopeScreenProps) {
           name="scope type"
           helpText="Choose how the service should match record namespaces."
           options={scopeOptions}
-          selectedIndex={selectedIndex}
+          focusedIndex={focusedIndex}
+          selectedIndex={editing ? focusedIndex : undefined}
         />
-        <FormTextInput
-          name={selectedIndex === 0 ? "namespace" : "namespace path"}
-          helpText="Enter the namespace value used to scope this request."
-          placeholder="/strategies/strategy-id/actors/actor-id"
-          errorText="A namespace value is required."
-          value={scope}
-          onChange={(value) => {
-            setScope(value);
-            setSubmitted(false);
-          }}
-          onSubmit={submit}
-        />
+        {editing && (
+          <FormTextInput
+            name={focusedIndex === 0 ? "namespace" : "namespace path"}
+            helpText="Enter the namespace value used to scope this request."
+            placeholder="/strategies/strategy-id/actors/actor-id"
+            errorText="A namespace value is required."
+            value={scope}
+            onChange={(value) => {
+              setScope(value);
+              setSubmitted(false);
+            }}
+          />
+        )}
         {submitted && scope.trim() === "" ? (
           <Text color={darkTheme.colors.error}>A namespace value is required.</Text>
         ) : null}

--- a/src/handlers/memory/record/record.screen.test.tsx
+++ b/src/handlers/memory/record/record.screen.test.tsx
@@ -71,6 +71,21 @@ describe("Memory record list flow", () => {
     expect(core.memory.calls.some((call) => call.method === "listMemoryRecords")).toBe(false);
   });
 
+  test("reveals the scope input only after enter and hides it again on escape", async () => {
+    const screen = renderScreen("/agentcore/memory/record/list/memory-1");
+    const fieldHelp = "Enter the namespace value used to scope this request.";
+
+    await waitForText(screen.lastFrame, "scope type");
+    expect(screen.lastFrame()).not.toContain(fieldHelp);
+
+    await screen.press("return");
+    await waitForText(screen.lastFrame, fieldHelp);
+
+    await screen.press("escape");
+    await waitFor(() => !(screen.lastFrame() ?? "").includes(fieldHelp));
+    expect(screen.core.memory.calls).toEqual([]);
+  });
+
   test("unwinds the record table through its scope and Memory pickers", async () => {
     const memoryId = "memory/blue one";
     const core = new TestCoreClient();
@@ -85,6 +100,7 @@ describe("Memory record list flow", () => {
     await waitForText(screen.lastFrame, memoryId);
     await screen.press("return");
     await waitForText(screen.lastFrame, "scope type");
+    await screen.press("return"); // focus the namespace input
     await screen.write("/customers/acme");
     await screen.press("return");
     await waitForText(screen.lastFrame, "Customer prefers email notifications.");
@@ -105,6 +121,7 @@ describe("Memory record list flow", () => {
     await waitForText(screen.lastFrame, "scope type");
     await screen.press("down");
     await screen.press("up");
+    await screen.press("return"); // focus the namespace input
     await screen.write("/customers/acme");
     await screen.press("return");
     await waitFor(() => core.memory.calls.some((call) => call.method === "listMemoryRecords"));
@@ -128,6 +145,7 @@ describe("Memory record list flow", () => {
     });
 
     await waitForText(screen.lastFrame, "scope type");
+    await screen.press("return"); // focus the namespace input
     await screen.write("/customers/acme");
     await screen.press("return");
     await waitForText(screen.lastFrame, "Customer prefers email notifications.");
@@ -181,6 +199,7 @@ describe("Memory record list flow", () => {
 
     await waitForText(screen.lastFrame, "scope type");
     await screen.press("down");
+    await screen.press("return"); // focus the namespace path input
     await screen.write("/customers/acme/*");
     await screen.press("return");
     await waitFor(() => core.memory.calls.some((call) => call.method === "listMemoryRecords"));
@@ -317,7 +336,8 @@ describe("Memory record list flow", () => {
     const screen = renderScreen("/agentcore/memory/record/list/memory-1");
 
     await waitForText(screen.lastFrame, "scope type");
-    await screen.press("return");
+    await screen.press("return"); // focus the namespace input
+    await screen.press("return"); // submit the empty value
     await waitForText(screen.lastFrame, "A namespace value is required.");
     expect(screen.core.memory.calls).toEqual([]);
   });

--- a/src/handlers/project/buildDeploy.screen.test.tsx
+++ b/src/handlers/project/buildDeploy.screen.test.tsx
@@ -62,9 +62,6 @@ function fakeBackend(options: FakeBackendOptions = {}) {
     async resolveDeployedResources() {
       return [];
     },
-    async resolveProjectResources() {
-      return [];
-    },
   };
   return { backend, deploys };
 }

--- a/src/handlers/project/create/screen.tsx
+++ b/src/handlers/project/create/screen.tsx
@@ -393,7 +393,7 @@ function WizardStep({ stepKey, values, patch, onNext, onBack, onSubmit }: Wizard
           name="what should the project be built around?"
           helpText="a project deploys either a managed harness or your own agent code"
           options={PROJECT_KIND_OPTIONS}
-          selectedIndex={PROJECT_KIND_OPTIONS.findIndex((option) => option.kind === values.kind)}
+          focusedIndex={PROJECT_KIND_OPTIONS.findIndex((option) => option.kind === values.kind)}
           onSelect={(index) => patch({ kind: PROJECT_KIND_OPTIONS[index]!.kind })}
           onNext={onNext}
           onBack={onBack}
@@ -414,9 +414,7 @@ function WizardStep({ stepKey, values, patch, onNext, onBack, onSubmit }: Wizard
           name="choose a template"
           helpText="the agent code scaffolded into the project"
           options={TEMPLATE_OPTIONS}
-          selectedIndex={TEMPLATE_OPTIONS.findIndex(
-            (option) => option.template === values.template,
-          )}
+          focusedIndex={TEMPLATE_OPTIONS.findIndex((option) => option.template === values.template)}
           onSelect={(index) => patch({ template: TEMPLATE_OPTIONS[index]!.template })}
           onNext={onNext}
           onBack={onBack}
@@ -428,7 +426,7 @@ function WizardStep({ stepKey, values, patch, onNext, onBack, onSubmit }: Wizard
           name="choose a memory configuration"
           helpText="how should the Strands agent remember conversations?"
           options={MEMORY_OPTIONS}
-          selectedIndex={MEMORY_OPTIONS.findIndex((option) => option.memory === values.memory)}
+          focusedIndex={MEMORY_OPTIONS.findIndex((option) => option.memory === values.memory)}
           onSelect={(index) => patch({ memory: MEMORY_OPTIONS[index]!.memory })}
           onNext={onNext}
           onBack={onBack}
@@ -495,7 +493,7 @@ function RadioStep({
   name,
   helpText,
   options,
-  selectedIndex,
+  focusedIndex,
   onSelect,
   onNext,
   onBack,
@@ -503,7 +501,7 @@ function RadioStep({
   name: string;
   helpText: string;
   options: FormRadioOption[];
-  selectedIndex: number;
+  focusedIndex: number;
   onSelect: (index: number) => void;
   onNext: () => void;
   onBack: () => void;
@@ -514,11 +512,11 @@ function RadioStep({
       return;
     }
     if (key.upArrow) {
-      onSelect(Math.max(0, selectedIndex - 1));
+      onSelect(Math.max(0, focusedIndex - 1));
       return;
     }
     if (key.downArrow) {
-      onSelect(Math.min(options.length - 1, selectedIndex + 1));
+      onSelect(Math.min(options.length - 1, focusedIndex + 1));
       return;
     }
     if (key.return) onNext();
@@ -530,7 +528,7 @@ function RadioStep({
         name={name}
         helpText={helpText}
         options={options}
-        selectedIndex={selectedIndex}
+        focusedIndex={focusedIndex}
       />
     </Box>
   );
@@ -706,7 +704,7 @@ function ModelStep({
           name="choose a model"
           helpText="the provider and model that will power the harness"
           options={options}
-          selectedIndex={providerIndex}
+          focusedIndex={providerIndex}
         />
         {fields.map((field, fieldIndex) => (
           <FormTextInput


### PR DESCRIPTION
## Description

This PR adds polishing changes to the formRadioButton component and two of its call paths: 
* `harness` -> `create` -> `model`
* `memory` -> `record` -> `list`

The two changes are as follows:

**1. Input fields:**
* Previously appeared on hover, which added visual noise to the screen 
* It was unclear to the user that they must click ENTER in order to advance
* Solution: hide inputs until user hits SELECT

**2. Select state:**
* Previously, there was a hover state on the models, but no select state
* This was another contributing factor to confusion on advancing from the user
* Solution: add distinct select state, which appears after user hits ENTER on the selected option

PR also updates the tests for both surface areas to exercise this new behavior. Additionally, removed duplicate import which was causing typecheck to fail (fix unrelated to commits in this PR)


https://github.com/user-attachments/assets/0095017b-8138-4c1d-b978-e8e1b0a7aa9d





## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe): Polishing chore

## Testing

How have you tested the change?

- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [x] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
