### PR TITLE
fix: allow arrow key navigation while filtering

### DIFF
--- a/src/components/PaginatedTablePicker.test.tsx
+++ b/src/components/PaginatedTablePicker.test.tsx
@@ -303,6 +303,91 @@ describe("paginated table picker contract", () => {
     expect(r.lastFrame()).toContain("agentcore → harness → get → alpha-1");
   });
 
+  test("moves focus from the Runtime filter into its matching rows", async () => {
+    const core = new TestCoreClient();
+    core.runtime.setListResponse({
+      agentRuntimes: [
+        runtime({
+          agentRuntimeId: "orders-alpha",
+          agentRuntimeName: "orders-alpha",
+        }),
+        runtime({
+          agentRuntimeId: "orders-beta",
+          agentRuntimeName: "orders-beta",
+        }),
+      ],
+    });
+    const r = renderScreen("/agentcore/runtime/list", { core });
+
+    await waitForText(r.lastFrame, "orders-beta");
+    await r.write("/");
+    await r.write("orders");
+    await waitForText(r.lastFrame, "/ Filter: orders");
+    expect(r.lastFrame()).not.toContain("❯ orders-alpha");
+
+    await r.press("down");
+    await waitForText(r.lastFrame, "❯ orders-alpha");
+    expect(r.lastFrame()).not.toContain("/ Filter: orders█");
+
+    await r.press("up");
+    await waitForText(r.lastFrame, "/ Filter: orders█");
+    expect(r.lastFrame()).not.toContain("❯ orders-alpha");
+
+    await r.press("down");
+    await waitForText(r.lastFrame, "❯ orders-alpha");
+    await r.press("down");
+    await waitForText(r.lastFrame, "❯ orders-beta");
+    await r.press("return");
+
+    await waitFor(() =>
+      core.runtime.calls.some(
+        (call) => call.method === "getRuntime" && call.args[0] === "orders-beta",
+      ),
+    );
+    expect(
+      core.runtime.calls.some(
+        (call) => call.method === "getRuntime" && call.args[0] === "orders-alpha",
+      ),
+    ).toBe(false);
+  });
+
+  test("restores server page navigation after moving focus out of the filter", async () => {
+    const core = new TestCoreClient();
+    core.runtime.setListResponse({
+      agentRuntimes: [
+        runtime({
+          agentRuntimeId: "page-one",
+          agentRuntimeName: "matching-page-one",
+        }),
+      ],
+      nextToken: "t2",
+    });
+    core.runtime.setListResponse(
+      {
+        agentRuntimes: [
+          runtime({
+            agentRuntimeId: "page-two",
+            agentRuntimeName: "matching-page-two",
+          }),
+        ],
+      },
+      "t2",
+    );
+    const r = renderScreen("/agentcore/runtime/list", { core });
+
+    await waitForText(r.lastFrame, "matching-page-one");
+    await r.write("/");
+    await r.write("matching");
+    await waitForText(r.lastFrame, "/ Filter: matching█");
+    await r.press("down");
+    await waitForText(r.lastFrame, "❯ matching-page-one");
+    await r.press("right");
+    await waitForText(r.lastFrame, "❯ matching-page-two");
+
+    expect(r.lastFrame()).toContain("/ Filter: matching");
+    expect(r.lastFrame()).not.toContain("/ Filter: matching█");
+  });
+
   test("fills the content area before and during a long filter", async () => {
     const longFilter = `${"filter-prefix-".repeat(8)}visible-suffix`;
     const core = new TestCoreClient();

--- a/src/components/ui/data-table/DataTable.tsx
+++ b/src/components/ui/data-table/DataTable.tsx
@@ -111,15 +111,25 @@ export function DataTable<T extends Record<string, unknown>>({
           setSearchQuery("");
           return;
         }
+        if (key.upArrow) {
+          return;
+        }
+        if (key.downArrow) {
+          setSelectedRow(0);
+          setSearchMode(false);
+          return;
+        }
         if (key.return) {
           setSearchMode(false);
           return;
         }
         if (key.backspace || key.delete) {
+          setSelectedRow(0);
           setSearchQuery((q) => q.slice(0, -1));
           return;
         }
         if (input && !key.ctrl && !key.meta && !/\p{Cc}/u.test(input)) {
+          setSelectedRow(0);
           setSearchQuery((q) => q + input);
         }
         return;
@@ -131,8 +141,10 @@ export function DataTable<T extends Record<string, unknown>>({
       }
 
       const serverPaged = onPrevPage !== undefined || onNextPage !== undefined;
-      if (key.upArrow || input === "k") setSelectedRow((r) => Math.max(0, r - 1));
-      else if (key.downArrow || input === "j")
+      if (key.upArrow || input === "k") {
+        if (selectedRow === 0 && searchQuery) setSearchMode(true);
+        else setSelectedRow((r) => Math.max(0, r - 1));
+      } else if (key.downArrow || input === "j")
         setSelectedRow((r) => Math.min(pageData.length - 1, r + 1));
       else if (key.leftArrow || input === "h") {
         if (serverPaged) {
@@ -267,7 +279,7 @@ export function DataTable<T extends Record<string, unknown>>({
           </Box>
         ) : (
           pageData.map((row, i) => {
-            const isSelected = i === selectedRow && selectable;
+            const isSelected = i === selectedRow && selectable && !searchMode;
             return (
               <Box key={i} flexDirection="row" columnGap={COLUMN_GAP}>
                 {selectable && (


### PR DESCRIPTION
## Description

The current `DataTable.tsx` used by pagination does not allow arrow key usage while filtering. The user has to click enter and then interact with the filtered items. The UI is confusing from the user perspective, as the first item in the table stays in focus while filtering. This gives the impression that the cursor is currently on the first list item. 

## Example before fix
* my cursor is in the "filter" input, but first harness still focused in the UI
* arrow key navigation is a no-op

<img width="280" height="125" alt="image" src="https://github.com/user-attachments/assets/f0f7635e-7c45-47ed-acd2-198758d9e9a6" />


## Example after fix: 
* table items lose focus when input is active
* User can click enter or down arrow to navigate to first table item, at which point item gains focus styling
* Filter input loses focus styling once enter or down arrow is clicked
* User can click "/" or scroll to top with up arrow to return to filter menu, at which point focus styles reset

**After example:**

https://github.com/user-attachments/assets/562c4bc7-bccb-45dd-b466-4a28f981cd2b




## Type of Change

<!-- Check all that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] `bun run test` (x pass, 0 fail)
- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [x] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
