### PR TITLE
fix: address double function implementation failing tsc

### DIFF
--- a/src/handlers/project/buildDeploy.screen.test.tsx
+++ b/src/handlers/project/buildDeploy.screen.test.tsx
@@ -62,9 +62,6 @@ function fakeBackend(options: FakeBackendOptions = {}) {
     async resolveDeployedResources() {
       return [];
     },
-    async resolveProjectResources() {
-      return [];
-    },
   };
   return { backend, deploys };
 }


### PR DESCRIPTION
### Problem 
The tsc is failing (again)
```
$ tsc --noEmit
src/handlers/project/buildDeploy.screen.test.tsx:65:11 - error TS2300: Duplicate identifier 'resolveProjectResources'.

65     async resolveProjectResources() {
             ~~~~~~~~~~~~~~~~~~~~~~~


Found 1 error in src/handlers/project/buildDeploy.screen.test.tsx:65



```
https://github.com/aws/agentcore-cli/actions/runs/33790922020/job/100784295618
### Solution
remove the duplicates

### Verification
 `bun run typecheck`