### PR TITLE
fix(project): point the no-targets error at `project deploy`

### DIFF
--- a/src/core/project/manager.tsx
+++ b/src/core/project/manager.tsx
@@ -1004,18 +1004,13 @@ export class FsProjectManager implements ProjectManager {
     name: string,
   ): Promise<AwsDeploymentTarget> {
     const targetsPath = join(project.rootPath, "agentcore", "aws-targets.json");
-    if (!existsSync(targetsPath)) {
-      throw new ProjectStateError(
-        `No deployment targets are configured for project '${project.name}'. ` +
-          `Add ${targetsPath}, for example:\n\n${TARGETS_EXAMPLE}`,
-      );
-    }
-
-    const targets = await this.json.read(targetsPath, AwsDeploymentTargetsSchema);
+    const targets = existsSync(targetsPath)
+      ? await this.json.read(targetsPath, AwsDeploymentTargetsSchema)
+      : [];
     if (targets.length === 0) {
       throw new ProjectStateError(
         `No deployment targets are configured for project '${project.name}'. ` +
-          `Add at least one to ${targetsPath}, for example:\n\n${TARGETS_EXAMPLE}`,
+          `Please deploy your project using 'agentcore project deploy'.`,
       );
     }
 

--- a/src/handlers/project/status/index.test.ts
+++ b/src/handlers/project/status/index.test.ts
@@ -213,7 +213,7 @@ describe("project status handler", () => {
     await inProject(subject, { memories: [memory("shortTerm")] }, []);
 
     await expect(subject.run()).rejects.toThrow(
-      /No deployment targets are configured for project 'orders'/,
+      /No deployment targets are configured for project 'orders'\. Please deploy your project using 'agentcore project deploy'\./,
     );
     expect(subject.targets).toEqual([]);
   });


### PR DESCRIPTION
`resolveExistingTarget` told the user to hand-write `aws-targets.json` with an example account id when a project declared no deployment targets:

```
No deployment targets are configured for project 'orders'. Add /path/agentcore/aws-targets.json, for example:

[{ "name": "default", "account": "111122223333", "region": "us-east-1" }]
```

A freshly created project hits this on its first `agentcore project status`, because `create` writes an empty `aws-targets.json` and only `deploy` fills it. Deploying is what the user should do, so the message now says so:

```
No deployment targets are configured for project 'orders'. Please deploy your project using 'agentcore project deploy'.
```

The missing-file and empty-array branches reported the same thing once the path/example was dropped, so they merge into one `targets.length === 0` check. The unknown-`--target` branch is unchanged — it still lists the declared target names, which is the useful fix for a typo.

This is a shared helper, so `deploy`, `remove`, and `invoke` get the same clearer message when a project has no targets.