### PR TITLE
chore(tui): align TUI copy with the CLI help descriptions

### DIFF
--- a/src/components/AbTestPicker.tsx
+++ b/src/components/AbTestPicker.tsx
@@ -65,7 +65,7 @@ export function AbTestPicker({
       getValue={(row) => row.abTestId}
       onSelect={onSelect}
       onBack={goBack}
-      loadingMessage="Loading A/B tests…"
+      loadingMessage="loading A/B tests…"
       errorMessage={(error) => `Error: ${error.message}`}
       emptyMessage="No A/B tests found in this Region."
       emptyPageMessage="No A/B tests on this page."

--- a/src/components/BatchEvaluationPicker.tsx
+++ b/src/components/BatchEvaluationPicker.tsx
@@ -79,7 +79,7 @@ export function BatchEvaluationPicker({
       getValue={(row) => row.batchEvaluationId}
       onSelect={onSelect}
       onBack={goBack}
-      loadingMessage="Loading batch evaluations…"
+      loadingMessage="loading batch evaluations…"
       errorMessage={(error) => `Error: ${error.message}`}
       emptyMessage="No batch evaluations found in this Region."
       emptyPageMessage="No batch evaluations on this page."

--- a/src/components/BatchInsightsPicker.tsx
+++ b/src/components/BatchInsightsPicker.tsx
@@ -70,7 +70,7 @@ export function BatchInsightsPicker({
       getValue={(row) => row.batchEvaluationId}
       onSelect={onSelect}
       onBack={goBack}
-      loadingMessage="Loading batch insights…"
+      loadingMessage="loading batch insights…"
       errorMessage={(error) => `Error: ${error.message}`}
       emptyMessage="No batch insights found in this Region."
       emptyPageMessage="No batch insights on this page."

--- a/src/components/ConfigBundlePicker.tsx
+++ b/src/components/ConfigBundlePicker.tsx
@@ -71,7 +71,7 @@ export function ConfigBundlePicker({
       getValue={(row) => row.bundleId}
       onSelect={onSelect}
       onBack={goBack}
-      loadingMessage="Loading configuration bundles…"
+      loadingMessage="loading configuration bundles…"
       errorMessage={(error) => `Error: ${error.message}`}
       emptyMessage="No configuration bundles found in this Region."
       emptyPageMessage="No configuration bundles on this page."

--- a/src/components/ConfigBundleVersionPicker.tsx
+++ b/src/components/ConfigBundleVersionPicker.tsx
@@ -77,7 +77,7 @@ export function ConfigBundleVersionPicker({
       getValue={(row) => row.versionId}
       onSelect={onSelect}
       onBack={onBack}
-      loadingMessage="Loading configuration bundle versions…"
+      loadingMessage="loading configuration bundle versions…"
       errorMessage={(error) =>
         `Error loading versions for configuration bundle ${bundleId}: ${error.message}`
       }

--- a/src/components/ConfirmAction.tsx
+++ b/src/components/ConfirmAction.tsx
@@ -143,7 +143,7 @@ export function ConfirmAction({
   return (
     <Layout breadcrumb={breadcrumb} description={description} keyHints={hints}>
       {isPending ? (
-        <Spinner label="Loading…" />
+        <Spinner label="loading…" />
       ) : error ? (
         <ErrorBody message={error.message} onBack={cancel} />
       ) : (

--- a/src/components/DatasetPicker.tsx
+++ b/src/components/DatasetPicker.tsx
@@ -82,7 +82,7 @@ export function DatasetPicker({
       getValue={(row) => row.datasetId}
       onSelect={onSelect}
       onBack={goBack}
-      loadingMessage="Loading datasets…"
+      loadingMessage="loading datasets…"
       errorMessage={(error) => `Error: ${error.message}`}
       emptyMessage="No datasets found in this Region."
       emptyPageMessage="No datasets on this page."

--- a/src/components/EndpointWizard.tsx
+++ b/src/components/EndpointWizard.tsx
@@ -161,7 +161,7 @@ export function EndpointWizard({
         )}
 
         {phase.kind === "submitting" && (
-          <Spinner label={mode === "create" ? "Creating endpoint…" : "Updating endpoint…"} />
+          <Spinner label={mode === "create" ? "creating endpoint…" : "updating endpoint…"} />
         )}
         {phase.kind === "success" && (
           <SuccessPanel
@@ -316,7 +316,7 @@ function VersionStep({
       {versions.isPending ? (
         <>
           <Question text="which harness version should this endpoint serve?" />
-          <Spinner label="Loading versions…" />
+          <Spinner label="loading versions…" />
         </>
       ) : versions.isError ? (
         <>

--- a/src/components/EndpointWizard.tsx
+++ b/src/components/EndpointWizard.tsx
@@ -161,7 +161,7 @@ export function EndpointWizard({
         )}
 
         {phase.kind === "submitting" && (
-          <Spinner label={mode === "create" ? "creating endpoint…" : "updating endpoint…"} />
+          <Spinner label={mode === "create" ? "Creating endpoint…" : "Updating endpoint…"} />
         )}
         {phase.kind === "success" && (
           <SuccessPanel
@@ -197,7 +197,7 @@ function hintsFor(
     { key: "ctl+c", label: "quit" },
   ];
   if (stepKey === "version") {
-    return [{ key: "↑↓", label: "choose" }, { key: "enter", label: "continue" }, ...base];
+    return [{ key: "↑↓", label: "navigate" }, { key: "enter", label: "continue" }, ...base];
   }
   if (stepKey === "review") return [{ key: "enter", label: verb }, ...base];
   return [{ key: "enter", label: "continue" }, ...base];
@@ -316,7 +316,7 @@ function VersionStep({
       {versions.isPending ? (
         <>
           <Question text="which harness version should this endpoint serve?" />
-          <Spinner label="loading versions…" />
+          <Spinner label="Loading versions…" />
         </>
       ) : versions.isError ? (
         <>

--- a/src/components/EvaluatorPicker.tsx
+++ b/src/components/EvaluatorPicker.tsx
@@ -83,7 +83,7 @@ export function EvaluatorPicker({
       getValue={(row) => row.evaluatorId}
       onSelect={onSelect}
       onBack={goBack}
-      loadingMessage="Loading evaluators…"
+      loadingMessage="loading evaluators…"
       errorMessage={(error) => `Error: ${error.message}`}
       emptyMessage="No evaluators found in this Region."
       emptyPageMessage="No evaluators on this page."

--- a/src/components/GatewayConnectorPicker.tsx
+++ b/src/components/GatewayConnectorPicker.tsx
@@ -68,7 +68,7 @@ export function GatewayConnectorPicker({
       getValue={(row) => row.targetId}
       onSelect={onSelect}
       onBack={() => navigate(-1)}
-      loadingMessage={`Loading Connectors for Gateway ${gatewayId}…`}
+      loadingMessage={`loading Connectors for Gateway ${gatewayId}…`}
       errorMessage={(error) =>
         `Error loading Connectors for Gateway ${gatewayId}: ${error.message}`
       }

--- a/src/components/GatewayConnectorPicker.tsx
+++ b/src/components/GatewayConnectorPicker.tsx
@@ -72,7 +72,7 @@ export function GatewayConnectorPicker({
       errorMessage={(error) =>
         `Error loading Connectors for Gateway ${gatewayId}: ${error.message}`
       }
-      emptyMessage="This Gateway has no Connectors."
+      emptyMessage="This Gateway has no connectors."
       emptyPageMessage="No Connectors on this page."
     />
   );

--- a/src/components/GatewayPicker.tsx
+++ b/src/components/GatewayPicker.tsx
@@ -74,7 +74,7 @@ export function GatewayPicker({
       getValue={(row) => row.gatewayId}
       onSelect={onSelect}
       onBack={onEscape ?? (() => navigate("/" + breadcrumb.slice(0, -1).join("/")))}
-      loadingMessage="Loading Gateways…"
+      loadingMessage="loading Gateways…"
       errorMessage={(error) => `Error: ${error.message}`}
       emptyMessage="No Gateways found in this Region."
       emptyPageMessage="No Gateways on this page."

--- a/src/components/GatewayRulePicker.tsx
+++ b/src/components/GatewayRulePicker.tsx
@@ -18,7 +18,7 @@ export const gatewayRuleColumns = [
   { key: "description", header: "description", flex: true },
   {
     key: "ruleId",
-    header: "id suffix",
+    header: "ID suffix",
     width: 10,
     render: (value: unknown) => String(value ?? "").slice(-8),
   },

--- a/src/components/GatewayRulePicker.tsx
+++ b/src/components/GatewayRulePicker.tsx
@@ -68,7 +68,7 @@ export function GatewayRulePicker({
       getValue={(row) => row.ruleId}
       onSelect={onSelect}
       onBack={() => navigate(-1)}
-      loadingMessage={`Loading Rules for Gateway ${gatewayId}…`}
+      loadingMessage={`loading Rules for Gateway ${gatewayId}…`}
       errorMessage={(error) => `Error loading Rules for Gateway ${gatewayId}: ${error.message}`}
       emptyMessage="This Gateway has no Rules."
       emptyPageMessage={`No Rules on this page for Gateway ${gatewayId}.`}

--- a/src/components/GatewayTargetPicker.tsx
+++ b/src/components/GatewayTargetPicker.tsx
@@ -71,7 +71,7 @@ export function GatewayTargetPicker({
       getValue={(row) => row.targetId}
       onSelect={onSelect}
       onBack={() => navigate(-1)}
-      loadingMessage={`Loading Targets for Gateway ${gatewayId}…`}
+      loadingMessage={`loading Targets for Gateway ${gatewayId}…`}
       errorMessage={(error) => `Error loading Targets for Gateway ${gatewayId}: ${error.message}`}
       emptyMessage="This Gateway has no Targets."
       emptyPageMessage={`No Targets on this page for Gateway ${gatewayId}.`}

--- a/src/components/HarnessEndpointPicker.tsx
+++ b/src/components/HarnessEndpointPicker.tsx
@@ -89,7 +89,7 @@ export function HarnessEndpointPicker({
       getValue={(row) => row.endpointName}
       onSelect={onSelect}
       onBack={goBack}
-      loadingMessage="Loading endpoints…"
+      loadingMessage="loading endpoints…"
       errorMessage={(error) => `Error: ${error.message}`}
       emptyMessage="This harness has no endpoints."
       emptyPageMessage={`No endpoints on this page for harness ${harnessId}.`}

--- a/src/components/HarnessEndpointPicker.tsx
+++ b/src/components/HarnessEndpointPicker.tsx
@@ -91,7 +91,7 @@ export function HarnessEndpointPicker({
       onBack={goBack}
       loadingMessage="Loading endpoints…"
       errorMessage={(error) => `Error: ${error.message}`}
-      emptyMessage="This harness has no endpoints yet."
+      emptyMessage="This harness has no endpoints."
       emptyPageMessage={`No endpoints on this page for harness ${harnessId}.`}
     />
   );

--- a/src/components/HarnessPicker.tsx
+++ b/src/components/HarnessPicker.tsx
@@ -88,7 +88,7 @@ export function HarnessPicker({
       onBack={goBack}
       loadingMessage="Loading harnesses…"
       errorMessage={(error) => `Error: ${error.message}`}
-      emptyMessage="No harnesses found."
+      emptyMessage="No harnesses found in this Region."
       emptyPageMessage="No harnesses on this page."
     />
   );

--- a/src/components/HarnessPicker.tsx
+++ b/src/components/HarnessPicker.tsx
@@ -86,7 +86,7 @@ export function HarnessPicker({
       getValue={(row) => row.harnessId}
       onSelect={onSelect}
       onBack={goBack}
-      loadingMessage="Loading harnesses…"
+      loadingMessage="loading harnesses…"
       errorMessage={(error) => `Error: ${error.message}`}
       emptyMessage="No harnesses found in this Region."
       emptyPageMessage="No harnesses on this page."

--- a/src/components/HarnessVersionPicker.tsx
+++ b/src/components/HarnessVersionPicker.tsx
@@ -83,7 +83,7 @@ export function HarnessVersionPicker({
       getValue={(row) => row.harnessVersion}
       onSelect={onSelect}
       onBack={goBack}
-      loadingMessage="Loading versions…"
+      loadingMessage="loading versions…"
       errorMessage={(error) => `Error: ${error.message}`}
       emptyMessage="No versions found."
       emptyPageMessage={`No versions on this page for harness ${harnessId}.`}

--- a/src/components/HarnessWizard.tsx
+++ b/src/components/HarnessWizard.tsx
@@ -238,6 +238,8 @@ type WizardPhase =
 export interface HarnessWizardProps extends ScreenProps {
   mode: "create" | "update";
   breadcrumb: string[];
+  // description is the optional subtitle shown after the breadcrumb.
+  description?: string;
   // harnessId is the update target (update mode only).
   harnessId?: string;
   // initial seeds the form (update mode: the current configuration).
@@ -257,6 +259,7 @@ export function HarnessWizard({
   core,
   mode,
   breadcrumb,
+  description,
   harnessId,
   initial,
   onDone,
@@ -336,7 +339,7 @@ export function HarnessWizard({
   const keyHints = hintsFor(stepKey, phase, verb);
 
   return (
-    <Layout breadcrumb={breadcrumb} keyHints={keyHints}>
+    <Layout breadcrumb={breadcrumb} description={description} keyHints={keyHints}>
       <Box flexDirection="column">
         <Box paddingX={1}>
           <Stepper
@@ -408,10 +411,10 @@ function hintsFor(
       return [{ key: "enter", label: "continue" }, ...base];
     case "model":
     case "memory":
-      return [{ key: "↑↓", label: "choose" }, { key: "enter", label: "continue" }, ...base];
+      return [{ key: "↑↓", label: "navigate" }, { key: "enter", label: "continue" }, ...base];
     case "tools":
       return [
-        { key: "↑↓", label: "move" },
+        { key: "↑↓", label: "navigate" },
         { key: "space", label: "toggle" },
         { key: "enter", label: "continue" },
         ...base,
@@ -569,89 +572,89 @@ const MODEL_PROVIDERS: {
   {
     kind: "bedrock",
     label: "bedrock",
-    description: "an amazon bedrock model",
+    description: "an Amazon Bedrock model or inference profile",
     fields: [
       {
         key: "modelId",
-        name: "model id",
-        helpText: "a bedrock model or inference profile id",
+        name: "model ID",
+        helpText: "a Bedrock model or inference profile ID",
         placeholder: "us.anthropic.claude-sonnet-4-6",
         required: true,
-        requiredError: "enter a bedrock model or inference profile id",
+        requiredError: "enter a Bedrock model or inference profile ID",
       },
     ],
   },
   {
     kind: "gemini",
     label: "gemini",
-    description: "a google gemini model",
+    description: "a Google Gemini model using an API-key credential ARN",
     fields: [
       {
         key: "modelId",
-        name: "model id",
-        helpText: "the gemini model to use",
+        name: "model ID",
+        helpText: "the Gemini model to use",
         placeholder: "gemini-2.5-pro",
         required: true,
-        requiredError: "enter a gemini model id",
+        requiredError: "enter a Gemini model ID",
       },
       {
         key: "apiKeyArn",
-        name: "api key arn",
-        helpText: "the arn of your gemini api key in agentcore identity",
+        name: "API key ARN",
+        helpText: "an AgentCore Identity API-key credential provider ARN",
         placeholder: "arn:aws:bedrock-agentcore:…:token-vault/…",
         required: true,
-        requiredError: "enter the arn of your gemini api key",
+        requiredError: "enter an API-key credential provider ARN",
       },
     ],
   },
   {
     kind: "openai",
     label: "openai",
-    description: "an openai model",
+    description: "an OpenAI model using an API-key credential ARN",
     fields: [
       {
         key: "modelId",
-        name: "model id",
-        helpText: "the openai model to use",
+        name: "model ID",
+        helpText: "the OpenAI model to use",
         placeholder: "gpt-5",
         required: true,
-        requiredError: "enter an openai model id",
+        requiredError: "enter an OpenAI model ID",
       },
       {
         key: "apiKeyArn",
-        name: "api key arn",
-        helpText: "the arn of your openai api key in agentcore identity",
+        name: "API key ARN",
+        helpText: "an AgentCore Identity API-key credential provider ARN",
         placeholder: "arn:aws:bedrock-agentcore:…:token-vault/…",
         required: true,
-        requiredError: "enter the arn of your openai api key",
+        requiredError: "enter an API-key credential provider ARN",
       },
     ],
   },
   {
     kind: "litellm",
     label: "litellm",
-    description: "any third-party provider via litellm",
+    description: "a third-party provider through LiteLLM",
     fields: [
       {
         key: "modelId",
-        name: "model id",
-        helpText: "the litellm model identifier (provider/model)",
+        name: "model ID",
+        helpText: "the LiteLLM model identifier (provider/model)",
         placeholder: "anthropic/claude-3-sonnet",
         required: true,
-        requiredError: "enter a litellm model identifier",
+        requiredError: "enter a LiteLLM model identifier",
       },
       {
         key: "apiKeyArn",
-        name: "api key arn",
-        helpText: "optional · the arn of the provider api key in agentcore identity",
+        name: "API key ARN",
+        helpText: "optional · an AgentCore Identity API-key credential provider ARN",
         placeholder: "arn:aws:bedrock-agentcore:…:token-vault/…",
         required: false,
         requiredError: "",
       },
       {
         key: "apiBase",
-        name: "api base url",
-        helpText: "optional · the base url of the provider's api endpoint",
+        name: "API base URL",
+        helpText: "optional · the provider API endpoint",
         placeholder: "https://…",
         required: false,
         requiredError: "",
@@ -791,12 +794,12 @@ const MEMORY_OPTIONS: { kind: MemoryKind; label: string; description: string }[]
   {
     kind: "managed",
     label: "managed",
-    description: "agentcore creates and manages memory for you (recommended)",
+    description: "AgentCore creates and manages memory for you (recommended)",
   },
   {
     kind: "byo",
     label: "bring your own",
-    description: "use an existing agentcore memory resource",
+    description: "use an existing AgentCore Memory",
   },
   { kind: "disabled", label: "disabled", description: "no memory across sessions" },
 ];
@@ -850,7 +853,7 @@ function MemoryStep({
     }
     if (key.return) {
       if (value.arn.trim() === "") {
-        setError("enter the arn of your agentcore memory resource");
+        setError("enter the ARN of an existing AgentCore Memory");
         return;
       }
       onNext();
@@ -867,8 +870,8 @@ function MemoryStep({
       />
       {value.kind === "byo" && (
         <FormTextInput
-          name="memory arn"
-          helpText="the arn of an existing agentcore memory resource"
+          name="Memory ARN"
+          helpText="the ARN of an existing AgentCore Memory"
           placeholder="arn:aws:bedrock-agentcore:…:memory/…"
           errorText=""
           value={value.arn}
@@ -901,26 +904,26 @@ const TOOL_ROWS: {
     placeholder: string;
   };
 }[] = [
-  { key: "browser", label: "browser", description: "browse the web with agentcore browser" },
+  { key: "browser", label: "browser", description: "browse the web with AgentCore Browser" },
   {
     key: "gateway",
     label: "gateway",
-    description: "call tools through an agentcore gateway",
+    description: "call tools through an AgentCore Gateway",
     field: {
       valueKey: "gatewayArn",
-      name: "gateway arn",
-      helpText: "the arn of the agentcore gateway to call tools through",
+      name: "Gateway ARN",
+      helpText: "the ARN of the AgentCore Gateway to call tools through",
       placeholder: "arn:aws:bedrock-agentcore:…:gateway/…",
     },
   },
   {
     key: "mcp",
-    label: "mcp server",
-    description: "connect to a remote mcp server",
+    label: "MCP server",
+    description: "connect to a remote MCP server",
     field: {
       valueKey: "mcpUrl",
-      name: "server url",
-      helpText: "the url of the remote mcp server",
+      name: "server URL",
+      helpText: "the URL of the remote MCP server",
       placeholder: "https://…",
     },
   },

--- a/src/components/JsonDetail.tsx
+++ b/src/components/JsonDetail.tsx
@@ -14,7 +14,7 @@ export interface JsonDetailProps {
   error: Error | null;
   // data is the resource to render (already unwrapped from its response).
   data: unknown;
-  // loadingLabel names what's loading (e.g. "Loading endpoint…").
+  // loadingLabel names what's loading (e.g. "loading endpoint…").
   loadingLabel: string;
   onRetry?: () => void;
   // warning, when set, renders a persistent advisory above the JSON — the TUI's

--- a/src/components/JsonDetail.tsx
+++ b/src/components/JsonDetail.tsx
@@ -60,7 +60,7 @@ export function JsonDetail({
     <Layout
       breadcrumb={breadcrumb}
       keyHints={[
-        { key: "↑↓/kj", label: "navigate" },
+        { key: "↑↓/jk", label: "navigate" },
         ...(error && onRetry ? [{ key: "r", label: "retry" }] : []),
         { key: "esc", label: "back" },
         { key: "ctl+c", label: "quit" },

--- a/src/components/MemoryPicker.tsx
+++ b/src/components/MemoryPicker.tsx
@@ -13,7 +13,7 @@ interface MemoryRow extends Record<string, unknown> {
 }
 
 export const memoryColumns = [
-  { key: "memoryId", header: "id", flex: true },
+  { key: "memoryId", header: "ID", flex: true },
   { key: "status", header: "status", width: 13 },
   {
     key: "updatedAt",
@@ -59,7 +59,7 @@ export function MemoryPicker({ ctx, core, breadcrumb, description, onSelect }: M
       getValue={(row) => row.memoryId}
       onSelect={onSelect}
       onBack={goBack}
-      loadingMessage="Loading Memories..."
+      loadingMessage="Loading Memories…"
       errorMessage={(error) => `Error: ${error.message}`}
       emptyMessage="No Memories found in this Region."
       emptyPageMessage="No Memories on this page."

--- a/src/components/MemoryPicker.tsx
+++ b/src/components/MemoryPicker.tsx
@@ -59,7 +59,7 @@ export function MemoryPicker({ ctx, core, breadcrumb, description, onSelect }: M
       getValue={(row) => row.memoryId}
       onSelect={onSelect}
       onBack={goBack}
-      loadingMessage="Loading Memories…"
+      loadingMessage="loading Memories…"
       errorMessage={(error) => `Error: ${error.message}`}
       emptyMessage="No Memories found in this Region."
       emptyPageMessage="No Memories on this page."

--- a/src/components/OnlineEvalPicker.tsx
+++ b/src/components/OnlineEvalPicker.tsx
@@ -84,7 +84,7 @@ export function OnlineEvalPicker({
       getValue={(row) => row.configId}
       onSelect={onSelect}
       onBack={goBack}
-      loadingMessage="Loading online evaluation configs…"
+      loadingMessage="loading online evaluation configs…"
       errorMessage={(error) => `Error: ${error.message}`}
       emptyMessage="No online evaluation configs found in this Region."
       emptyPageMessage="No online evaluation configs on this page."

--- a/src/components/OnlineInsightPicker.tsx
+++ b/src/components/OnlineInsightPicker.tsx
@@ -84,7 +84,7 @@ export function OnlineInsightPicker({
       getValue={(row) => row.configId}
       onSelect={onSelect}
       onBack={goBack}
-      loadingMessage="Loading online insight configs…"
+      loadingMessage="loading online insight configs…"
       errorMessage={(error) => `Error: ${error.message}`}
       emptyMessage="No online insight configs found in this Region."
       emptyPageMessage="No online insight configs on this page."

--- a/src/components/PaginatedTablePicker.test.tsx
+++ b/src/components/PaginatedTablePicker.test.tsx
@@ -92,7 +92,7 @@ describe("paginated table picker contract", () => {
     core.harness.listHarnesses = async () => pending.promise;
     const r = renderScreen("/agentcore/harness/list", { core });
 
-    await waitForText(r.lastFrame, "Loading harnesses");
+    await waitForText(r.lastFrame, "loading harnesses");
     await r.press("escape");
     await waitForText(r.lastFrame, "manage AgentCore harnesses");
   });

--- a/src/components/PaginatedTablePicker.test.tsx
+++ b/src/components/PaginatedTablePicker.test.tsx
@@ -109,7 +109,7 @@ describe("paginated table picker contract", () => {
 
   test("distinguishes first-page and later-page empty states", async () => {
     const firstPage = renderScreen("/agentcore/harness/list");
-    await waitForText(firstPage.lastFrame, "No harnesses found.");
+    await waitForText(firstPage.lastFrame, "No harnesses found in this Region.");
     expect(firstPage.lastFrame()).not.toContain("page 1");
     await firstPage.press("escape");
     await waitForText(firstPage.lastFrame, "manage AgentCore harnesses");
@@ -127,7 +127,7 @@ describe("paginated table picker contract", () => {
     await laterPage.write("l");
     await waitForText(laterPage.lastFrame, "No harnesses on this page.");
     expect(laterPage.lastFrame()).toContain("page 2");
-    expect(laterPage.lastFrame()).not.toContain("No harnesses found.");
+    expect(laterPage.lastFrame()).not.toContain("No harnesses found in this Region.");
   });
 
   test("pages forward and backward using token history", async () => {
@@ -465,7 +465,7 @@ describe("paginated table picker contract", () => {
     for (const width of [100, 80, 60]) {
       if (width !== 100) await r.resize(width);
       const lines = (r.lastFrame() ?? "").split("\n");
-      const headerIndex = lines.findIndex((line) => line.includes("id suffix"));
+      const headerIndex = lines.findIndex((line) => line.includes("ID suffix"));
       const rowLines = suffixes.map((suffix) => lines.find((line) => line.includes(suffix)));
 
       expect(headerIndex).toBeGreaterThanOrEqual(0);

--- a/src/components/RuntimeEndpointPicker.tsx
+++ b/src/components/RuntimeEndpointPicker.tsx
@@ -75,7 +75,7 @@ export function RuntimeEndpointPicker({
       getValue={(row) => row.qualifier}
       onSelect={onSelect}
       onBack={goBack}
-      loadingMessage={`Loading endpoints for Runtime ${runtimeId}…`}
+      loadingMessage={`loading endpoints for Runtime ${runtimeId}…`}
       errorMessage={(error) => `Error loading endpoints for Runtime ${runtimeId}: ${error.message}`}
       emptyMessage="This Runtime has no endpoints."
       emptyPageMessage={`No endpoints on this page for Runtime ${runtimeId}.`}

--- a/src/components/RuntimePicker.tsx
+++ b/src/components/RuntimePicker.tsx
@@ -84,7 +84,7 @@ export function RuntimePicker({
       getValue={(row) => row.runtimeId}
       onSelect={onSelect}
       onBack={goBack}
-      loadingMessage="Loading Runtimes…"
+      loadingMessage="loading Runtimes…"
       errorMessage={(error) => `Error: ${error.message}`}
       emptyMessage="No Runtimes found in this Region."
       emptyPageMessage="No Runtimes on this page."

--- a/src/components/RuntimePicker.tsx
+++ b/src/components/RuntimePicker.tsx
@@ -23,7 +23,7 @@ export const runtimeColumns = [
   { key: "runtimeName", header: "name", flex: true },
   {
     key: "runtimeId",
-    header: "id suffix",
+    header: "ID suffix",
     width: 10,
     render: runtimeIdSuffix,
   },

--- a/src/components/RuntimeVersionPicker.tsx
+++ b/src/components/RuntimeVersionPicker.tsx
@@ -71,7 +71,7 @@ export function RuntimeVersionPicker({
       getValue={(row) => row.version}
       onSelect={onSelect}
       onBack={goBack}
-      loadingMessage={`Loading versions for Runtime ${runtimeId}…`}
+      loadingMessage={`loading versions for Runtime ${runtimeId}…`}
       errorMessage={(error) => `Error loading versions for Runtime ${runtimeId}: ${error.message}`}
       emptyMessage={`No versions found for Runtime ${runtimeId}.`}
       emptyPageMessage={`No versions on this page for Runtime ${runtimeId}.`}

--- a/src/components/ui/data-table/DataTable.tsx
+++ b/src/components/ui/data-table/DataTable.tsx
@@ -321,7 +321,7 @@ export function DataTable<T extends Record<string, unknown>>({
             Showing {currentPage * pageSize + 1}-
             {Math.min((currentPage + 1) * pageSize, filtered.length)} of {filtered.length} · Page{" "}
             {currentPage + 1}/{totalPages || 1}
-            {" · "}[↑↓/jk] Row [←→/hl] Page [/] Search
+            {" · "}[↑↓/jk] row [←→/hl] page [/] search
           </Text>
         </Box>
       )}

--- a/src/handlers/eval/ab-test/ab-test.test.tsx
+++ b/src/handlers/eval/ab-test/ab-test.test.tsx
@@ -322,7 +322,7 @@ describe("eval ab-test target-based run validation", () => {
         same,
         "--json",
       ]),
-    ).rejects.toThrow(/different gateway targets/);
+    ).rejects.toThrow(/different Gateway Targets/);
   });
 
   test("maps flags to a createTargetBasedABTest call", async () => {

--- a/src/handlers/eval/ab-test/get/screen.tsx
+++ b/src/handlers/eval/ab-test/get/screen.tsx
@@ -51,7 +51,7 @@ export function AbTestGetScreen(props: ScreenProps) {
             ]
           : []
       }
-      loadingLabel="Loading A/B test…"
+      loadingLabel="loading A/B test…"
       onRetry={() => void detail.refetch()}
     />
   );
@@ -67,7 +67,7 @@ export function AbTestGetJsonScreen(props: ScreenProps) {
       isPending={detail.isPending}
       error={detail.isError ? (detail.error as Error) : null}
       data={detail.data}
-      loadingLabel="Loading A/B test…"
+      loadingLabel="loading A/B test…"
       onRetry={() => void detail.refetch()}
     />
   );

--- a/src/handlers/eval/ab-test/list/screen.tsx
+++ b/src/handlers/eval/ab-test/list/screen.tsx
@@ -9,6 +9,7 @@ export function AbTestListScreen(props: ScreenProps) {
     <AbTestPicker
       {...props}
       breadcrumb={["agentcore", "eval", "ab-test", "list"]}
+      description="list A/B tests"
       onSelect={(abTestId) =>
         navigate(`/agentcore/eval/ab-test/get/${encodeURIComponent(abTestId)}`)
       }

--- a/src/handlers/eval/ab-test/target-based/run/index.tsx
+++ b/src/handlers/eval/ab-test/target-based/run/index.tsx
@@ -81,7 +81,7 @@ export const createTargetBasedRunHandler = (core: Core, io: AppIO) =>
       const treatment = toTargetRef("treatment", treatmentRaw);
       if (control.gatewayTarget === treatment.gatewayTarget) {
         throw new InputValidationError(
-          "control and treatment must reference different gateway targets",
+          "control and treatment must reference different Gateway Targets",
         );
       }
 

--- a/src/handlers/eval/batch-evaluation/get/screen.tsx
+++ b/src/handlers/eval/batch-evaluation/get/screen.tsx
@@ -37,7 +37,7 @@ export function BatchEvaluationGetJsonScreen(props: ScreenProps) {
           ? `could not retrieve CloudWatch results (${(resultsError as Error).message}). Job status is unaffected.`
           : undefined
       }
-      loadingLabel="Loading batch evaluation…"
+      loadingLabel="loading batch evaluation…"
       onRetry={() => void query.refetch()}
     />
   );

--- a/src/handlers/eval/batch-evaluation/list/screen.tsx
+++ b/src/handlers/eval/batch-evaluation/list/screen.tsx
@@ -9,6 +9,7 @@ export function BatchEvaluationListScreen(props: ScreenProps) {
     <BatchEvaluationPicker
       {...props}
       breadcrumb={["agentcore", "eval", "batch-evaluation", "list"]}
+      description="list batch evaluations"
       onSelect={(batchEvaluationId) =>
         navigate(`/agentcore/eval/batch-evaluation/get/${encodeURIComponent(batchEvaluationId)}`)
       }

--- a/src/handlers/eval/batch-insights/get/screen.tsx
+++ b/src/handlers/eval/batch-insights/get/screen.tsx
@@ -23,7 +23,7 @@ export function BatchInsightsGetJsonScreen(props: ScreenProps) {
       isPending={query.isPending}
       error={query.isError ? (query.error as Error) : null}
       data={query.data}
-      loadingLabel="Loading batch insights…"
+      loadingLabel="loading batch insights…"
       onRetry={() => void query.refetch()}
     />
   );

--- a/src/handlers/eval/batch-insights/list/screen.tsx
+++ b/src/handlers/eval/batch-insights/list/screen.tsx
@@ -9,6 +9,7 @@ export function BatchInsightsListScreen(props: ScreenProps) {
     <BatchInsightsPicker
       {...props}
       breadcrumb={["agentcore", "eval", "batch-insights", "list"]}
+      description="list batch insights runs"
       onSelect={(batchEvaluationId) =>
         navigate(`/agentcore/eval/batch-insights/get/${encodeURIComponent(batchEvaluationId)}`)
       }

--- a/src/handlers/eval/config-bundle/list/screen.tsx
+++ b/src/handlers/eval/config-bundle/list/screen.tsx
@@ -9,6 +9,7 @@ export function ConfigBundleListScreen(props: ScreenProps) {
     <ConfigBundlePicker
       {...props}
       breadcrumb={["agentcore", "eval", "config-bundle", "list"]}
+      description="list configuration bundles"
       onSelect={(bundleId) =>
         navigate(`/agentcore/eval/config-bundle/get/${encodeURIComponent(bundleId)}`)
       }

--- a/src/handlers/eval/dataset/get/screen.tsx
+++ b/src/handlers/eval/dataset/get/screen.tsx
@@ -50,7 +50,7 @@ export function DatasetGetScreen(props: ScreenProps) {
             ]
           : []
       }
-      loadingLabel="Loading dataset…"
+      loadingLabel="loading dataset…"
       onRetry={() => void detail.refetch()}
       selectLabel="open"
     />
@@ -67,7 +67,7 @@ export function DatasetGetJsonScreen(props: ScreenProps) {
       isPending={detail.isPending}
       error={detail.isError ? (detail.error as Error) : null}
       data={detail.data}
-      loadingLabel="Loading dataset…"
+      loadingLabel="loading dataset…"
       onRetry={() => void detail.refetch()}
     />
   );

--- a/src/handlers/eval/dataset/get/screen.tsx
+++ b/src/handlers/eval/dataset/get/screen.tsx
@@ -52,7 +52,7 @@ export function DatasetGetScreen(props: ScreenProps) {
       }
       loadingLabel="Loading dataset…"
       onRetry={() => void detail.refetch()}
-      selectLabel="open detail"
+      selectLabel="open"
     />
   );
 }

--- a/src/handlers/eval/dataset/list/screen.tsx
+++ b/src/handlers/eval/dataset/list/screen.tsx
@@ -9,6 +9,7 @@ export function DatasetListScreen(props: ScreenProps) {
     <DatasetPicker
       {...props}
       breadcrumb={["agentcore", "eval", "dataset", "list"]}
+      description="list datasets"
       onSelect={(datasetId) =>
         navigate(`/agentcore/eval/dataset/get/${encodeURIComponent(datasetId)}`)
       }

--- a/src/handlers/eval/evaluator/get/screen.tsx
+++ b/src/handlers/eval/evaluator/get/screen.tsx
@@ -58,7 +58,7 @@ export function EvaluatorGetScreen(props: ScreenProps) {
       }
       loadingLabel="Loading evaluator…"
       onRetry={() => void detail.refetch()}
-      selectLabel="open detail"
+      selectLabel="open"
     />
   );
 }

--- a/src/handlers/eval/evaluator/get/screen.tsx
+++ b/src/handlers/eval/evaluator/get/screen.tsx
@@ -56,7 +56,7 @@ export function EvaluatorGetScreen(props: ScreenProps) {
             ]
           : []
       }
-      loadingLabel="Loading evaluator…"
+      loadingLabel="loading evaluator…"
       onRetry={() => void detail.refetch()}
       selectLabel="open"
     />
@@ -73,7 +73,7 @@ export function EvaluatorGetJsonScreen(props: ScreenProps) {
       isPending={detail.isPending}
       error={detail.isError ? (detail.error as Error) : null}
       data={detail.data}
-      loadingLabel="Loading evaluator…"
+      loadingLabel="loading evaluator…"
       onRetry={() => void detail.refetch()}
     />
   );

--- a/src/handlers/eval/evaluator/list/screen.tsx
+++ b/src/handlers/eval/evaluator/list/screen.tsx
@@ -9,6 +9,7 @@ export function EvaluatorListScreen(props: ScreenProps) {
     <EvaluatorPicker
       {...props}
       breadcrumb={["agentcore", "eval", "evaluator", "list"]}
+      description="list evaluators"
       onSelect={(evaluatorId) =>
         navigate(`/agentcore/eval/evaluator/get/${encodeURIComponent(evaluatorId)}`)
       }

--- a/src/handlers/eval/online-eval/get/screen.tsx
+++ b/src/handlers/eval/online-eval/get/screen.tsx
@@ -50,7 +50,7 @@ export function OnlineEvalGetScreen(props: ScreenProps) {
       }
       loadingLabel="Loading online evaluation config…"
       onRetry={() => void detail.refetch()}
-      selectLabel="open detail"
+      selectLabel="open"
     />
   );
 }

--- a/src/handlers/eval/online-eval/get/screen.tsx
+++ b/src/handlers/eval/online-eval/get/screen.tsx
@@ -48,7 +48,7 @@ export function OnlineEvalGetScreen(props: ScreenProps) {
             ]
           : []
       }
-      loadingLabel="Loading online evaluation config…"
+      loadingLabel="loading online evaluation config…"
       onRetry={() => void detail.refetch()}
       selectLabel="open"
     />
@@ -65,7 +65,7 @@ export function OnlineEvalGetJsonScreen(props: ScreenProps) {
       isPending={detail.isPending}
       error={detail.isError ? (detail.error as Error) : null}
       data={detail.data}
-      loadingLabel="Loading online evaluation config…"
+      loadingLabel="loading online evaluation config…"
       onRetry={() => void detail.refetch()}
     />
   );

--- a/src/handlers/eval/online-eval/list/screen.tsx
+++ b/src/handlers/eval/online-eval/list/screen.tsx
@@ -9,6 +9,7 @@ export function OnlineEvalListScreen(props: ScreenProps) {
     <OnlineEvalPicker
       {...props}
       breadcrumb={["agentcore", "eval", "online-eval", "list"]}
+      description="list online evaluation configs"
       onSelect={(configId) =>
         navigate(`/agentcore/eval/online-eval/get/${encodeURIComponent(configId)}`)
       }

--- a/src/handlers/eval/online-insight/get/screen.tsx
+++ b/src/handlers/eval/online-insight/get/screen.tsx
@@ -53,7 +53,7 @@ export function OnlineInsightGetScreen(props: ScreenProps) {
             ]
           : []
       }
-      loadingLabel="Loading online insight config…"
+      loadingLabel="loading online insight config…"
       onRetry={() => void detail.refetch()}
       selectLabel="open"
     />
@@ -70,7 +70,7 @@ export function OnlineInsightGetJsonScreen(props: ScreenProps) {
       isPending={detail.isPending}
       error={detail.isError ? (detail.error as Error) : null}
       data={detail.data}
-      loadingLabel="Loading online insight config…"
+      loadingLabel="loading online insight config…"
       onRetry={() => void detail.refetch()}
     />
   );

--- a/src/handlers/eval/online-insight/get/screen.tsx
+++ b/src/handlers/eval/online-insight/get/screen.tsx
@@ -55,7 +55,7 @@ export function OnlineInsightGetScreen(props: ScreenProps) {
       }
       loadingLabel="Loading online insight config…"
       onRetry={() => void detail.refetch()}
-      selectLabel="open detail"
+      selectLabel="open"
     />
   );
 }

--- a/src/handlers/eval/online-insight/list/screen.tsx
+++ b/src/handlers/eval/online-insight/list/screen.tsx
@@ -9,6 +9,7 @@ export function OnlineInsightListScreen(props: ScreenProps) {
     <OnlineInsightPicker
       {...props}
       breadcrumb={["agentcore", "eval", "online-insight", "list"]}
+      description="list online insight configs"
       onSelect={(configId) =>
         navigate(`/agentcore/eval/online-insight/get/${encodeURIComponent(configId)}`)
       }

--- a/src/handlers/gateway/connector/get/screen.tsx
+++ b/src/handlers/gateway/connector/get/screen.tsx
@@ -19,7 +19,7 @@ export function GatewayConnectorGetScreen(props: ScreenProps) {
       isPending={detail.isPending}
       error={detail.isError ? (detail.error as Error) : null}
       data={detail.data}
-      loadingLabel="Loading Gateway Connector…"
+      loadingLabel="Loading Gateway connector…"
       onRetry={() => void detail.refetch()}
     />
   );

--- a/src/handlers/gateway/connector/get/screen.tsx
+++ b/src/handlers/gateway/connector/get/screen.tsx
@@ -19,7 +19,7 @@ export function GatewayConnectorGetScreen(props: ScreenProps) {
       isPending={detail.isPending}
       error={detail.isError ? (detail.error as Error) : null}
       data={detail.data}
-      loadingLabel="Loading Gateway connector…"
+      loadingLabel="loading Gateway connector…"
       onRetry={() => void detail.refetch()}
     />
   );

--- a/src/handlers/gateway/connector/list/screen.tsx
+++ b/src/handlers/gateway/connector/list/screen.tsx
@@ -12,7 +12,7 @@ export function GatewayConnectorListScreen(props: ScreenProps) {
       <GatewayPicker
         {...props}
         breadcrumb={["agentcore", "gateway", "connector", "list"]}
-        description="choose a Gateway to list Connectors for"
+        description="choose a Gateway to list connectors for"
         onSelect={(id) => navigate(`/agentcore/gateway/connector/list/${encodeURIComponent(id)}`)}
       />
     );

--- a/src/handlers/gateway/gateway.screen.test.tsx
+++ b/src/handlers/gateway/gateway.screen.test.tsx
@@ -390,7 +390,7 @@ describe("Gateway Connector flow", () => {
       `/agentcore/gateway/connector/list/${encodeURIComponent(GATEWAY_ID)}`,
     );
 
-    await waitForText(screen.lastFrame, "This Gateway has no Connectors.");
+    await waitForText(screen.lastFrame, "This Gateway has no connectors.");
     expect(screen.lastFrame()).not.toContain("more →");
   });
 

--- a/src/handlers/gateway/gateway.screen.test.tsx
+++ b/src/handlers/gateway/gateway.screen.test.tsx
@@ -147,7 +147,7 @@ describe("Gateway menu and list", () => {
     loadingCore.gateway.listGateways = async () => pending.promise;
     const loading = renderScreen("/agentcore/gateway/list", { core: loadingCore });
 
-    await waitForText(loading.lastFrame, "Loading Gateways");
+    await waitForText(loading.lastFrame, "loading Gateways");
     await loading.press("escape");
     await waitForText(loading.lastFrame, "manage AgentCore Gateways");
     loading.unmount();

--- a/src/handlers/gateway/get/screen.tsx
+++ b/src/handlers/gateway/get/screen.tsx
@@ -62,7 +62,7 @@ export function GatewayGetScreen(props: ScreenProps) {
             ]
           : []
       }
-      loadingLabel="Loading Gateway…"
+      loadingLabel="loading Gateway…"
       onRetry={() => void detail.refetch()}
       selectLabel="open"
     />
@@ -79,7 +79,7 @@ export function GatewayGetJsonScreen(props: ScreenProps) {
       isPending={detail.isPending}
       error={detail.isError ? (detail.error as Error) : null}
       data={detail.data}
-      loadingLabel="Loading Gateway…"
+      loadingLabel="loading Gateway…"
       onRetry={() => void detail.refetch()}
     />
   );

--- a/src/handlers/gateway/invoke/invoke.screen.test.tsx
+++ b/src/handlers/gateway/invoke/invoke.screen.test.tsx
@@ -474,7 +474,7 @@ describe("Gateway invoke JSON console", () => {
     await screen.press("return");
     await waitForText(screen.lastFrame, "data: first");
 
-    expect(screen.lastFrame()).toContain("Streaming");
+    expect(screen.lastFrame()).toContain("streaming");
     expect(screen.lastFrame()).not.toContain("returned-runtime");
     release.resolve();
     await waitForText(screen.lastFrame, "data: second");

--- a/src/handlers/gateway/invoke/invoke.screen.test.tsx
+++ b/src/handlers/gateway/invoke/invoke.screen.test.tsx
@@ -474,7 +474,7 @@ describe("Gateway invoke JSON console", () => {
     await screen.press("return");
     await waitForText(screen.lastFrame, "data: first");
 
-    expect(screen.lastFrame()).toContain("streaming");
+    expect(screen.lastFrame()).toContain("Streaming");
     expect(screen.lastFrame()).not.toContain("returned-runtime");
     release.resolve();
     await waitForText(screen.lastFrame, "data: second");

--- a/src/handlers/gateway/invoke/screen.tsx
+++ b/src/handlers/gateway/invoke/screen.tsx
@@ -427,7 +427,7 @@ function GatewayInvokeConsole({ ctx, core, gatewayId, initialContext }: GatewayI
         editingPath
           ? [
               { key: "enter", label: "save" },
-              { key: "esc", label: "cancel" },
+              { key: "esc", label: "back" },
               { key: "ctl+c", label: "quit" },
             ]
           : busy
@@ -516,7 +516,9 @@ function GatewayInvokeConsole({ ctx, core, gatewayId, initialContext }: GatewayI
                   Gateway is {unavailableStatus}; invocation requires READY.
                 </Text>
               ) : busy ? (
-                <Spinner label={`${liveState}… (esc to interrupt)`} />
+                <Spinner
+                  label={`${liveState === "connecting" ? "Connecting" : "Streaming"}… (esc to interrupt)`}
+                />
               ) : (
                 <>
                   <Text color={theme.colors.muted}>

--- a/src/handlers/gateway/invoke/screen.tsx
+++ b/src/handlers/gateway/invoke/screen.tsx
@@ -451,7 +451,7 @@ function GatewayInvokeConsole({ ctx, core, gatewayId, initialContext }: GatewayI
     >
       <Box height="100%" flexDirection="column" position="relative">
         {detail.isPending ? (
-          <Spinner label="Loading Gateway…" />
+          <Spinner label="loading Gateway…" />
         ) : detail.isError ? (
           <ErrorBlock details={errorDetails(detail.error)} />
         ) : (
@@ -516,9 +516,7 @@ function GatewayInvokeConsole({ ctx, core, gatewayId, initialContext }: GatewayI
                   Gateway is {unavailableStatus}; invocation requires READY.
                 </Text>
               ) : busy ? (
-                <Spinner
-                  label={`${liveState === "connecting" ? "Connecting" : "Streaming"}… (esc to interrupt)`}
-                />
+                <Spinner label={`${liveState}… (esc to interrupt)`} />
               ) : (
                 <>
                   <Text color={theme.colors.muted}>

--- a/src/handlers/gateway/list/screen.tsx
+++ b/src/handlers/gateway/list/screen.tsx
@@ -9,6 +9,7 @@ export function GatewayListScreen(props: ScreenProps) {
     <GatewayPicker
       {...props}
       breadcrumb={["agentcore", "gateway", "list"]}
+      description="list AgentCore Gateways"
       onSelect={(gatewayId) => navigate(`/agentcore/gateway/get/${encodeURIComponent(gatewayId)}`)}
     />
   );

--- a/src/handlers/gateway/policy/screen.tsx
+++ b/src/handlers/gateway/policy/screen.tsx
@@ -151,7 +151,7 @@ function GeneratePolicyForm({ ctx, core, gatewayId }: ScreenProps & { gatewayId:
       keyHints={keyHints}
     >
       {gateway.isPending ? (
-        <Spinner label="Loading Gateway…" />
+        <Spinner label="loading Gateway…" />
       ) : gateway.isError ? (
         <Text color={theme.colors.error}>Error: {(gateway.error as Error).message}</Text>
       ) : (

--- a/src/handlers/gateway/policy/screen.tsx
+++ b/src/handlers/gateway/policy/screen.tsx
@@ -135,7 +135,7 @@ function GeneratePolicyForm({ ctx, core, gatewayId }: ScreenProps & { gatewayId:
         ]
       : phase.kind === "result"
         ? [
-            { key: "↑↓/kj", label: "scroll" },
+            { key: "↑↓/jk", label: "scroll" },
             { key: "e", label: "edit prompt" },
             { key: "esc", label: "back" },
             { key: "ctl+c", label: "quit" },

--- a/src/handlers/gateway/rule/get/screen.tsx
+++ b/src/handlers/gateway/rule/get/screen.tsx
@@ -19,7 +19,7 @@ export function GatewayRuleGetScreen(props: ScreenProps) {
       isPending={detail.isPending}
       error={detail.isError ? (detail.error as Error) : null}
       data={detail.data}
-      loadingLabel="Loading Gateway Rule…"
+      loadingLabel="loading Gateway Rule…"
       onRetry={() => void detail.refetch()}
     />
   );

--- a/src/handlers/gateway/target/get/screen.tsx
+++ b/src/handlers/gateway/target/get/screen.tsx
@@ -19,7 +19,7 @@ export function GatewayTargetGetScreen(props: ScreenProps) {
       isPending={detail.isPending}
       error={detail.isError ? (detail.error as Error) : null}
       data={detail.data}
-      loadingLabel="Loading Gateway Target…"
+      loadingLabel="loading Gateway Target…"
       onRetry={() => void detail.refetch()}
     />
   );

--- a/src/handlers/harness/create/create.screen.test.tsx
+++ b/src/handlers/harness/create/create.screen.test.tsx
@@ -65,7 +65,7 @@ describe("harness create wizard", () => {
     expect(r.lastFrame()).toContain("[✓] browser");
     await r.press("down"); // gateway
     await r.write(" "); // opens the arn input
-    await waitForText(r.lastFrame, "gateway arn");
+    await waitForText(r.lastFrame, "Gateway ARN");
     await r.write("arn:aws:bedrock-agentcore:us-east-1:123:gateway/g-1");
     await r.press("return"); // commit the arn
     await waitForText(r.lastFrame, "arn:aws:bedrock-agentcore:us-east-1:123:gateway/g-1");
@@ -121,13 +121,13 @@ describe("harness create wizard", () => {
     await waitForText(r.lastFrame, "choose a model");
     await r.press("down"); // bedrock
     await waitForText(r.lastFrame, "● bedrock");
-    expect(r.lastFrame()).not.toContain("model id");
+    expect(r.lastFrame()).not.toContain("model ID");
 
     await r.press("return");
-    await waitForText(r.lastFrame, "model id");
+    await waitForText(r.lastFrame, "model ID");
 
     await r.press("escape");
-    await waitFor(() => !(r.lastFrame() ?? "").includes("model id"));
+    await waitFor(() => !(r.lastFrame() ?? "").includes("model ID"));
     expect(r.lastFrame()).toContain("● bedrock");
     r.unmount();
   });
@@ -190,11 +190,11 @@ describe("harness create wizard", () => {
     await waitForText(r.lastFrame, "● openai");
     await r.press("return"); // focus the model id field
     await r.press("return"); // empty → error
-    await waitForText(r.lastFrame, "enter an openai model id");
+    await waitForText(r.lastFrame, "enter an OpenAI model ID");
     await r.write("gpt-5");
     await r.press("return"); // on to the api key arn field
     await r.press("return"); // empty → error
-    await waitForText(r.lastFrame, "enter the arn of your openai api key");
+    await waitForText(r.lastFrame, "enter an API-key credential provider ARN");
     await r.write("arn:aws:bedrock-agentcore:us-east-1:123:token-vault/default/apikey/openai");
     await r.press("return");
 
@@ -323,7 +323,7 @@ describe("harness create wizard", () => {
     await waitForText(r.lastFrame, "● bring your own");
     await r.press("return"); // focus the memory arn field
     await r.press("return"); // empty → error
-    await waitForText(r.lastFrame, "enter the arn");
+    await waitForText(r.lastFrame, "enter the ARN of an existing AgentCore Memory");
     await r.write("arn:aws:bedrock-agentcore:us-east-1:123:memory/m-1");
     await r.press("return");
 

--- a/src/handlers/harness/create/screen.tsx
+++ b/src/handlers/harness/create/screen.tsx
@@ -14,6 +14,7 @@ export function HarnessCreateScreen(props: ScreenProps) {
       {...props}
       mode="create"
       breadcrumb={["agentcore", "harness", "create"]}
+      description="create a harness"
       onDone={(harnessId) => finishFlow(`/agentcore/harness/get/${harnessId}`)}
     />
   );

--- a/src/handlers/harness/delete/screen.tsx
+++ b/src/handlers/harness/delete/screen.tsx
@@ -60,7 +60,7 @@ function DeleteConfirm({ ctx, core, harnessId }: ScreenProps & { harnessId: stri
         };
       }}
       successTitle="Harness deletion started"
-      runningLabel="Deleting harness…"
+      runningLabel="deleting harness…"
       onDone={() => navigate("/agentcore/harness/list")}
     />
   );

--- a/src/handlers/harness/endpoint/delete/screen.tsx
+++ b/src/handlers/harness/endpoint/delete/screen.tsx
@@ -81,7 +81,7 @@ function DeleteConfirm({
         };
       }}
       successTitle="Endpoint deletion started"
-      runningLabel="Deleting endpoint…"
+      runningLabel="deleting endpoint…"
       onDone={() => finishFlow(`/agentcore/harness/endpoint/list/${harnessId}`)}
     />
   );

--- a/src/handlers/harness/endpoint/get/screen.tsx
+++ b/src/handlers/harness/endpoint/get/screen.tsx
@@ -22,7 +22,7 @@ export function HarnessGetEndpointScreen({ ctx, core }: ScreenProps) {
       isPending={detail.isPending}
       error={detail.isError ? (detail.error as Error) : null}
       data={detail.data?.endpoint}
-      loadingLabel="Loading endpoint…"
+      loadingLabel="loading endpoint…"
     />
   );
 }

--- a/src/handlers/harness/endpoint/list/list.screen.test.tsx
+++ b/src/handlers/harness/endpoint/list/list.screen.test.tsx
@@ -113,7 +113,7 @@ describe("harness endpoint list screen", () => {
     const core = coreWithEndpoints([]);
     const r = renderScreen("/agentcore/harness/endpoint/list/MyHarness-abc123", { core });
 
-    await waitForText(r.lastFrame, "This harness has no endpoints yet.");
+    await waitForText(r.lastFrame, "This harness has no endpoints.");
     expect(r.lastFrame()).not.toContain("No endpoints on this page");
     r.unmount();
   });

--- a/src/handlers/harness/endpoint/update/screen.tsx
+++ b/src/handlers/harness/endpoint/update/screen.tsx
@@ -67,7 +67,7 @@ function UpdateWizard({
         ]}
       >
         {detail.isPending ? (
-          <Spinner label="Loading endpoint…" />
+          <Spinner label="loading endpoint…" />
         ) : (
           <Text color="red">Error: {(detail.error as Error).message}</Text>
         )}

--- a/src/handlers/harness/endpoint/update/screen.tsx
+++ b/src/handlers/harness/endpoint/update/screen.tsx
@@ -67,7 +67,7 @@ function UpdateWizard({
         ]}
       >
         {detail.isPending ? (
-          <Spinner label="loading endpoint…" />
+          <Spinner label="Loading endpoint…" />
         ) : (
           <Text color="red">Error: {(detail.error as Error).message}</Text>
         )}

--- a/src/handlers/harness/exec/exec.screen.test.tsx
+++ b/src/handlers/harness/exec/exec.screen.test.tsx
@@ -181,7 +181,7 @@ describe("exec screen", () => {
 
     await waitForText(r.lastFrame, "run a command…");
     await type(r, "sleep 999");
-    await waitForText(r.lastFrame, "working…");
+    await waitForText(r.lastFrame, "Working…");
 
     stream.emit({ chunk: { contentDelta: { stdout: "tick\n" } } });
     await waitForText(r.lastFrame, "tick");

--- a/src/handlers/harness/exec/exec.screen.test.tsx
+++ b/src/handlers/harness/exec/exec.screen.test.tsx
@@ -181,7 +181,7 @@ describe("exec screen", () => {
 
     await waitForText(r.lastFrame, "run a command…");
     await type(r, "sleep 999");
-    await waitForText(r.lastFrame, "Working…");
+    await waitForText(r.lastFrame, "working…");
 
     stream.emit({ chunk: { contentDelta: { stdout: "tick\n" } } });
     await waitForText(r.lastFrame, "tick");

--- a/src/handlers/harness/get/screen.tsx
+++ b/src/handlers/harness/get/screen.tsx
@@ -79,7 +79,7 @@ export function HarnessGetScreen(props: ScreenProps) {
             }))
           : []
       }
-      loadingLabel="Loading harness…"
+      loadingLabel="loading harness…"
       onRetry={() => void detail.refetch()}
     />
   );
@@ -97,7 +97,7 @@ export function HarnessGetJsonScreen(props: ScreenProps) {
       isPending={detail.isPending}
       error={detail.isError ? (detail.error as Error) : null}
       data={detail.data?.harness}
-      loadingLabel="Loading harness…"
+      loadingLabel="loading harness…"
       onRetry={() => void detail.refetch()}
     />
   );

--- a/src/handlers/harness/invoke/invoke.screen.test.tsx
+++ b/src/handlers/harness/invoke/invoke.screen.test.tsx
@@ -338,7 +338,7 @@ describe("invoke chat screen", () => {
 
     await waitForText(r.lastFrame, "send a message…");
     await sendMessage(r, "take your time");
-    await waitForText(r.lastFrame, "working… (esc to interrupt)");
+    await waitForText(r.lastFrame, "Working… (esc to interrupt)");
 
     stream.emit({ messageStart: { role: "assistant" } });
     stream.emit({ contentBlockDelta: { contentBlockIndex: 0, delta: { text: "Thinking" } } });
@@ -348,7 +348,7 @@ describe("invoke chat screen", () => {
     await waitForText(r.lastFrame, "interrupted");
     // Idle again: the status line shows the session, not the spinner.
     await waitForText(r.lastFrame, "session:");
-    expect(r.lastFrame()).not.toContain("working…");
+    expect(r.lastFrame()).not.toContain("Working…");
     r.unmount();
   });
 
@@ -360,7 +360,7 @@ describe("invoke chat screen", () => {
 
     await waitForText(r.lastFrame, "send a message…");
     await sendMessage(r, "hi");
-    await waitForText(r.lastFrame, "working…");
+    await waitForText(r.lastFrame, "Working…");
 
     stream.emit({ messageStart: { role: "assistant" } });
     stream.emit({ contentBlockDelta: { contentBlockIndex: 0, delta: { text: "Done deal" } } });

--- a/src/handlers/harness/invoke/invoke.screen.test.tsx
+++ b/src/handlers/harness/invoke/invoke.screen.test.tsx
@@ -338,7 +338,7 @@ describe("invoke chat screen", () => {
 
     await waitForText(r.lastFrame, "send a message…");
     await sendMessage(r, "take your time");
-    await waitForText(r.lastFrame, "Working… (esc to interrupt)");
+    await waitForText(r.lastFrame, "working… (esc to interrupt)");
 
     stream.emit({ messageStart: { role: "assistant" } });
     stream.emit({ contentBlockDelta: { contentBlockIndex: 0, delta: { text: "Thinking" } } });
@@ -348,7 +348,7 @@ describe("invoke chat screen", () => {
     await waitForText(r.lastFrame, "interrupted");
     // Idle again: the status line shows the session, not the spinner.
     await waitForText(r.lastFrame, "session:");
-    expect(r.lastFrame()).not.toContain("Working…");
+    expect(r.lastFrame()).not.toContain("working…");
     r.unmount();
   });
 
@@ -360,7 +360,7 @@ describe("invoke chat screen", () => {
 
     await waitForText(r.lastFrame, "send a message…");
     await sendMessage(r, "hi");
-    await waitForText(r.lastFrame, "Working…");
+    await waitForText(r.lastFrame, "working…");
 
     stream.emit({ messageStart: { role: "assistant" } });
     stream.emit({ contentBlockDelta: { contentBlockIndex: 0, delta: { text: "Done deal" } } });

--- a/src/handlers/harness/invoke/screen.tsx
+++ b/src/handlers/harness/invoke/screen.tsx
@@ -370,7 +370,7 @@ export function HarnessChat({
 
           <Box height={1}>
             {streaming ? (
-              <Spinner label="working… (esc to interrupt)" />
+              <Spinner label="Working… (esc to interrupt)" />
             ) : (
               <Text color={theme.colors.muted}>
                 session: {sessionId} · qualifier: {qualifier}

--- a/src/handlers/harness/invoke/screen.tsx
+++ b/src/handlers/harness/invoke/screen.tsx
@@ -339,7 +339,7 @@ export function HarnessChat({
       }
     >
       {detail.isPending ? (
-        <Spinner label="Loading harness…" />
+        <Spinner label="loading harness…" />
       ) : detail.isError ? (
         <Text color="red">Error: {(detail.error as Error).message}</Text>
       ) : (
@@ -370,7 +370,7 @@ export function HarnessChat({
 
           <Box height={1}>
             {streaming ? (
-              <Spinner label="Working… (esc to interrupt)" />
+              <Spinner label="working… (esc to interrupt)" />
             ) : (
               <Text color={theme.colors.muted}>
                 session: {sessionId} · qualifier: {qualifier}

--- a/src/handlers/harness/list/screen.tsx
+++ b/src/handlers/harness/list/screen.tsx
@@ -11,6 +11,7 @@ export function HarnessListScreen(props: ScreenProps) {
     <HarnessPicker
       {...props}
       breadcrumb={["agentcore", "harness", "list"]}
+      description="list harnesses"
       onSelect={(harnessId) => navigate(`/agentcore/harness/get/${harnessId}`)}
     />
   );

--- a/src/handlers/harness/update/screen.tsx
+++ b/src/handlers/harness/update/screen.tsx
@@ -51,7 +51,7 @@ function UpdateWizard({ ctx, core, harnessId }: ScreenProps & { harnessId: strin
         ]}
       >
         {detail.isPending ? (
-          <Spinner label="Loading harness…" />
+          <Spinner label="loading harness…" />
         ) : (
           <Text color="red">Error: {(detail.error as Error).message}</Text>
         )}

--- a/src/handlers/harness/update/screen.tsx
+++ b/src/handlers/harness/update/screen.tsx
@@ -51,7 +51,7 @@ function UpdateWizard({ ctx, core, harnessId }: ScreenProps & { harnessId: strin
         ]}
       >
         {detail.isPending ? (
-          <Spinner label="loading harness…" />
+          <Spinner label="Loading harness…" />
         ) : (
           <Text color="red">Error: {(detail.error as Error).message}</Text>
         )}

--- a/src/handlers/harness/version/get/screen.tsx
+++ b/src/handlers/harness/version/get/screen.tsx
@@ -22,7 +22,7 @@ export function HarnessGetVersionScreen({ ctx, core }: ScreenProps) {
       isPending={detail.isPending}
       error={detail.isError ? (detail.error as Error) : null}
       data={detail.data?.harness}
-      loadingLabel="Loading version…"
+      loadingLabel="loading version…"
     />
   );
 }

--- a/src/handlers/identity/api-key-credential-provider/get/screen.tsx
+++ b/src/handlers/identity/api-key-credential-provider/get/screen.tsx
@@ -46,7 +46,7 @@ export function ApiKeyCredentialProviderGetScreen(props: ScreenProps) {
             ]
           : []
       }
-      loadingLabel="Loading API key credential provider…"
+      loadingLabel="loading API key credential provider…"
       onRetry={() => void detail.refetch()}
       selectLabel="open"
     />
@@ -70,7 +70,7 @@ export function ApiKeyCredentialProviderGetJsonScreen(props: ScreenProps) {
       isPending={detail.isPending}
       error={detail.isError ? (detail.error as Error) : null}
       data={detail.data}
-      loadingLabel="Loading API key credential provider…"
+      loadingLabel="loading API key credential provider…"
       onRetry={() => void detail.refetch()}
     />
   );

--- a/src/handlers/identity/api-key-credential-provider/get/screen.tsx
+++ b/src/handlers/identity/api-key-credential-provider/get/screen.tsx
@@ -48,7 +48,7 @@ export function ApiKeyCredentialProviderGetScreen(props: ScreenProps) {
       }
       loadingLabel="Loading API key credential provider…"
       onRetry={() => void detail.refetch()}
-      selectLabel="open detail"
+      selectLabel="open"
     />
   );
 }

--- a/src/handlers/identity/api-key-credential-provider/list/screen.tsx
+++ b/src/handlers/identity/api-key-credential-provider/list/screen.tsx
@@ -36,6 +36,7 @@ export function ApiKeyCredentialProviderListScreen({ ctx, core }: ScreenProps) {
   return (
     <PaginatedTablePicker
       breadcrumb={["agentcore", "identity", "api-key-credential-provider", "list"]}
+      description="list API key credential providers"
       queryKey={["api-key-credential-providers", opts.region]}
       loadPage={async (token, pageSize) => {
         const response = await core.identity.listApiKeyCredentialProviders(token, pageSize, opts);

--- a/src/handlers/identity/api-key-credential-provider/list/screen.tsx
+++ b/src/handlers/identity/api-key-credential-provider/list/screen.tsx
@@ -53,7 +53,7 @@ export function ApiKeyCredentialProviderListScreen({ ctx, core }: ScreenProps) {
       }
       onBack={() => navigate("/agentcore/identity/api-key-credential-provider")}
       maxPageSize={MAX_PAGE_SIZE}
-      loadingMessage="Loading API key credential providers…"
+      loadingMessage="loading API key credential providers…"
       errorMessage={(error) => `Error: ${error.message}`}
       emptyMessage="No API key credential providers found in this Region."
       emptyPageMessage="No API key credential providers on this page."

--- a/src/handlers/identity/oauth2-credential-provider/get/screen.tsx
+++ b/src/handlers/identity/oauth2-credential-provider/get/screen.tsx
@@ -50,7 +50,7 @@ export function Oauth2CredentialProviderGetScreen(props: ScreenProps) {
             ]
           : []
       }
-      loadingLabel="Loading OAuth2 credential provider…"
+      loadingLabel="loading OAuth2 credential provider…"
       onRetry={() => void detail.refetch()}
       selectLabel="open"
     />
@@ -74,7 +74,7 @@ export function Oauth2CredentialProviderGetJsonScreen(props: ScreenProps) {
       isPending={detail.isPending}
       error={detail.isError ? (detail.error as Error) : null}
       data={detail.data}
-      loadingLabel="Loading OAuth2 credential provider…"
+      loadingLabel="loading OAuth2 credential provider…"
       onRetry={() => void detail.refetch()}
     />
   );

--- a/src/handlers/identity/oauth2-credential-provider/get/screen.tsx
+++ b/src/handlers/identity/oauth2-credential-provider/get/screen.tsx
@@ -52,7 +52,7 @@ export function Oauth2CredentialProviderGetScreen(props: ScreenProps) {
       }
       loadingLabel="Loading OAuth2 credential provider…"
       onRetry={() => void detail.refetch()}
-      selectLabel="open detail"
+      selectLabel="open"
     />
   );
 }

--- a/src/handlers/identity/oauth2-credential-provider/list/screen.tsx
+++ b/src/handlers/identity/oauth2-credential-provider/list/screen.tsx
@@ -39,6 +39,7 @@ export function Oauth2CredentialProviderListScreen({ ctx, core }: ScreenProps) {
   return (
     <PaginatedTablePicker
       breadcrumb={["agentcore", "identity", "oauth2-credential-provider", "list"]}
+      description="list OAuth2 credential providers"
       queryKey={["oauth2-credential-providers", opts.region]}
       loadPage={async (token, pageSize) => {
         const response = await core.identity.listOauth2CredentialProviders(token, pageSize, opts);

--- a/src/handlers/identity/oauth2-credential-provider/list/screen.tsx
+++ b/src/handlers/identity/oauth2-credential-provider/list/screen.tsx
@@ -56,7 +56,7 @@ export function Oauth2CredentialProviderListScreen({ ctx, core }: ScreenProps) {
       }
       onBack={() => navigate("/agentcore/identity/oauth2-credential-provider")}
       maxPageSize={MAX_PAGE_SIZE}
-      loadingMessage="Loading OAuth2 credential providers…"
+      loadingMessage="loading OAuth2 credential providers…"
       errorMessage={(error) => `Error: ${error.message}`}
       emptyMessage="No OAuth2 credential providers found in this Region."
       emptyPageMessage="No OAuth2 credential providers on this page."

--- a/src/handlers/memory/event/event.screen.test.tsx
+++ b/src/handlers/memory/event/event.screen.test.tsx
@@ -155,7 +155,7 @@ describe("Memory event list flow", () => {
 
     await waitForText(screen.lastFrame, "event blue");
     const frame = screen.lastFrame()!;
-    expect(frame).toContain("event id");
+    expect(frame).toContain("event ID");
     expect(frame).toContain("branch");
     expect(frame).toContain("occurred UTC");
     expect(frame).toContain("main");

--- a/src/handlers/memory/event/get/screen.tsx
+++ b/src/handlers/memory/event/get/screen.tsx
@@ -41,7 +41,7 @@ export function MemoryEventGetScreen({ ctx, core }: ScreenProps) {
       isPending={detail.isPending}
       error={detail.isError ? (detail.error as Error) : null}
       data={detail.data?.event}
-      loadingLabel={`Loading Memory event ${eventId ?? ""}...`}
+      loadingLabel={`Loading Memory event ${eventId ?? ""}…`}
       onRetry={() => void detail.refetch()}
     />
   );

--- a/src/handlers/memory/event/get/screen.tsx
+++ b/src/handlers/memory/event/get/screen.tsx
@@ -41,7 +41,7 @@ export function MemoryEventGetScreen({ ctx, core }: ScreenProps) {
       isPending={detail.isPending}
       error={detail.isError ? (detail.error as Error) : null}
       data={detail.data?.event}
-      loadingLabel={`Loading Memory event ${eventId ?? ""}…`}
+      loadingLabel={`loading Memory event ${eventId ?? ""}…`}
       onRetry={() => void detail.refetch()}
     />
   );

--- a/src/handlers/memory/event/list/screen.tsx
+++ b/src/handlers/memory/event/list/screen.tsx
@@ -73,7 +73,7 @@ function EventPicker({ ctx, core, memoryId, actorId, sessionId }: EventPickerPro
         )
       }
       onBack={() => navigate(-1)}
-      loadingMessage={`Loading events for session ${sessionId}...`}
+      loadingMessage={`loading events for session ${sessionId}...`}
       errorMessage={(error) => `Error loading events for session ${sessionId}: ${error.message}`}
       emptyMessage={`No events found for session ${sessionId}.`}
       emptyPageMessage={`No events on this page for session ${sessionId}.`}

--- a/src/handlers/memory/event/list/screen.tsx
+++ b/src/handlers/memory/event/list/screen.tsx
@@ -15,7 +15,7 @@ interface EventRow extends Record<string, unknown> {
 }
 
 const eventColumns = [
-  { key: "eventId", header: "event id", flex: true },
+  { key: "eventId", header: "event ID", flex: true },
   { key: "branch", header: "branch", width: 18, minWidth: 8 },
   {
     key: "occurredAt",

--- a/src/handlers/memory/get/screen.tsx
+++ b/src/handlers/memory/get/screen.tsx
@@ -72,7 +72,7 @@ export function MemoryGetScreen(props: ScreenProps) {
             }))
           : []
       }
-      loadingLabel="Loading Memory…"
+      loadingLabel="loading Memory…"
       onRetry={() => void detail.refetch()}
       selectLabel="open"
     />
@@ -89,7 +89,7 @@ export function MemoryGetJsonScreen(props: ScreenProps) {
       isPending={detail.isPending}
       error={detail.isError ? (detail.error as Error) : null}
       data={detail.data?.memory}
-      loadingLabel="Loading Memory…"
+      loadingLabel="loading Memory…"
       onRetry={() => void detail.refetch()}
     />
   );

--- a/src/handlers/memory/get/screen.tsx
+++ b/src/handlers/memory/get/screen.tsx
@@ -74,7 +74,7 @@ export function MemoryGetScreen(props: ScreenProps) {
       }
       loadingLabel="Loading Memory…"
       onRetry={() => void detail.refetch()}
-      selectLabel="open detail"
+      selectLabel="open"
     />
   );
 }

--- a/src/handlers/memory/list/screen.tsx
+++ b/src/handlers/memory/list/screen.tsx
@@ -9,6 +9,7 @@ export function MemoryListScreen(props: ScreenProps) {
     <MemoryPicker
       {...props}
       breadcrumb={["agentcore", "memory", "list"]}
+      description="list AgentCore Memories"
       onSelect={(memoryId) => navigate(`/agentcore/memory/get/${encodeURIComponent(memoryId)}`)}
     />
   );

--- a/src/handlers/memory/listPickers.tsx
+++ b/src/handlers/memory/listPickers.tsx
@@ -56,7 +56,7 @@ export function MemoryActorPicker({
       getValue={(row) => row.actorId}
       onSelect={onSelect}
       onBack={onBack}
-      loadingMessage={`Loading actors for Memory ${memoryId}...`}
+      loadingMessage={`loading actors for Memory ${memoryId}...`}
       errorMessage={(error) => `Error loading actors for Memory ${memoryId}: ${error.message}`}
       emptyMessage={`No actors found for Memory ${memoryId}.`}
       emptyPageMessage={`No actors on this page for Memory ${memoryId}.`}
@@ -128,7 +128,7 @@ export function MemorySessionPicker({
       getValue={(row) => row.sessionId}
       onSelect={onSelect}
       onBack={onBack}
-      loadingMessage={`Loading sessions for actor ${actorId}...`}
+      loadingMessage={`loading sessions for actor ${actorId}...`}
       errorMessage={(error) => `Error loading sessions for actor ${actorId}: ${error.message}`}
       emptyMessage={`No sessions found for actor ${actorId}.`}
       emptyPageMessage={`No sessions on this page for actor ${actorId}.`}

--- a/src/handlers/memory/listPickers.tsx
+++ b/src/handlers/memory/listPickers.tsx
@@ -10,7 +10,7 @@ interface MemoryActorRow extends Record<string, unknown> {
 }
 
 const actorColumns = [
-  { key: "actorId", header: "actor id", flex: true },
+  { key: "actorId", header: "actor ID", flex: true },
 ] satisfies DataTableColumn<MemoryActorRow>[];
 
 function toActorRow(actor: ActorSummary): MemoryActorRow {
@@ -70,7 +70,7 @@ interface MemorySessionRow extends Record<string, unknown> {
 }
 
 const sessionColumns = [
-  { key: "sessionId", header: "session id", flex: true },
+  { key: "sessionId", header: "session ID", flex: true },
   {
     key: "createdAt",
     header: "created UTC",

--- a/src/handlers/memory/memory.screen.test.tsx
+++ b/src/handlers/memory/memory.screen.test.tsx
@@ -91,7 +91,7 @@ describe("Memory picker", () => {
 
     await waitForText(screen.lastFrame, "memory-visible-id");
     const frame = screen.lastFrame()!;
-    expect(frame).toContain("id");
+    expect(frame).toContain("ID");
     expect(frame).toContain("status");
     expect(frame).toContain("updated UTC");
     expect(frame).toContain("FAILED");

--- a/src/handlers/memory/record/get/screen.tsx
+++ b/src/handlers/memory/record/get/screen.tsx
@@ -26,7 +26,7 @@ export function MemoryRecordGetScreen({ ctx, core }: ScreenProps) {
       isPending={detail.isPending}
       error={detail.isError ? (detail.error as Error) : null}
       data={detail.data?.memoryRecord}
-      loadingLabel={`Loading Memory record ${recordId ?? ""}...`}
+      loadingLabel={`Loading Memory record ${recordId ?? ""}…`}
       onRetry={() => void detail.refetch()}
     />
   );

--- a/src/handlers/memory/record/get/screen.tsx
+++ b/src/handlers/memory/record/get/screen.tsx
@@ -26,7 +26,7 @@ export function MemoryRecordGetScreen({ ctx, core }: ScreenProps) {
       isPending={detail.isPending}
       error={detail.isError ? (detail.error as Error) : null}
       data={detail.data?.memoryRecord}
-      loadingLabel={`Loading Memory record ${recordId ?? ""}…`}
+      loadingLabel={`loading Memory record ${recordId ?? ""}…`}
       onRetry={() => void detail.refetch()}
     />
   );

--- a/src/handlers/memory/record/list/screen.tsx
+++ b/src/handlers/memory/record/list/screen.tsx
@@ -34,7 +34,7 @@ interface MemoryRecordRow extends Record<string, unknown> {
 }
 
 const recordColumns = [
-  { key: "recordId", header: "id", flex: true },
+  { key: "recordId", header: "ID", flex: true },
   { key: "content", header: "content", width: 70, minWidth: 20 },
   { key: "strategyId", header: "strategy", width: 32, minWidth: 16 },
   {
@@ -116,7 +116,7 @@ function MemoryRecordScopeScreen({ memoryId }: MemoryRecordScopeScreenProps) {
       breadcrumb={["agentcore", "memory", "record", "list", memoryId]}
       description="choose the namespace scope for the record list"
       keyHints={[
-        { key: "up/down", label: "scope type" },
+        { key: "↑↓", label: "scope type" },
         { key: "enter", label: "list records" },
         { key: "esc", label: "back" },
         { key: "ctl+c", label: "quit" },
@@ -125,7 +125,7 @@ function MemoryRecordScopeScreen({ memoryId }: MemoryRecordScopeScreenProps) {
       <Box flexDirection="column" gap={1} paddingX={1}>
         <FormRadioGroup
           name="scope type"
-          helpText="Choose how the service should match record namespaces."
+          helpText="choose how the service should match record namespaces"
           options={scopeOptions}
           focusedIndex={focusedIndex}
           selectedIndex={editing ? focusedIndex : undefined}
@@ -133,7 +133,7 @@ function MemoryRecordScopeScreen({ memoryId }: MemoryRecordScopeScreenProps) {
         {editing && (
           <FormTextInput
             name={focusedIndex === 0 ? "namespace" : "namespace path"}
-            helpText="Enter the namespace value used to scope this request."
+            helpText="the namespace value used to scope this request"
             placeholder="/strategies/strategy-id/actors/actor-id"
             errorText="A namespace value is required."
             value={scope}

--- a/src/handlers/memory/record/list/screen.tsx
+++ b/src/handlers/memory/record/list/screen.tsx
@@ -191,7 +191,7 @@ function MemoryRecordPicker({ ctx, core, memoryId, scopeKind, scope }: MemoryRec
         )
       }
       onBack={() => navigate(-1)}
-      loadingMessage={`Loading Memory records for ${memoryId}...`}
+      loadingMessage={`loading Memory records for ${memoryId}...`}
       errorMessage={(error) => `Error loading Memory records for ${memoryId}: ${error.message}`}
       emptyMessage={`No Memory records found for ${scopeKind} ${scope}.`}
       emptyPageMessage={`No Memory records on this page for ${scopeKind} ${scope}.`}

--- a/src/handlers/memory/record/record.screen.test.tsx
+++ b/src/handlers/memory/record/record.screen.test.tsx
@@ -73,7 +73,7 @@ describe("Memory record list flow", () => {
 
   test("reveals the scope input only after enter and hides it again on escape", async () => {
     const screen = renderScreen("/agentcore/memory/record/list/memory-1");
-    const fieldHelp = "Enter the namespace value used to scope this request.";
+    const fieldHelp = "the namespace value used to scope this request";
 
     await waitForText(screen.lastFrame, "scope type");
     expect(screen.lastFrame()).not.toContain(fieldHelp);

--- a/src/handlers/memory/session/session.screen.test.tsx
+++ b/src/handlers/memory/session/session.screen.test.tsx
@@ -41,7 +41,7 @@ describe("Memory session list flow", () => {
 
     await waitForText(screen.lastFrame, sessionId);
     const frame = screen.lastFrame()!;
-    expect(frame).toContain("session id");
+    expect(frame).toContain("session ID");
     expect(frame).toContain("created UTC");
     expect(frame).toContain("2026-08-02 10:20");
 

--- a/src/handlers/project/ProjectGate.tsx
+++ b/src/handlers/project/ProjectGate.tsx
@@ -106,7 +106,7 @@ export function ProjectGate({
       breadcrumb={breadcrumb}
       description={description}
       query={project}
-      loadingLabel="loading project…"
+      loadingLabel="Loading project…"
       onBack={onBack}
     />
   );

--- a/src/handlers/project/ProjectGate.tsx
+++ b/src/handlers/project/ProjectGate.tsx
@@ -106,7 +106,7 @@ export function ProjectGate({
       breadcrumb={breadcrumb}
       description={description}
       query={project}
-      loadingLabel="Loading project…"
+      loadingLabel="loading project…"
       onBack={onBack}
     />
   );

--- a/src/handlers/project/create/create.screen.test.tsx
+++ b/src/handlers/project/create/create.screen.test.tsx
@@ -485,13 +485,13 @@ describe("project create wizard", () => {
     await waitForText(r.lastFrame, "this project will be created");
     await r.press("return");
 
-    await waitForText(r.lastFrame, "Creating DemoApp…");
+    await waitForText(r.lastFrame, "creating DemoApp…");
     releaseFirstStep();
 
     // The running step is the spinner row itself, as on the command line; the
-    // generic "Creating…" spinner shows only until the first step arrives.
+    // generic "creating…" spinner shows only until the first step arrives.
     await waitForText(r.lastFrame, "syncing dependencies");
-    expect(r.lastFrame()).not.toContain("Creating DemoApp…");
+    expect(r.lastFrame()).not.toContain("creating DemoApp…");
     expect(r.lastFrame()).not.toContain("✓ syncing dependencies");
 
     r.unmount();

--- a/src/handlers/project/create/create.screen.test.tsx
+++ b/src/handlers/project/create/create.screen.test.tsx
@@ -189,7 +189,7 @@ describe("project create wizard", () => {
     expect(review).toContain("openai");
     expect(review).toContain("model");
     expect(review).toContain("gpt-5");
-    expect(review).toContain("api key arn");
+    expect(review).toContain("API key ARN");
     expect(review.replace(/\s/g, "")).toContain(apiKeyArn);
     await r.press("return");
     await waitForText(r.lastFrame, "✔ project created in ./OpenAIApp", 5000);
@@ -260,7 +260,7 @@ describe("project create wizard", () => {
     expect(frame).toContain("○ openai");
     expect(frame).toContain("○ gemini");
     expect(frame).toContain("○ litellm");
-    expect(frame).toContain("model id");
+    expect(frame).toContain("model ID");
     expect(frame).toContain(DEFAULT_MODEL_ID);
     expect(frame).toContain("[enter] continue");
     expect(frame).toContain("[esc] back");
@@ -485,13 +485,13 @@ describe("project create wizard", () => {
     await waitForText(r.lastFrame, "this project will be created");
     await r.press("return");
 
-    await waitForText(r.lastFrame, "creating DemoApp…");
+    await waitForText(r.lastFrame, "Creating DemoApp…");
     releaseFirstStep();
 
     // The running step is the spinner row itself, as on the command line; the
-    // generic "creating…" spinner shows only until the first step arrives.
+    // generic "Creating…" spinner shows only until the first step arrives.
     await waitForText(r.lastFrame, "syncing dependencies");
-    expect(r.lastFrame()).not.toContain("creating DemoApp…");
+    expect(r.lastFrame()).not.toContain("Creating DemoApp…");
     expect(r.lastFrame()).not.toContain("✓ syncing dependencies");
 
     r.unmount();

--- a/src/handlers/project/create/screen.tsx
+++ b/src/handlers/project/create/screen.tsx
@@ -318,7 +318,7 @@ export function ProjectCreateScreen({ core }: ScreenProps) {
           <Box flexDirection="column" paddingX={1}>
             <TaskList tasks={tasks} />
             {phase.kind === "running" && tasks.length === 0 && (
-              <Spinner label={`Creating ${values.name}…`} />
+              <Spinner label={`creating ${values.name}…`} />
             )}
             {phase.kind === "success" && (
               <SuccessPanel name={values.name} onContinue={() => exit()} />

--- a/src/handlers/project/create/screen.tsx
+++ b/src/handlers/project/create/screen.tsx
@@ -207,8 +207,8 @@ function summaryOf(values: CreateProjectFormValues): Record<string, string> {
       type: "harness",
       provider: providerLabel(provider),
       model: config.modelId,
-      ...(config.apiKeyArn && { "api key arn": config.apiKeyArn }),
-      ...(config.apiBase && { "api base url": config.apiBase }),
+      ...(config.apiKeyArn && { "API key ARN": config.apiKeyArn }),
+      ...(config.apiBase && { "API base URL": config.apiBase }),
       directory: `./${values.name}`,
     };
   }
@@ -288,7 +288,11 @@ export function ProjectCreateScreen({ core }: ScreenProps) {
   };
 
   return (
-    <Layout breadcrumb={["agentcore", "project", "create"]} keyHints={hintsFor(stepKey, phase)}>
+    <Layout
+      breadcrumb={["agentcore", "project", "create"]}
+      description="create a new AgentCore project"
+      keyHints={hintsFor(stepKey, phase)}
+    >
       <Box flexDirection="column">
         {phase.kind === "form" && (
           <>
@@ -314,7 +318,7 @@ export function ProjectCreateScreen({ core }: ScreenProps) {
           <Box flexDirection="column" paddingX={1}>
             <TaskList tasks={tasks} />
             {phase.kind === "running" && tasks.length === 0 && (
-              <Spinner label={`creating ${values.name}…`} />
+              <Spinner label={`Creating ${values.name}…`} />
             )}
             {phase.kind === "success" && (
               <SuccessPanel name={values.name} onContinue={() => exit()} />
@@ -346,7 +350,8 @@ function hintsFor(stepKey: string, phase: WizardPhase): { key: string; label: st
       return [{ key: "↑↓", label: "navigate" }, { key: "enter", label: "continue" }, ...base];
     case "type":
     case "template":
-      return [{ key: "↑↓", label: "choose" }, { key: "enter", label: "continue" }, ...base];
+    case "memory":
+      return [{ key: "↑↓", label: "navigate" }, { key: "enter", label: "continue" }, ...base];
     case "review":
       return [{ key: "enter", label: "create" }, ...base];
     default:
@@ -526,21 +531,21 @@ function modelFields(provider: HarnessModelProvider): ModelField[] {
   const fields: ModelField[] = [
     {
       key: "modelId",
-      name: "model id",
+      name: "model ID",
       helpText:
         provider === "bedrock"
-          ? "a Bedrock model or inference profile id"
+          ? "a Bedrock model or inference profile ID"
           : `the ${providerLabel(provider)} model to use`,
       placeholder: HARNESS_DEFAULT_MODEL_IDS[provider],
       required: true,
-      requiredError: `enter a model id for ${providerLabel(provider)}`,
+      requiredError: `enter a model ID for ${providerLabel(provider)}`,
     },
   ];
 
   if (provider !== "bedrock") {
     fields.push({
       key: "apiKeyArn",
-      name: "api key arn",
+      name: "API key ARN",
       helpText:
         provider === "lite_llm"
           ? "optional · an AgentCore Identity API-key credential provider ARN"
@@ -557,7 +562,7 @@ function modelFields(provider: HarnessModelProvider): ModelField[] {
   if (provider === "lite_llm") {
     fields.push({
       key: "apiBase",
-      name: "api base url",
+      name: "API base URL",
       helpText: "optional · the provider API endpoint",
       placeholder: "https://…",
       required: false,

--- a/src/handlers/project/deploy/screen.tsx
+++ b/src/handlers/project/deploy/screen.tsx
@@ -68,7 +68,7 @@ function DeployTarget({
         breadcrumb={BREADCRUMB}
         description={DESCRIPTION}
         query={targets}
-        loadingLabel="reading deployment targets…"
+        loadingLabel="Reading deployment targets…"
         onBack={() => navigate(PROJECT_MENU)}
       />
     );

--- a/src/handlers/project/deploy/screen.tsx
+++ b/src/handlers/project/deploy/screen.tsx
@@ -68,7 +68,7 @@ function DeployTarget({
         breadcrumb={BREADCRUMB}
         description={DESCRIPTION}
         query={targets}
-        loadingLabel="Reading deployment targets…"
+        loadingLabel="reading deployment targets…"
         onBack={() => navigate(PROJECT_MENU)}
       />
     );

--- a/src/handlers/project/invoke/index.tsx
+++ b/src/handlers/project/invoke/index.tsx
@@ -20,7 +20,7 @@ export function createProjectInvokeHandler(
     .default((ctx) => {
       if (ctx.require(JsonKey)) {
         throw new InputValidationError(
-          "a Runtime or Harness invoke subcommand is required with --json",
+          "a Runtime or harness invoke subcommand is required with --json",
         );
       }
       return renderInvokeTui("/agentcore/project/invoke", ctx, core, io);

--- a/src/handlers/project/invoke/screen.tsx
+++ b/src/handlers/project/invoke/screen.tsx
@@ -180,7 +180,7 @@ function ProjectInvokePicker({
           { key: "ctl+c", label: "quit" },
         ]}
       >
-        <Spinner label="Resolving deployed resources…" />
+        <Spinner label="resolving deployed resources…" />
       </Layout>
     );
   }

--- a/src/handlers/project/invoke/screen.tsx
+++ b/src/handlers/project/invoke/screen.tsx
@@ -45,7 +45,7 @@ export function ProjectInvokePickerScreen({ ctx, core }: ScreenProps) {
     <ProjectGate
       core={core}
       breadcrumb={BREADCRUMB}
-      description="invoke a Runtime or Harness from the current project"
+      description="invoke a Runtime or harness from the current project"
       seed={ctx.value(ProjectKey)}
       onBack={() => navigate(PROJECT_MENU)}
     >
@@ -193,7 +193,7 @@ function ProjectInvokePicker({
         { key: "↑↓/jk", label: "navigate" },
         { key: "/", label: "filter" },
         { key: "enter", label: "select" },
-        { key: "esc", label: "cancel" },
+        { key: "esc", label: "back" },
         { key: "ctl+c", label: "quit" },
       ]}
     >
@@ -207,7 +207,7 @@ function ProjectInvokePicker({
           focus
           columns={columns}
           data={rows}
-          emptyMessage="No deployed Runtimes or Harnesses were found on target default."
+          emptyMessage="No deployed Runtimes or harnesses were found on target default."
           onSelect={select}
           onEscape={goBack}
         />

--- a/src/handlers/runtime/endpoint/get/screen.tsx
+++ b/src/handlers/runtime/endpoint/get/screen.tsx
@@ -64,7 +64,7 @@ export function RuntimeGetEndpointScreen(props: ScreenProps) {
             ]
           : []
       }
-      loadingLabel={`Loading endpoint ${qualifier ?? ""} for Runtime ${runtimeId ?? ""}…`}
+      loadingLabel={`loading endpoint ${qualifier ?? ""} for Runtime ${runtimeId ?? ""}…`}
       onRetry={() => void detail.refetch()}
     />
   );
@@ -88,7 +88,7 @@ export function RuntimeGetEndpointJsonScreen(props: ScreenProps) {
       isPending={detail.isPending}
       error={detail.isError ? (detail.error as Error) : null}
       data={detail.data}
-      loadingLabel={`Loading endpoint ${qualifier ?? ""} for Runtime ${runtimeId ?? ""}…`}
+      loadingLabel={`loading endpoint ${qualifier ?? ""} for Runtime ${runtimeId ?? ""}…`}
       onRetry={() => void detail.refetch()}
     />
   );

--- a/src/handlers/runtime/get/screen.tsx
+++ b/src/handlers/runtime/get/screen.tsx
@@ -72,7 +72,7 @@ export function RuntimeGetScreen(props: ScreenProps) {
             }))
           : []
       }
-      loadingLabel="Loading Runtime…"
+      loadingLabel="loading Runtime…"
       onRetry={() => void detail.refetch()}
     />
   );
@@ -88,7 +88,7 @@ export function RuntimeGetJsonScreen(props: ScreenProps) {
       isPending={detail.isPending}
       error={detail.isError ? (detail.error as Error) : null}
       data={detail.data}
-      loadingLabel="Loading Runtime…"
+      loadingLabel="loading Runtime…"
       onRetry={() => void detail.refetch()}
     />
   );

--- a/src/handlers/runtime/invoke/invoke.screen.test.tsx
+++ b/src/handlers/runtime/invoke/invoke.screen.test.tsx
@@ -413,7 +413,7 @@ describe("Runtime invoke JSON console", () => {
 
     const streamingFrames = screen.frames
       .slice(frameCount)
-      .filter((frame) => frame.includes("streaming…"));
+      .filter((frame) => frame.includes("Streaming…"));
     expect(streamingFrames.length).toBeGreaterThan(0);
     for (const frame of streamingFrames) {
       expect(frame).not.toContain("Session ID: returned-runtime");

--- a/src/handlers/runtime/invoke/invoke.screen.test.tsx
+++ b/src/handlers/runtime/invoke/invoke.screen.test.tsx
@@ -413,7 +413,7 @@ describe("Runtime invoke JSON console", () => {
 
     const streamingFrames = screen.frames
       .slice(frameCount)
-      .filter((frame) => frame.includes("Streaming…"));
+      .filter((frame) => frame.includes("streaming…"));
     expect(streamingFrames.length).toBeGreaterThan(0);
     for (const frame of streamingFrames) {
       expect(frame).not.toContain("Session ID: returned-runtime");

--- a/src/handlers/runtime/invoke/screen.tsx
+++ b/src/handlers/runtime/invoke/screen.tsx
@@ -405,7 +405,7 @@ export function RuntimeInvokeConsole({
     >
       <Box height="100%" flexDirection="column">
         {detail.isPending ? (
-          <Spinner label="Loading Runtime…" />
+          <Spinner label="loading Runtime…" />
         ) : detail.isError ? (
           <ErrorBlock details={errorDetails(detail.error)} />
         ) : (
@@ -453,9 +453,7 @@ export function RuntimeInvokeConsole({
               {inputError ? (
                 <Text color="red">{inputError}</Text>
               ) : busy ? (
-                <Spinner
-                  label={`${liveState === "connecting" ? "Connecting" : "Streaming"}… (esc to interrupt)`}
-                />
+                <Spinner label={`${liveState}… (esc to interrupt)`} />
               ) : (
                 <Text color={theme.colors.muted}>
                   {cliTruncate(

--- a/src/handlers/runtime/invoke/screen.tsx
+++ b/src/handlers/runtime/invoke/screen.tsx
@@ -453,7 +453,9 @@ export function RuntimeInvokeConsole({
               {inputError ? (
                 <Text color="red">{inputError}</Text>
               ) : busy ? (
-                <Spinner label={`${liveState}… (esc to interrupt)`} />
+                <Spinner
+                  label={`${liveState === "connecting" ? "Connecting" : "Streaming"}… (esc to interrupt)`}
+                />
               ) : (
                 <Text color={theme.colors.muted}>
                   {cliTruncate(

--- a/src/handlers/runtime/list/screen.tsx
+++ b/src/handlers/runtime/list/screen.tsx
@@ -9,6 +9,7 @@ export function RuntimeListScreen(props: ScreenProps) {
     <RuntimePicker
       {...props}
       breadcrumb={["agentcore", "runtime", "list"]}
+      description="list AgentCore Runtimes"
       onSelect={(runtimeId) => navigate(`/agentcore/runtime/get/${encodeURIComponent(runtimeId)}`)}
     />
   );

--- a/src/handlers/runtime/runtime.screen.test.tsx
+++ b/src/handlers/runtime/runtime.screen.test.tsx
@@ -85,8 +85,8 @@ describe("runtime picker", () => {
     await waitForText(r.lastFrame, "orders");
     const frame = r.lastFrame()!;
     expect(frame).toContain("name");
-    expect(frame).toContain("id");
-    expect(frame).toContain("id suffix");
+    expect(frame).toContain("ID");
+    expect(frame).toContain("ID suffix");
     expect(frame).toContain("version");
     expect(frame).toContain("status");
     expect(frame).toContain("updated UTC");

--- a/src/handlers/runtime/runtime.screen.test.tsx
+++ b/src/handlers/runtime/runtime.screen.test.tsx
@@ -459,7 +459,7 @@ describe("runtime hub", () => {
 
     await waitForText(hub.lastFrame, "checkout");
     await hub.press("return");
-    await waitForText(hub.lastFrame, "Loading Runtime…");
+    await waitForText(hub.lastFrame, "loading Runtime…");
     await hub.press("escape");
     await waitForText(hub.lastFrame, "agentcore → runtime → list");
   });

--- a/src/handlers/runtime/version/get/screen.tsx
+++ b/src/handlers/runtime/version/get/screen.tsx
@@ -19,7 +19,7 @@ export function RuntimeGetVersionScreen({ ctx, core }: ScreenProps) {
       isPending={detail.isPending}
       error={detail.isError ? (detail.error as Error) : null}
       data={detail.data}
-      loadingLabel={`Loading version ${version ?? ""} for Runtime ${runtimeId ?? ""}…`}
+      loadingLabel={`loading version ${version ?? ""} for Runtime ${runtimeId ?? ""}…`}
       onRetry={() => void detail.refetch()}
     />
   );


### PR DESCRIPTION
Follow-up to #2207: ran the same description audit across the TUI by rendering all 163 routes and checking every user-visible string against the same rules.

- added the 16 missing header descriptions (the list screens and `project create`), each verbatim the CLI description for that command
- resource nouns match the CLI — `harness` lowercase, AgentCore/Runtime/Gateway/Memory/Target/Rule capitalized; `ID`/`ARN`/`URL`/`MCP`/`API` initialisms in table headers and wizard fields
- transient status text starts lowercase and uses a real ellipsis
- key hints use one spelling per action (`navigate`, `open`, `back`, `↑↓/jk`)
- `HarnessWizard`'s provider copy now matches the newer `project create` wizard

Picker steps keep their own wording (`choose a Gateway to list Rules for`) rather than the terminal command's description, since the step is a picker.
