### PR TITLE
chore: use shared FormRadio component in endpointWizard

### DIFF
--- a/src/components/EndpointWizard.tsx
+++ b/src/components/EndpointWizard.tsx
@@ -9,6 +9,7 @@ import type {
 import type { ScreenProps } from "../handlers/types";
 import { coreOptsFromCtx } from "../handlers/utils";
 import { Layout } from "./Layout";
+import { FormRadioGroup, type FormRadioOption } from "./FormRadioGroup";
 import { Stepper, type Step } from "./ui/stepper";
 import { TextInput } from "./ui/text-input";
 import { Spinner } from "./ui/spinner";
@@ -254,10 +255,8 @@ function NameStep({
   );
 }
 
-interface VersionOption {
+interface VersionOption extends FormRadioOption {
   value: string;
-  label: string;
-  detail: string;
 }
 
 function VersionStep({
@@ -285,14 +284,18 @@ function VersionStep({
       .map((v) => ({
         value: v.harnessVersion ?? "",
         label: `version ${v.harnessVersion}`,
-        detail: `${v.status} · updated ${v.updatedAt?.toISOString().slice(0, 10) ?? ""}`,
+        description: `${v.status} · updated ${v.updatedAt?.toISOString().slice(0, 10) ?? ""}`,
       }))
       .sort((a, b) => Number(b.value) - Number(a.value));
     // Create mode offers "latest": omitting targetVersion tracks the newest
     // version at creation time.
     return mode === "create"
       ? [
-          { value: "", label: "latest", detail: "track the most recent version (default)" },
+          {
+            value: "",
+            label: "latest",
+            description: "track the most recent version (default)",
+          },
           ...listed,
         ]
       : listed;
@@ -322,28 +325,28 @@ function VersionStep({
 
   return (
     <Box flexDirection="column">
-      <Question text="which harness version should this endpoint serve?" />
       {versions.isPending ? (
-        <Spinner label="loading versions…" />
+        <>
+          <Question text="which harness version should this endpoint serve?" />
+          <Spinner label="loading versions…" />
+        </>
       ) : versions.isError ? (
-        <Text color={theme.colors.error}>✗ {(versions.error as Error).message}</Text>
+        <>
+          <Question text="which harness version should this endpoint serve?" />
+          <Text color={theme.colors.error}>✗ {(versions.error as Error).message}</Text>
+        </>
       ) : options.length === 0 ? (
-        <Text color={theme.colors.muted}>this harness has no versions</Text>
+        <>
+          <Question text="which harness version should this endpoint serve?" />
+          <Text color={theme.colors.muted}>this harness has no versions</Text>
+        </>
       ) : (
-        options.map((option, i) => {
-          const selected = i === index;
-          return (
-            <Box key={option.value === "" ? "(latest)" : option.value}>
-              <Text color={selected ? theme.colors.focus : theme.colors.muted}>
-                {selected ? "● " : "○ "}
-              </Text>
-              <Text bold={selected} color={selected ? theme.colors.focus : theme.colors.text}>
-                {option.label.padEnd(12)}
-              </Text>
-              <Text color={theme.colors.muted}>{option.detail}</Text>
-            </Box>
-          );
-        })
+        <FormRadioGroup
+          name="choose a harness version"
+          helpText="which harness version should this endpoint serve?"
+          options={options}
+          focusedIndex={index}
+        />
       )}
     </Box>
   );

--- a/src/components/EndpointWizard.tsx
+++ b/src/components/EndpointWizard.tsx
@@ -342,7 +342,6 @@ function VersionStep({
         </>
       ) : (
         <FormRadioGroup
-          name="choose a harness version"
           helpText="which harness version should this endpoint serve?"
           options={options}
           focusedIndex={index}

--- a/src/components/FormRadioGroup.tsx
+++ b/src/components/FormRadioGroup.tsx
@@ -9,7 +9,7 @@ export interface FormRadioOption {
 }
 
 export interface FormRadioGroupProps {
-  name: string;
+  name?: string;
   helpText: string;
   options: FormRadioOption[];
   // highlighted/hovered row
@@ -32,7 +32,7 @@ export function FormRadioGroup({
   return (
     <Box flexDirection="column">
       <Box flexDirection="column">
-        <Text color={theme.colors.text}>{name}</Text>
+        {name && <Text color={theme.colors.text}>{name}</Text>}
         <Text color={theme.colors.muted}>{helpText}</Text>
       </Box>
       <Box

--- a/src/handlers/harness/endpoint/create/create.screen.test.tsx
+++ b/src/handlers/harness/endpoint/create/create.screen.test.tsx
@@ -82,6 +82,7 @@ describe("harness endpoint create wizard", () => {
     // Versions listed newest first after the "latest" default.
     await waitForText(r.lastFrame, "which harness version should this endpoint serve?");
     expect(r.lastFrame()).toContain("● latest");
+    expect(r.lastFrame()).toContain("│ ● latest");
     expect(r.lastFrame()).toContain("version 2");
     expect(r.lastFrame()).toContain("version 1");
     await r.press("down"); // version 2

--- a/src/handlers/harness/endpoint/update/update.screen.test.tsx
+++ b/src/handlers/harness/endpoint/update/update.screen.test.tsx
@@ -90,6 +90,7 @@ describe("harness endpoint update wizard", () => {
     // The endpoint's current target (version 1) is preselected; no "latest"
     // option exists in update mode.
     await waitForText(r.lastFrame, "● version 1");
+    expect(r.lastFrame()).toContain("│ ● version 1");
     expect(r.lastFrame()).not.toContain("latest");
     await r.press("up"); // version 2 (sorted newest first)
     await waitForText(r.lastFrame, "● version 2");


### PR DESCRIPTION
## Description

`EndpointWizard.tsx` was added before the `FormRadioGroup` shared component was created, as until now was using its own radio button logic. 

This PR updates endpoint wizard to use the shared component, aligning it to the style and handling the rest of the TUI uses. 

Before: 
<img width="571" height="114" alt="image" src="https://github.com/user-attachments/assets/960d752c-bf96-4995-ad09-7e14831f03cb" />
After:
<img width="575" height="147" alt="image" src="https://github.com/user-attachments/assets/2d90e334-2cfe-46d2-a0d3-f98ae6d249de" />


## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe): Tech debt

## Testing

How have you tested the change?

- [x] `bun run test` (2854 pass, 0 fail)
- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [x] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
