### PR TITLE
fix: used FormTextInput for endpoint create name

### DIFF
--- a/src/components/EndpointWizard.tsx
+++ b/src/components/EndpointWizard.tsx
@@ -10,8 +10,8 @@ import type { ScreenProps } from "../handlers/types";
 import { coreOptsFromCtx } from "../handlers/utils";
 import { Layout } from "./Layout";
 import { FormRadioGroup, type FormRadioOption } from "./FormRadioGroup";
+import { FormTextInput } from "./FormTextInput";
 import { Stepper, type Step } from "./ui/stepper";
-import { TextInput } from "./ui/text-input";
 import { Spinner } from "./ui/spinner";
 import { CodeBlock } from "./ui/code-block";
 import { darkTheme } from "./ui/_core.js";
@@ -220,37 +220,25 @@ function NameStep({
   onNext: () => void;
   onBack: () => void;
 }) {
-  const [error, setError] = useState<string | null>(null);
-
   useInput((_input, key) => {
     if (key.escape) {
       onBack();
       return;
     }
-    if (key.return) {
-      if (NAME_PATTERN.test(value)) onNext();
-      else setError("must start with a letter; letters, numbers, and underscores only");
-    }
+    if (key.return && NAME_PATTERN.test(value)) onNext();
   });
 
   return (
     <Box flexDirection="column">
-      <Question text="what should this endpoint be called?" />
-      <TextInput
+      <FormTextInput
+        name="what should this endpoint be called?"
+        helpText="letters, numbers, underscores; starts with a letter"
+        errorText="must start with a letter; letters, numbers, and underscores only"
         value={value}
-        onChange={(next) => {
-          onChange(next);
-          setError(null);
-        }}
+        onChange={onChange}
         placeholder="production"
+        pattern={NAME_PATTERN}
       />
-      {error ? (
-        <Text color={theme.colors.error}>{"  " + error}</Text>
-      ) : (
-        <Text color={theme.colors.muted}>
-          {"  letters, numbers, underscores; starts with a letter"}
-        </Text>
-      )}
     </Box>
   );
 }

--- a/src/handlers/harness/endpoint/create/create.screen.test.tsx
+++ b/src/handlers/harness/endpoint/create/create.screen.test.tsx
@@ -68,6 +68,7 @@ describe("harness endpoint create wizard", () => {
     expect(r.lastFrame()).toContain("choose a harness to create an endpoint for");
     await r.press("return");
     await waitForText(r.lastFrame, "what should this endpoint be called?");
+    expect(r.lastFrame()).toContain("│❯ production");
     r.unmount();
   });
 


### PR DESCRIPTION
## Description

Update `harness endpoint create` TUI flow to use `FormTextInput` - bringing the UX in line with the standard throughout the code base.

**Before:**
<img width="496" height="120" alt="image" src="https://github.com/user-attachments/assets/29080d9e-8c7d-4f45-85f8-f7acd9fa0676" />


**After:**
<img width="501" height="145" alt="image" src="https://github.com/user-attachments/assets/c62b8658-a11a-4ddc-8fa1-6eb4d2a2a84b" />


## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other (please describe): tech debt

## Testing

How have you tested the change?

- [x] `bun run test` (2961 pass, 0 fail)
- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [x] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
