### PR TITLE
chore(help): make --help descriptions consistent across the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ agentcore                          # interactive TUI
 │   └── record
 │       ├── get                    # get a long-term Memory record
 │       └── list                   # list long-term Memory records
-├── gateway                        # inspect AgentCore Gateways
+├── gateway                        # manage AgentCore Gateways
 │   ├── get                        # get a Gateway by id
 │   ├── list                       # list Gateways (server-side paginated)
 │   ├── invoke                     # invoke a Gateway headlessly or in a persistent console

--- a/src/components/CliOnlyScreen.test.tsx
+++ b/src/components/CliOnlyScreen.test.tsx
@@ -76,7 +76,7 @@ describe("menus list command-line-only subcommands below a divider", () => {
   test("the divider is omitted when nothing is command line only", async () => {
     const r = renderScreen("/agentcore/harness");
 
-    await waitForText(r.lastFrame, "manage agentcore harnesses");
+    await waitForText(r.lastFrame, "manage AgentCore harnesses");
     expect(r.lastFrame()).not.toContain("command line only");
     r.unmount();
   });
@@ -149,7 +149,7 @@ describe("paths without a screen of their own", () => {
     expect(frame).toContain("--authorizer-type");
 
     await r.press("escape");
-    await waitForText(r.lastFrame, "inspect AgentCore Gateways");
+    await waitForText(r.lastFrame, "manage AgentCore Gateways");
     r.unmount();
   });
 });

--- a/src/components/PaginatedTablePicker.test.tsx
+++ b/src/components/PaginatedTablePicker.test.tsx
@@ -94,7 +94,7 @@ describe("paginated table picker contract", () => {
 
     await waitForText(r.lastFrame, "Loading harnesses");
     await r.press("escape");
-    await waitForText(r.lastFrame, "manage agentcore harnesses");
+    await waitForText(r.lastFrame, "manage AgentCore harnesses");
   });
 
   test("keeps Escape active after a query fails", async () => {
@@ -104,7 +104,7 @@ describe("paginated table picker contract", () => {
 
     await waitForText(r.lastFrame, "access denied");
     await r.press("escape");
-    await waitForText(r.lastFrame, "manage agentcore harnesses");
+    await waitForText(r.lastFrame, "manage AgentCore harnesses");
   });
 
   test("distinguishes first-page and later-page empty states", async () => {
@@ -112,7 +112,7 @@ describe("paginated table picker contract", () => {
     await waitForText(firstPage.lastFrame, "No harnesses found.");
     expect(firstPage.lastFrame()).not.toContain("page 1");
     await firstPage.press("escape");
-    await waitForText(firstPage.lastFrame, "manage agentcore harnesses");
+    await waitForText(firstPage.lastFrame, "manage AgentCore harnesses");
     firstPage.unmount();
 
     const core = new TestCoreClient();
@@ -234,7 +234,7 @@ describe("paginated table picker contract", () => {
     expect(core.harness.calls.some((call) => call.method === "getHarness")).toBe(false);
 
     await r.press("escape");
-    await waitForText(r.lastFrame, "manage agentcore harnesses");
+    await waitForText(r.lastFrame, "manage AgentCore harnesses");
     previousPage.resolve();
   });
 

--- a/src/components/RouterScreen.test.tsx
+++ b/src/components/RouterScreen.test.tsx
@@ -14,13 +14,13 @@ describe("menu rendering", () => {
 
     const frame = r.lastFrame()!;
     expect(frame).toContain("harness");
-    expect(frame).toContain("manage agentcore harnesses");
+    expect(frame).toContain("manage AgentCore harnesses");
     expect(frame).toContain("runtime");
     expect(frame).toContain("inspect AgentCore Runtimes");
     expect(frame).toContain("memory");
-    expect(frame).toContain("manage AgentCore Memories");
+    expect(frame).toContain("inspect AgentCore Memories");
     expect(frame).toContain("gateway");
-    expect(frame).toContain("inspect AgentCore Gateways");
+    expect(frame).toContain("manage AgentCore Gateways");
     expect(frame).toContain("config");
     expect(frame).toContain("read/write global config values");
     r.unmount();

--- a/src/handlers/config/handler.tsx
+++ b/src/handlers/config/handler.tsx
@@ -18,10 +18,10 @@ export const createConfigHandler = () =>
     arguments: [
       argument(
         "key",
-        "config key in JSON path notation (e.g. telemetry.enabled)",
+        "the config key in JSON path notation (e.g. telemetry.enabled)",
         z.enum(getKeys(DEFAULT_GLOBAL_CONFIG)).optional(),
       ),
-      argument("value", "value to set for the key", z.string().optional()),
+      argument("value", "the value to set for the key", z.string().optional()),
     ],
     handle: async (ctx, _flags, args) => {
       const globalConfigAccessor = ctx.require(GlobalConfigAccessorKey);

--- a/src/handlers/eval/ab-test/config-based/index.tsx
+++ b/src/handlers/eval/ab-test/config-based/index.tsx
@@ -4,7 +4,7 @@ import type { Core } from "../../../types";
 import { createConfigBasedRunHandler } from "./run";
 
 export function createConfigBasedAbTestHandler(core: Core, io: AppIO): Router {
-  return new Router("config-based", "config-based A/B tests").handler(
+  return new Router("config-based", "run config-based A/B tests").handler(
     createConfigBasedRunHandler(core, io),
   );
 }

--- a/src/handlers/eval/ab-test/config-based/run/index.tsx
+++ b/src/handlers/eval/ab-test/config-based/run/index.tsx
@@ -32,10 +32,10 @@ function toBundleRef(name: string, raw: unknown): BundleRef {
 export const createConfigBasedRunHandler = (core: Core, io: AppIO) =>
   createHandler({
     name: "run",
-    description: "run an A/B test between two config-bundle versions on one gateway",
+    description: "run an A/B test between two config-bundle versions on one Gateway",
     flags: [
       flag("name", "the A/B test name", z.string().optional()),
-      flag("gateway", "deployed gateway id", z.string().optional()),
+      flag("gateway", "deployed Gateway ID", z.string().optional()),
       flag(
         "control",
         'control JSON {"config-bundle","bundle-version"} (inline, file://, or -)',
@@ -46,7 +46,7 @@ export const createConfigBasedRunHandler = (core: Core, io: AppIO) =>
         'treatment JSON {"config-bundle","bundle-version"} (inline, file://, or -)',
         z.string().optional(),
       ),
-      flag("online-eval", "online-evaluation config id", z.string().optional()),
+      flag("online-eval", "online-evaluation config ID", z.string().optional()),
       flag(
         "treatment-weight",
         "1-99; control weight = 100 - this (default 50)",
@@ -57,11 +57,7 @@ export const createConfigBasedRunHandler = (core: Core, io: AppIO) =>
         'GatewayFilter JSON, e.g. {"targetPaths":["/orders"]} (inline, file://, or -)',
         z.string().optional(),
       ),
-      flag(
-        "role-arn",
-        "execution-role override (default: auto-provisioned)",
-        z.string().optional(),
-      ),
+      flag("role-arn", "execution-role override (default auto-provisioned)", z.string().optional()),
       flag(
         "enable-on-create",
         "whether to start the test immediately (default true; pass false to create it paused)",

--- a/src/handlers/eval/ab-test/get/index.tsx
+++ b/src/handlers/eval/ab-test/get/index.tsx
@@ -9,7 +9,7 @@ import { coreOptsFromCtx } from "../../../utils";
 export const createGetAbTestHandler = (core: Core, _io: AppIO) =>
   createHandler({
     name: "get",
-    description: "get an A/B test by id, with per-evaluator comparison metrics",
+    description: "get an A/B test by ID, with per-evaluator comparison metrics",
     flags: [flag("id", "the ID of the A/B test", z.string().optional())],
     handle: async (ctx, flags) => {
       const id = flags["id"];

--- a/src/handlers/eval/ab-test/index.tsx
+++ b/src/handlers/eval/ab-test/index.tsx
@@ -13,7 +13,7 @@ import { createConfigBasedAbTestHandler } from "./config-based";
 import { createTargetBasedAbTestHandler } from "./target-based";
 
 export function createAbTestHandler(core: Core, io: AppIO): Router {
-  return new Router("ab-test", "inspect AgentCore A/B tests")
+  return new Router("ab-test", "manage AgentCore A/B tests")
     .use(withTuiOnEmptyFlagsAndArgs(core, io))
     .default(renderTui(core, io))
     .supportedTuiCommands("get", "list")

--- a/src/handlers/eval/ab-test/target-based/index.tsx
+++ b/src/handlers/eval/ab-test/target-based/index.tsx
@@ -4,7 +4,7 @@ import type { Core } from "../../../types";
 import { createTargetBasedRunHandler } from "./run";
 
 export function createTargetBasedAbTestHandler(core: Core, io: AppIO): Router {
-  return new Router("target-based", "target-based A/B tests").handler(
+  return new Router("target-based", "run target-based A/B tests").handler(
     createTargetBasedRunHandler(core, io),
   );
 }

--- a/src/handlers/eval/ab-test/target-based/run/index.tsx
+++ b/src/handlers/eval/ab-test/target-based/run/index.tsx
@@ -27,10 +27,10 @@ function toTargetRef(name: string, raw: unknown): TargetVariantRef {
 export const createTargetBasedRunHandler = (core: Core, io: AppIO) =>
   createHandler({
     name: "run",
-    description: "run an A/B test between two gateway targets and their online evaluations",
+    description: "run an A/B test between two Gateway Targets and their online evaluations",
     flags: [
       flag("name", "the A/B test name", z.string().optional()),
-      flag("gateway", "deployed gateway id", z.string().optional()),
+      flag("gateway", "deployed Gateway ID", z.string().optional()),
       flag(
         "control",
         'control JSON {"gateway-target":"<name>","online-eval":"<id>"} (inline, file://, or -)',
@@ -51,11 +51,7 @@ export const createTargetBasedRunHandler = (core: Core, io: AppIO) =>
         'GatewayFilter JSON, e.g. {"targetPaths":["/orders"]} (inline, file://, or -)',
         z.string().optional(),
       ),
-      flag(
-        "role-arn",
-        "execution-role override (default: auto-provisioned)",
-        z.string().optional(),
-      ),
+      flag("role-arn", "execution-role override (default auto-provisioned)", z.string().optional()),
       flag(
         "enable-on-create",
         "whether to start the test immediately (default true; pass false to create it paused)",

--- a/src/handlers/eval/batch-evaluation/evaluate/index.tsx
+++ b/src/handlers/eval/batch-evaluation/evaluate/index.tsx
@@ -11,10 +11,10 @@ import { SessionSource } from "../../sessionSource";
 export const createEvaluateBatchEvaluationHandler = (core: Core, io: AppIO) =>
   createHandler({
     name: "evaluate",
-    description: "evaluate existing sessions service-side (async; returns a job id)",
+    description: "evaluate existing sessions service-side (async; returns a job ID)",
     flags: [
       ...SessionSource.flags,
-      flag("evaluator", "evaluator id(s) to apply", z.array(z.string()).optional()),
+      flag("evaluator", "evaluator ID(s) to apply", z.array(z.string()).optional()),
       flag(
         "ground-truth",
         "session ground truth (JSON SessionMetadataShape[]; inline, file://<path>, or -)",

--- a/src/handlers/eval/batch-evaluation/get/index.tsx
+++ b/src/handlers/eval/batch-evaluation/get/index.tsx
@@ -11,7 +11,7 @@ import { coreOptsFromCtx } from "../../../utils";
 export const createGetBatchEvaluationHandler = (core: Core, io: AppIO) =>
   createHandler({
     name: "get",
-    description: "get a batch evaluation by id, with CloudWatch-backed results when available",
+    description: "get a batch evaluation by ID, with CloudWatch-backed results when available",
     flags: [
       flag("id", "the ID of the batch evaluation", z.string().optional()),
       flag(

--- a/src/handlers/eval/batch-evaluation/simulate/index.tsx
+++ b/src/handlers/eval/batch-evaluation/simulate/index.tsx
@@ -12,10 +12,10 @@ import { parseRuntimeInvokeHeaders } from "../../../runtime/invoke/request";
 export const createSimulateBatchEvaluationHandler = (core: Core, _io: AppIO) =>
   createHandler({
     name: "simulate",
-    description: "replay a dataset against a runtime, then batch-evaluate the resulting sessions",
+    description: "replay a dataset against a Runtime, then batch-evaluate the resulting sessions",
     flags: [
-      flag("runtime-id", "runtime id to invoke per scenario", z.string().optional()),
-      flag("qualifier", "runtime endpoint qualifier (default DEFAULT)", z.string().optional()),
+      flag("runtime-id", "Runtime ID to invoke per scenario", z.string().optional()),
+      flag("qualifier", "Runtime endpoint qualifier (default DEFAULT)", z.string().optional()),
       flag(
         "payload-template",
         'JSON payload template; {input} is the scenario input, e.g. {"prompt":"{input}"}',
@@ -26,14 +26,14 @@ export const createSimulateBatchEvaluationHandler = (core: Core, _io: AppIO) =>
       }),
       flag(
         "bearer-token",
-        "CUSTOM_JWT bearer token (for JWT-auth runtimes)",
+        "CUSTOM_JWT bearer token (for JWT-auth Runtimes)",
         z.string().optional(),
         { sensitive: true },
       ),
-      flag("user-id", "runtime user id", z.string().optional()),
-      flag("dataset", "dataset source: local JSONL path or a dataset id", z.string().optional()),
-      flag("dataset-version", "dataset version (with a dataset id)", z.string().optional()),
-      flag("evaluator", "evaluator id(s) to apply", z.array(z.string()).optional()),
+      flag("user-id", "Runtime user ID", z.string().optional()),
+      flag("dataset", "dataset source: local JSONL path or a dataset ID", z.string().optional()),
+      flag("dataset-version", "dataset version (with a dataset ID)", z.string().optional()),
+      flag("evaluator", "evaluator ID(s) to apply", z.array(z.string()).optional()),
       flag("name", "batch evaluation name (unique in the account)", z.string().optional()),
       flag("description", "description for the batch evaluation", z.string().optional()),
       flag("kms-key-arn", "KMS key to encrypt evaluation data at rest", z.string().optional()),

--- a/src/handlers/eval/batch-insights/get/index.tsx
+++ b/src/handlers/eval/batch-insights/get/index.tsx
@@ -8,7 +8,7 @@ import { coreOptsFromCtx } from "../../../utils";
 export const createGetBatchInsightsHandler = (core: Core) =>
   createHandler({
     name: "get",
-    description: "get a batch insights run and its reports by id",
+    description: "get a batch insights run and its reports by ID",
     flags: [flag("id", "the ID of the batch insights run", z.string().optional())],
     handle: async (ctx, flags) => {
       const id = flags["id"];

--- a/src/handlers/eval/batch-insights/index.tsx
+++ b/src/handlers/eval/batch-insights/index.tsx
@@ -8,7 +8,7 @@ import { createListBatchInsightsHandler } from "./list";
 import { createRunBatchInsightsHandler } from "./run";
 
 export function createBatchInsightsHandler(core: Core, io: AppIO): Router {
-  return new Router("batch-insights", "run and inspect batch insights")
+  return new Router("batch-insights", "run and inspect AgentCore batch insights")
     .use(withTuiOnEmptyFlagsAndArgs(core, io))
     .default(renderTui(core, io))
     .supportedTuiCommands("get", "list")

--- a/src/handlers/eval/batch-insights/run/index.tsx
+++ b/src/handlers/eval/batch-insights/run/index.tsx
@@ -15,10 +15,10 @@ export const createRunBatchInsightsHandler = (core: Core, io: AppIO) =>
     description: "start an asynchronous batch insights run over existing sessions",
     flags: [
       ...SessionSource.flags,
-      flag("insight", "insight id(s) to run", z.array(z.string()).default([DEFAULT_INSIGHT])),
+      flag("insight", "insight ID(s) to run", z.array(z.string()).default([DEFAULT_INSIGHT])),
       flag(
         "evaluator",
-        "optional evaluator id(s) to run alongside the insights",
+        "optional evaluator ID(s) to run alongside the insights",
         z.array(z.string()).optional(),
       ),
       flag("name", "batch insights name (must be unique in the account)", z.string().optional()),

--- a/src/handlers/eval/evaluator/delete/index.tsx
+++ b/src/handlers/eval/evaluator/delete/index.tsx
@@ -8,7 +8,7 @@ import { coreOptsFromCtx } from "../../../utils";
 export const createDeleteEvaluatorHandler = (core: Core) =>
   createHandler({
     name: "delete",
-    description: "delete an evaluator by id",
+    description: "delete an evaluator by ID",
     flags: [flag("id", "the ID of the evaluator to delete", z.string().optional())],
     handle: async (ctx, flags) => {
       if (!flags["id"]) throw new InputValidationError("required option '--id <id>' not specified");

--- a/src/handlers/eval/evaluator/evaluator.screen.test.tsx
+++ b/src/handlers/eval/evaluator/evaluator.screen.test.tsx
@@ -64,7 +64,7 @@ describe("evaluator menu", () => {
   test("lists the read-only commands, then the rest as command line only", async () => {
     const screen = renderScreen("/agentcore/eval/evaluator");
 
-    await waitForText(screen.lastFrame, "get an evaluator by id");
+    await waitForText(screen.lastFrame, "get an evaluator by ID");
     expect(menuEntries(screen.lastFrame()!)).toEqual({
       screens: ["get", "list"],
       cliOnly: ["llm-as-a-judge", "code-based", "delete"],

--- a/src/handlers/eval/evaluator/get/index.tsx
+++ b/src/handlers/eval/evaluator/get/index.tsx
@@ -8,7 +8,7 @@ import { coreOptsFromCtx } from "../../../utils";
 export const createGetEvaluatorHandler = (core: Core) =>
   createHandler({
     name: "get",
-    description: "get an evaluator by id",
+    description: "get an evaluator by ID",
     flags: [flag("id", "the ID of the evaluator", z.string().optional())],
     handle: async (ctx, flags) => {
       if (!flags["id"]) throw new InputValidationError("required option '--id <id>' not specified");

--- a/src/handlers/eval/evaluator/llm-as-a-judge/create/index.tsx
+++ b/src/handlers/eval/evaluator/llm-as-a-judge/create/index.tsx
@@ -15,7 +15,7 @@ export const createLlmAsAJudgeCreateHandler = (core: Core, io: AppIO) =>
     flags: [
       flag("name", "the name of the evaluator", z.string().optional()),
       flag("level", `evaluation level (${LEVELS.join(" | ")})`, z.enum(LEVELS).optional()),
-      flag("model", "the Bedrock model id used to judge", z.string().optional()),
+      flag("model", "the Bedrock model ID used to judge", z.string().optional()),
       instructionsFlag,
       ratingScaleFlag,
       flag("kms-key-arn", "customer managed KMS key ARN for evaluator data", z.string().optional()),

--- a/src/handlers/eval/evaluator/llm-as-a-judge/update/index.tsx
+++ b/src/handlers/eval/evaluator/llm-as-a-judge/update/index.tsx
@@ -14,7 +14,7 @@ export const createLlmAsAJudgeUpdateHandler = (core: Core, io: AppIO) =>
     flags: [
       flag("id", "the ID of the evaluator to update", z.string().optional()),
       instructionsFlag,
-      flag("model", "the Bedrock model id used to judge", z.string().optional()),
+      flag("model", "the Bedrock model ID used to judge", z.string().optional()),
       ratingScaleFlag,
       flag("kms-key-arn", "customer managed KMS key ARN for evaluator data", z.string().optional()),
     ],

--- a/src/handlers/eval/ondemand/evaluate/index.tsx
+++ b/src/handlers/eval/ondemand/evaluate/index.tsx
@@ -15,11 +15,11 @@ export const createEvaluateOnDemandHandler = (core: Core, io: AppIO) =>
     flags: [
       flag(
         "agent",
-        "source: harness id or runtime id whose sessions to evaluate",
+        "source: harness ID or Runtime ID whose sessions to evaluate",
         z.string().optional(),
       ),
-      flag("endpoint", "runtime endpoint qualifier (default DEFAULT)", z.string().optional()),
-      flag("evaluator", "evaluator id(s) to apply", z.array(z.string()).optional()),
+      flag("endpoint", "Runtime endpoint qualifier (default DEFAULT)", z.string().optional()),
+      flag("evaluator", "evaluator ID(s) to apply", z.array(z.string()).optional()),
       flag(
         "lookback-days",
         "time filter: evaluate sessions from the last N days",
@@ -35,10 +35,10 @@ export const createEvaluateOnDemandHandler = (core: Core, io: AppIO) =>
         "time filter: window end (ISO-8601, with --start-time)",
         z.string().optional(),
       ),
-      flag("session-ids", "filter: specific session ids", z.array(z.string()).optional()),
+      flag("session-ids", "filter: specific session IDs", z.array(z.string()).optional()),
       flag(
         "trace-id",
-        "filter: a single trace id (session id is read off the span)",
+        "filter: a single trace ID (session ID is read off the span)",
         z.string().optional(),
       ),
       flag(

--- a/src/handlers/eval/ondemand/simulate/index.tsx
+++ b/src/handlers/eval/ondemand/simulate/index.tsx
@@ -13,10 +13,10 @@ import { withUserCancellation } from "../../../../runnable";
 export const createSimulateOnDemandHandler = (core: Core, _io: AppIO) =>
   createHandler({
     name: "simulate",
-    description: "replay a dataset against a runtime, then evaluate the sessions client-side",
+    description: "replay a dataset against a Runtime, then evaluate the sessions client-side",
     flags: [
-      flag("runtime-id", "runtime id to invoke per scenario", z.string().optional()),
-      flag("qualifier", "runtime endpoint qualifier (default DEFAULT)", z.string().optional()),
+      flag("runtime-id", "Runtime ID to invoke per scenario", z.string().optional()),
+      flag("qualifier", "Runtime endpoint qualifier (default DEFAULT)", z.string().optional()),
       flag(
         "payload-template",
         'JSON payload template; {input} is the scenario input, e.g. {"prompt":"{input}"}',
@@ -27,14 +27,14 @@ export const createSimulateOnDemandHandler = (core: Core, _io: AppIO) =>
       }),
       flag(
         "bearer-token",
-        "CUSTOM_JWT bearer token (for JWT-auth runtimes)",
+        "CUSTOM_JWT bearer token (for JWT-auth Runtimes)",
         z.string().optional(),
         { sensitive: true },
       ),
-      flag("user-id", "runtime user id", z.string().optional()),
-      flag("dataset", "dataset source: local JSONL path or a dataset id", z.string().optional()),
-      flag("dataset-version", "dataset version (with a dataset id)", z.string().optional()),
-      flag("evaluator", "evaluator id(s) to apply", z.array(z.string()).optional()),
+      flag("user-id", "Runtime user ID", z.string().optional()),
+      flag("dataset", "dataset source: local JSONL path or a dataset ID", z.string().optional()),
+      flag("dataset-version", "dataset version (with a dataset ID)", z.string().optional()),
+      flag("evaluator", "evaluator ID(s) to apply", z.array(z.string()).optional()),
       flag(
         "ingestion-wait-ms",
         "ms to wait for span ingestion before grading (default 180000; 0 to skip)",

--- a/src/handlers/eval/online-eval/create/index.tsx
+++ b/src/handlers/eval/online-eval/create/index.tsx
@@ -13,7 +13,7 @@ export const createCreateOnlineEvalHandler = (core: Core, io: AppIO) =>
     description: "create an online evaluation config",
     flags: [
       flag("name", "the name of the online evaluation config", z.string().optional()),
-      flag("agent", "harness ID or runtime ID whose traffic to sample", z.string().optional()),
+      flag("agent", "harness ID or Runtime ID whose traffic to sample", z.string().optional()),
       flag(
         "endpoint",
         "the agent endpoint qualifier to scope monitoring to (default DEFAULT)",
@@ -42,7 +42,7 @@ export const createCreateOnlineEvalHandler = (core: Core, io: AppIO) =>
       ),
       flag(
         "role-arn",
-        "IAM role the online evaluation assumes (default: auto-provisioned)",
+        "IAM role the online evaluation assumes (default auto-provisioned)",
         z.string().optional(),
       ),
       flag(

--- a/src/handlers/eval/online-eval/delete/index.tsx
+++ b/src/handlers/eval/online-eval/delete/index.tsx
@@ -8,7 +8,7 @@ import { coreOptsFromCtx } from "../../../utils";
 export const createDeleteOnlineEvalHandler = (core: Core) =>
   createHandler({
     name: "delete",
-    description: "delete an online evaluation config by id",
+    description: "delete an online evaluation config by ID",
     flags: [flag("id", "the ID of the online evaluation config to delete", z.string().optional())],
     handle: async (ctx, flags) => {
       if (!flags["id"]) throw new InputValidationError("required option '--id <id>' not specified");

--- a/src/handlers/eval/online-eval/get/index.tsx
+++ b/src/handlers/eval/online-eval/get/index.tsx
@@ -8,7 +8,7 @@ import { coreOptsFromCtx } from "../../../utils";
 export const createGetOnlineEvalHandler = (core: Core) =>
   createHandler({
     name: "get",
-    description: "get an online evaluation config by id",
+    description: "get an online evaluation config by ID",
     flags: [flag("id", "the ID of the online evaluation config", z.string().optional())],
     handle: async (ctx, flags) => {
       if (!flags["id"]) throw new InputValidationError("required option '--id <id>' not specified");

--- a/src/handlers/eval/online-eval/online-eval.screen.test.tsx
+++ b/src/handlers/eval/online-eval/online-eval.screen.test.tsx
@@ -64,7 +64,7 @@ describe("online-eval menu", () => {
   test("lists the read-only commands, then the rest as command line only", async () => {
     const screen = renderScreen("/agentcore/eval/online-eval");
 
-    await waitForText(screen.lastFrame, "get an online evaluation config by id");
+    await waitForText(screen.lastFrame, "get an online evaluation config by ID");
     expect(menuEntries(screen.lastFrame()!)).toEqual({
       screens: ["get", "list"],
       cliOnly: ["create", "update", "pause", "resume", "delete"],

--- a/src/handlers/eval/online-eval/update/index.tsx
+++ b/src/handlers/eval/online-eval/update/index.tsx
@@ -34,7 +34,7 @@ export const createUpdateOnlineEvalHandler = (core: Core, io: AppIO) =>
         "the ID(s) of the evaluators to apply (replaces the existing list)",
         z.array(z.string()).optional(),
       ),
-      flag("agent", "repoint at a different harness ID or runtime ID", z.string().optional()),
+      flag("agent", "repoint at a different harness ID or Runtime ID", z.string().optional()),
       flag(
         "endpoint",
         "re-scope monitoring to a different agent endpoint qualifier",

--- a/src/handlers/eval/online-insight/create/index.tsx
+++ b/src/handlers/eval/online-insight/create/index.tsx
@@ -17,7 +17,7 @@ export const createCreateOnlineInsightHandler = (core: Core, io: AppIO) =>
     flags: [
       flag("name", "the name of the online insight config", z.string().optional()),
       flag("role-arn", "IAM role the online insight assumes", z.string().optional()),
-      flag("agent", "harness ID or runtime ID whose traffic to sample", z.string().optional()),
+      flag("agent", "harness ID or Runtime ID whose traffic to sample", z.string().optional()),
       flag(
         "endpoint",
         "the agent endpoint qualifier to scope monitoring to (default DEFAULT)",

--- a/src/handlers/eval/online-insight/delete/index.tsx
+++ b/src/handlers/eval/online-insight/delete/index.tsx
@@ -8,7 +8,7 @@ import { coreOptsFromCtx } from "../../../utils";
 export const createDeleteOnlineInsightHandler = (core: Core) =>
   createHandler({
     name: "delete",
-    description: "delete an online insight config by id",
+    description: "delete an online insight config by ID",
     flags: [flag("id", "the ID of the online insight config to delete", z.string().optional())],
     handle: async (ctx, flags) => {
       if (!flags["id"]) throw new InputValidationError("required option '--id <id>' not specified");

--- a/src/handlers/eval/online-insight/get/index.tsx
+++ b/src/handlers/eval/online-insight/get/index.tsx
@@ -8,7 +8,7 @@ import { coreOptsFromCtx } from "../../../utils";
 export const createGetOnlineInsightHandler = (core: Core) =>
   createHandler({
     name: "get",
-    description: "get an online insight config by id",
+    description: "get an online insight config by ID",
     flags: [flag("id", "the ID of the online insight config", z.string().optional())],
     handle: async (ctx, flags) => {
       if (!flags["id"]) throw new InputValidationError("required option '--id <id>' not specified");

--- a/src/handlers/eval/online-insight/online-insight.screen.test.tsx
+++ b/src/handlers/eval/online-insight/online-insight.screen.test.tsx
@@ -66,7 +66,7 @@ describe("online-insight menu", () => {
   test("lists the read-only commands, then the rest as command line only", async () => {
     const screen = renderScreen("/agentcore/eval/online-insight");
 
-    await waitForText(screen.lastFrame, "get an online insight config by id");
+    await waitForText(screen.lastFrame, "get an online insight config by ID");
     expect(menuEntries(screen.lastFrame()!)).toEqual({
       screens: ["get", "list"],
       cliOnly: ["create", "update", "pause", "resume", "delete"],

--- a/src/handlers/eval/online-insight/update/index.tsx
+++ b/src/handlers/eval/online-insight/update/index.tsx
@@ -41,7 +41,7 @@ export const createUpdateOnlineInsightHandler = (core: Core, io: AppIO) =>
         "insight clustering cadence(s) (replaces the existing set): DAILY, WEEKLY, MONTHLY",
         z.array(z.enum(["DAILY", "WEEKLY", "MONTHLY"])).optional(),
       ),
-      flag("agent", "repoint at a different runtime ID", z.string().optional()),
+      flag("agent", "repoint at a different Runtime ID", z.string().optional()),
       flag(
         "endpoint",
         "re-scope monitoring to a different agent endpoint qualifier",

--- a/src/handlers/eval/recommendation/delete/index.tsx
+++ b/src/handlers/eval/recommendation/delete/index.tsx
@@ -8,7 +8,7 @@ import { coreOptsFromCtx } from "../../../utils";
 export const createDeleteRecommendationHandler = (core: Core) =>
   createHandler({
     name: "delete",
-    description: "delete a recommendation by id",
+    description: "delete a recommendation by ID",
     flags: [flag("id", "the ID of the recommendation to delete", z.string().optional())],
     handle: async (ctx, flags) => {
       if (!flags["id"]) throw new InputValidationError("required option '--id <id>' not specified");

--- a/src/handlers/eval/recommendation/get/index.tsx
+++ b/src/handlers/eval/recommendation/get/index.tsx
@@ -8,7 +8,7 @@ import { coreOptsFromCtx } from "../../../utils";
 export const createGetRecommendationHandler = (core: Core) =>
   createHandler({
     name: "get",
-    description: "get a recommendation by id",
+    description: "get a recommendation by ID",
     flags: [flag("id", "the ID of the recommendation", z.string().optional())],
     handle: async (ctx, flags) => {
       if (!flags["id"]) throw new InputValidationError("required option '--id <id>' not specified");

--- a/src/handlers/eval/sessionSource.tsx
+++ b/src/handlers/eval/sessionSource.tsx
@@ -8,10 +8,10 @@ import type { SessionSourceValue, SessionWindow } from "./types";
 
 export class SessionSource {
   static readonly flags = [
-    flag("agent", "source: harness id or runtime id whose sessions to use", z.string().optional()),
+    flag("agent", "source: harness ID or Runtime ID whose sessions to use", z.string().optional()),
     flag(
       "endpoint",
-      "runtime endpoint qualifier (default DEFAULT; only with --agent)",
+      "Runtime endpoint qualifier (default DEFAULT; only with --agent)",
       z.string().optional(),
     ),
     flag(
@@ -36,7 +36,7 @@ export class SessionSource {
     ),
     flag(
       "session-ids",
-      "filter: specific session ids (only with --agent)",
+      "filter: specific session IDs (only with --agent)",
       z.array(z.string()).optional(),
     ),
   ] as const;

--- a/src/handlers/feedback/index.tsx
+++ b/src/handlers/feedback/index.tsx
@@ -11,7 +11,7 @@ import type { Core } from "../types.tsx";
 export const createFeedbackHandler = (core: Core, io: AppIO) =>
   createHandler({
     name: "feedback",
-    description: "Send feedback about the AgentCore CLI to the team.",
+    description: "send feedback about the AgentCore CLI to the team",
     arguments: [argument("message", "the feedback message to send", z.string())],
     flags: [
       flag(

--- a/src/handlers/gateway/connector/get/index.tsx
+++ b/src/handlers/gateway/connector/get/index.tsx
@@ -8,7 +8,7 @@ import { coreOptsFromCtx } from "../../../utils";
 export const createGetGatewayConnectorHandler = (core: Core) =>
   createHandler({
     name: "get",
-    description: "get a connector configured for an AgentCore Gateway",
+    description: "get a connector-backed Gateway Target",
     flags: [
       flag("gateway-id", "the ID of the Gateway", z.string().optional()),
       flag("id", "the ID of the connector-backed Gateway Target", z.string().optional()),

--- a/src/handlers/gateway/connector/index.tsx
+++ b/src/handlers/gateway/connector/index.tsx
@@ -9,7 +9,7 @@ import { createListGatewayConnectorsHandler } from "./list";
 import { createUpdateGatewayConnectorHandler } from "./update";
 
 export function createGatewayConnectorHandler(core: Core, io: AppIO): Router {
-  return new Router("connector", "inspect connectors configured for an AgentCore Gateway")
+  return new Router("connector", "manage connectors configured for an AgentCore Gateway")
     .default(renderTui(core, io))
     .supportedTuiCommands("get", "list")
     .handler(createCreateGatewayConnectorHandler(core, io))

--- a/src/handlers/gateway/gateway.screen.test.tsx
+++ b/src/handlers/gateway/gateway.screen.test.tsx
@@ -114,7 +114,7 @@ describe("Gateway menu and list", () => {
   test("renders the Gateway command menu without calling Core", async () => {
     const screen = renderScreen("/agentcore/gateway");
 
-    await waitForText(screen.lastFrame, "inspect AgentCore Gateways");
+    await waitForText(screen.lastFrame, "manage AgentCore Gateways");
     expect(menuEntries(screen.lastFrame()!)).toEqual({
       screens: ["get", "list", "invoke", "target", "connector", "rule", "policy"],
       cliOnly: ["create", "update", "delete"],
@@ -149,7 +149,7 @@ describe("Gateway menu and list", () => {
 
     await waitForText(loading.lastFrame, "Loading Gateways");
     await loading.press("escape");
-    await waitForText(loading.lastFrame, "inspect AgentCore Gateways");
+    await waitForText(loading.lastFrame, "manage AgentCore Gateways");
     loading.unmount();
 
     const empty = renderScreen("/agentcore/gateway/list");
@@ -218,7 +218,7 @@ describe("Gateway Target flow", () => {
   test("renders the Target command menu without calling Core", async () => {
     const screen = renderScreen("/agentcore/gateway/target");
 
-    await waitForText(screen.lastFrame, "inspect targets for an AgentCore Gateway");
+    await waitForText(screen.lastFrame, "manage Targets for an AgentCore Gateway");
     expect(menuEntries(screen.lastFrame()!)).toEqual({
       screens: ["get", "list"],
       cliOnly: ["create", "update", "delete"],
@@ -313,7 +313,7 @@ describe("Gateway Target flow", () => {
     await screen.press("escape");
     await waitForText(screen.lastFrame, "choose a Gateway to list Targets for");
     await screen.press("escape");
-    await waitForText(screen.lastFrame, "inspect targets for an AgentCore Gateway");
+    await waitForText(screen.lastFrame, "manage Targets for an AgentCore Gateway");
   });
 });
 
@@ -321,7 +321,7 @@ describe("Gateway Connector flow", () => {
   test("renders the separate Connector command menu without calling Core", async () => {
     const screen = renderScreen("/agentcore/gateway/connector");
 
-    await waitForText(screen.lastFrame, "inspect connectors configured for an AgentCore Gateway");
+    await waitForText(screen.lastFrame, "manage connectors configured for an AgentCore Gateway");
     expect(menuEntries(screen.lastFrame()!)).toEqual({
       screens: ["get", "list"],
       cliOnly: ["create", "update", "delete"],
@@ -407,7 +407,7 @@ describe("Gateway Rule flow", () => {
   test("renders the Rule command menu without calling Core", async () => {
     const screen = renderScreen("/agentcore/gateway/rule");
 
-    await waitForText(screen.lastFrame, "inspect rules for an AgentCore Gateway");
+    await waitForText(screen.lastFrame, "manage Rules for an AgentCore Gateway");
     expect(menuEntries(screen.lastFrame()!)).toEqual({
       screens: ["get", "list"],
       cliOnly: ["create", "update", "delete"],

--- a/src/handlers/gateway/index.tsx
+++ b/src/handlers/gateway/index.tsx
@@ -15,7 +15,7 @@ import { createGatewayTargetHandler } from "./target";
 import { createUpdateGatewayHandler } from "./update";
 
 export function createGatewayHandler(core: Core, io: AppIO): Router {
-  return new Router("gateway", "inspect AgentCore Gateways")
+  return new Router("gateway", "manage AgentCore Gateways")
     .use(withTuiOnEmptyFlagsAndArgs(core, io))
     .default(renderTui(core, io))
     .supportedTuiCommands("get", "list", "invoke", "target", "connector", "rule", "policy")

--- a/src/handlers/gateway/invoke/invoke.screen.test.tsx
+++ b/src/handlers/gateway/invoke/invoke.screen.test.tsx
@@ -112,7 +112,7 @@ describe("Gateway invoke routing", () => {
     expect(screen.lastFrame()).toContain("checkout-gateway");
 
     await screen.press("escape");
-    await waitForText(screen.lastFrame, "inspect AgentCore Gateways");
+    await waitForText(screen.lastFrame, "manage AgentCore Gateways");
   });
 });
 

--- a/src/handlers/gateway/policy/generate.tsx
+++ b/src/handlers/gateway/policy/generate.tsx
@@ -25,7 +25,7 @@ export const createGeneratePolicyHandler = (
       ),
       flag(
         "policy-engine-id",
-        "the ID or ARN of the Policy Engine (defaults to the Gateway's attached engine)",
+        "the ID or ARN of the Policy Engine (default the Gateway's attached engine)",
         z.string().optional(),
       ),
       flag(
@@ -35,7 +35,7 @@ export const createGeneratePolicyHandler = (
       ),
       flag(
         "name",
-        "name of the generation request (defaults to cli_generation_<timestamp>)",
+        "name of the generation request (default cli_generation_<timestamp>)",
         z.string().optional(),
       ),
     ],

--- a/src/handlers/gateway/rule/get/index.tsx
+++ b/src/handlers/gateway/rule/get/index.tsx
@@ -8,7 +8,7 @@ import { coreOptsFromCtx } from "../../../utils";
 export const createGetGatewayRuleHandler = (core: Core) =>
   createHandler({
     name: "get",
-    description: "get an AgentCore Gateway Rule",
+    description: "get a Gateway Rule",
     flags: [
       flag("gateway-id", "the ID of the Gateway", z.string().optional()),
       flag("rule-id", "the ID of the Gateway Rule", z.string().optional()),

--- a/src/handlers/gateway/rule/index.tsx
+++ b/src/handlers/gateway/rule/index.tsx
@@ -9,7 +9,7 @@ import { createListGatewayRulesHandler } from "./list";
 import { createUpdateGatewayRuleHandler } from "./update";
 
 export function createGatewayRuleHandler(core: Core, io: AppIO): Router {
-  return new Router("rule", "inspect rules for an AgentCore Gateway")
+  return new Router("rule", "manage Rules for an AgentCore Gateway")
     .default(renderTui(core, io))
     .supportedTuiCommands("get", "list")
     .handler(createCreateGatewayRuleHandler(core, io))

--- a/src/handlers/gateway/rule/list/index.tsx
+++ b/src/handlers/gateway/rule/list/index.tsx
@@ -8,7 +8,7 @@ import { coreOptsFromCtx } from "../../../utils";
 export const createListGatewayRulesHandler = (core: Core) =>
   createHandler({
     name: "list",
-    description: "list rules for an AgentCore Gateway",
+    description: "list Rules for an AgentCore Gateway",
     flags: [
       flag("gateway-id", "the ID of the Gateway", z.string().optional()),
       flag("next-token", "pagination token returned by a previous request", z.string().optional()),

--- a/src/handlers/gateway/target/get/index.tsx
+++ b/src/handlers/gateway/target/get/index.tsx
@@ -8,7 +8,7 @@ import { coreOptsFromCtx } from "../../../utils";
 export const createGetGatewayTargetHandler = (core: Core) =>
   createHandler({
     name: "get",
-    description: "get an AgentCore Gateway Target",
+    description: "get a Gateway Target",
     flags: [
       flag("gateway-id", "the ID of the Gateway", z.string().optional()),
       flag("target-id", "the ID of the Gateway Target", z.string().optional()),

--- a/src/handlers/gateway/target/index.tsx
+++ b/src/handlers/gateway/target/index.tsx
@@ -9,7 +9,7 @@ import { createListGatewayTargetsHandler } from "./list";
 import { createUpdateGatewayTargetHandler } from "./update";
 
 export function createGatewayTargetHandler(core: Core, io: AppIO): Router {
-  return new Router("target", "inspect targets for an AgentCore Gateway")
+  return new Router("target", "manage Targets for an AgentCore Gateway")
     .default(renderTui(core, io))
     .supportedTuiCommands("get", "list")
     .handler(createCreateGatewayTargetHandler(core, io))

--- a/src/handlers/gateway/target/list/index.tsx
+++ b/src/handlers/gateway/target/list/index.tsx
@@ -8,7 +8,7 @@ import { coreOptsFromCtx } from "../../../utils";
 export const createListGatewayTargetsHandler = (core: Core) =>
   createHandler({
     name: "list",
-    description: "list targets for an AgentCore Gateway",
+    description: "list Targets for an AgentCore Gateway",
     flags: [
       flag("gateway-id", "the ID of the Gateway", z.string().optional()),
       flag("next-token", "pagination token returned by a previous request", z.string().optional()),

--- a/src/handlers/harness/create/create.screen.test.tsx
+++ b/src/handlers/harness/create/create.screen.test.tsx
@@ -412,7 +412,7 @@ describe("harness create wizard", () => {
 
     // Esc from the hub: the finished wizard must not come back.
     await r.press("escape");
-    await waitForText(r.lastFrame, "manage agentcore harnesses");
+    await waitForText(r.lastFrame, "manage AgentCore harnesses");
     expect(r.lastFrame()).not.toContain("the name of your harness");
     r.unmount();
   });
@@ -428,7 +428,7 @@ describe("harness create wizard", () => {
     await waitForText(r.lastFrame, "the name of your harness");
 
     await r.press("escape");
-    await waitForText(r.lastFrame, "manage agentcore harnesses");
+    await waitForText(r.lastFrame, "manage AgentCore harnesses");
     r.unmount();
   });
 });

--- a/src/handlers/harness/delete/index.tsx
+++ b/src/handlers/harness/delete/index.tsx
@@ -13,7 +13,7 @@ export const createDeleteHarnessHandler = (core: Core) =>
       flag("id", "the ID of the harness to delete", z.string().max(48).optional()),
       flag(
         "delete-managed-memory",
-        "whether to also delete the managed memory (default true; pass false to keep it)",
+        "whether to also delete the managed Memory (default true; pass false to keep it)",
         z.enum(["true", "false"]).optional(),
       ),
     ],

--- a/src/handlers/harness/endpoint/create/index.tsx
+++ b/src/handlers/harness/endpoint/create/index.tsx
@@ -14,7 +14,7 @@ export const createCreateEndpointHandler = (core: Core) =>
       flag("name", "the name of the endpoint", z.string().optional()),
       flag(
         "target-version",
-        "the harness version the endpoint points to (defaults to the latest)",
+        "the harness version the endpoint points to (default latest)",
         z.string().optional(),
       ),
       flag("tags", "tags to apply (JSON object of key/value strings)", z.string().optional()),

--- a/src/handlers/harness/exec/index.tsx
+++ b/src/handlers/harness/exec/index.tsx
@@ -17,7 +17,7 @@ export const createExecHarnessHandler = (core: Core, io: AppIO) =>
       flag("command", "the shell command to run", z.string().optional()),
       flag(
         "session-id",
-        "the runtime session ID to run in (33-100 characters)",
+        "the Runtime session ID to run in (33-100 characters)",
         z.string().min(33).max(100).optional(),
       ),
       flag(

--- a/src/handlers/harness/index.tsx
+++ b/src/handlers/harness/index.tsx
@@ -14,7 +14,7 @@ import { createEndpointHandler } from "./endpoint";
 import { createVersionHandler } from "./version";
 
 export function createHarnessHandler(core: Core, io: AppIO): Router {
-  const harness = new Router("harness", "manage agentcore harnesses");
+  const harness = new Router("harness", "manage AgentCore harnesses");
 
   // Open the TUI by default if no flags or arguments are passed
   harness.use(withTuiOnEmptyFlagsAndArgs(core, io));

--- a/src/handlers/harness/invoke/index.tsx
+++ b/src/handlers/harness/invoke/index.tsx
@@ -17,7 +17,7 @@ export const createInvokeHarnessHandler = (core: Core, io: AppIO) =>
       flag("prompt", "the message to send to the harness", z.string().optional()),
       flag(
         "session-id",
-        "the runtime session ID to continue (33-100 characters)",
+        "the Runtime session ID to continue (33-100 characters)",
         z.string().min(33).max(100).optional(),
       ),
       flag(

--- a/src/handlers/harness/invoke/invoke.screen.test.tsx
+++ b/src/handlers/harness/invoke/invoke.screen.test.tsx
@@ -109,7 +109,7 @@ describe("invoke picker screen", () => {
 
     await waitForText(r.lastFrame, "MyHarness");
     await r.press("escape");
-    await waitForText(r.lastFrame, "manage agentcore harnesses");
+    await waitForText(r.lastFrame, "manage AgentCore harnesses");
     r.unmount();
   });
 });

--- a/src/handlers/harness/version/index.tsx
+++ b/src/handlers/harness/version/index.tsx
@@ -6,7 +6,7 @@ import { createGetVersionHandler } from "./get";
 import { createListVersionsHandler } from "./list";
 
 export function createVersionHandler(core: Core, io: AppIO): Router {
-  const version = new Router("version", "manage harness versions");
+  const version = new Router("version", "inspect harness versions");
 
   // Open the TUI at this root, i.e., `agentcore harness version`. Leaves
   // inherit the harness router's TUI-on-empty-flags middleware.

--- a/src/handlers/identity/oauth2-credential-provider/create/index.tsx
+++ b/src/handlers/identity/oauth2-credential-provider/create/index.tsx
@@ -32,11 +32,11 @@ export const createCreateOauth2CredentialProviderHandler = (core: Core, io: AppI
         'external secret reference JSON: {"secretId":"<arn>","jsonKey":"<key>"}',
         z.string().optional(),
       ),
-      flag("client-id", "OAuth2 client ID (guided Custom OAuth2)", z.string().optional()),
-      flag("discovery-url", "OAuth2 discovery URL (guided Custom OAuth2)", z.string().optional()),
+      flag("client-id", "OAuth2 client ID (guided custom OAuth2)", z.string().optional()),
+      flag("discovery-url", "OAuth2 discovery URL (guided custom OAuth2)", z.string().optional()),
       flag(
         "authorization-server-metadata",
-        "authorization server metadata JSON (guided Custom OAuth2)",
+        "authorization server metadata JSON (guided custom OAuth2)",
         z.string().optional(),
       ),
       flag(

--- a/src/handlers/identity/oauth2-credential-provider/update/index.tsx
+++ b/src/handlers/identity/oauth2-credential-provider/update/index.tsx
@@ -54,11 +54,11 @@ export const createUpdateOauth2CredentialProviderHandler = (core: Core, io: AppI
         'external secret reference JSON: {"secretId":"<arn>","jsonKey":"<key>"}',
         z.string().optional(),
       ),
-      flag("client-id", "OAuth2 client ID (guided Custom OAuth2)", z.string().optional()),
-      flag("discovery-url", "OAuth2 discovery URL (guided Custom OAuth2)", z.string().optional()),
+      flag("client-id", "OAuth2 client ID (guided custom OAuth2)", z.string().optional()),
+      flag("discovery-url", "OAuth2 discovery URL (guided custom OAuth2)", z.string().optional()),
       flag(
         "authorization-server-metadata",
-        "authorization server metadata JSON (guided Custom OAuth2)",
+        "authorization server metadata JSON (guided custom OAuth2)",
         z.string().optional(),
       ),
       flag(

--- a/src/handlers/memory/index.tsx
+++ b/src/handlers/memory/index.tsx
@@ -11,7 +11,7 @@ import { createMemoryRecordHandler } from "./record";
 import { createMemorySessionHandler } from "./session";
 
 export function createMemoryHandler(core: Core, io: AppIO): Router {
-  return new Router("memory", "manage AgentCore Memories")
+  return new Router("memory", "inspect AgentCore Memories")
     .use(withTuiOnEmptyFlagsAndArgs(core, io))
     .default(renderTui(core, io))
     .handler(createGetMemoryHandler(core))

--- a/src/handlers/memory/memory.screen.test.tsx
+++ b/src/handlers/memory/memory.screen.test.tsx
@@ -69,7 +69,7 @@ describe("Memory picker", () => {
   test("shows event, record, actor, and session commands in the Memory TUI menu", async () => {
     const screen = renderScreen("/agentcore/memory");
 
-    await waitForText(screen.lastFrame, "manage AgentCore Memories");
+    await waitForText(screen.lastFrame, "inspect AgentCore Memories");
     const frame = screen.lastFrame()!;
     expect(frame).toContain("get");
     expect(frame).toContain("list");

--- a/src/handlers/project/add/config-bundle/index.ts
+++ b/src/handlers/project/add/config-bundle/index.ts
@@ -22,7 +22,7 @@ const ComponentsSchema = z
 export const createAddConfigBundleHandler = (config: AddProjectResourceConfig) =>
   createHandler({
     name: "config-bundle",
-    description: "adds a configuration bundle to the current project",
+    description: "add a configuration bundle to the current project",
     flags: [
       flag("name", "the name of the configuration bundle", ConfigBundleNameSchema.optional()),
       flag(

--- a/src/handlers/project/add/gateway-connector/index.ts
+++ b/src/handlers/project/add/gateway-connector/index.ts
@@ -13,7 +13,7 @@ import type { AddProjectResourceConfig } from "../types";
 export const createAddGatewayConnectorHandler = (config: AddProjectResourceConfig) =>
   createHandler({
     name: "gateway-connector",
-    description: "adds a connector-backed Target to a project Gateway",
+    description: "add a connector-backed Target to a project Gateway",
     flags: [
       flag("gateway", "name of the parent Gateway in this project", z.string().optional()),
       flag("name", "the Target name for a connector shortcut", z.string().optional()),

--- a/src/handlers/project/add/gateway-target/index.ts
+++ b/src/handlers/project/add/gateway-target/index.ts
@@ -15,7 +15,7 @@ import type { AddProjectResourceConfig } from "../types";
 export const createAddGatewayTargetHandler = (config: AddProjectResourceConfig) =>
   createHandler({
     name: "gateway-target",
-    description: "adds a Target to a project Gateway",
+    description: "add a Target to a project Gateway",
     flags: [
       flag("gateway", "name of the parent Gateway in this project", z.string().optional()),
       flag("name", "the Target name for endpoint or Runtime shortcuts", z.string().optional()),

--- a/src/handlers/project/add/gateway/index.ts
+++ b/src/handlers/project/add/gateway/index.ts
@@ -22,7 +22,7 @@ export function gatewayResourceName(
 export const createAddGatewayHandler = (config: AddProjectResourceConfig) =>
   createHandler({
     name: "gateway",
-    description: "adds a Gateway to the current project",
+    description: "add a Gateway to the current project",
     flags: [
       flag("name", "the Gateway name", z.string().optional()),
       flag(

--- a/src/handlers/project/add/harness/index.ts
+++ b/src/handlers/project/add/harness/index.ts
@@ -15,7 +15,7 @@ export const DEFAULT_HARNESS_MODEL = {
 export const createAddHarnessHandler = (config: AddProjectResourceConfig) =>
   createHandler({
     name: "harness",
-    description: "adds a harness to the current project",
+    description: "add a harness to the current project",
     flags: [
       flag("name", "the name of the harness", z.string().optional()),
       flag(

--- a/src/handlers/project/add/memory/index.ts
+++ b/src/handlers/project/add/memory/index.ts
@@ -107,10 +107,10 @@ JSON example:
 export const createAddMemoryHandler = (config: AddProjectResourceConfig) =>
   createHandler({
     name: "memory",
-    description: "adds a memory to the current project",
+    description: "add a Memory to the current project",
     flags: [
-      flag("name", "the name of the memory", z.string().optional()),
-      flag("description", "a description of what the memory stores", z.string().optional()),
+      flag("name", "the name of the Memory", z.string().optional()),
+      flag("description", "a description of what the Memory stores", z.string().optional()),
       flag(
         "event-expiry-duration",
         "how long raw events are retained, in days (3-365)",
@@ -118,7 +118,7 @@ export const createAddMemoryHandler = (config: AddProjectResourceConfig) =>
       ),
       flag(
         "strategies",
-        "long-term memory strategies: comma-separated types, or the JSON strategies[] as stored in agentcore.json",
+        "long-term Memory strategies: comma-separated types, or the JSON strategies[] as stored in agentcore.json",
         z.string().optional(),
         { help: strategiesHelp },
       ),
@@ -129,17 +129,17 @@ export const createAddMemoryHandler = (config: AddProjectResourceConfig) =>
       ),
       flag(
         "stream-delivery-resources",
-        "destinations memory records are streamed to (JSON StreamDeliveryResources)",
+        "destinations Memory records are streamed to (JSON StreamDeliveryResources)",
         z.string().optional(),
       ),
       flag(
         "encryption-key-arn",
-        "customer managed KMS key ARN used to encrypt the memory",
+        "customer managed KMS key ARN used to encrypt the Memory",
         z.string().optional(),
       ),
       flag(
         "execution-role-arn",
-        "IAM role the memory assumes; a default role is created when omitted",
+        "IAM role the Memory assumes; a default role is created when omitted",
         z.string().optional(),
       ),
       flag("tags", "tags to apply (JSON object of key/value strings)", z.string().optional()),

--- a/src/handlers/project/add/online-eval/index.ts
+++ b/src/handlers/project/add/online-eval/index.ts
@@ -8,12 +8,12 @@ import type { AddProjectResourceConfig } from "../types";
 export const createAddOnlineEvalHandler = (config: AddProjectResourceConfig) =>
   createHandler({
     name: "online-eval",
-    description: "adds an online evaluation config to the current project",
+    description: "add an online evaluation config to the current project",
     flags: [
       flag("name", "the name of the online evaluation config", z.string().optional()),
       flag(
         "agent",
-        "runtime name whose traffic to sample (mutually exclusive with --log-group-name)",
+        "Runtime name whose traffic to sample (mutually exclusive with --log-group-name)",
         z.string().optional(),
       ),
       flag(

--- a/src/handlers/project/add/online-insight/index.ts
+++ b/src/handlers/project/add/online-insight/index.ts
@@ -11,12 +11,12 @@ const ARN_PREFIX = "arn:";
 export const createAddOnlineInsightHandler = (config: AddProjectResourceConfig) =>
   createHandler({
     name: "online-insight",
-    description: "adds an online insight config to the current project",
+    description: "add an online insight config to the current project",
     flags: [
       flag("name", "the name of the online insight config", z.string().optional()),
       flag(
         "agent",
-        "runtime name whose traffic to sample (mutually exclusive with --log-group-name)",
+        "Runtime name whose traffic to sample (mutually exclusive with --log-group-name)",
         z.string().optional(),
       ),
       flag(

--- a/src/handlers/project/add/payment-connector/index.ts
+++ b/src/handlers/project/add/payment-connector/index.ts
@@ -6,7 +6,7 @@ import type { AddProjectResourceConfig } from "../types";
 export const createAddPaymentConnectorHandler = (config: AddProjectResourceConfig) =>
   createHandler({
     name: "payment-connector",
-    description: "adds a connector to a project payment manager",
+    description: "add a connector to a project payment manager",
     flags: [
       flag("manager", "the parent payment manager", z.string().optional()),
       flag("name", "the payment connector name", z.string().optional()),

--- a/src/handlers/project/add/payment-manager/index.ts
+++ b/src/handlers/project/add/payment-manager/index.ts
@@ -12,7 +12,7 @@ import type { AddProjectResourceConfig } from "../types";
 export const createAddPaymentManagerHandler = (config: AddProjectResourceConfig) =>
   createHandler({
     name: "payment-manager",
-    description: "adds a payment manager to the current project",
+    description: "add a payment manager to the current project",
     flags: [
       flag("name", "the payment manager name", z.string().optional()),
       flag(

--- a/src/handlers/project/add/policy-engine/index.ts
+++ b/src/handlers/project/add/policy-engine/index.ts
@@ -15,7 +15,7 @@ export function policyEngineResourceName(projectName: string, engineName: string
 export const createAddPolicyEngineHandler = (config: AddProjectResourceConfig) =>
   createHandler({
     name: "policy-engine",
-    description: "adds a Policy Engine to the current project",
+    description: "add a Policy Engine to the current project",
     flags: [
       flag("name", "the Policy Engine name", z.string().optional()),
       flag("description", "Policy Engine description", z.string().optional()),

--- a/src/handlers/project/add/policy/index.ts
+++ b/src/handlers/project/add/policy/index.ts
@@ -22,7 +22,7 @@ const ENFORCEMENT_MODES = { active: "ACTIVE", "log-only": "LOG_ONLY" } as const;
 export const createAddPolicyHandler = (config: AddProjectResourceConfig) =>
   createHandler({
     name: "policy",
-    description: "adds a Cedar Policy to a project Policy Engine",
+    description: "add a Cedar Policy to a project Policy Engine",
     flags: [
       flag("engine", "name of the parent Policy Engine in this project", z.string().optional()),
       flag("name", "the Policy name", z.string().optional()),

--- a/src/handlers/project/add/runtime/index.ts
+++ b/src/handlers/project/add/runtime/index.ts
@@ -29,10 +29,10 @@ import { RegionKey } from "../../../keys";
 export const createAddRuntimeHandler = (config: AddProjectResourceConfig) =>
   createHandler({
     name: "runtime",
-    description: "adds a runtime to the current project",
+    description: "add a Runtime to the current project",
     flags: [
-      flag("name", "the name of the runtime", z.string().max(42).optional()),
-      flag("description", "an optional description of the runtime", z.string().optional()),
+      flag("name", "the name of the Runtime", z.string().max(42).optional()),
+      flag("description", "an optional description of the Runtime", z.string().optional()),
       flag(
         "type",
         "create scaffolds new agent code (the default); import translates a Bedrock Agent version",
@@ -51,13 +51,13 @@ export const createAddRuntimeHandler = (config: AddProjectResourceConfig) =>
       ),
       flag(
         "template",
-        "a preset of flags for scaffolding the runtime; compatible flags override preset values",
+        "a preset of flags for scaffolding the Runtime; compatible flags override preset values",
         z.enum(RUNTIME_TEMPLATE_SHORTCUT_NAMES).optional(),
       ),
       flag("build", "build type: CodeZip or Container", BuildTypeSchema.optional()),
       flag(
         "language",
-        "target language for the scaffolded runtime code",
+        "target language for the scaffolded Runtime code",
         z.enum(["Python", "TypeScript"]).optional(),
       ),
       flag(
@@ -67,7 +67,7 @@ export const createAddRuntimeHandler = (config: AddProjectResourceConfig) =>
       ),
       flag(
         "model-provider",
-        "model provider for the scaffolded runtime code (Bedrock, Anthropic, OpenAI, or Gemini)",
+        "model provider for the scaffolded Runtime code (Bedrock, Anthropic, OpenAI, or Gemini)",
         ModelProviderSchema.optional(),
       ),
       flag(
@@ -78,12 +78,12 @@ export const createAddRuntimeHandler = (config: AddProjectResourceConfig) =>
       ),
       flag(
         "memory",
-        "memory option for the scaffolded runtime",
+        "memory option for the scaffolded Runtime",
         z.enum(MEMORY_SHORTCUT_NAMES).optional(),
       ),
       flag(
         "role-arn",
-        "IAM role ARN that provides permissions for the runtime",
+        "IAM role ARN that provides permissions for the Runtime",
         z.string().optional(),
       ),
       flag(
@@ -98,7 +98,7 @@ export const createAddRuntimeHandler = (config: AddProjectResourceConfig) =>
       ),
       flag(
         "network-mode",
-        "network mode for the runtime environment (PUBLIC or VPC)",
+        "network mode for the Runtime environment (PUBLIC or VPC)",
         NetworkModeSchema.optional(),
       ),
       flag("network-config", "VPC network configuration (JSON)", z.string().optional()),
@@ -114,7 +114,7 @@ export const createAddRuntimeHandler = (config: AddProjectResourceConfig) =>
       ),
       flag(
         "request-header-allowlist",
-        "request headers to pass through to the runtime",
+        "request headers to pass through to the Runtime",
         z.array(z.string()).optional(),
       ),
       flag("lifecycle-configuration", "lifecycle configuration (JSON)", z.string().optional()),

--- a/src/handlers/project/create/index.ts
+++ b/src/handlers/project/create/index.ts
@@ -88,17 +88,17 @@ export const createCreateProjectHandler = (config: CreateProjectHandlerConfig) =
       flag("name", "name of the project to create", ProjectNameSchema.optional()),
       flag(
         "template",
-        "a preset of flags for scaffolding the runtime; compatible flags override preset values",
+        "a preset of flags for scaffolding the Runtime; compatible flags override preset values",
         z.enum(RUNTIME_TEMPLATE_SHORTCUT_NAMES).optional(),
       ),
       flag(
         "build",
-        "build type for the scaffolded runtime code",
+        "build type for the scaffolded Runtime code",
         z.enum(["CodeZip", "Container"]).optional(),
       ),
       flag(
         "language",
-        "target language for the scaffolded runtime code",
+        "target language for the scaffolded Runtime code",
         z.enum(["Python", "TypeScript"]).optional(),
       ),
       flag(
@@ -114,7 +114,7 @@ export const createCreateProjectHandler = (config: CreateProjectHandlerConfig) =
       flag(
         "model-provider",
         "model provider: bedrock, open_ai, gemini, or lite_llm for harnesses; " +
-          "bedrock, anthropic, open_ai, or gemini for runtime code",
+          "bedrock, anthropic, open_ai, or gemini for Runtime code",
         ModelProviderFlagSchema.optional(),
       ),
       flag(
@@ -125,10 +125,10 @@ export const createCreateProjectHandler = (config: CreateProjectHandlerConfig) =
       ),
       flag(
         "memory",
-        "memory option for the scaffolded runtime",
+        "memory option for the scaffolded Runtime",
         z.enum(MEMORY_SHORTCUT_NAMES).optional(),
       ),
-      flag("runtime-name", "name of the scaffolded runtime", z.string().max(42).optional()),
+      flag("runtime-name", "name of the scaffolded Runtime", z.string().max(42).optional()),
       flag(
         "type",
         "create scaffolds new agent code (the default); import translates a Bedrock Agent version",

--- a/src/handlers/project/dev/index.ts
+++ b/src/handlers/project/dev/index.ts
@@ -94,7 +94,7 @@ export const createDevProjectHandler = (config: DevProjectHandlerConfig) =>
     name: "dev",
     description: "run the project locally for development",
     flags: [
-      flag("agent", "runtime to run", z.string().optional()),
+      flag("agent", "Runtime to run", z.string().optional()),
       flag(
         "port",
         "port for the development server",

--- a/src/handlers/project/export/harness.ts
+++ b/src/handlers/project/export/harness.ts
@@ -13,7 +13,7 @@ import { harnessIdFromArn, mapServiceHarnessToSpec, regionFromHarnessArn } from 
 export const createExportHarnessHandler = (config: ExportProjectResourceConfig) =>
   createHandler({
     name: "harness",
-    description: "convert a harness into an editable Strands runtime agent",
+    description: "convert a harness into an editable Strands Runtime agent",
     flags: [
       flag("name", "the name of an in-project harness to export", z.string().optional()),
       flag(
@@ -23,7 +23,7 @@ export const createExportHarnessHandler = (config: ExportProjectResourceConfig) 
       ),
       flag(
         "target-agent-name",
-        "the name of the generated runtime agent (default: <harnessName>Agent)",
+        "the name of the generated Runtime agent (default <harnessName>Agent)",
         z.string().optional(),
       ),
     ],

--- a/src/handlers/project/invoke/harness.tsx
+++ b/src/handlers/project/invoke/harness.tsx
@@ -16,11 +16,11 @@ export const createProjectInvokeHarnessHandler = (
 ) =>
   createHandler({
     name: "harness",
-    description: "invoke a Harness from the current project",
+    description: "invoke a harness from the current project",
     flags: [
-      flag("name", "the logical project Harness name", z.string().optional()),
+      flag("name", "the logical project harness name", z.string().optional()),
       flag("target", "project deployment target", z.string().default("default")),
-      flag("prompt", "the message to send to the Harness", z.string().optional()),
+      flag("prompt", "the message to send to the harness", z.string().optional()),
       flag(
         "session-id",
         "the Runtime session ID to continue (33-100 characters)",
@@ -28,7 +28,7 @@ export const createProjectInvokeHarnessHandler = (
       ),
       flag(
         "qualifier",
-        "the Harness endpoint qualifier to invoke (default DEFAULT)",
+        "the harness endpoint qualifier to invoke (default DEFAULT)",
         z.string().optional(),
       ),
     ],

--- a/src/handlers/project/invoke/index.tsx
+++ b/src/handlers/project/invoke/index.tsx
@@ -13,7 +13,7 @@ export function createProjectInvokeHandler(
   io: AppIO,
   renderInvokeTui: typeof renderTuiAt = renderTuiAt,
 ): Router {
-  return new Router("invoke", "invoke a Runtime or Harness from the current project")
+  return new Router("invoke", "invoke a Runtime or harness from the current project")
     .use(withProject({ projectManager: core.projectManager }))
     .handler(createProjectInvokeRuntimeHandler(core, io, renderInvokeTui))
     .handler(createProjectInvokeHarnessHandler(core, io, renderInvokeTui))

--- a/src/handlers/project/invoke/runtime.tsx
+++ b/src/handlers/project/invoke/runtime.tsx
@@ -33,7 +33,7 @@ export const createProjectInvokeRuntimeHandler = (
       flag("content-type", "the payload content type", z.string().optional()),
       flag("accept", "the accepted response content type", z.string().optional()),
       flag("session-id", "the Runtime session ID", z.string().optional()),
-      flag("user-id", 'the Runtime user ID (default: "default")', z.string().optional()),
+      flag("user-id", 'the Runtime user ID (default "default")', z.string().optional()),
       flag("header", "an ordered application header", z.array(z.string()).optional(), {
         sensitive: true,
       }),

--- a/src/handlers/runtime/invoke/index.tsx
+++ b/src/handlers/runtime/invoke/index.tsx
@@ -30,7 +30,7 @@ export const createInvokeRuntimeHandler = (core: Core, io: AppIO) =>
       flag("content-type", "the payload content type", z.string().optional()),
       flag("accept", "the accepted response content type", z.string().optional()),
       flag("session-id", "the Runtime session ID", z.string().optional()),
-      flag("user-id", 'the Runtime user ID (default: "default")', z.string().optional()),
+      flag("user-id", 'the Runtime user ID (default "default")', z.string().optional()),
       flag("header", "an ordered application header", z.array(z.string()).optional(), {
         sensitive: true,
       }),

--- a/src/handlers/runtime/traces/get/index.tsx
+++ b/src/handlers/runtime/traces/get/index.tsx
@@ -12,7 +12,7 @@ const runtimeFlags = [flag("id", "the ID of the Runtime", runtimeIdSchema)] as c
 export const createGetRuntimeTraceHandler = (core: Core, io: AppIO) =>
   createGetTraceHandler(io, {
     description: "download a trace's log records to a JSON file",
-    outputDescription: "the output file path (default: <traceId>.json in the current directory)",
+    outputDescription: "the output file path (default <traceId>.json in the current directory)",
     flags: runtimeFlags,
     read: (ctx, flags, query, signal) => {
       const source = {

--- a/src/handlers/update/index.tsx
+++ b/src/handlers/update/index.tsx
@@ -71,7 +71,7 @@ export async function handleUpdate(
 export const createUpdateHandler = (io: AppIO) =>
   createHandler({
     name: "update",
-    description: "Check for and install CLI updates",
+    description: "check for and install CLI updates",
     flags: [flag("check", "check for updates without installing", z.boolean().default(false))],
     handle: async (ctx, flags) => {
       const result = await handleUpdate(flags.check, {


### PR DESCRIPTION
Audited every `--help` description across the CLI surface (191 commands, 774 options, 5 arguments) for casing, verb form, and accuracy.

Rules applied:
- lowercase, no terminal punctuation
- imperative verb — `add`, not `adds`
- `manage` only when descendants mutate; `inspect` when read-only (e.g. `memory` was `manage` but is get/list only; `gateway` was `inspect` but has create/update/delete)
- every group has a verb (`eval ab-test config-based` had none)
- resource nouns capitalized — Runtime, Gateway, Memory, Target, Rule; `harness` stays lowercase
- `ID`/`IDs`, not `id`/`ids`
- `(default X)`, not `(default: X)` or `(defaults to X)`

`README.md`'s command tree updated where it quoted a changed description.