### PR TITLE
fix: deflake watchFile and invoke backspace tests

### DIFF
--- a/src/handlers/harness/invoke/invoke.screen.test.tsx
+++ b/src/handlers/harness/invoke/invoke.screen.test.tsx
@@ -435,11 +435,12 @@ describe("invoke chat screen", () => {
     await sendMessage(r, "hi agent");
     await waitForText(r.lastFrame, "end_turn");
 
-    await r.write("abcd");
-    await waitForText(r.lastFrame, "abcd");
+    // Non-hex letters, so the random session UUID in the frame can never contain them.
+    await r.write("wxyz");
+    await waitForText(r.lastFrame, "wxyz");
     await r.write("\x7f"); // backspace
-    await waitFor(() => !(r.lastFrame() ?? "").includes("abcd"));
-    expect(r.lastFrame()).toContain("abc");
+    await waitFor(() => !(r.lastFrame() ?? "").includes("wxyz"));
+    expect(r.lastFrame()).toContain("wxy");
     r.unmount();
   });
 

--- a/src/io/watchFile.test.ts
+++ b/src/io/watchFile.test.ts
@@ -2,6 +2,7 @@ import { afterEach, expect, test } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { waitFor } from "../testing";
 import { watchFile } from "./watchFile";
 
 let dir: string | undefined;
@@ -22,11 +23,12 @@ test("debounces a burst of edits into a single callback and stops on abort", asy
   const controller = new AbortController();
   let calls = 0;
   watchFile(path, () => calls++, controller.signal);
+  // Bun registers the macOS kqueue watch off-thread, so earlier edits are never reported.
+  await Bun.sleep(100);
 
   writeFileSync(path, '{"a":1}');
   writeFileSync(path, '{"a":2}');
-  await Bun.sleep(250);
-  expect(calls).toBe(1);
+  await waitFor(() => calls === 1);
 
   controller.abort();
   writeFileSync(path, '{"a":3}');

--- a/src/io/watchFile.test.ts
+++ b/src/io/watchFile.test.ts
@@ -23,7 +23,7 @@ test("debounces a burst of edits into a single callback and stops on abort", asy
   const controller = new AbortController();
   let calls = 0;
   watchFile(path, () => calls++, controller.signal);
-  // Bun registers the macOS kqueue watch off-thread; edits written before it is live are dropped.
+  // Bun registers the macOS kqueue watch off-thread, so edits written before it is live are dropped.
   await Bun.sleep(100);
 
   writeFileSync(path, '{"a":1}');

--- a/src/io/watchFile.test.ts
+++ b/src/io/watchFile.test.ts
@@ -23,12 +23,13 @@ test("debounces a burst of edits into a single callback and stops on abort", asy
   const controller = new AbortController();
   let calls = 0;
   watchFile(path, () => calls++, controller.signal);
-  // Bun registers the macOS kqueue watch off-thread, so earlier edits are never reported.
+  // Bun registers the macOS kqueue watch off-thread; edits written before it is live are dropped.
   await Bun.sleep(100);
 
   writeFileSync(path, '{"a":1}');
   writeFileSync(path, '{"a":2}');
-  await waitFor(() => calls === 1);
+  await waitFor(() => calls > 0);
+  expect(calls).toBe(1);
 
   controller.abort();
   writeFileSync(path, '{"a":3}');


### PR DESCRIPTION
Closes #2140
Closes #2176

## watchFile.test.ts (#2140)
Bun registers the macOS kqueue watch off the main thread. Edits written synchronously right after `watch()` are sometimes never reported (5 of 60 runs locally with no delay, 0 of 60 with a 20 ms settle). The test now settles 100 ms before writing and waits for the callback instead of sleeping a fixed 250 ms. 100 of 100 local runs pass; the previous version failed about 1 in 8 locally.

Test-only: `project dev` starts watching long before the user edits, so production is unaffected.

## invoke.screen.test.tsx (#2176)
The chat frame renders `session: <crypto.randomUUID()>`. The backspace test asserted that `"abcd"` disappears from the whole frame, which can never happen when the random UUID contains that hex substring (about 1 in 2500 runs). Reproduced deterministically by seeding a session id containing `abcd` via the `/:sessionId` route. The test now types non-hex letters.

## Verification
- `bun test` full suite with `--coverage` passes locally
- lint and typecheck clean