### PR TITLE
fix(tui): wrap long JSON values in detail views

### DIFF
--- a/src/components/JsonDetail.tsx
+++ b/src/components/JsonDetail.tsx
@@ -77,6 +77,7 @@ export function JsonDetail({
             language="json"
             showLineNumbers={false}
             showBorder={false}
+            wrap
             code={JSON.stringify(data, null, 2)}
           />
         </ScrollView>

--- a/src/handlers/harness/get/get.screen.test.tsx
+++ b/src/handlers/harness/get/get.screen.test.tsx
@@ -169,6 +169,19 @@ describe("harness hub screen", () => {
 });
 
 describe("harness JSON detail screen", () => {
+  test("wraps long JSON values instead of truncating them", async () => {
+    const longPrompt = `${"reply sarcastically but accurately and concisely ".repeat(5)}WRAP_SENTINEL`;
+    const response = getResponse();
+    response.harness!.systemPrompt = [{ text: longPrompt }];
+
+    const core = new TestCoreClient();
+    core.harness.setGetResponse(response);
+    const r = renderScreen("/agentcore/harness/get/MyHarness-abc123/json", { core });
+
+    await waitForText(r.lastFrame, "WRAP_SENTINEL");
+    r.unmount();
+  });
+
   test("renders the harness JSON and scrolls without crashing", async () => {
     const core = new TestCoreClient();
     core.harness.setGetResponse(getResponse());


### PR DESCRIPTION
Wrap long JSON values in TUI detail views instead of truncating them.
Adds regression coverage for long harness prompts.


before: 
<img width="2547" height="246" alt="image" src="https://github.com/user-attachments/assets/a19baa81-2331-42f7-96fc-de9ff58a78cd" />




after: 
<img width="2547" height="246" alt="image" src="https://github.com/user-attachments/assets/3f6e8434-3450-496d-8fa3-a29d89e04689" />
