### PR TITLE
feat(project): add agent-python-strands-container template

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ agentcore harness invoke --id <id from the deploy outputs> --prompt "hello"
 
 # Scaffold runtime code instead (pass a template or framework flags).
 agentcore project create --name MyAgent --template agent-python-strands
+# The same Strands agent built as a container image, with a Dockerfile.
+agentcore project create --name MyAgent --template agent-python-strands-container
 
 # Translate an existing Amazon Bedrock Agent version into editable runtime code.
 # The selected alias identifies the immutable source version; generated code

--- a/src/handlers/project/create/create.screen.test.tsx
+++ b/src/handlers/project/create/create.screen.test.tsx
@@ -364,38 +364,45 @@ describe("project create wizard", () => {
     r.unmount();
   }, 10000);
 
-  test("template flow: the container strands template asks about memory", async () => {
-    await inTempDirectory();
-    const core = new TestCoreClient();
-    const inputs = spyOnCreate(core);
-    const r = renderScreen("/agentcore/project/create", { core });
+  test.each([
+    ["agent-python-strands-container", 1],
+    ["a2a-python-strands", 4],
+  ] as const)(
+    "template flow: %s asks about memory",
+    async (template, downPresses) => {
+      await inTempDirectory();
+      const core = new TestCoreClient();
+      const inputs = spyOnCreate(core);
+      const r = renderScreen("/agentcore/project/create", { core });
 
-    await waitForText(r.lastFrame, "name your project");
-    await r.write("ContainerApp");
-    await r.press("return");
-    await waitForText(r.lastFrame, "what should the project be built around?");
-    await r.press("down");
-    await r.press("return");
-    await waitForText(r.lastFrame, "choose a template");
-    await r.press("down"); // agent-python-strands-container
-    await waitForText(r.lastFrame, "● agent-python-strands-container");
-    await r.press("return");
-    await waitForText(r.lastFrame, "choose a memory configuration");
-    await r.press("return");
-    await waitForText(r.lastFrame, "this project will be created");
-    await r.press("return");
-    await waitForText(r.lastFrame, "project created in ./ContainerApp", 5000);
+      await waitForText(r.lastFrame, "name your project");
+      await r.write("StrandsVariant");
+      await r.press("return");
+      await waitForText(r.lastFrame, "what should the project be built around?");
+      await r.press("down");
+      await r.press("return");
+      await waitForText(r.lastFrame, "choose a template");
+      for (let i = 0; i < downPresses; i++) await r.press("down");
+      await waitForText(r.lastFrame, `● ${template}`);
+      await r.press("return");
+      await waitForText(r.lastFrame, "choose a memory configuration");
+      await r.press("return");
+      await waitForText(r.lastFrame, "this project will be created");
+      await r.press("return");
+      await waitForText(r.lastFrame, "project created in ./StrandsVariant", 5000);
 
-    expect(inputs).toEqual([
-      {
-        name: "ContainerApp",
-        skipInstall: false,
-        skipGit: false,
-        scaffoldRuntimeInput: resolveRuntimeTemplateShortcut("agent-python-strands-container"),
-      },
-    ]);
-    r.unmount();
-  }, 10000);
+      expect(inputs).toEqual([
+        {
+          name: "StrandsVariant",
+          skipInstall: false,
+          skipGit: false,
+          scaffoldRuntimeInput: resolveRuntimeTemplateShortcut(template),
+        },
+      ]);
+      r.unmount();
+    },
+    10000,
+  );
 
   test("template flow: hello-world skips the memory question", async () => {
     await inTempDirectory();

--- a/src/handlers/project/create/create.screen.test.tsx
+++ b/src/handlers/project/create/create.screen.test.tsx
@@ -364,6 +364,39 @@ describe("project create wizard", () => {
     r.unmount();
   }, 10000);
 
+  test("template flow: the container strands template asks about memory", async () => {
+    await inTempDirectory();
+    const core = new TestCoreClient();
+    const inputs = spyOnCreate(core);
+    const r = renderScreen("/agentcore/project/create", { core });
+
+    await waitForText(r.lastFrame, "name your project");
+    await r.write("ContainerApp");
+    await r.press("return");
+    await waitForText(r.lastFrame, "what should the project be built around?");
+    await r.press("down");
+    await r.press("return");
+    await waitForText(r.lastFrame, "choose a template");
+    await r.press("down"); // agent-python-strands-container
+    await waitForText(r.lastFrame, "● agent-python-strands-container");
+    await r.press("return");
+    await waitForText(r.lastFrame, "choose a memory configuration");
+    await r.press("return");
+    await waitForText(r.lastFrame, "this project will be created");
+    await r.press("return");
+    await waitForText(r.lastFrame, "project created in ./ContainerApp", 5000);
+
+    expect(inputs).toEqual([
+      {
+        name: "ContainerApp",
+        skipInstall: false,
+        skipGit: false,
+        scaffoldRuntimeInput: resolveRuntimeTemplateShortcut("agent-python-strands-container"),
+      },
+    ]);
+    r.unmount();
+  }, 10000);
+
   test("template flow: hello-world skips the memory question", async () => {
     await inTempDirectory();
     const core = new TestCoreClient();
@@ -377,6 +410,7 @@ describe("project create wizard", () => {
     await r.press("down");
     await r.press("return");
     await waitForText(r.lastFrame, "choose a template");
+    await r.press("down");
     await r.press("down"); // agent-python
     await waitForText(r.lastFrame, "● agent-python ");
     await r.press("return");

--- a/src/handlers/project/create/screen.tsx
+++ b/src/handlers/project/create/screen.tsx
@@ -7,6 +7,7 @@ import type { HarnessModelProvider } from "../../../projectSchemas/harness";
 import type { ScreenProps } from "../../types";
 import type { CreateProjectInput } from "../types";
 import {
+  RUNTIME_TEMPLATE_SHORTCUTS,
   resolveRuntimeTemplateShortcut,
   type MemoryShortcutName,
   type RuntimeTemplateShortcutName,
@@ -126,6 +127,11 @@ const TEMPLATE_OPTIONS: {
     description: "Strands agent on Bedrock with memory (CodeZip build)",
   },
   {
+    template: "agent-python-strands-container",
+    label: "agent-python-strands-container",
+    description: "Strands agent on Bedrock with memory (Container build)",
+  },
+  {
     template: "agent-python",
     label: "agent-python",
     description: "minimal Python agent on Bedrock, no framework (CodeZip build)",
@@ -141,6 +147,9 @@ const TEMPLATE_OPTIONS: {
     description: "Strands agent speaking the A2A protocol on Bedrock (CodeZip build)",
   },
 ];
+
+const asksMemory = (template: RuntimeTemplateShortcutName) =>
+  RUNTIME_TEMPLATE_SHORTCUTS[template].framework === "strands";
 
 const MEMORY_OPTIONS: { memory: MemoryShortcutName; label: string; description: string }[] = [
   {
@@ -188,9 +197,7 @@ export function buildCreateInput(values: CreateProjectFormValues): CreateProject
     skipGit: false,
     scaffoldRuntimeInput: resolveRuntimeTemplateShortcut(
       values.template,
-      // Memory is a strands question; the non-strands templates keep their own
-      // (memory-less) defaults, exactly like `--template` without `--memory`.
-      values.template === "agent-python-strands" ? { memory: values.memory } : undefined,
+      asksMemory(values.template) ? { memory: values.memory } : undefined,
     ),
   };
 }
@@ -212,7 +219,7 @@ function summaryOf(values: CreateProjectFormValues): Record<string, string> {
     };
   }
   const withTemplate = { ...base, type: "agent code", template: values.template };
-  return values.template === "agent-python-strands"
+  return asksMemory(values.template)
     ? {
         ...withTemplate,
         memory: MEMORY_OPTIONS.find((option) => option.memory === values.memory)!.label,
@@ -256,9 +263,7 @@ export function ProjectCreateScreen({ core }: ScreenProps) {
         ? [{ key: "model", title: "model" }]
         : [
             { key: "template", title: "template" },
-            ...(values.template === "agent-python-strands"
-              ? [{ key: "memory", title: "memory" }]
-              : []),
+            ...(asksMemory(values.template) ? [{ key: "memory", title: "memory" }] : []),
           ];
     return [
       { key: "name", title: "name" },

--- a/src/handlers/project/project.test.ts
+++ b/src/handlers/project/project.test.ts
@@ -490,19 +490,12 @@ describe("project create", () => {
     expect(envLocal).toContain("test-api-key");
   });
 
-  test("scaffolds a Container agent from the strands template", async () => {
+  test.each([
+    ["--build Container override", ["--template", "agent-python-strands", "--build", "Container"]],
+    ["container template", ["--template", "agent-python-strands-container"]],
+  ])("scaffolds a Container agent from the strands template (%s)", async (_label, flags) => {
     const directory = await inTempDirectory();
-    await run([
-      "create",
-      "--name",
-      "MyProject",
-      "--template",
-      "agent-python-strands",
-      "--build",
-      "Container",
-      "--skip-install",
-      "--skip-git",
-    ]);
+    await run(["create", "--name", "MyProject", ...flags, "--skip-install", "--skip-git"]);
 
     const projectRoot = join(directory, "MyProject");
     const spec = await Bun.file(join(projectRoot, "agentcore", "agentcore.json")).json();

--- a/src/handlers/project/shortcuts.ts
+++ b/src/handlers/project/shortcuts.ts
@@ -68,6 +68,14 @@ export const RUNTIME_TEMPLATE_SHORTCUTS = {
     memory: "longAndShortTerm",
     runtimeVersion: "PYTHON_3_14",
   },
+  "agent-python-strands-container": {
+    runtimeName: "agent_python_strands",
+    build: "Container",
+    language: "Python",
+    framework: "strands",
+    modelProvider: "Bedrock",
+    memory: "longAndShortTerm",
+  },
   "agent-typescript-strands": {
     runtimeName: "agent_typescript_strands",
     build: "CodeZip",

--- a/src/handlers/project/shortcuts.ts
+++ b/src/handlers/project/shortcuts.ts
@@ -139,7 +139,10 @@ export function resolveRuntimeTemplateShortcut(
     modelProvider: overrides?.modelProvider ?? template.modelProvider,
     ...(overrides?.apiKey !== undefined && { apiKey: overrides.apiKey }),
     ...(memory && { memory }),
-    runtimeVersion: build === "CodeZip" ? (template.runtimeVersion ?? "PYTHON_3_14") : undefined,
+    runtimeVersion:
+      build === "CodeZip"
+        ? (template.runtimeVersion ?? LANGUAGE_VERSION_DEFAULTS[template.language])
+        : undefined,
   };
 
   const result = ScaffoldRuntimeInputSchema.safeParse(input);


### PR DESCRIPTION
## Summary

The TUI create wizard has no build question, so a Container build of the Strands agent was unreachable from it. This adds an `agent-python-strands-container` template preset: `agent-python-strands` with `build: Container`, which keeps the `Dockerfile` and `.dockerignore` in the scaffold.

- `shortcuts.ts`: the preset. The `--template` enum is derived from the table, so the flag accepts it automatically.
- `create/screen.tsx`: the wizard option, placed after the recommended Strands entry. The three memory-step gates that hardcoded `"agent-python-strands"` are now one `asksMemory` helper keyed on the preset's framework.
- README: one example line.

On the CLI this is a second spelling of `--template agent-python-strands --build Container`. The preset exists for the TUI, and the parameterized test asserts both spellings scaffold identically.

**Behavior change:** because the memory gate keys off framework, `a2a-python-strands` now also gets the memory question in the wizard. Its resolver supports memory and its preset already defaults to long and short-term, matching the flag path.

## Testing

- `bun test`: 2854 pass. `tsc --noEmit` clean.
- Flags: built `dist/index.js`, ran `project create --template agent-python-strands-container`. Dockerfile and `.dockerignore` present, CMD rendered with `opentelemetry-instrument`, spec has `build: Container` and no `runtimeVersion`, memory with four strategies, `uv.lock` generated.
- TUI: drove the wizard through the TUI harness. New option renders, selecting it shows the memory step, review shows the template, project created. The TUI scaffold and the flag scaffold diff identically apart from the project name.
- Live deploy to us-east-1: runtime reached READY with an ECR container URI, `project invoke runtime` returned the expected reply over the event stream. Torn down with `project remove all --yes` then `project deploy --yes`. Stack and ECR repository gone.