### PR TITLE
fix(invoke): default Accept to text/event-stream for non-MCP runtimes

### DIFF
--- a/src/handlers/runtime/invoke/invoke.test.tsx
+++ b/src/handlers/runtime/invoke/invoke.test.tsx
@@ -107,6 +107,7 @@ describe("runtime invoke", () => {
       payload: new TextEncoder().encode('{"prompt":"hello"}'),
       contentType: "application/json",
       runtimeUserId: "default",
+      accept: "text/event-stream",
     });
     expect(invoke.args[1]).toEqual({ region: REGION });
     expect(lookup.args[2]).toBe(invoke.args[2]);

--- a/src/handlers/runtime/invoke/request.test.ts
+++ b/src/handlers/runtime/invoke/request.test.ts
@@ -221,6 +221,34 @@ describe("normalizeRuntimeInvokeRequest", () => {
     expect(request.runtimeUserId).toBe("default");
   });
 
+  test.each([["HTTP"], ["A2A"]] as const)(
+    "defaults %s requests to JSON content and SSE accept",
+    (serverProtocol) => {
+      const request = normalizeRuntimeInvokeRequest(
+        detail({ protocolConfiguration: { serverProtocol } }),
+        {
+          runtimeId: RUNTIME_ID,
+          payload: new Uint8Array(),
+        },
+      );
+
+      expect(request.contentType).toBe("application/json");
+      expect(request.accept).toBe("text/event-stream");
+    },
+  );
+
+  test("lets explicit content-type and accept override the defaults", () => {
+    const request = normalizeRuntimeInvokeRequest(detail(), {
+      runtimeId: RUNTIME_ID,
+      payload: new Uint8Array(),
+      contentType: "application/cbor",
+      accept: "application/json",
+    });
+
+    expect(request.contentType).toBe("application/cbor");
+    expect(request.accept).toBe("application/json");
+  });
+
   test("maps every request field and ordered allowed headers once", () => {
     const request = normalizeRuntimeInvokeRequest(
       detail({

--- a/src/handlers/runtime/invoke/request.ts
+++ b/src/handlers/runtime/invoke/request.ts
@@ -172,7 +172,7 @@ export function normalizeRuntimeInvokeRequest(
     contentType: contentType || "application/json",
     ...modeled,
     runtimeUserId: modeled.runtimeUserId ?? DEFAULT_RUNTIME_USER_ID,
-    accept: modeled.accept ?? (mcp ? "application/json, text/event-stream" : undefined),
+    accept: modeled.accept ?? (mcp ? "application/json, text/event-stream" : "text/event-stream"),
     ...(applicationHeaders.length > 0 && { applicationHeaders }),
   };
 }


### PR DESCRIPTION
## Problem. 
On the refactor branch, the CLI invoke path doesn't send the headers the TS runtime requires, so invoking a TS agent 415/406s unless the user manually passes --accept text/event-stream (and JSON content-type). 

This is due to an explicit check in the TS requiring these headers, whereas the same is not true in python. 

## Solution
- `agentcore invoke / project invoke` runtime default Content-Type: application/json and Accept: text/event-stream on the HTTP/A2A streaming path, chosen per protocol (MCP uses its own
  negotiation), and overridable by explicit flags. 

## Verification.
Reproduce the bug with the current version on refactor:
```
$ agentcore runtime invoke --id testTS_agent_typescript_strands-kGTWAh9ySn --payload '{ "prompt": "hello" }'
Error: Received error (406) from runtime. Please check your CloudWatch logs for more information.
[rebuild with latest changes]
$ agentcore runtime invoke --id testTS_agent_typescript_strands-kGTWAh9ySn --payload '{ "prompt": "hello" }'
data: "Hello"

data: "! How can I help you today?\n"

status=200 content-type=text/event-stream runtime-session-id=ba742184-ae2d-44df-b51d-16dee7b6a61d mcp-session-id=- mcp-protocol-version=- trace-id=- trace-parent=- trace-state=- baggage=- complete=true bytes=54
```