### PR TITLE
fix(eval): keep CLI-only commands out of the TUI menu

### DIFF
--- a/src/handlers/eval/batch-evaluation/index.tsx
+++ b/src/handlers/eval/batch-evaluation/index.tsx
@@ -8,13 +8,14 @@ import { createListBatchEvaluationsHandler } from "./list";
 import { createEvaluateBatchEvaluationHandler } from "./evaluate";
 import { createSimulateBatchEvaluationHandler } from "./simulate";
 
-// batch-evaluation supports evaluate (start an async job) plus get + list. A bare
-// invocation opens the interactive TUI (list → get), matching evaluator and
-// online-eval.
+// batch-evaluation supports evaluate + simulate (start jobs) plus get + list. A
+// bare invocation opens the interactive TUI (list → get), matching evaluator and
+// online-eval; evaluate/simulate are CLI-only and stay out of the TUI menu.
 export function createBatchEvaluationHandler(core: Core, io: AppIO): Router {
   return new Router("batch-evaluation", "run and inspect AgentCore batch evaluations")
     .use(withTuiOnEmptyFlagsAndArgs(core, io))
     .default(renderTui(core, io))
+    .supportedTuiCommands("get", "list")
     .handler(createEvaluateBatchEvaluationHandler(core, io))
     .handler(createSimulateBatchEvaluationHandler(core, io))
     .handler(createGetBatchEvaluationHandler(core, io))

--- a/src/handlers/eval/index.tsx
+++ b/src/handlers/eval/index.tsx
@@ -15,19 +15,33 @@ import { createAbTestHandler } from "./ab-test";
 import { createRecommendationHandler } from "./recommendation";
 
 export function createEvalHandler(core: Core, io: AppIO): Router {
-  return new Router("eval", "evaluate and optimize AgentCore agents")
-    .use(withTuiOnEmptyFlagsAndArgs(core, io))
-    .default(renderTui(core, io))
-    .handler(createEvaluatorHandler(core, io))
-    .handler(createOnlineEvalHandler(core, io))
-    .handler(createOnlineInsightHandler(core, io))
-    .handler(createDatasetHandler(core, io))
-    .handler(createBatchEvaluationHandler(core, io))
-    .handler(createBatchInsightsHandler(core, io))
-    .handler(createOnDemandHandler(core, io))
-    .handler(createConfigBundleHandler(core, io))
-    .handler(createAbTestHandler(core, io))
-    .handler(createRecommendationHandler(core, io));
+  return (
+    new Router("eval", "evaluate and optimize AgentCore agents")
+      .use(withTuiOnEmptyFlagsAndArgs(core, io))
+      .default(renderTui(core, io))
+      // Only the groups with an interactive screen belong in the TUI menu.
+      // ondemand (help-only) and recommendation (no screen) are CLI-only.
+      .supportedTuiCommands(
+        "evaluator",
+        "online-eval",
+        "online-insight",
+        "dataset",
+        "batch-evaluation",
+        "batch-insights",
+        "config-bundle",
+        "ab-test",
+      )
+      .handler(createEvaluatorHandler(core, io))
+      .handler(createOnlineEvalHandler(core, io))
+      .handler(createOnlineInsightHandler(core, io))
+      .handler(createDatasetHandler(core, io))
+      .handler(createBatchEvaluationHandler(core, io))
+      .handler(createBatchInsightsHandler(core, io))
+      .handler(createOnDemandHandler(core, io))
+      .handler(createConfigBundleHandler(core, io))
+      .handler(createAbTestHandler(core, io))
+      .handler(createRecommendationHandler(core, io))
+  );
 }
 
 export { EvalScreen } from "./screen.tsx";


### PR DESCRIPTION
## Problem

The `eval` router and its `batch-evaluation` subgroup open an interactive TUI on a bare invocation (`.default(renderTui(...))`) but never called `.supportedTuiCommands(...)`, so the menu (`RouterScreen` → `isTuiCommandSupported`) offered commands that have **no interactive screen**:

- **`eval` menu** listed `ondemand` (help-only default) and `recommendation` (no screen).
- **`eval batch-evaluation` menu** listed `evaluate` and `simulate` (imperative job-starting commands with required flags).

Selecting any of them navigated to a route with no screen. Every sibling with the same shape (`batch-insights`, `ab-test`, `online-eval`, `dataset`, `config-bundle`, …) already restricts the menu to `("get", "list")`; these two were the outliers.

## Fix

Add the missing allowlists, matching the existing `batch-insights` / `gateway` pattern:

- `eval` → the 8 groups that actually have an interactive screen (drops `ondemand` + `recommendation`).
- `eval batch-evaluation` → `("get", "list")` (drops `evaluate` + `simulate`).

Behaviour of the commands themselves is unchanged — `agentcore eval ondemand` still prints help, `batch-evaluation simulate` still runs from the CLI. This only gates **TUI-menu membership**.

## Tests

Mirror the gateway command-hierarchy suite (`supportsTui` helper + `test.each` for supported vs CLI-only):

- New `src/handlers/eval/eval.test.tsx` — the 8 screen-backed groups are offered; `ondemand` + `recommendation` are hidden.
- `batch-evaluation.test.tsx` — `get`/`list` (and bare group) offered; `evaluate`/`simulate` hidden.

`bun test src/handlers/eval/` → **377 pass, 0 fail**. `oxlint` + `prettier` clean on changed files.

> Note: `tsc --noEmit` surfaces a pre-existing duplicate-identifier error in `src/handlers/project/buildDeploy.screen.test.tsx` (present on `refactor` before this branch; unrelated to these files).