### PR TITLE
feat(tui): Linked Resources on project status and the harness hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ responses. `agentcore` wraps all of that behind one ergonomic tool.
 Commands with operation flags run headlessly. Bare Harness, Runtime, Memory,
 Identity, and Gateway branches and leaves open their interactive flows, as does
 a bare `project create` in a terminal (any flag, `--json`, or a non-TTY stays
-headless).
+headless). A bare `project status` opens a Linked Resources view that groups
+the project's resources by agent and forwards to each deployed resource's
+detail page. The harness hub (`harness get`) ends with the same kind of Linked
+Resources tree for the Runtime, Memory, Gateway, Browser, Code Interpreter and
+credential providers wired to that harness, each opening in its own region.
 
 ```
 agentcore                          # interactive TUI
@@ -134,7 +138,7 @@ agentcore                          # interactive TUI
 │   ├── invoke                     # invoke a deployed project resource
 │   │   ├── runtime                # use the existing Runtime invoke experience
 │   │   └── harness                # use the existing Harness invoke experience
-│   ├── status                     # inspect deployed project resources
+│   ├── status                     # inspect deployed project resources (TUI when run bare)
 │   └── build                      # synthesize the project's CloudFormation templates
 └── config                         # read/write global config values
 ```

--- a/src/components/LinkedResources.tsx
+++ b/src/components/LinkedResources.tsx
@@ -1,0 +1,109 @@
+import { useState } from "react";
+import { Box, Text } from "ink";
+import { TreeView, type TreeNode } from "./ui/tree-view";
+import { Divider } from "./ui/divider";
+import { darkTheme } from "./ui/_core.js";
+
+// A "Linked Resources" tree lists the AgentCore resources reachable from
+// somewhere — a project's deployed resources on the status screen, the
+// runtime, memory, gateway and credential providers wired to a harness on its
+// hub. Rows share one shape: a padded type column, the resource name and a
+// muted annotation; enter forwards to the resource's detail route when it has
+// one and explains itself otherwise.
+
+export interface LinkedResourceData {
+  // route is where enter forwards (query string included, e.g. ?region=);
+  // rows without one show `hint` under the tree instead.
+  route?: string;
+  hint?: string;
+}
+
+export type LinkedResourceNode = TreeNode<LinkedResourceData>;
+
+// A row's type label, with how many two-character guide steps the tree draws
+// before it (0 on the baseline; see linkedResourceLabel).
+export interface TypeColumnEntry {
+  type: string;
+  guideDepth?: number;
+}
+
+// typeColumnWidth is the width of the type column that keeps names aligned
+// across these rows: the widest label, counting the guide characters a nested
+// row is pushed right by, plus two spaces.
+export function typeColumnWidth(entries: (string | TypeColumnEntry)[]): number {
+  const widths = entries.map((entry) =>
+    typeof entry === "string" ? entry.length : entry.type.length + 2 * (entry.guideDepth ?? 0),
+  );
+  return Math.max(...widths, 0) + 2;
+}
+
+// linkedResourceLabel lays out one row's label. Rows nested `guideDepth`
+// two-character guide steps below the tree's baseline are pushed right by as
+// much, so the column shrinks to keep the names aligned; the type always
+// keeps at least one space after it.
+export function linkedResourceLabel(
+  type: string,
+  name: string,
+  typeWidth: number,
+  guideDepth = 0,
+): string {
+  return `${type.padEnd(Math.max(typeWidth - 2 * guideDepth, type.length + 1))}${name}`;
+}
+
+export interface LinkedResourcesTreeProps {
+  nodes: LinkedResourceNode[];
+  /** The divider title above the tree. */
+  title?: string;
+  /** Whether the tree owns the keyboard (and shows the ❯ marker). */
+  focus: boolean;
+  /** Up on the first row hands focus back; see TreeView's onUpFromFirst. */
+  onUpFromFirst?: () => void;
+  onOpen: (route: string) => void;
+}
+
+// LinkedResourcesTree renders a titled divider, the tree and, once enter lands
+// on a row without a detail view, that row's hint beneath it.
+export function LinkedResourcesTree({
+  nodes,
+  title = "linked resources",
+  focus,
+  onUpFromFirst,
+  onOpen,
+}: LinkedResourcesTreeProps) {
+  const [hint, setHint] = useState<string>();
+
+  const select = (node: LinkedResourceNode) => {
+    if (node.data?.route) {
+      onOpen(node.data.route);
+      return;
+    }
+    setHint(node.data?.hint);
+  };
+
+  return (
+    <>
+      <Divider title={title} />
+      <Box flexDirection="column" paddingLeft={1}>
+        <TreeView
+          nodes={nodes}
+          onSelect={select}
+          showIcons={false}
+          focusMarker
+          focus={focus}
+          onUpFromFirst={onUpFromFirst}
+        />
+        {hint !== undefined && (
+          <Box marginTop={1}>
+            <Text color={darkTheme.colors.muted}>{hint}</Text>
+          </Box>
+        )}
+      </Box>
+    </>
+  );
+}
+
+// hasNestedRows reports whether any row can collapse or expand, which decides
+// whether the ←→ key hint is worth showing.
+export function hasNestedRows(nodes: LinkedResourceNode[]): boolean {
+  return nodes.some((node) => (node.children?.length ?? 0) > 0);
+}

--- a/src/components/LinkedResources.tsx
+++ b/src/components/LinkedResources.tsx
@@ -30,11 +30,11 @@ export interface TypeColumnEntry {
 // typeColumnWidth is the width of the type column that keeps names aligned
 // across these rows: the widest label, counting the guide characters a nested
 // row is pushed right by, plus two spaces.
-export function typeColumnWidth(entries: (string | TypeColumnEntry)[]): number {
+export function typeColumnWidth(entries: (string | TypeColumnEntry)[], min: number = 0): number {
   const widths = entries.map((entry) =>
     typeof entry === "string" ? entry.length : entry.type.length + 2 * (entry.guideDepth ?? 0),
   );
-  return Math.max(...widths, 0) + 2;
+  return Math.max(min, Math.max(...widths, 0)) + 2;
 }
 
 // linkedResourceLabel lays out one row's label. Rows nested `guideDepth`
@@ -83,7 +83,7 @@ export function LinkedResourcesTree({
   return (
     <>
       <Divider title={title} />
-      <Box flexDirection="column" paddingLeft={1}>
+      <Box flexDirection="column">
         <TreeView
           nodes={nodes}
           onSelect={select}

--- a/src/components/ResourceDetailScreen.tsx
+++ b/src/components/ResourceDetailScreen.tsx
@@ -3,6 +3,7 @@ import { Box, Text, useInput } from "ink";
 import { useNavigate } from "react-router";
 import { KeyValueTable } from "./KeyValueTable.js";
 import { Layout } from "./Layout";
+import { hasNestedRows, LinkedResourcesTree, type LinkedResourceNode } from "./LinkedResources";
 import { darkTheme, glyphs } from "./ui/_core.js";
 import { Divider } from "./ui/divider/Divider.js";
 import { Spinner } from "./ui/spinner";
@@ -11,6 +12,12 @@ export interface ResourceDetailAction {
   name: string;
   description: string;
   onSelect: () => void;
+}
+
+export interface ResourceDetailLinkedResources {
+  nodes: LinkedResourceNode[];
+  /** Divider title above the tree; defaults to "linked resources". */
+  title?: string;
 }
 
 export interface ResourceDetailScreenProps {
@@ -22,7 +29,17 @@ export interface ResourceDetailScreenProps {
   loadingLabel: string;
   onRetry?: () => void;
   selectLabel?: string;
+  /**
+   * An optional Linked Resources tree under the actions (see
+   * LinkedResourcesTree). The action list and the tree behave as one
+   * continuous list: down from the last action moves into the tree, up from
+   * the tree's first row comes back, and only the focused zone shows the ❯
+   * marker.
+   */
+  linkedResources?: ResourceDetailLinkedResources;
 }
+
+type FocusZone = "actions" | "linked";
 
 export function ResourceDetailScreen({
   breadcrumb,
@@ -33,10 +50,17 @@ export function ResourceDetailScreen({
   loadingLabel,
   onRetry,
   selectLabel = "select",
+  linkedResources,
 }: ResourceDetailScreenProps) {
   const navigate = useNavigate();
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [zone, setZone] = useState<FocusZone>("actions");
   const ready = !isPending && !error;
+
+  const linkedNodes = linkedResources?.nodes ?? [];
+  const hasLinked = ready && linkedNodes.length > 0;
+  // With no actions to focus, the tree is the only list and owns the keys.
+  const linkedFocused = hasLinked && (zone === "linked" || actions.length === 0);
 
   useInput((input, key) => {
     if (key.escape) {
@@ -47,12 +71,18 @@ export function ResourceDetailScreen({
       onRetry();
       return;
     }
-    if (!ready || actions.length === 0) return;
+    // While the tree is focused it handles its own keys (and reports up from
+    // its first row through onUpFromFirst).
+    if (!ready || linkedFocused || actions.length === 0) return;
     if (key.upArrow || input === "k") {
       setSelectedIndex((current) => Math.max(0, current - 1));
       return;
     }
     if (key.downArrow || input === "j") {
+      if (hasLinked && selectedIndex === actions.length - 1) {
+        setZone("linked");
+        return;
+      }
       setSelectedIndex((current) => Math.min(actions.length - 1, current + 1));
       return;
     }
@@ -60,13 +90,18 @@ export function ResourceDetailScreen({
   });
 
   const nameWidth = actions.reduce((width, action) => Math.max(width, action.name.length), 0) + 3;
+  const navigable = ready && (actions.length > 1 || hasLinked);
+  const selectable = ready && (actions.length > 0 || hasLinked);
 
   return (
     <Layout
       breadcrumb={breadcrumb}
       keyHints={[
-        ...(ready && actions.length > 1 ? [{ key: "↑↓/jk", label: "navigate" }] : []),
-        ...(ready && actions.length > 0 ? [{ key: "enter", label: selectLabel }] : []),
+        ...(navigable ? [{ key: "↑↓/jk", label: "navigate" }] : []),
+        ...(linkedFocused && hasNestedRows(linkedNodes)
+          ? [{ key: "←→", label: "collapse/expand" }]
+          : []),
+        ...(selectable ? [{ key: "enter", label: linkedFocused ? "open" : selectLabel }] : []),
         ...(error && onRetry ? [{ key: "r", label: "retry" }] : []),
         { key: "esc", label: "back" },
         { key: "ctrl+c", label: "quit" },
@@ -88,7 +123,7 @@ export function ResourceDetailScreen({
 
               <Box flexDirection="column" paddingLeft={1}>
                 {actions.map((action, actionIndex) => {
-                  const selected = actionIndex === selectedIndex;
+                  const selected = actionIndex === selectedIndex && !linkedFocused;
                   return (
                     <Box key={action.name}>
                       <Text color={darkTheme.colors.focus}>
@@ -106,6 +141,16 @@ export function ResourceDetailScreen({
                 })}
               </Box>
             </>
+          )}
+
+          {hasLinked && (
+            <LinkedResourcesTree
+              nodes={linkedNodes}
+              title={linkedResources?.title}
+              focus={linkedFocused}
+              onUpFromFirst={actions.length > 0 ? () => setZone("actions") : undefined}
+              onOpen={(route) => navigate(route)}
+            />
           )}
         </Box>
       )}

--- a/src/components/Root.tsx
+++ b/src/components/Root.tsx
@@ -115,6 +115,7 @@ import { BuildProjectScreen } from "../handlers/project/build/screen.tsx";
 import { DeployProjectScreen } from "../handlers/project/deploy/screen.tsx";
 import { ProjectCreateScreen } from "../handlers/project/create/screen.tsx";
 import { ProjectInvokePickerScreen } from "../handlers/project/invoke/screen.tsx";
+import { ProjectStatusScreen } from "../handlers/project/status/screen.tsx";
 import { HelpScreen, RootScreen } from "../handlers/screen.tsx";
 import type { Context } from "../router";
 
@@ -784,6 +785,10 @@ export function Root({ path, ctx, core, queryClient }: RootProps) {
           <Route
             path="agentcore/project/create"
             element={<ProjectCreateScreen ctx={ctx} core={core} />}
+          />
+          <Route
+            path="agentcore/project/status"
+            element={<ProjectStatusScreen ctx={ctx} core={core} />}
           />
           {/* Every known command without a screen of its own: a group opens its
               menu and a leaf its interactive help. Unknown routes retain the

--- a/src/components/ui/tree-view/TreeView.tsx
+++ b/src/components/ui/tree-view/TreeView.tsx
@@ -6,6 +6,8 @@ import type { InkUITheme } from "../_core.js";
 export interface TreeNode<T = unknown> {
   id: string;
   label: string;
+  /** Muted text rendered after the label (e.g. a status or description). */
+  annotation?: string;
   children?: TreeNode<T>[];
   icon?: string;
   defaultExpanded?: boolean;
@@ -23,7 +25,18 @@ export interface TreeViewProps<T = unknown> {
   leafIcon?: string;
   branchIcon?: string;
   branchOpenIcon?: string;
+  /**
+   * Mark the focused row with a "❯ " prefix in the focus color instead of
+   * inverse video, matching the selection style of DataTable and the menus.
+   */
+  focusMarker?: boolean;
   focus?: boolean;
+  /**
+   * Called when up (or k) is pressed while the first enabled row is focused,
+   * so a parent that stacks the tree under another list can hand focus back
+   * to it. Without it the press is a no-op, as before.
+   */
+  onUpFromFirst?: () => void;
   theme?: InkUITheme;
 }
 
@@ -62,7 +75,9 @@ export function TreeView<T = unknown>({
   leafIcon = glyphs.file,
   branchIcon = glyphs.folder,
   branchOpenIcon = glyphs.folderOpen,
+  focusMarker = false,
   focus = true,
+  onUpFromFirst,
   theme = darkTheme,
 }: TreeViewProps<T>): React.ReactElement {
   const [expandedIds, setExpandedIds] = useState<Set<string>>(
@@ -84,6 +99,12 @@ export function TreeView<T = unknown>({
       const current = flatNodes.find((f) => f.node.id === focusedId);
 
       if (key.upArrow || input === "k") {
+        // Nothing above the first enabled row (or no valid focus yet): let the
+        // parent take focus back when it asked to.
+        if (currentIdx <= 0 && onUpFromFirst) {
+          onUpFromFirst();
+          return;
+        }
         const prev = enabledFlat[Math.max(0, currentIdx - 1)];
         if (prev) setFocusedId(prev.node.id);
       } else if (key.downArrow || input === "j") {
@@ -149,6 +170,7 @@ export function TreeView<T = unknown>({
 
         return (
           <Box key={node.id} flexDirection="row">
+            {focusMarker && <Text color={theme.colors.focus}>{isFocused ? "❯ " : "  "}</Text>}
             {guides && depth > 0 && <Text color={theme.colors.border}>{guidePrefix}</Text>}
             <Text
               color={
@@ -160,7 +182,7 @@ export function TreeView<T = unknown>({
               }
               bold={isFocused}
               dimColor={node.disabled}
-              inverse={isFocused}
+              inverse={isFocused && !focusMarker}
             >
               <Text color={hasBranch ? theme.colors.primary : theme.colors.muted}>
                 {branchChar}
@@ -168,6 +190,12 @@ export function TreeView<T = unknown>({
               {showIcons ? ` ${icon} ` : " "}
               {node.label}
             </Text>
+            {node.annotation !== undefined && (
+              <Text color={theme.colors.muted} dimColor={node.disabled}>
+                {" "}
+                {node.annotation}
+              </Text>
+            )}
           </Box>
         );
       })}

--- a/src/components/ui/tree-view/TreeView.tsx
+++ b/src/components/ui/tree-view/TreeView.tsx
@@ -187,7 +187,7 @@ export function TreeView<T = unknown>({
               <Text color={hasBranch ? theme.colors.primary : theme.colors.muted}>
                 {branchChar}
               </Text>
-              {showIcons ? ` ${icon} ` : " "}
+              {showIcons ? ` ${icon} ` : ""}
               {node.label}
             </Text>
             {node.annotation !== undefined && (

--- a/src/components/ui/tree-view/TreeView.tsx
+++ b/src/components/ui/tree-view/TreeView.tsx
@@ -26,7 +26,7 @@ export interface TreeViewProps<T = unknown> {
   branchIcon?: string;
   branchOpenIcon?: string;
   /**
-   * Mark the focused row with a "❯ " prefix in the focus color instead of
+   * Mark the focused row with a pointer prefix in the focus color instead of
    * inverse video, matching the selection style of DataTable and the menus.
    */
   focusMarker?: boolean;
@@ -170,7 +170,9 @@ export function TreeView<T = unknown>({
 
         return (
           <Box key={node.id} flexDirection="row">
-            {focusMarker && <Text color={theme.colors.focus}>{isFocused ? "❯ " : "  "}</Text>}
+            {focusMarker && (
+              <Text color={theme.colors.focus}>{isFocused ? `${glyphs.pointer} ` : "  "}</Text>
+            )}
             {guides && depth > 0 && <Text color={theme.colors.border}>{guidePrefix}</Text>}
             <Text
               color={

--- a/src/core/arn.test.ts
+++ b/src/core/arn.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from "bun:test";
+import {
+  credentialProviderTypeFromArn,
+  parseArn,
+  regionFromArn,
+  resourceNameFromArn,
+  serviceIdFromArn,
+} from "./arn";
+
+const PREFIX = "arn:aws:bedrock-agentcore:us-west-2:123456789012";
+const API_KEY_ARN = `${PREFIX}:token-vault/default/apikeycredentialprovider/openai-key`;
+const OAUTH2_ARN = `${PREFIX}:token-vault/default/oauth2credentialprovider/github-oauth`;
+
+describe("parseArn", () => {
+  test("splits an ARN into its fields", () => {
+    expect(parseArn(`${PREFIX}:memory/recall-AbC123`)).toEqual({
+      partition: "aws",
+      service: "bedrock-agentcore",
+      region: "us-west-2",
+      account: "123456789012",
+      resource: "memory/recall-AbC123",
+    });
+  });
+
+  test("keeps colons inside the resource part", () => {
+    expect(parseArn("arn:aws:lambda:us-east-1:123456789012:function:name:1")?.resource).toBe(
+      "function:name:1",
+    );
+  });
+
+  test("returns undefined for a non-ARN", () => {
+    expect(parseArn("recall-AbC123")).toBeUndefined();
+    expect(parseArn("")).toBeUndefined();
+  });
+});
+
+describe("serviceIdFromArn", () => {
+  test("returns the memory id", () => {
+    expect(serviceIdFromArn(`${PREFIX}:memory/recall-AbC123`)).toBe("recall-AbC123");
+  });
+
+  test("returns the gateway id", () => {
+    expect(serviceIdFromArn(`${PREFIX}:gateway/tools-GwId12345`)).toBe("tools-GwId12345");
+  });
+
+  test("returns the runtime id", () => {
+    expect(serviceIdFromArn(`${PREFIX}:runtime/harness_support-AbCdEf1234`)).toBe(
+      "harness_support-AbCdEf1234",
+    );
+  });
+
+  test("returns the id of an AWS-managed default resource", () => {
+    expect(serviceIdFromArn("arn:aws:bedrock-agentcore:us-east-1:aws:browser/aws.browser.v1")).toBe(
+      "aws.browser.v1",
+    );
+  });
+
+  test("returns the whole path under the type for a credential provider", () => {
+    expect(serviceIdFromArn(API_KEY_ARN)).toBe("default/apikeycredentialprovider/openai-key");
+  });
+
+  test("passes a non-ARN through unchanged", () => {
+    expect(serviceIdFromArn("TARGETID123")).toBe("TARGETID123");
+  });
+
+  test("passes an ARN without a resource path through unchanged", () => {
+    expect(serviceIdFromArn("arn:aws:iam::123456789012:root")).toBe(
+      "arn:aws:iam::123456789012:root",
+    );
+  });
+});
+
+describe("resourceNameFromArn", () => {
+  test("returns the trailing name of an API key credential provider", () => {
+    expect(resourceNameFromArn(API_KEY_ARN)).toBe("openai-key");
+  });
+
+  test("returns the trailing name of an OAuth2 credential provider", () => {
+    expect(resourceNameFromArn(OAUTH2_ARN)).toBe("github-oauth");
+  });
+
+  test("is the service id for single-segment resources", () => {
+    expect(resourceNameFromArn(`${PREFIX}:memory/recall-AbC123`)).toBe("recall-AbC123");
+  });
+
+  test("passes a non-ARN through unchanged", () => {
+    expect(resourceNameFromArn("openai-key")).toBe("openai-key");
+  });
+});
+
+describe("regionFromArn", () => {
+  test("reads the region", () => {
+    expect(regionFromArn(`${PREFIX}:runtime/harness_support-AbCdEf1234`)).toBe("us-west-2");
+  });
+
+  test("is undefined for a global ARN", () => {
+    expect(regionFromArn("arn:aws:iam::123456789012:role/MyRole")).toBeUndefined();
+  });
+
+  test("is undefined for a non-ARN", () => {
+    expect(regionFromArn("recall-AbC123")).toBeUndefined();
+  });
+});
+
+describe("credentialProviderTypeFromArn", () => {
+  test("recognises an API key provider", () => {
+    expect(credentialProviderTypeFromArn(API_KEY_ARN)).toBe("api-key");
+  });
+
+  test("recognises an OAuth2 provider", () => {
+    expect(credentialProviderTypeFromArn(OAUTH2_ARN)).toBe("oauth2");
+  });
+
+  test("is undefined for other token-vault resources", () => {
+    expect(credentialProviderTypeFromArn(`${PREFIX}:token-vault/default`)).toBeUndefined();
+  });
+
+  test("is undefined for other resources and non-ARNs", () => {
+    expect(credentialProviderTypeFromArn(`${PREFIX}:memory/recall-AbC123`)).toBeUndefined();
+    expect(credentialProviderTypeFromArn("openai-key")).toBeUndefined();
+  });
+});

--- a/src/core/arn.ts
+++ b/src/core/arn.ts
@@ -1,0 +1,66 @@
+// Helpers for reading ids out of AgentCore ARNs. The service reports most
+// links between resources as ARNs (a harness's runtime, memory, gateway and
+// credential providers; a project's deployed resources) while the CLI's detail
+// routes and Core clients take the bare service id, so screens go through
+// these to turn one into the other. Values that are not ARNs pass through
+// unchanged so callers can hand over ids they already have.
+
+// An ARN is arn:<partition>:<service>:<region>:<account>:<resource>; the
+// resource part may itself contain colons and slashes.
+const ARN_PATTERN = /^arn:([^:]*):([^:]*):([^:]*):([^:]*):(.+)$/;
+
+export interface ParsedArn {
+  partition: string;
+  service: string;
+  region: string;
+  account: string;
+  resource: string;
+}
+
+export function parseArn(value: string): ParsedArn | undefined {
+  const match = ARN_PATTERN.exec(value);
+  if (!match) return undefined;
+  const [, partition = "", service = "", region = "", account = "", resource = ""] = match;
+  return { partition, service, region, account, resource };
+}
+
+// serviceIdFromArn returns the resource path after the type prefix — for
+// arn:aws:bedrock-agentcore:<region>:<account>:memory/<memoryId> that is
+// `<memoryId>`, which is what the detail routes and Core clients take. Ids that
+// are not ARNs (a gateway target's id, for one) pass through unchanged.
+export function serviceIdFromArn(id: string): string {
+  const resource = parseArn(id)?.resource;
+  const slash = resource?.indexOf("/") ?? -1;
+  return resource !== undefined && slash >= 0 ? resource.slice(slash + 1) : id;
+}
+
+// resourceNameFromArn returns the last path segment of an ARN's resource, for
+// resources addressed by name under a longer path: a credential provider's ARN
+// is arn:…:token-vault/<vault>/apikeycredentialprovider/<name> and its routes
+// and Core calls want `<name>`. Non-ARNs pass through unchanged.
+export function resourceNameFromArn(id: string): string {
+  const resource = parseArn(id)?.resource;
+  if (resource === undefined) return id;
+  return resource.slice(resource.lastIndexOf("/") + 1);
+}
+
+// regionFromArn reads the region an ARN was minted in, or undefined for a
+// non-ARN or a global (regionless) ARN.
+export function regionFromArn(arn: string): string | undefined {
+  const region = parseArn(arn)?.region;
+  return region ? region : undefined;
+}
+
+export type CredentialProviderType = "api-key" | "oauth2";
+
+// credentialProviderTypeFromArn tells an API key provider ARN apart from an
+// OAuth2 one by the path segment under the token vault; the two have different
+// detail screens and Core calls but the ARN is the only thing a linking
+// resource carries.
+export function credentialProviderTypeFromArn(arn: string): CredentialProviderType | undefined {
+  const segments = parseArn(arn)?.resource.split("/") ?? [];
+  if (segments[0] !== "token-vault") return undefined;
+  if (segments.includes("apikeycredentialprovider")) return "api-key";
+  if (segments.includes("oauth2credentialprovider")) return "oauth2";
+  return undefined;
+}

--- a/src/handlers/gateway/get/screen.tsx
+++ b/src/handlers/gateway/get/screen.tsx
@@ -3,10 +3,10 @@ import { useNavigate, useParams } from "react-router";
 import { JsonDetail } from "../../../components/JsonDetail";
 import { ResourceDetailScreen } from "../../../components/ResourceDetailScreen";
 import type { ScreenProps } from "../../types";
-import { coreOptsFromCtx } from "../../utils";
+import { useCoreOpts } from "../../utils";
 
 function useGatewayDetail({ ctx, core }: ScreenProps, gatewayId: string | undefined) {
-  const opts = coreOptsFromCtx(ctx);
+  const opts = useCoreOpts(ctx);
   return useQuery({
     queryKey: ["gateway", opts.region, gatewayId],
     queryFn: () => core.gateway.getGateway(gatewayId!, opts),

--- a/src/handlers/gateway/target/get/screen.tsx
+++ b/src/handlers/gateway/target/get/screen.tsx
@@ -2,11 +2,11 @@ import { useQuery } from "@tanstack/react-query";
 import { useParams } from "react-router";
 import { JsonDetail } from "../../../../components/JsonDetail";
 import type { ScreenProps } from "../../../types";
-import { coreOptsFromCtx } from "../../../utils";
+import { useCoreOpts } from "../../../utils";
 
 export function GatewayTargetGetScreen(props: ScreenProps) {
   const { gatewayId, targetId } = useParams();
-  const opts = coreOptsFromCtx(props.ctx);
+  const opts = useCoreOpts(props.ctx);
   const detail = useQuery({
     queryKey: ["gateway-target", opts.region, gatewayId, targetId],
     queryFn: () => props.core.gateway.getGatewayTarget(gatewayId!, targetId!, opts),

--- a/src/handlers/harness/get/get.screen.test.tsx
+++ b/src/handlers/harness/get/get.screen.test.tsx
@@ -277,12 +277,12 @@ describe("harness hub linked resources", () => {
     await waitForText(r.lastFrame, "linked resources");
     expect(r.lastFrame()).toContain("── linked resources ");
     const frame = flatFrame(r.lastFrame);
-    expect(frame).toMatch(/Runtime\s+harness_MyHarness/);
-    expect(frame).toMatch(new RegExp(`Memory\\s+${MEMORY_ID} managed`));
-    expect(frame).toMatch(new RegExp(`Gateway\\s+${GATEWAY_ID}`));
-    expect(frame).toMatch(/OAuth2 Provider\s+github-oauth outbound auth/);
-    expect(frame).toMatch(/Browser\s+default aws default/);
-    expect(frame).toMatch(/API Key\s+openai-key model gpt-4o/);
+    expect(frame).toMatch(new RegExp(`runtime\\s+${RUNTIME_ID}`));
+    expect(frame).toMatch(new RegExp(`memory\\s+${MEMORY_ID} managed`));
+    expect(frame).toMatch(new RegExp(`gateway\\s+${GATEWAY_ID}`));
+    expect(frame).toMatch(/oauth2 provider\s+github-oauth outbound auth/);
+    expect(frame).toMatch(/browser\s+default aws default/);
+    expect(frame).toMatch(/api key\s+openai-key model gpt-4o/);
     expect(frame).not.toContain("docs_mcp");
     r.unmount();
   });
@@ -298,8 +298,8 @@ describe("harness hub linked resources", () => {
 
     await waitForText(r.lastFrame, "linked resources");
     const frame = flatFrame(r.lastFrame);
-    expect(frame).toMatch(/Runtime\s+harness_MyHarness/);
-    for (const type of ["Memory", "Gateway", "Browser", "Code Interpreter", "API Key"]) {
+    expect(frame).toMatch(new RegExp(`runtime\\s+${RUNTIME_ID}`));
+    for (const type of ["memory", "gateway", "browser", "code interpreter", "api key"]) {
       expect(frame).not.toContain(type);
     }
     r.unmount();
@@ -316,14 +316,14 @@ describe("harness hub linked resources", () => {
     await r.press("down");
     let marked = markedLines(r.lastFrame());
     expect(marked).toHaveLength(1);
-    expect(marked[0]).toContain("Runtime");
+    expect(marked[0]).toContain("runtime");
     expect(marked[0]).not.toContain("update");
 
     // Down again moves within the tree, not the action list.
     await r.press("down");
     marked = markedLines(r.lastFrame());
     expect(marked).toHaveLength(1);
-    expect(marked[0]).toContain("Memory");
+    expect(marked[0]).toContain("memory");
 
     await r.press("up");
     await r.press("up");
@@ -415,7 +415,7 @@ describe("harness hub linked resources", () => {
 
     await waitForText(r.lastFrame, "linked resources");
     await focusTree(r, 3);
-    expect(markedLines(r.lastFrame())[0]).toContain("OAuth2 Provider");
+    expect(markedLines(r.lastFrame())[0]).toContain("oauth2 provider");
     await r.press("return");
 
     await waitForText(
@@ -438,7 +438,7 @@ describe("harness hub linked resources", () => {
 
     await waitForText(r.lastFrame, "linked resources");
     await focusTree(r, 5);
-    expect(markedLines(r.lastFrame())[0]).toContain("API Key");
+    expect(markedLines(r.lastFrame())[0]).toContain("api key");
     await r.press("return");
 
     await waitForText(
@@ -461,10 +461,10 @@ describe("harness hub linked resources", () => {
 
     await waitForText(r.lastFrame, "linked resources");
     await focusTree(r, 4);
-    expect(markedLines(r.lastFrame())[0]).toContain("Browser");
+    expect(markedLines(r.lastFrame())[0]).toContain("browser");
     await r.press("return");
 
-    await waitForText(r.lastFrame, "Browser default has no detail view.");
+    await waitForText(r.lastFrame, "browser default has no detail view.");
     expect(r.lastFrame()).toContain("agentcore → harness → get → MyHarness-abc123");
     expect(r.lastFrame()).toContain("linked resources");
     expect(core.runtime.calls).toHaveLength(0);
@@ -500,7 +500,7 @@ describe("buildHarnessLinkNodes", () => {
     const gateway = nodes[2]!;
     expect(gateway.defaultExpanded).toBe(true);
     expect(gateway.children?.map((node) => node.id)).toEqual(["tool:0/oauth"]);
-    expect(gateway.children?.[0]?.label).toContain("OAuth2 Provider");
+    expect(gateway.children?.[0]?.label).toContain("oauth2 provider");
     expect(gateway.children?.[0]?.annotation).toBe("outbound auth");
   });
 
@@ -550,14 +550,14 @@ describe("buildHarnessLinkNodes", () => {
 
     // Browsers come before Code Interpreters regardless of tools[] order.
     expect(tools.map((node) => node.id)).toEqual(["tool:1", "tool:2", "tool:0"]);
-    expect(tools[0]?.label).toMatch(/Browser\s+aws\.browser\.v1$/);
+    expect(tools[0]?.label).toMatch(/browser\s+aws\.browser\.v1$/);
     expect(tools[0]?.annotation).toBe("aws default");
-    expect(tools[1]?.label).toMatch(/Browser\s+default$/);
+    expect(tools[1]?.label).toMatch(/browser\s+default$/);
     expect(tools[1]?.annotation).toBe("aws default");
-    expect(tools[1]?.data).toEqual({ hint: "Browser default has no detail view." });
-    expect(tools[2]?.label).toMatch(/Code Interpreter\s+ci-123$/);
+    expect(tools[1]?.data).toEqual({ hint: "browser default has no detail view." });
+    expect(tools[2]?.label).toMatch(/code interpreter\s+ci-123$/);
     expect(tools[2]?.annotation).toBeUndefined();
-    expect(tools[2]?.data).toEqual({ hint: "Code Interpreter ci-123 has no detail view." });
+    expect(tools[2]?.data).toEqual({ hint: "code interpreter ci-123 has no detail view." });
   });
 
   test("keeps the name column aligned across the tree", () => {
@@ -573,11 +573,11 @@ describe("buildHarnessLinkNodes", () => {
     const column = (label: string) => label.search(/\S+$/);
 
     // TreeView draws four guide characters ("│ └─") before a row nested under
-    // a top-level one, so the nested "OAuth2 Provider" is the widest entry:
+    // a top-level one, so the nested "oauth2 provider" is the widest entry:
     // every top-level name starts after it plus two spaces, and the nested
     // row gives those four columns back so its name lands in the same place.
     const nestedGuides = 4;
-    const width = "OAuth2 Provider".length + nestedGuides + 2;
+    const width = "oauth2 provider".length + nestedGuides + 2;
     for (const node of nodes) expect(column(node.label)).toBe(width);
     expect(column(nodes[2]!.children![0]!.label)).toBe(width - nestedGuides);
   });
@@ -640,12 +640,12 @@ describe("buildHarnessLinkNodes", () => {
     const keys = nodes.filter((node) => node.id.startsWith("skill:"));
 
     expect(keys.map((node) => node.id)).toEqual(["skill:1/key", "skill:2/key"]);
-    expect(keys[0]?.label).toMatch(/API Key\s+openai-key$/);
+    expect(keys[0]?.label).toMatch(/api key\s+openai-key$/);
     expect(keys[0]?.annotation).toBe("skill skills/search");
     expect(keys[0]?.data?.route).toBe(
       `/agentcore/identity/api-key-credential-provider/get/openai-key?region=${LINK_REGION}`,
     );
-    expect(keys[1]?.label).toMatch(/OAuth2 Provider\s+github-oauth$/);
+    expect(keys[1]?.label).toMatch(/oauth2 provider\s+github-oauth$/);
     expect(keys[1]?.annotation).toBe("skill https://github.com/acme/private.git");
     expect(nodes.some((node) => node.id === "model-key")).toBe(false);
   });

--- a/src/handlers/harness/get/get.screen.test.tsx
+++ b/src/handlers/harness/get/get.screen.test.tsx
@@ -1,12 +1,22 @@
 import { test, expect, describe, afterEach } from "bun:test";
-import type { GetHarnessResponse } from "@aws-sdk/client-bedrock-agentcore-control";
+import type {
+  GetAgentRuntimeResponse,
+  GetApiKeyCredentialProviderResponse,
+  GetGatewayResponse,
+  GetHarnessResponse,
+  GetMemoryOutput,
+  GetOauth2CredentialProviderResponse,
+  Harness,
+} from "@aws-sdk/client-bedrock-agentcore-control";
 import {
   renderScreen,
   waitForText,
   waitFor,
   cleanupScreens,
+  flatFrame,
   TestCoreClient,
 } from "../../../testing";
+import { buildHarnessLinkNodes } from "./screen";
 
 afterEach(cleanupScreens);
 
@@ -165,6 +175,501 @@ describe("harness hub screen", () => {
     await waitForText(r.lastFrame, "MyHarness");
     await waitFor(() => core.harness.calls.some((c) => c.method === "listHarnesses"));
     r.unmount();
+  });
+});
+
+// The linked resources live in us-west-2 while the test context's ambient
+// region is us-east-1, so a forward navigation has to fetch where each ARN
+// says rather than where the hub was opened.
+const LINK_REGION = "us-west-2";
+const LINK_ARN = `arn:aws:bedrock-agentcore:${LINK_REGION}:123`;
+const RUNTIME_ID = "harness_MyHarness-Rt123456";
+const MEMORY_ID = "harness_MyHarness_ab12-Mem12345";
+const GATEWAY_ID = "tools-Gw1234567";
+const API_KEY_ARN = `${LINK_ARN}:token-vault/default/apikeycredentialprovider/openai-key`;
+const OAUTH2_ARN = `${LINK_ARN}:token-vault/default/oauth2credentialprovider/github-oauth`;
+
+// linkedHarness is wired to everything the tree can list: the provisioned
+// runtime, a managed memory, a gateway tool with OAuth outbound auth, a
+// default browser tool, an OpenAI model with an API key — plus a remote MCP
+// tool, which is not an AgentCore resource and must not appear.
+function linkedHarness(overrides: Partial<Harness> = {}): Harness {
+  return {
+    ...getResponse().harness!,
+    environment: {
+      agentCoreRuntimeEnvironment: {
+        agentRuntimeArn: `${LINK_ARN}:runtime/${RUNTIME_ID}`,
+        agentRuntimeName: "harness_MyHarness",
+        agentRuntimeId: RUNTIME_ID,
+      },
+    },
+    memory: { managedMemoryConfiguration: { arn: `${LINK_ARN}:memory/${MEMORY_ID}` } },
+    tools: [
+      {
+        type: "agentcore_gateway",
+        name: "tools",
+        config: {
+          agentCoreGateway: {
+            gatewayArn: `${LINK_ARN}:gateway/${GATEWAY_ID}`,
+            outboundAuth: { oauth: { providerArn: OAUTH2_ARN, scopes: ["repo"] } },
+          },
+        },
+      },
+      { type: "agentcore_browser", config: { agentCoreBrowser: {} } },
+      {
+        type: "remote_mcp",
+        name: "docs_mcp",
+        config: { remoteMcp: { url: "https://mcp.example" } },
+      },
+    ],
+    model: { openAiModelConfig: { modelId: "gpt-4o", apiKeyArn: API_KEY_ARN } },
+    ...overrides,
+  } as Harness;
+}
+
+function linkedHubScreen(harness: Harness = linkedHarness()) {
+  const core = new TestCoreClient();
+  core.harness.setGetResponse({ harness });
+  core.runtime.setGetResponse({
+    agentRuntimeId: RUNTIME_ID,
+    agentRuntimeArn: `${LINK_ARN}:runtime/${RUNTIME_ID}`,
+    status: "READY",
+  } as GetAgentRuntimeResponse);
+  core.memory.setGetResponse({
+    memory: {
+      id: MEMORY_ID,
+      name: "harness_MyHarness_ab12",
+      arn: `${LINK_ARN}:memory/${MEMORY_ID}`,
+      status: "ACTIVE",
+    },
+  } as GetMemoryOutput);
+  core.gateway.setGetResponse({
+    gatewayId: GATEWAY_ID,
+    gatewayArn: `${LINK_ARN}:gateway/${GATEWAY_ID}`,
+    status: "READY",
+  } as GetGatewayResponse);
+  core.identity.setGetApiKeyResponse({
+    name: "openai-key",
+    credentialProviderArn: API_KEY_ARN,
+  } as GetApiKeyCredentialProviderResponse);
+  core.identity.setGetOauth2Response({
+    name: "github-oauth",
+    credentialProviderArn: OAUTH2_ARN,
+  } as GetOauth2CredentialProviderResponse);
+  return { core, r: renderScreen("/agentcore/harness/get/MyHarness-abc123", { core }) };
+}
+
+// markedLines returns the lines carrying the ❯ focus marker.
+function markedLines(frame: string | undefined): string[] {
+  return (frame ?? "").split("\n").filter((line) => line.includes("❯"));
+}
+
+// The action list has six entries, so five downs reach `update` and the sixth
+// crosses into the tree.
+async function focusTree(r: ReturnType<typeof renderScreen>, row = 0) {
+  for (let press = 0; press < 6 + row; press++) await r.press("down");
+}
+
+describe("harness hub linked resources", () => {
+  test("lists one row per linked resource under a titled divider", async () => {
+    const { r } = linkedHubScreen();
+
+    await waitForText(r.lastFrame, "linked resources");
+    expect(r.lastFrame()).toContain("── linked resources ");
+    const frame = flatFrame(r.lastFrame);
+    expect(frame).toMatch(/Runtime\s+harness_MyHarness/);
+    expect(frame).toMatch(new RegExp(`Memory\\s+${MEMORY_ID} managed`));
+    expect(frame).toMatch(new RegExp(`Gateway\\s+${GATEWAY_ID}`));
+    expect(frame).toMatch(/OAuth2 Provider\s+github-oauth outbound auth/);
+    expect(frame).toMatch(/Browser\s+default aws default/);
+    expect(frame).toMatch(/API Key\s+openai-key model gpt-4o/);
+    expect(frame).not.toContain("docs_mcp");
+    r.unmount();
+  });
+
+  test("shows only the Runtime row for a harness with disabled memory and no tools", async () => {
+    const { r } = linkedHubScreen(
+      linkedHarness({
+        memory: { disabled: {} },
+        tools: [],
+        model: { bedrockModelConfig: { modelId: "global.anthropic.claude-sonnet-4-6" } },
+      }),
+    );
+
+    await waitForText(r.lastFrame, "linked resources");
+    const frame = flatFrame(r.lastFrame);
+    expect(frame).toMatch(/Runtime\s+harness_MyHarness/);
+    for (const type of ["Memory", "Gateway", "Browser", "Code Interpreter", "API Key"]) {
+      expect(frame).not.toContain(type);
+    }
+    r.unmount();
+  });
+
+  test("down past the last action focuses the first tree row and up returns", async () => {
+    const { r } = linkedHubScreen();
+
+    await waitForText(r.lastFrame, "linked resources");
+    for (let press = 0; press < 5; press++) await r.press("down");
+    expect(markedLines(r.lastFrame())).toHaveLength(1);
+    expect(markedLines(r.lastFrame())[0]).toContain("update");
+
+    await r.press("down");
+    let marked = markedLines(r.lastFrame());
+    expect(marked).toHaveLength(1);
+    expect(marked[0]).toContain("Runtime");
+    expect(marked[0]).not.toContain("update");
+
+    // Down again moves within the tree, not the action list.
+    await r.press("down");
+    marked = markedLines(r.lastFrame());
+    expect(marked).toHaveLength(1);
+    expect(marked[0]).toContain("Memory");
+
+    await r.press("up");
+    await r.press("up");
+    marked = markedLines(r.lastFrame());
+    expect(marked).toHaveLength(1);
+    expect(marked[0]).toContain("update");
+    r.unmount();
+  });
+
+  test("the marker is never shown twice while crossing the zones", async () => {
+    const { r } = linkedHubScreen();
+
+    await waitForText(r.lastFrame, "linked resources");
+    for (let press = 0; press < 8; press++) {
+      await r.press("down");
+      expect(markedLines(r.lastFrame())).toHaveLength(1);
+    }
+    for (let press = 0; press < 8; press++) {
+      await r.press("up");
+      expect(markedLines(r.lastFrame())).toHaveLength(1);
+    }
+    expect(markedLines(r.lastFrame())[0]).toContain("detail");
+    r.unmount();
+  });
+
+  test("enter on the Runtime row opens the Runtime hub in the runtime ARN's region", async () => {
+    const { core, r } = linkedHubScreen();
+
+    await waitForText(r.lastFrame, "linked resources");
+    await focusTree(r);
+    await r.press("return");
+
+    await waitForText(r.lastFrame, `agentcore → runtime → get → ${RUNTIME_ID}`);
+    await waitForText(r.lastFrame, "READY");
+    const call = core.runtime.calls.find(({ method }) => method === "getRuntime")!;
+    expect(call.args[0]).toBe(RUNTIME_ID);
+    expect(call.args[1]).toMatchObject({ region: LINK_REGION });
+    r.unmount();
+  });
+
+  test("escape from a linked page returns to the hub with the tree", async () => {
+    const { r } = linkedHubScreen();
+
+    await waitForText(r.lastFrame, "linked resources");
+    await focusTree(r);
+    await r.press("return");
+    await waitForText(r.lastFrame, `agentcore → runtime → get → ${RUNTIME_ID}`);
+
+    await r.press("escape");
+    // History-back re-renders the hub, which refetches the harness before the
+    // tree is back.
+    await waitForText(r.lastFrame, "linked resources");
+    expect(r.lastFrame()).toContain("agentcore → harness → get → MyHarness-abc123");
+    r.unmount();
+  });
+
+  test("enter on the Memory row opens the Memory hub", async () => {
+    const { core, r } = linkedHubScreen();
+
+    await waitForText(r.lastFrame, "linked resources");
+    await focusTree(r, 1);
+    await r.press("return");
+
+    await waitForText(r.lastFrame, `agentcore → memory → get → ${MEMORY_ID}`);
+    await waitForText(r.lastFrame, "ACTIVE");
+    const call = core.memory.calls.find(({ method }) => method === "getMemory")!;
+    expect(call.args[0]).toBe(MEMORY_ID);
+    expect(call.args[2]).toMatchObject({ region: LINK_REGION });
+    r.unmount();
+  });
+
+  test("enter on the Gateway row opens the Gateway hub", async () => {
+    const { core, r } = linkedHubScreen();
+
+    await waitForText(r.lastFrame, "linked resources");
+    await focusTree(r, 2);
+    await r.press("return");
+
+    await waitForText(r.lastFrame, `agentcore → gateway → get → ${GATEWAY_ID}`);
+    await waitFor(() => core.gateway.calls.some(({ method }) => method === "getGateway"));
+    const call = core.gateway.calls.find(({ method }) => method === "getGateway")!;
+    expect(call.args[0]).toBe(GATEWAY_ID);
+    expect(call.args[1]).toMatchObject({ region: LINK_REGION });
+    r.unmount();
+  });
+
+  test("enter on the nested OAuth2 Provider row opens that provider's hub", async () => {
+    const { core, r } = linkedHubScreen();
+
+    await waitForText(r.lastFrame, "linked resources");
+    await focusTree(r, 3);
+    expect(markedLines(r.lastFrame())[0]).toContain("OAuth2 Provider");
+    await r.press("return");
+
+    await waitForText(
+      r.lastFrame,
+      "agentcore → identity → oauth2-credential-provider → get → github-oauth",
+    );
+    await waitFor(() =>
+      core.identity.calls.some(({ method }) => method === "getOauth2CredentialProvider"),
+    );
+    const call = core.identity.calls.find(
+      ({ method }) => method === "getOauth2CredentialProvider",
+    )!;
+    expect(call.args[0]).toBe("github-oauth");
+    expect(call.args[1]).toMatchObject({ region: LINK_REGION });
+    r.unmount();
+  });
+
+  test("enter on the API Key row opens the API key credential provider hub by name", async () => {
+    const { core, r } = linkedHubScreen();
+
+    await waitForText(r.lastFrame, "linked resources");
+    await focusTree(r, 5);
+    expect(markedLines(r.lastFrame())[0]).toContain("API Key");
+    await r.press("return");
+
+    await waitForText(
+      r.lastFrame,
+      "agentcore → identity → api-key-credential-provider → get → openai-key",
+    );
+    await waitFor(() =>
+      core.identity.calls.some(({ method }) => method === "getApiKeyCredentialProvider"),
+    );
+    const call = core.identity.calls.find(
+      ({ method }) => method === "getApiKeyCredentialProvider",
+    )!;
+    expect(call.args[0]).toBe("openai-key");
+    expect(call.args[1]).toMatchObject({ region: LINK_REGION });
+    r.unmount();
+  });
+
+  test("enter on the Browser row shows the no-detail hint and stays put", async () => {
+    const { core, r } = linkedHubScreen();
+
+    await waitForText(r.lastFrame, "linked resources");
+    await focusTree(r, 4);
+    expect(markedLines(r.lastFrame())[0]).toContain("Browser");
+    await r.press("return");
+
+    await waitForText(r.lastFrame, "Browser default has no detail view.");
+    expect(r.lastFrame()).toContain("agentcore → harness → get → MyHarness-abc123");
+    expect(r.lastFrame()).toContain("linked resources");
+    expect(core.runtime.calls).toHaveLength(0);
+    r.unmount();
+  });
+
+  test("the footer hints follow the focused zone", async () => {
+    const { r } = linkedHubScreen();
+
+    await waitForText(r.lastFrame, "linked resources");
+    expect(r.lastFrame()).toContain("select");
+    expect(r.lastFrame()).not.toContain("collapse/expand");
+    await focusTree(r);
+    expect(r.lastFrame()).toContain("open");
+    expect(r.lastFrame()).toContain("collapse/expand");
+    r.unmount();
+  });
+});
+
+describe("buildHarnessLinkNodes", () => {
+  const FALLBACK = "us-east-1";
+
+  test("orders the rows and nests the OAuth2 provider under its gateway", () => {
+    const nodes = buildHarnessLinkNodes(linkedHarness(), FALLBACK);
+
+    expect(nodes.map((node) => node.id)).toEqual([
+      "runtime",
+      "memory",
+      "tool:0",
+      "tool:1",
+      "model-key",
+    ]);
+    const gateway = nodes[2]!;
+    expect(gateway.defaultExpanded).toBe(true);
+    expect(gateway.children?.map((node) => node.id)).toEqual(["tool:0/oauth"]);
+    expect(gateway.children?.[0]?.label).toContain("OAuth2 Provider");
+    expect(gateway.children?.[0]?.annotation).toBe("outbound auth");
+  });
+
+  test("links each row to its detail route in the region of its ARN", () => {
+    const nodes = buildHarnessLinkNodes(linkedHarness(), FALLBACK);
+    const routes = Object.fromEntries(nodes.map((node) => [node.id, node.data?.route]));
+
+    expect(routes.runtime).toBe(`/agentcore/runtime/get/${RUNTIME_ID}?region=${LINK_REGION}`);
+    expect(routes.memory).toBe(`/agentcore/memory/get/${MEMORY_ID}?region=${LINK_REGION}`);
+    expect(routes["tool:0"]).toBe(`/agentcore/gateway/get/${GATEWAY_ID}?region=${LINK_REGION}`);
+    expect(routes["model-key"]).toBe(
+      `/agentcore/identity/api-key-credential-provider/get/openai-key?region=${LINK_REGION}`,
+    );
+    expect(nodes[2]?.children?.[0]?.data?.route).toBe(
+      `/agentcore/identity/oauth2-credential-provider/get/github-oauth?region=${LINK_REGION}`,
+    );
+  });
+
+  test("gives Browser and Code Interpreter rows a hint instead of a route", () => {
+    const nodes = buildHarnessLinkNodes(
+      linkedHarness({
+        tools: [
+          {
+            type: "agentcore_code_interpreter",
+            name: "sandbox",
+            config: {
+              agentCoreCodeInterpreter: {
+                codeInterpreterArn: `${LINK_ARN}:code-interpreter/ci-123`,
+              },
+            },
+          },
+          {
+            type: "agentcore_browser",
+            name: "aws_browser_v1",
+            config: {
+              agentCoreBrowser: {
+                browserArn: "arn:aws:bedrock-agentcore:us-east-1:aws:browser/aws.browser.v1",
+              },
+            },
+          },
+          { type: "agentcore_browser", config: { agentCoreBrowser: {} } },
+        ],
+      }),
+      FALLBACK,
+    );
+    const tools = nodes.filter((node) => node.id.startsWith("tool:"));
+
+    // Browsers come before Code Interpreters regardless of tools[] order.
+    expect(tools.map((node) => node.id)).toEqual(["tool:1", "tool:2", "tool:0"]);
+    expect(tools[0]?.label).toMatch(/Browser\s+aws\.browser\.v1$/);
+    expect(tools[0]?.annotation).toBe("aws default");
+    expect(tools[1]?.label).toMatch(/Browser\s+default$/);
+    expect(tools[1]?.annotation).toBe("aws default");
+    expect(tools[1]?.data).toEqual({ hint: "Browser default has no detail view." });
+    expect(tools[2]?.label).toMatch(/Code Interpreter\s+ci-123$/);
+    expect(tools[2]?.annotation).toBeUndefined();
+    expect(tools[2]?.data).toEqual({ hint: "Code Interpreter ci-123 has no detail view." });
+  });
+
+  test("keeps the name column aligned across the tree", () => {
+    const nodes = buildHarnessLinkNodes(
+      linkedHarness({
+        tools: [
+          ...linkedHarness().tools!,
+          { type: "agentcore_code_interpreter", config: { agentCoreCodeInterpreter: {} } },
+        ],
+      }),
+      FALLBACK,
+    );
+    const column = (label: string) => label.search(/\S+$/);
+
+    // TreeView draws four guide characters ("│ └─") before a row nested under
+    // a top-level one, so the nested "OAuth2 Provider" is the widest entry:
+    // every top-level name starts after it plus two spaces, and the nested
+    // row gives those four columns back so its name lands in the same place.
+    const nestedGuides = 4;
+    const width = "OAuth2 Provider".length + nestedGuides + 2;
+    for (const node of nodes) expect(column(node.label)).toBe(width);
+    expect(column(nodes[2]!.children![0]!.label)).toBe(width - nestedGuides);
+  });
+
+  test("annotates an attached memory and omits a disabled or absent one", () => {
+    const attached = buildHarnessLinkNodes(
+      linkedHarness({
+        memory: { agentCoreMemoryConfiguration: { arn: `${LINK_ARN}:memory/${MEMORY_ID}` } },
+      }),
+      FALLBACK,
+    );
+    expect(attached.find((node) => node.id === "memory")?.annotation).toBe("attached");
+
+    const disabled = buildHarnessLinkNodes(linkedHarness({ memory: { disabled: {} } }), FALLBACK);
+    expect(disabled.some((node) => node.id === "memory")).toBe(false);
+
+    const absent = buildHarnessLinkNodes(linkedHarness({ memory: undefined }), FALLBACK);
+    expect(absent.some((node) => node.id === "memory")).toBe(false);
+  });
+
+  test("falls back to the harness's region when an ARN carries none", () => {
+    const nodes = buildHarnessLinkNodes(
+      linkedHarness({
+        environment: {
+          agentCoreRuntimeEnvironment: {
+            agentRuntimeId: RUNTIME_ID,
+            agentRuntimeName: "harness_MyHarness",
+          },
+        },
+      } as Partial<Harness>),
+      FALLBACK,
+    );
+
+    expect(nodes[0]?.data?.route).toBe(`/agentcore/runtime/get/${RUNTIME_ID}?region=${FALLBACK}`);
+  });
+
+  test("lists a git skill's API key provider annotated with the skill", () => {
+    const nodes = buildHarnessLinkNodes(
+      linkedHarness({
+        model: { bedrockModelConfig: { modelId: "global.anthropic.claude-sonnet-4-6" } },
+        skills: [
+          { path: "/skills/local" },
+          {
+            git: {
+              url: "https://github.com/acme/skills.git",
+              path: "skills/search",
+              auth: { credentialArn: API_KEY_ARN },
+            },
+          },
+          {
+            git: {
+              url: "https://github.com/acme/private.git",
+              auth: { credentialArn: OAUTH2_ARN },
+            },
+          },
+        ],
+      }),
+      FALLBACK,
+    );
+    const keys = nodes.filter((node) => node.id.startsWith("skill:"));
+
+    expect(keys.map((node) => node.id)).toEqual(["skill:1/key", "skill:2/key"]);
+    expect(keys[0]?.label).toMatch(/API Key\s+openai-key$/);
+    expect(keys[0]?.annotation).toBe("skill skills/search");
+    expect(keys[0]?.data?.route).toBe(
+      `/agentcore/identity/api-key-credential-provider/get/openai-key?region=${LINK_REGION}`,
+    );
+    expect(keys[1]?.label).toMatch(/OAuth2 Provider\s+github-oauth$/);
+    expect(keys[1]?.annotation).toBe("skill https://github.com/acme/private.git");
+    expect(nodes.some((node) => node.id === "model-key")).toBe(false);
+  });
+
+  test("skips inline-function and remote-MCP tools", () => {
+    const nodes = buildHarnessLinkNodes(
+      linkedHarness({
+        tools: [
+          {
+            type: "remote_mcp",
+            name: "docs",
+            config: { remoteMcp: { url: "https://mcp.example" } },
+          },
+          {
+            type: "inline_function",
+            name: "add",
+            config: { inlineFunction: { description: "adds", inputSchema: {} } },
+          },
+        ],
+      }),
+      FALLBACK,
+    );
+
+    expect(nodes.some((node) => node.id.startsWith("tool:"))).toBe(false);
   });
 });
 

--- a/src/handlers/harness/get/screen.tsx
+++ b/src/handlers/harness/get/screen.tsx
@@ -1,8 +1,23 @@
+import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate, useParams } from "react-router";
+import type { Harness, HarnessTool } from "@aws-sdk/client-bedrock-agentcore-control";
 import type { ScreenProps } from "../../types";
-import { coreOptsFromCtx } from "../../utils";
+import { useCoreOpts } from "../../utils";
+import {
+  credentialProviderTypeFromArn,
+  parseArn,
+  regionFromArn,
+  resourceNameFromArn,
+  serviceIdFromArn,
+  type CredentialProviderType,
+} from "../../../core/arn";
 import { JsonDetail } from "../../../components/JsonDetail";
+import {
+  linkedResourceLabel,
+  typeColumnWidth,
+  type LinkedResourceNode,
+} from "../../../components/LinkedResources";
 import { ResourceDetailScreen } from "../../../components/ResourceDetailScreen";
 
 // The actions offered for a harness, in menu order. Each routes into the
@@ -40,24 +55,247 @@ const ACTIONS: { name: string; description: string; to: (id: string) => string }
   },
 ];
 
-// HarnessGetScreen is the hub for a single harness: a summary overlay (name,
-// ARN, execution role, status) above an action selector that jumps into the
-// harness's flows (detail JSON, endpoints, versions, invoke, exec). The harness
-// ID comes from the `:harnessId` route path value.
+// The detail routes a linked resource forwards to, by the id the route takes.
+// Browsers and Code Interpreters have no detail screen and get a hint instead.
+const DETAIL_ROUTES = {
+  runtime: (id: string) => `/agentcore/runtime/get/${encodeURIComponent(id)}`,
+  memory: (id: string) => `/agentcore/memory/get/${encodeURIComponent(id)}`,
+  gateway: (id: string) => `/agentcore/gateway/get/${encodeURIComponent(id)}`,
+  "api-key": (name: string) =>
+    `/agentcore/identity/api-key-credential-provider/get/${encodeURIComponent(name)}`,
+  oauth2: (name: string) =>
+    `/agentcore/identity/oauth2-credential-provider/get/${encodeURIComponent(name)}`,
+} as const;
+
+const CREDENTIAL_PROVIDER_TYPES: Record<CredentialProviderType, string> = {
+  "api-key": "API Key",
+  oauth2: "OAuth2 Provider",
+};
+
+// A resource the harness is wired to, before it becomes a tree row.
+interface HarnessLink {
+  id: string;
+  type: string;
+  name: string;
+  annotation?: string;
+  // The detail route (without a region); unset rows show a hint instead.
+  route?: string;
+  // The ARN the resource's region is read from.
+  arn?: string;
+  children?: HarnessLink[];
+}
+
+function credentialLink(id: string, arn: string, annotation: string): HarnessLink | undefined {
+  // The ARN is all a linking resource carries, so it decides between the two
+  // credential provider screens; anything else under the vault is skipped.
+  const providerType = credentialProviderTypeFromArn(arn);
+  if (!providerType) return undefined;
+  const name = resourceNameFromArn(arn);
+  return {
+    id,
+    type: CREDENTIAL_PROVIDER_TYPES[providerType],
+    name,
+    annotation,
+    route: DETAIL_ROUTES[providerType](name),
+    arn,
+  };
+}
+
+// managedToolLink describes a Browser or Code Interpreter tool. An unset ARN
+// means the AWS-managed default; the service also reports that default by an
+// ARN under the `aws` account.
+function managedToolLink(
+  id: string,
+  type: string,
+  tool: HarnessTool,
+  arn: string | undefined,
+): HarnessLink {
+  const awsDefault = !arn || parseArn(arn)?.account === "aws";
+  return {
+    id,
+    type,
+    name: arn ? serviceIdFromArn(arn) : (tool.name ?? "default"),
+    annotation: awsDefault ? "aws default" : undefined,
+    arn,
+  };
+}
+
+// collectLinks reads the linked resources out of a GetHarness response, in
+// display order: the Runtime the service provisioned under the harness, its
+// Memory, then the AgentCore tools (Gateways with their outbound OAuth2
+// provider nested beneath, Browsers, Code Interpreters) and finally the
+// credential providers the model and git-backed skills authenticate with.
+// Inline-function and remote-MCP tools are not AgentCore resources and are
+// left out.
+function collectLinks(harness: Harness): HarnessLink[] {
+  const links: HarnessLink[] = [];
+
+  const runtime = harness.environment?.agentCoreRuntimeEnvironment;
+  if (runtime?.agentRuntimeId) {
+    links.push({
+      id: "runtime",
+      type: "Runtime",
+      name: runtime.agentRuntimeName ?? runtime.agentRuntimeId,
+      route: DETAIL_ROUTES.runtime(runtime.agentRuntimeId),
+      arn: runtime.agentRuntimeArn,
+    });
+  }
+
+  // A disabled memory (or one not yet provisioned) has nothing to open.
+  const managedMemoryArn = harness.memory?.managedMemoryConfiguration?.arn;
+  const memoryArn = managedMemoryArn ?? harness.memory?.agentCoreMemoryConfiguration?.arn;
+  if (memoryArn) {
+    const memoryId = serviceIdFromArn(memoryArn);
+    links.push({
+      id: "memory",
+      type: "Memory",
+      name: memoryId,
+      annotation: managedMemoryArn ? "managed" : "attached",
+      route: DETAIL_ROUTES.memory(memoryId),
+      arn: memoryArn,
+    });
+  }
+
+  const tools = harness.tools ?? [];
+  tools.forEach((tool, index) => {
+    const gateway = tool.config?.agentCoreGateway;
+    if (!gateway?.gatewayArn) return;
+    const gatewayId = serviceIdFromArn(gateway.gatewayArn);
+    const providerArn = gateway.outboundAuth?.oauth?.providerArn;
+    const provider = providerArn
+      ? credentialLink(`tool:${index}/oauth`, providerArn, "outbound auth")
+      : undefined;
+    links.push({
+      id: `tool:${index}`,
+      type: "Gateway",
+      name: gatewayId,
+      route: DETAIL_ROUTES.gateway(gatewayId),
+      arn: gateway.gatewayArn,
+      children: provider ? [provider] : undefined,
+    });
+  });
+  tools.forEach((tool, index) => {
+    const browser = tool.config?.agentCoreBrowser;
+    if (browser) links.push(managedToolLink(`tool:${index}`, "Browser", tool, browser.browserArn));
+  });
+  tools.forEach((tool, index) => {
+    const interpreter = tool.config?.agentCoreCodeInterpreter;
+    if (interpreter) {
+      links.push(
+        managedToolLink(`tool:${index}`, "Code Interpreter", tool, interpreter.codeInterpreterArn),
+      );
+    }
+  });
+
+  const model = harness.model;
+  const keyedModel =
+    model?.openAiModelConfig ?? model?.geminiModelConfig ?? model?.liteLlmModelConfig;
+  if (keyedModel?.apiKeyArn) {
+    const link = credentialLink(
+      "model-key",
+      keyedModel.apiKeyArn,
+      keyedModel.modelId ? `model ${keyedModel.modelId}` : "model",
+    );
+    if (link) links.push(link);
+  }
+
+  (harness.skills ?? []).forEach((skill, index) => {
+    const git = skill.git;
+    const credentialArn = git?.auth?.credentialArn;
+    if (!git || !credentialArn) return;
+    // A git skill has no name of its own; its path in the repository (or the
+    // repository itself) is what identifies it.
+    const skillName = git.path ?? git.url;
+    const link = credentialLink(
+      `skill:${index}/key`,
+      credentialArn,
+      skillName ? `skill ${skillName}` : "skill",
+    );
+    if (link) links.push(link);
+  });
+
+  return links;
+}
+
+// guideDepthOf counts the two-character guide steps TreeView draws before a
+// row at `depth`: none on the top level, then one per ancestor plus the branch
+// itself.
+function guideDepthOf(depth: number): number {
+  return depth === 0 ? 0 : depth + 1;
+}
+
+function flattenLinks(links: HarnessLink[], depth = 0): { link: HarnessLink; depth: number }[] {
+  return links.flatMap((link) => [
+    { link, depth },
+    ...flattenLinks(link.children ?? [], depth + 1),
+  ]);
+}
+
+// buildHarnessLinkNodes maps a GetHarness response to the rows of the hub's
+// Linked Resources tree. Each row with a detail screen links there with
+// ?region= taken from the resource's own ARN, so it opens where it lives (see
+// useCoreOpts); `fallbackRegion` — the region the harness itself was fetched
+// in — covers ARNs without one. Rows without a detail screen carry a hint.
+export function buildHarnessLinkNodes(
+  harness: Harness,
+  fallbackRegion: string,
+): LinkedResourceNode[] {
+  const links = collectLinks(harness);
+  const typeWidth = typeColumnWidth(
+    flattenLinks(links).map(({ link, depth }) => ({
+      type: link.type,
+      guideDepth: guideDepthOf(depth),
+    })),
+  );
+
+  const toNode = (link: HarnessLink, depth: number): LinkedResourceNode => {
+    const children = link.children?.map((child) => toNode(child, depth + 1));
+    const region = (link.arn && regionFromArn(link.arn)) || fallbackRegion;
+    return {
+      id: link.id,
+      label: linkedResourceLabel(link.type, link.name, typeWidth, guideDepthOf(depth)),
+      annotation: link.annotation,
+      ...(children?.length ? { defaultExpanded: true, children } : {}),
+      data: link.route
+        ? { route: `${link.route}?region=${encodeURIComponent(region)}` }
+        : { hint: `${link.type} ${link.name} has no detail view.` },
+    };
+  };
+
+  return links.map((link) => toNode(link, 0));
+}
+
+// The harness ID comes from the `:harnessId` route path value; the fetch
+// honours a ?region= link (see useCoreOpts) and reports the region it used so
+// the linked rows can fall back to it.
 function useHarnessDetail({ ctx, core }: ScreenProps, harnessId: string | undefined) {
-  const opts = coreOptsFromCtx(ctx);
-  return useQuery({
+  const opts = useCoreOpts(ctx);
+  const query = useQuery({
     queryKey: ["harness", opts.region, harnessId],
     queryFn: () => core.harness.getHarness(harnessId!, opts),
     enabled: harnessId !== undefined,
   });
+  return { query, region: opts.region };
 }
 
+// HarnessGetScreen is the hub for a single harness: a summary overlay (name,
+// ARN, execution role, status) above an action selector that jumps into the
+// harness's flows (detail JSON, endpoints, versions, invoke, exec, update),
+// followed by a Linked Resources tree of what the harness is wired to — the
+// Runtime provisioned underneath it, its managed or attached Memory, Gateway
+// (with its outbound OAuth2 provider), Browser and Code Interpreter tools, and
+// the API key providers behind the model and git-backed skills. Enter on a
+// linked row opens that resource's own hub in the region its ARN names.
 export function HarnessGetScreen(props: ScreenProps) {
   const navigate = useNavigate();
   const { harnessId } = useParams();
-  const detail = useHarnessDetail(props, harnessId);
+  const { query: detail, region } = useHarnessDetail(props, harnessId);
   const harness = detail.data?.harness;
+
+  const linkedNodes = useMemo(
+    () => (harness ? buildHarnessLinkNodes(harness, region) : []),
+    [harness, region],
+  );
 
   return (
     <ResourceDetailScreen
@@ -80,6 +318,7 @@ export function HarnessGetScreen(props: ScreenProps) {
           : []
       }
       loadingLabel="loading harness…"
+      linkedResources={{ nodes: linkedNodes }}
       onRetry={() => void detail.refetch()}
     />
   );
@@ -89,7 +328,7 @@ export function HarnessGetScreen(props: ScreenProps) {
 // (the hub's "detail" action).
 export function HarnessGetJsonScreen(props: ScreenProps) {
   const { harnessId } = useParams();
-  const detail = useHarnessDetail(props, harnessId);
+  const { query: detail } = useHarnessDetail(props, harnessId);
 
   return (
     <JsonDetail

--- a/src/handlers/harness/get/screen.tsx
+++ b/src/handlers/harness/get/screen.tsx
@@ -68,8 +68,8 @@ const DETAIL_ROUTES = {
 } as const;
 
 const CREDENTIAL_PROVIDER_TYPES: Record<CredentialProviderType, string> = {
-  "api-key": "API Key",
-  oauth2: "OAuth2 Provider",
+  "api-key": "api key",
+  oauth2: "oauth2 provider",
 };
 
 // A resource the harness is wired to, before it becomes a tree row.
@@ -134,8 +134,8 @@ function collectLinks(harness: Harness): HarnessLink[] {
   if (runtime?.agentRuntimeId) {
     links.push({
       id: "runtime",
-      type: "Runtime",
-      name: runtime.agentRuntimeName ?? runtime.agentRuntimeId,
+      type: "runtime",
+      name: runtime.agentRuntimeId,
       route: DETAIL_ROUTES.runtime(runtime.agentRuntimeId),
       arn: runtime.agentRuntimeArn,
     });
@@ -148,7 +148,7 @@ function collectLinks(harness: Harness): HarnessLink[] {
     const memoryId = serviceIdFromArn(memoryArn);
     links.push({
       id: "memory",
-      type: "Memory",
+      type: "memory",
       name: memoryId,
       annotation: managedMemoryArn ? "managed" : "attached",
       route: DETAIL_ROUTES.memory(memoryId),
@@ -167,7 +167,7 @@ function collectLinks(harness: Harness): HarnessLink[] {
       : undefined;
     links.push({
       id: `tool:${index}`,
-      type: "Gateway",
+      type: "gateway",
       name: gatewayId,
       route: DETAIL_ROUTES.gateway(gatewayId),
       arn: gateway.gatewayArn,
@@ -176,13 +176,13 @@ function collectLinks(harness: Harness): HarnessLink[] {
   });
   tools.forEach((tool, index) => {
     const browser = tool.config?.agentCoreBrowser;
-    if (browser) links.push(managedToolLink(`tool:${index}`, "Browser", tool, browser.browserArn));
+    if (browser) links.push(managedToolLink(`tool:${index}`, "browser", tool, browser.browserArn));
   });
   tools.forEach((tool, index) => {
     const interpreter = tool.config?.agentCoreCodeInterpreter;
     if (interpreter) {
       links.push(
-        managedToolLink(`tool:${index}`, "Code Interpreter", tool, interpreter.codeInterpreterArn),
+        managedToolLink(`tool:${index}`, "code interpreter", tool, interpreter.codeInterpreterArn),
       );
     }
   });
@@ -246,6 +246,7 @@ export function buildHarnessLinkNodes(
       type: link.type,
       guideDepth: guideDepthOf(depth),
     })),
+    10,
   );
 
   const toNode = (link: HarnessLink, depth: number): LinkedResourceNode => {

--- a/src/handlers/identity/api-key-credential-provider/get/screen.tsx
+++ b/src/handlers/identity/api-key-credential-provider/get/screen.tsx
@@ -3,10 +3,10 @@ import { useNavigate, useParams } from "react-router";
 import { JsonDetail } from "../../../../components/JsonDetail";
 import { ResourceDetailScreen } from "../../../../components/ResourceDetailScreen";
 import type { ScreenProps } from "../../../types";
-import { coreOptsFromCtx } from "../../../utils";
+import { useCoreOpts } from "../../../utils";
 
 function useApiKeyProviderDetail({ ctx, core }: ScreenProps, name: string | undefined) {
-  const opts = coreOptsFromCtx(ctx);
+  const opts = useCoreOpts(ctx);
   return useQuery({
     queryKey: ["api-key-credential-provider", opts.region, name],
     queryFn: () => core.identity.getApiKeyCredentialProvider(name!, opts),

--- a/src/handlers/identity/oauth2-credential-provider/get/screen.tsx
+++ b/src/handlers/identity/oauth2-credential-provider/get/screen.tsx
@@ -3,10 +3,10 @@ import { useNavigate, useParams } from "react-router";
 import { JsonDetail } from "../../../../components/JsonDetail";
 import { ResourceDetailScreen } from "../../../../components/ResourceDetailScreen";
 import type { ScreenProps } from "../../../types";
-import { coreOptsFromCtx } from "../../../utils";
+import { useCoreOpts } from "../../../utils";
 
 function useOauth2ProviderDetail({ ctx, core }: ScreenProps, name: string | undefined) {
-  const opts = coreOptsFromCtx(ctx);
+  const opts = useCoreOpts(ctx);
   return useQuery({
     queryKey: ["oauth2-credential-provider", opts.region, name],
     queryFn: () => core.identity.getOauth2CredentialProvider(name!, opts),

--- a/src/handlers/memory/get/screen.tsx
+++ b/src/handlers/memory/get/screen.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useParams } from "react-router";
 import { JsonDetail } from "../../../components/JsonDetail";
 import { ResourceDetailScreen } from "../../../components/ResourceDetailScreen";
 import type { ScreenProps } from "../../types";
-import { coreOptsFromCtx } from "../../utils";
+import { useCoreOpts } from "../../utils";
 
 const ACTIONS = [
   {
@@ -34,7 +34,7 @@ const ACTIONS = [
 ] as const;
 
 function useMemoryDetail({ ctx, core }: ScreenProps, memoryId: string | undefined) {
-  const opts = coreOptsFromCtx(ctx);
+  const opts = useCoreOpts(ctx);
   return useQuery({
     queryKey: ["memory", opts.region, memoryId, "full"],
     queryFn: () => core.memory.getMemory(memoryId!, "full", opts),

--- a/src/handlers/project/index.ts
+++ b/src/handlers/project/index.ts
@@ -35,6 +35,7 @@ export function createProjectHandler({ core, io }: ProjectHandlerConfig): Router
     "invoke",
     "build",
     "deploy",
+    "status",
   );
 
   // Without a default, a bare `agentcore project` falls back to Commander's help
@@ -98,11 +99,26 @@ export function createProjectHandler({ core, io }: ProjectHandlerConfig): Router
     ),
   );
   project.handler(createProjectInvokeHandler(core, io));
-  project.handler(
-    withProject({ projectManager: config.projectManager })(
-      createStatusProjectHandler({ projectManager: config.projectManager }),
-    ),
-  );
+  // A bare `agentcore project status` in an interactive session opens the TUI
+  // linked-resources screen; any user-supplied flag, --json, or a non-TTY
+  // invocation keeps the headless JSON report (same dispatch shape as create).
+  // withProject stays outermost so the not-found guidance outside a project is
+  // the CLI's own, and the resolved project seeds the screen via ProjectKey.
+  const statusProject = createStatusProjectHandler({ projectManager: config.projectManager });
+  const statusProjectWithTui = withTuiOnEmptyFlagsAndArgs(core, io)(statusProject);
+  const statusProjectDispatch: Handler = {
+    name: () => statusProject.name(),
+    description: () => statusProject.description(),
+    flags: () => statusProject.flags(),
+    arguments: () => statusProject.arguments(),
+    doesSupportTui: () => statusProject.doesSupportTui(),
+    children: () => statusProject.children(),
+    handle: (ctx, flags, args) =>
+      isInteractive()
+        ? statusProjectWithTui.handle(ctx, flags, args)
+        : statusProject.handle(ctx, flags, args),
+  };
+  project.handler(withProject({ projectManager: config.projectManager })(statusProjectDispatch));
   // withProject wraps only the commands that require an existing project, so
   // `create` (which refuses to nest inside one) stays unaffected.
   project.handler(

--- a/src/handlers/project/project.screen.test.tsx
+++ b/src/handlers/project/project.screen.test.tsx
@@ -89,7 +89,7 @@ describe("project menu: command-line-only subcommands", () => {
     const r = renderScreen("/agentcore/project");
 
     await waitForText(r.lastFrame, "command line only");
-    const withScreens = ["create", "deploy", "invoke", "build"];
+    const withScreens = ["create", "deploy", "invoke", "build", "status"];
     const { screens, cliOnly } = menuEntries(r.lastFrame()!);
     expect(screens.toSorted()).toEqual(withScreens.toSorted());
     expect(cliOnly.toSorted()).toEqual(

--- a/src/handlers/project/status/index.test.ts
+++ b/src/handlers/project/status/index.test.ts
@@ -8,6 +8,8 @@ import {
   TestCoreClient,
   TestGlobalConfigAccessor,
   testIO,
+  ttyTestIO,
+  waitFor,
 } from "../../../testing";
 import type { ProjectBackend } from "../../../core/project";
 import type { AwsDeploymentTarget } from "../../../projectSchemas/aws-targets";
@@ -45,8 +47,7 @@ function fakeBackend(deployed: ResolvedProjectResource[]) {
   return { targets, backend };
 }
 
-function testStatusCommand(deployed: ResolvedProjectResource[] = []) {
-  const io = testIO();
+function testStatusCommand(deployed: ResolvedProjectResource[] = [], io = testIO()) {
   const fake = fakeBackend(deployed);
   const root = createRootHandler(new TestCoreClient({ backends: { CDK: fake.backend } }), {
     io: io.io,
@@ -230,5 +231,63 @@ describe("project status handler", () => {
     await expect(subject.run(["--target", "typo"])).rejects.toThrow(
       /has no deployment target named 'typo'/,
     );
+  });
+});
+
+describe("project status dispatch", () => {
+  // The bare-invocation tests above run without a TTY and assert the exact
+  // JSON envelope, which pins the non-TTY headless path; these cover how a TTY
+  // changes (and does not change) the dispatch.
+  test("bare status in a TTY session opens the TUI instead of printing JSON", async () => {
+    const tty = ttyTestIO();
+    const subject = testStatusCommand([HARNESS_ROW], tty.streams);
+    await inProject(subject);
+
+    // outcome never rejects, so a mid-pump failure cannot trip bun's
+    // unhandled-rejection detection before the final assertion.
+    const outcome = subject.run().then(
+      () => ({ ok: true as const }),
+      (error: unknown) => ({ ok: false as const, error }),
+    );
+    let settled = false;
+    void outcome.finally(() => {
+      settled = true;
+    });
+
+    // The screen never finishes on its own; Ctrl+C (re-sent until the app
+    // reacts) closes it and resolves the route cleanly.
+    await waitFor(
+      () => {
+        if (!settled) tty.stdin.write("\x03");
+        return settled;
+      },
+      5000,
+      150,
+    );
+    expect(await outcome).toEqual({ ok: true });
+    expect(subject.io.stdout()).not.toContain('"projectName"');
+  }, 10000);
+
+  test("an explicitly passed --target stays headless even in a TTY", async () => {
+    const subject = testStatusCommand([HARNESS_ROW], ttyTestIO().streams);
+    await inProject(subject);
+
+    await subject.run(["--target", "default"]);
+
+    expect(subject.json()).toMatchObject({ projectName: "orders", target: "default" });
+  });
+
+  test("--json stays headless even in a TTY", async () => {
+    const subject = testStatusCommand([HARNESS_ROW], ttyTestIO().streams);
+    await inProject(subject);
+
+    await subject.run(["--json"]);
+
+    expect(subject.json()).toEqual({
+      projectName: "orders",
+      target: "default",
+      region: "us-east-1",
+      resources: [HARNESS_ROW],
+    });
   });
 });

--- a/src/handlers/project/status/screen.tsx
+++ b/src/handlers/project/status/screen.tsx
@@ -1,0 +1,275 @@
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Box, Text, useInput } from "ink";
+import { useNavigate } from "react-router";
+import { Layout } from "../../../components/Layout";
+import { TreeView } from "../../../components/ui/tree-view";
+import {
+  linkedResourceLabel,
+  typeColumnWidth,
+  type LinkedResourceNode,
+} from "../../../components/LinkedResources";
+import { serviceIdFromArn } from "../../../core/arn";
+import { darkTheme } from "../../../components/ui/_core.js";
+import { ProjectKey } from "../../../router";
+import type { ScreenProps } from "../../types";
+import type { DeployableResource, Project, ResolvedProjectResource } from "../types";
+import { LoadingFrame, ProjectGate } from "../ProjectGate";
+
+const theme = darkTheme;
+
+const BREADCRUMB = ["agentcore", "project", "status"];
+const PROJECT_MENU = "/agentcore/project";
+// The TUI opens only from a bare invocation (an explicit --target keeps the
+// headless report), so the screen always shows the default target, like the
+// invoke picker.
+const TARGET_NAME = "default";
+
+const RESOURCE_TYPE_LABELS: Record<DeployableResource, string> = {
+  runtime: "Runtime",
+  harness: "Harness",
+  memory: "Memory",
+  "knowledge-base": "Knowledge Base",
+  credential: "Credential",
+  evaluator: "Evaluator",
+  "online-eval": "Online Eval",
+  gateway: "Gateway",
+  "gateway-target": "Gateway Target",
+  "policy-engine": "Policy Engine",
+  policy: "Policy",
+  "config-bundle": "Config Bundle",
+  "payment-manager": "Payment Manager",
+  "payment-connector": "Payment Connector",
+};
+
+// The detail routes a deployed resource can forward to. Types without a detail
+// screen are listed but not navigable.
+const DETAIL_ROUTES: Partial<Record<DeployableResource, (id: string) => string>> = {
+  runtime: (id) => `/agentcore/runtime/get/${encodeURIComponent(id)}`,
+  harness: (id) => `/agentcore/harness/get/${encodeURIComponent(id)}`,
+  memory: (id) => `/agentcore/memory/get/${encodeURIComponent(id)}`,
+  gateway: (id) => `/agentcore/gateway/get/${encodeURIComponent(id)}`,
+};
+
+// resolveProjectResources reports most ids as ARNs (e.g.
+// arn:aws:bedrock-agentcore:<region>:<account>:memory/<memoryId>) while the
+// detail routes and Core clients take the bare service id — see
+// serviceIdFromArn, which passes non-ARN ids (a gateway target's, for one)
+// through unchanged.
+type StatusNode = LinkedResourceNode;
+
+// routeFor resolves the detail route for a deployed resource. Gateway targets
+// have a detail screen too, but its route needs the owning gateway's id, which
+// only the parent row carries.
+function routeFor(
+  resource: ResolvedProjectResource,
+  parent?: ResolvedProjectResource,
+): string | undefined {
+  if (resource.deploymentState !== "deployed") return undefined;
+  if (resource.resourceType === "gateway-target") {
+    if (parent?.deploymentState !== "deployed") return undefined;
+    const gatewayId = encodeURIComponent(serviceIdFromArn(parent.id));
+    return `/agentcore/gateway/target/get/${gatewayId}/${encodeURIComponent(resource.id)}`;
+  }
+  return DETAIL_ROUTES[resource.resourceType]?.(serviceIdFromArn(resource.id));
+}
+
+// buildStatusNodes groups the resolved resources by agent. Each entry in
+// spec.runtimes (code agents) and spec.harnesses (managed harness agents) is a
+// top-level group holding the agent's own deployed resource; everything not
+// attributable to an agent lands in a shared "project" group so nothing the
+// project declares is dropped.
+//
+// Memories group under runtime agents: the CDK L3 injects a MEMORY_<NAME>_ID
+// env var for every declared memory into every runtime (see
+// src/core/project/templates/runtime.ts), so each declared memory is reachable
+// from each runtime agent. A harness's memory binding lives in its own
+// harness.json (HarnessMemoryRefSchema), not in the project spec this report is
+// built from — a managed one is provisioned inside the harness and never
+// appears here — so harness groups list just the harness itself and memories a
+// harness may reference by name stay visible under the project group.
+export function buildStatusNodes(
+  spec: Project["spec"],
+  resources: ResolvedProjectResource[],
+): StatusNode[] {
+  const byKey = new Map(resources.map((r) => [`${r.resourceType}:${r.name}`, r]));
+  const claimed = new Set<string>();
+  const claim = (resourceType: DeployableResource, name: string) => {
+    const resource = byKey.get(`${resourceType}:${name}`);
+    if (resource) claimed.add(`${resourceType}:${name}`);
+    return resource;
+  };
+
+  // The type column is sized for the resource rows (depth 1); rows nested
+  // deeper give up the width their guide characters take.
+  const typeWidth = typeColumnWidth(resources.map((r) => RESOURCE_TYPE_LABELS[r.resourceType]));
+
+  const resourceNode = (
+    resource: ResolvedProjectResource,
+    parentId: string,
+    depth: number,
+    parent?: ResolvedProjectResource,
+  ): StatusNode => {
+    const id = `${parentId}/${resource.resourceType}:${resource.name}`;
+    const type = RESOURCE_TYPE_LABELS[resource.resourceType];
+    const route = routeFor(resource, parent);
+    const deployed = resource.deploymentState === "deployed";
+    return {
+      id,
+      label: linkedResourceLabel(type, resource.name, typeWidth, depth - 1),
+      annotation: deployed ? "deployed" : "local-only",
+      // A declared-but-undeployed resource has nothing to fetch, so its row
+      // cannot be selected; deployed types without a detail screen stay
+      // selectable and explain themselves instead.
+      disabled: !deployed,
+      defaultExpanded: true,
+      children: resource.children?.map((child) => resourceNode(child, id, depth + 1, resource)),
+      data: route ? { route } : { hint: `${type} ${resource.name} has no detail view.` },
+    };
+  };
+
+  const agentGroups: StatusNode[] = [
+    ...spec.runtimes.map(({ name }): StatusNode => {
+      const id = `agent:${name}`;
+      const children = [
+        claim("runtime", name),
+        ...spec.memories.map(({ name: memoryName }) => claim("memory", memoryName)),
+      ].filter((resource) => resource !== undefined);
+      return {
+        id,
+        label: name,
+        annotation: "agent",
+        defaultExpanded: true,
+        children: children.map((resource) => resourceNode(resource, id, 1)),
+      };
+    }),
+    ...spec.harnesses.map(({ name }): StatusNode => {
+      const id = `agent:${name}`;
+      const children = [claim("harness", name)].filter((resource) => resource !== undefined);
+      return {
+        id,
+        label: name,
+        annotation: "agent",
+        defaultExpanded: true,
+        children: children.map((resource) => resourceNode(resource, id, 1)),
+      };
+    }),
+  ];
+
+  const shared = resources.filter((r) => !claimed.has(`${r.resourceType}:${r.name}`));
+  const sharedGroup: StatusNode[] = shared.length
+    ? [
+        {
+          id: "project",
+          label: "project",
+          annotation: "shared resources",
+          defaultExpanded: true,
+          children: shared.map((resource) => resourceNode(resource, "project", 1)),
+        },
+      ]
+    : [];
+
+  return [...agentGroups, ...sharedGroup];
+}
+
+// The project comes from the launch context when a project command opened the
+// TUI, and is resolved from the cwd otherwise — the gate reports the CLI's own
+// not-found guidance when there is none.
+export function ProjectStatusScreen({ ctx, core }: ScreenProps) {
+  const navigate = useNavigate();
+  return (
+    <ProjectGate
+      core={core}
+      breadcrumb={BREADCRUMB}
+      description="the project's linked resources on target default"
+      seed={ctx.value(ProjectKey)}
+      onBack={() => navigate(PROJECT_MENU)}
+    >
+      {(project) => <ProjectStatusView core={core} project={project} />}
+    </ProjectGate>
+  );
+}
+
+function ProjectStatusView({
+  core,
+  project,
+}: Pick<ScreenProps, "core"> & {
+  project: Project;
+}) {
+  const navigate = useNavigate();
+  const [hint, setHint] = useState<string>();
+
+  const status = useQuery({
+    queryKey: ["project-status", project.rootPath, TARGET_NAME],
+    queryFn: () => core.projectManager.resolveProjectResources(project, { target: TARGET_NAME }),
+  });
+
+  const nodes = useMemo(
+    () => (status.data ? buildStatusNodes(project.spec, status.data.resources) : []),
+    [project, status.data],
+  );
+
+  const goBack = () => navigate(PROJECT_MENU);
+  // Only once the tree is up — while loading or on an error the LoadingFrame
+  // below owns escape (and retry).
+  useInput((_input, key) => {
+    if (key.escape && status.data !== undefined) goBack();
+  });
+
+  if (!status.data) {
+    return (
+      <LoadingFrame
+        breadcrumb={BREADCRUMB}
+        description="the project's linked resources on target default"
+        query={status}
+        loadingLabel="Resolving project resources…"
+        onBack={goBack}
+      />
+    );
+  }
+
+  const select = (node: StatusNode) => {
+    if (node.data?.route) {
+      // The detail screens fetch in their context's region, which is the
+      // ambient one — link with ?region= so the destination fetches where the
+      // project actually deployed (see useCoreOpts). Escape there is a history
+      // pop back here.
+      const region = encodeURIComponent(status.data.target.region);
+      navigate(`${node.data.route}?region=${region}`);
+      return;
+    }
+    setHint(node.data?.hint);
+  };
+
+  return (
+    <Layout
+      breadcrumb={BREADCRUMB}
+      description={`the project's linked resources on target ${status.data.target.name}`}
+      keyHints={[
+        { key: "↑↓/jk", label: "navigate" },
+        { key: "←→", label: "collapse/expand" },
+        { key: "enter", label: "open" },
+        { key: "esc", label: "back" },
+        { key: "ctl+c", label: "quit" },
+      ]}
+    >
+      <Box flexDirection="column" paddingX={1}>
+        <Text bold>Linked Resources</Text>
+        <Box marginTop={1} flexDirection="column">
+          {nodes.length === 0 ? (
+            <Text color={theme.colors.muted}>
+              No resources are declared in this project. Run `agentcore project add` to declare one.
+            </Text>
+          ) : (
+            <TreeView nodes={nodes} onSelect={select} showIcons={false} focusMarker />
+          )}
+        </Box>
+        {hint !== undefined && (
+          <Box marginTop={1}>
+            <Text color={theme.colors.muted}>{hint}</Text>
+          </Box>
+        )}
+      </Box>
+    </Layout>
+  );
+}

--- a/src/handlers/project/status/screen.tsx
+++ b/src/handlers/project/status/screen.tsx
@@ -233,7 +233,7 @@ function ProjectStatusView({
         { key: "←→", label: "collapse/expand" },
         { key: "enter", label: "open" },
         { key: "esc", label: "back" },
-        { key: "ctl+c", label: "quit" },
+        { key: "ctrl+c", label: "quit" },
       ]}
     >
       <Box flexDirection="column" paddingX={1}>

--- a/src/handlers/project/status/screen.tsx
+++ b/src/handlers/project/status/screen.tsx
@@ -25,23 +25,6 @@ const PROJECT_MENU = "/agentcore/project";
 // invoke picker.
 const TARGET_NAME = "default";
 
-const RESOURCE_TYPE_LABELS: Record<DeployableResource, string> = {
-  runtime: "Runtime",
-  harness: "Harness",
-  memory: "Memory",
-  "knowledge-base": "Knowledge Base",
-  credential: "Credential",
-  evaluator: "Evaluator",
-  "online-eval": "Online Eval",
-  gateway: "Gateway",
-  "gateway-target": "Gateway Target",
-  "policy-engine": "Policy Engine",
-  policy: "Policy",
-  "config-bundle": "Config Bundle",
-  "payment-manager": "Payment Manager",
-  "payment-connector": "Payment Connector",
-};
-
 // The detail routes a deployed resource can forward to. Types without a detail
 // screen are listed but not navigable.
 const DETAIL_ROUTES: Partial<Record<DeployableResource, (id: string) => string>> = {
@@ -102,7 +85,7 @@ export function buildStatusNodes(
 
   // The type column is sized for the resource rows (depth 1); rows nested
   // deeper give up the width their guide characters take.
-  const typeWidth = typeColumnWidth(resources.map((r) => RESOURCE_TYPE_LABELS[r.resourceType]));
+  const typeWidth = typeColumnWidth(resources.map((r) => r.resourceType));
 
   const resourceNode = (
     resource: ResolvedProjectResource,
@@ -111,7 +94,7 @@ export function buildStatusNodes(
     parent?: ResolvedProjectResource,
   ): StatusNode => {
     const id = `${parentId}/${resource.resourceType}:${resource.name}`;
-    const type = RESOURCE_TYPE_LABELS[resource.resourceType];
+    const type = resource.resourceType;
     const route = routeFor(resource, parent);
     const deployed = resource.deploymentState === "deployed";
     return {
@@ -254,8 +237,8 @@ function ProjectStatusView({
       ]}
     >
       <Box flexDirection="column" paddingX={1}>
-        <Text bold>Linked Resources</Text>
-        <Box marginTop={1} flexDirection="column">
+        <Text bold>resources</Text>
+        <Box flexDirection="column">
           {nodes.length === 0 ? (
             <Text color={theme.colors.muted}>
               No resources are declared in this project. Run `agentcore project add` to declare one.

--- a/src/handlers/project/status/status.screen.test.tsx
+++ b/src/handlers/project/status/status.screen.test.tsx
@@ -107,6 +107,13 @@ function renderStatus(value: TestCoreClient, seed: Project = RUNTIME_PROJECT) {
   });
 }
 
+// waitForGroup waits for the tree to be up: the agent group row is the first
+// thing only a resolved status renders (the description mentions resources
+// while loading too).
+function waitForGroup(screen: ReturnType<typeof renderStatus>, name = "checkout") {
+  return waitForFlatText(screen.lastFrame, `${name} agent`);
+}
+
 // focusedLine returns the line carrying the ❯ marker.
 function focusedLine(frame: string | undefined): string {
   return (frame ?? "").split("\n").find((line) => line.includes("❯")) ?? "";
@@ -116,11 +123,11 @@ describe("project status screen", () => {
   test("groups the runtime agent's Runtime and Memory beneath it", async () => {
     const screen = renderStatus(core());
 
-    await waitForText(screen.lastFrame, "Linked Resources");
+    await waitForGroup(screen);
     const frame = flatFrame(screen.lastFrame);
     expect(frame).toContain("checkout agent");
-    expect(frame).toMatch(/Runtime\s+checkout deployed/);
-    expect(frame).toMatch(/Memory\s+recall deployed/);
+    expect(frame).toMatch(/runtime\s+checkout deployed/);
+    expect(frame).toMatch(/memory\s+recall deployed/);
     // Both resources are attributed to the agent — no shared group appears.
     expect(frame).not.toContain("project shared resources");
   });
@@ -136,12 +143,12 @@ describe("project status screen", () => {
       ]),
     );
 
-    await waitForText(screen.lastFrame, "Linked Resources");
+    await waitForGroup(screen);
     const frame = flatFrame(screen.lastFrame);
     expect(frame).toContain("project shared resources");
-    expect(frame).toMatch(/Gateway\s+tools deployed/);
-    expect(frame).toMatch(/Gateway Target\s+search deployed/);
-    expect(frame).toMatch(/Credential\s+svc-key local-only/);
+    expect(frame).toMatch(/gateway\s+tools deployed/);
+    expect(frame).toMatch(/gateway-target\s+search deployed/);
+    expect(frame).toMatch(/credential\s+svc-key local-only/);
   });
 
   test("marks declared-but-undeployed rows local-only and skips them when navigating", async () => {
@@ -156,16 +163,16 @@ describe("project status screen", () => {
     // Down from the agent group focuses the Runtime; the disabled Memory row
     // cannot take focus, so a second press leaves the focus where it is.
     await screen.press("down");
-    expect(focusedLine(screen.lastFrame())).toContain("Runtime");
+    expect(focusedLine(screen.lastFrame())).toContain("runtime");
     await screen.press("down");
-    expect(focusedLine(screen.lastFrame())).toContain("Runtime");
+    expect(focusedLine(screen.lastFrame())).toContain("runtime");
   });
 
   test("enter on the Runtime opens the Runtime detail page in the target region", async () => {
     const value = core();
     const screen = renderStatus(value);
 
-    await waitForText(screen.lastFrame, "Linked Resources");
+    await waitForGroup(screen);
     await screen.press("down");
     await screen.press("return");
 
@@ -180,7 +187,7 @@ describe("project status screen", () => {
     const value = core();
     const screen = renderStatus(value);
 
-    await waitForText(screen.lastFrame, "Linked Resources");
+    await waitForGroup(screen);
     await screen.press("down");
     await screen.press("down");
     await screen.press("return");
@@ -198,7 +205,7 @@ describe("project status screen", () => {
       project({ harnesses: [{ name: "support", path: "app/support" }] }),
     );
 
-    await waitForText(screen.lastFrame, "Linked Resources");
+    await waitForGroup(screen, "support");
     await screen.press("down");
     await screen.press("return");
 
@@ -208,13 +215,13 @@ describe("project status screen", () => {
   test("escape from a detail page returns to the status screen", async () => {
     const screen = renderStatus(core());
 
-    await waitForText(screen.lastFrame, "Linked Resources");
+    await waitForGroup(screen);
     await screen.press("down");
     await screen.press("return");
     await waitForText(screen.lastFrame, "agentcore → runtime → get");
 
     await screen.press("escape");
-    await waitForText(screen.lastFrame, "Linked Resources");
+    await waitForGroup(screen);
   });
 
   test("a deployed resource without a detail screen explains itself instead of navigating", async () => {
@@ -222,31 +229,31 @@ describe("project status screen", () => {
       core([...RUNTIME_RESOURCES, deployed("credential", "svc-key", `${ARN}:token-vault/default`)]),
     );
 
-    await waitForText(screen.lastFrame, "Linked Resources");
+    await waitForGroup(screen);
     // group → runtime → memory → project group → credential.
     for (let press = 0; press < 4; press++) await screen.press("down");
-    expect(focusedLine(screen.lastFrame())).toContain("Credential");
+    expect(focusedLine(screen.lastFrame())).toContain("credential");
     await screen.press("return");
 
-    await waitForText(screen.lastFrame, "Credential svc-key has no detail view.");
-    expect(screen.lastFrame()).toContain("Linked Resources");
+    await waitForText(screen.lastFrame, "credential svc-key has no detail view.");
+    expect(screen.lastFrame()).toContain("agentcore → project → status");
   });
 
   test("left and right arrows collapse and expand an agent group", async () => {
     const screen = renderStatus(core());
 
-    await waitForText(screen.lastFrame, "Linked Resources");
-    expect(screen.lastFrame()).toContain("Runtime");
+    await waitForGroup(screen);
+    expect(screen.lastFrame()).toContain("runtime");
     await screen.press("left");
-    expect(screen.lastFrame()).not.toContain("Runtime");
+    expect(screen.lastFrame()).not.toContain("runtime");
     await screen.press("right");
-    await waitForText(screen.lastFrame, "Runtime");
+    await waitForText(screen.lastFrame, "runtime");
   });
 
   test("esc returns to the project command menu", async () => {
     const screen = renderStatus(core());
 
-    await waitForText(screen.lastFrame, "Linked Resources");
+    await waitForGroup(screen);
     await screen.press("escape");
     await waitForText(screen.lastFrame, "manage an AgentCore project");
   });

--- a/src/handlers/project/status/status.screen.test.tsx
+++ b/src/handlers/project/status/status.screen.test.tsx
@@ -1,0 +1,284 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type {
+  GetAgentRuntimeResponse,
+  GetHarnessResponse,
+  GetMemoryOutput,
+} from "@aws-sdk/client-bedrock-agentcore-control";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ProjectSpecSchema } from "../../../projectSchemas/project";
+import { ProjectKey } from "../../../router";
+import {
+  cleanupScreens,
+  flatFrame,
+  renderScreen,
+  TestCoreClient,
+  waitForFlatText,
+  waitForText,
+} from "../../../testing";
+import type { Project, ResolvedProjectResource } from "../types";
+
+const originalCwd = process.cwd();
+const tempDirectories: string[] = [];
+
+afterEach(cleanupScreens);
+afterEach(async () => {
+  process.chdir(originalCwd);
+  await Promise.all(
+    tempDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+// The target region differs from the base context's us-east-1 on purpose: the
+// detail screens must fetch where the project deployed, not in the ambient
+// region.
+const TARGET = { name: "default", account: "111122223333", region: "eu-west-1" } as const;
+const ARN = `arn:aws:bedrock-agentcore:${TARGET.region}:${TARGET.account}`;
+const RUNTIME_ID = "checkout-AbCdEf1234";
+const MEMORY_ID = "recallMemory-XyZ123";
+const HARNESS_ID = "support-AbCdEf1234";
+
+function project(spec: Record<string, unknown>): Project {
+  return {
+    name: "orders",
+    rootPath: "/tmp/orders",
+    spec: ProjectSpecSchema.parse({ name: "orders", version: 1, ...spec }),
+  };
+}
+
+const RUNTIME_PROJECT = project({
+  runtimes: [
+    {
+      name: "checkout",
+      build: "CodeZip",
+      entrypoint: "main.py",
+      codeLocation: "app/checkout",
+      runtimeVersion: "PYTHON_3_14",
+    },
+  ],
+  memories: [{ name: "recall", eventExpiryDuration: 30 }],
+});
+
+const deployed = (
+  resourceType: ResolvedProjectResource["resourceType"],
+  name: string,
+  id: string,
+  children?: ResolvedProjectResource[],
+): ResolvedProjectResource => ({
+  resourceType,
+  name,
+  ...(children ? { children } : {}),
+  deploymentState: "deployed",
+  id,
+});
+
+const localOnly = (
+  resourceType: ResolvedProjectResource["resourceType"],
+  name: string,
+): ResolvedProjectResource => ({ resourceType, name, deploymentState: "local-only" });
+
+const RUNTIME_RESOURCES: ResolvedProjectResource[] = [
+  deployed("runtime", "checkout", `${ARN}:runtime/${RUNTIME_ID}`),
+  deployed("memory", "recall", `${ARN}:memory/${MEMORY_ID}`),
+];
+
+function core(resources: ResolvedProjectResource[] = RUNTIME_RESOURCES): TestCoreClient {
+  const value = new TestCoreClient();
+  value.projectManager.resolveProjectResources = async () => ({ resources, target: TARGET });
+  value.runtime.setGetResponse({
+    agentRuntimeId: RUNTIME_ID,
+    agentRuntimeArn: `${ARN}:runtime/${RUNTIME_ID}`,
+    status: "READY",
+  } as GetAgentRuntimeResponse);
+  value.memory.setGetResponse({
+    memory: { id: MEMORY_ID, name: "recall", arn: `${ARN}:memory/${MEMORY_ID}`, status: "ACTIVE" },
+  } as GetMemoryOutput);
+  value.harness.setGetResponse({
+    harness: { harnessId: HARNESS_ID, harnessName: "support", arn: `${ARN}:harness/${HARNESS_ID}` },
+  } as GetHarnessResponse);
+  return value;
+}
+
+function renderStatus(value: TestCoreClient, seed: Project = RUNTIME_PROJECT) {
+  return renderScreen("/agentcore/project/status", {
+    core: value,
+    withContext: (ctx) => ctx.withValue(ProjectKey, seed),
+  });
+}
+
+// focusedLine returns the line carrying the ❯ marker.
+function focusedLine(frame: string | undefined): string {
+  return (frame ?? "").split("\n").find((line) => line.includes("❯")) ?? "";
+}
+
+describe("project status screen", () => {
+  test("groups the runtime agent's Runtime and Memory beneath it", async () => {
+    const screen = renderStatus(core());
+
+    await waitForText(screen.lastFrame, "Linked Resources");
+    const frame = flatFrame(screen.lastFrame);
+    expect(frame).toContain("checkout agent");
+    expect(frame).toMatch(/Runtime\s+checkout deployed/);
+    expect(frame).toMatch(/Memory\s+recall deployed/);
+    // Both resources are attributed to the agent — no shared group appears.
+    expect(frame).not.toContain("project shared resources");
+  });
+
+  test("keeps unattributable resources visible under a shared project group", async () => {
+    const screen = renderStatus(
+      core([
+        ...RUNTIME_RESOURCES,
+        deployed("gateway", "tools", `${ARN}:gateway/tools-GwId12345`, [
+          deployed("gateway-target", "search", "TARGETID123"),
+        ]),
+        localOnly("credential", "svc-key"),
+      ]),
+    );
+
+    await waitForText(screen.lastFrame, "Linked Resources");
+    const frame = flatFrame(screen.lastFrame);
+    expect(frame).toContain("project shared resources");
+    expect(frame).toMatch(/Gateway\s+tools deployed/);
+    expect(frame).toMatch(/Gateway Target\s+search deployed/);
+    expect(frame).toMatch(/Credential\s+svc-key local-only/);
+  });
+
+  test("marks declared-but-undeployed rows local-only and skips them when navigating", async () => {
+    const screen = renderStatus(
+      core([
+        deployed("runtime", "checkout", `${ARN}:runtime/${RUNTIME_ID}`),
+        localOnly("memory", "recall"),
+      ]),
+    );
+
+    await waitForText(screen.lastFrame, "local-only");
+    // Down from the agent group focuses the Runtime; the disabled Memory row
+    // cannot take focus, so a second press leaves the focus where it is.
+    await screen.press("down");
+    expect(focusedLine(screen.lastFrame())).toContain("Runtime");
+    await screen.press("down");
+    expect(focusedLine(screen.lastFrame())).toContain("Runtime");
+  });
+
+  test("enter on the Runtime opens the Runtime detail page in the target region", async () => {
+    const value = core();
+    const screen = renderStatus(value);
+
+    await waitForText(screen.lastFrame, "Linked Resources");
+    await screen.press("down");
+    await screen.press("return");
+
+    await waitForText(screen.lastFrame, "agentcore → runtime → get → " + RUNTIME_ID);
+    await waitForText(screen.lastFrame, "READY");
+    const call = value.runtime.calls.find(({ method }) => method === "getRuntime")!;
+    expect(call.args[0]).toBe(RUNTIME_ID);
+    expect(call.args[1]).toMatchObject({ region: TARGET.region });
+  });
+
+  test("enter on the Memory opens the Memory detail page in the target region", async () => {
+    const value = core();
+    const screen = renderStatus(value);
+
+    await waitForText(screen.lastFrame, "Linked Resources");
+    await screen.press("down");
+    await screen.press("down");
+    await screen.press("return");
+
+    await waitForText(screen.lastFrame, "agentcore → memory → get → " + MEMORY_ID);
+    await waitForText(screen.lastFrame, "ACTIVE");
+    const call = value.memory.calls.find(({ method }) => method === "getMemory")!;
+    expect(call.args[0]).toBe(MEMORY_ID);
+    expect(call.args[2]).toMatchObject({ region: TARGET.region });
+  });
+
+  test("enter on a Harness opens the Harness detail page", async () => {
+    const screen = renderStatus(
+      core([deployed("harness", "support", `${ARN}:harness/${HARNESS_ID}`)]),
+      project({ harnesses: [{ name: "support", path: "app/support" }] }),
+    );
+
+    await waitForText(screen.lastFrame, "Linked Resources");
+    await screen.press("down");
+    await screen.press("return");
+
+    await waitForText(screen.lastFrame, "agentcore → harness → get → " + HARNESS_ID);
+  });
+
+  test("escape from a detail page returns to the status screen", async () => {
+    const screen = renderStatus(core());
+
+    await waitForText(screen.lastFrame, "Linked Resources");
+    await screen.press("down");
+    await screen.press("return");
+    await waitForText(screen.lastFrame, "agentcore → runtime → get");
+
+    await screen.press("escape");
+    await waitForText(screen.lastFrame, "Linked Resources");
+  });
+
+  test("a deployed resource without a detail screen explains itself instead of navigating", async () => {
+    const screen = renderStatus(
+      core([...RUNTIME_RESOURCES, deployed("credential", "svc-key", `${ARN}:token-vault/default`)]),
+    );
+
+    await waitForText(screen.lastFrame, "Linked Resources");
+    // group → runtime → memory → project group → credential.
+    for (let press = 0; press < 4; press++) await screen.press("down");
+    expect(focusedLine(screen.lastFrame())).toContain("Credential");
+    await screen.press("return");
+
+    await waitForText(screen.lastFrame, "Credential svc-key has no detail view.");
+    expect(screen.lastFrame()).toContain("Linked Resources");
+  });
+
+  test("left and right arrows collapse and expand an agent group", async () => {
+    const screen = renderStatus(core());
+
+    await waitForText(screen.lastFrame, "Linked Resources");
+    expect(screen.lastFrame()).toContain("Runtime");
+    await screen.press("left");
+    expect(screen.lastFrame()).not.toContain("Runtime");
+    await screen.press("right");
+    await waitForText(screen.lastFrame, "Runtime");
+  });
+
+  test("esc returns to the project command menu", async () => {
+    const screen = renderStatus(core());
+
+    await waitForText(screen.lastFrame, "Linked Resources");
+    await screen.press("escape");
+    await waitForText(screen.lastFrame, "manage an AgentCore project");
+  });
+
+  test("shows resolution errors with the standard treatment", async () => {
+    const value = core();
+    value.projectManager.resolveProjectResources = async () => {
+      throw new Error("No deployment targets are configured for project 'orders'.");
+    };
+    const screen = renderStatus(value);
+
+    await waitForText(screen.lastFrame, "No deployment targets are configured");
+    expect(screen.lastFrame()).toContain("✗");
+    await screen.press("escape");
+    await waitForText(screen.lastFrame, "manage an AgentCore project");
+  });
+
+  test("an empty project reports that nothing is declared", async () => {
+    const screen = renderStatus(core([]), project({}));
+
+    await waitForText(screen.lastFrame, "No resources are declared in this project.");
+  });
+
+  test("reports the CLI's own guidance outside a project", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "agentcore-status-no-project-"));
+    tempDirectories.push(directory);
+    process.chdir(directory);
+    const screen = renderScreen("/agentcore/project/status", { core: core() });
+
+    await waitForFlatText(screen.lastFrame, "No AgentCore project found");
+    expect(flatFrame(screen.lastFrame)).toContain("agentcore project create");
+    await screen.press("escape");
+    await waitForText(screen.lastFrame, "manage an AgentCore project");
+  });
+});

--- a/src/handlers/runtime/get/screen.tsx
+++ b/src/handlers/runtime/get/screen.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useParams } from "react-router";
 import { JsonDetail } from "../../../components/JsonDetail";
 import { ResourceDetailScreen } from "../../../components/ResourceDetailScreen";
 import type { ScreenProps } from "../../types";
-import { coreOptsFromCtx } from "../../utils";
+import { useCoreOpts } from "../../utils";
 
 const ACTIONS = [
   {
@@ -36,7 +36,7 @@ const ACTIONS = [
 ] as const;
 
 function useRuntimeDetail({ ctx, core }: ScreenProps, runtimeId: string | undefined) {
-  const opts = coreOptsFromCtx(ctx);
+  const opts = useCoreOpts(ctx);
   return useQuery({
     queryKey: ["runtime", opts.region, runtimeId],
     queryFn: () => core.runtime.getRuntime(runtimeId!, opts),

--- a/src/handlers/utils.tsx
+++ b/src/handlers/utils.tsx
@@ -1,3 +1,4 @@
+import { useSearchParams } from "react-router";
 import type { Context } from "../router";
 import type z from "zod";
 import type { CoreOptions } from "../core/types";
@@ -16,6 +17,19 @@ export function coreOptsFromCtx(ctx: Context): CoreOptions {
     region: ctx.require(RegionKey),
     endpointUrl: ctx.value(EndpointKey),
   };
+}
+
+// useCoreOpts is coreOptsFromCtx for screens that can be linked to across
+// regions. The context's region is the ambient one resolved at launch, which is
+// not necessarily where the resource a screen is asked to show lives — project
+// status forwards to detail pages on a target that may be deployed elsewhere,
+// and links there with `?region=<target region>`. A region in the query string
+// wins; without one the context's region applies as usual.
+export function useCoreOpts(ctx: Context): CoreOptions {
+  const [search] = useSearchParams();
+  const region = search.get("region");
+  const opts = coreOptsFromCtx(ctx);
+  return region ? { ...opts, region } : opts;
 }
 
 // parseJsonFlag parses a flag's raw string as JSON, typed as the API structure


### PR DESCRIPTION
## What

Two Linked Resources trees, built on the vendored `TreeView`, that turn the ARNs the service reports into navigable rows.

**`agentcore project status`** was headless-only. A bare invocation in a terminal now opens an interactive tree; any user-supplied flag, `--json`, or a non-TTY invocation keeps producing exactly the current headless JSON report.

- **Grouped by agent**: each entry in `spec.runtimes` (code agents) and `spec.harnesses` (managed harness agents) is a top-level group holding the agent's deployed Runtime/Harness and its linked Memories. Resources not attributable to an agent (gateways, credentials, config bundles, …) stay visible under a shared `project` group, with the resolver's nested children (gateway → targets, policy engine → policies, payment manager → connectors) carried through.
- **Selection forwards to detail pages**: enter on a deployed Runtime, Harness, Memory, Gateway, or Gateway Target opens its existing detail screen. Local-only rows are dimmed, annotated `local-only`, and non-selectable; deployed types without a detail screen explain themselves instead of navigating.
- `status` joins the project router's `supportedTuiCommands`, so the `agentcore project` menu lists it above the "command line only" divider.

**The harness hub** (`agentcore harness get` → a harness) now ends with a `linked resources` divider and the same kind of tree, listing what `GetHarness` reports the harness is wired to:

- `runtime` — the AgentCore Runtime the service provisioned under the harness, named by its id (the value every `runtime` command takes)
- `memory` — `managed` (`managedMemoryConfiguration.arn`) or `attached` (`agentCoreMemoryConfiguration.arn`); omitted when memory is absent or `disabled`
- `gateway` rows for `agentCoreGateway` tools, with the outbound-auth `oauth2 provider` nested beneath (expanded by default)
- `browser` / `code interpreter` rows for those tools, annotated `aws default` when the ARN is unset or owned by the `aws` account
- `api key` rows for the model's `apiKeyArn` (annotated with the model id) and for git skills' `auth.credentialArn` (annotated with the skill path or repository)

Enter opens the resource's existing hub; Browser and Code Interpreter have none, so they stay selectable and print `<type> <name> has no detail view.` under the tree. Inline-function and remote-MCP tools are not AgentCore resources and never appear.

## Why

Creating a harness always provisions a Runtime and almost always a managed Memory, and a harness can reference a Gateway, Browser, Code Interpreter and credential providers — all reported as ARNs that already have detail screens. Until now neither the project nor the harness hub showed any of it; the user had to read the JSON and find each resource by hand.

## Design decisions

- **Memory ↔ agent rule** (commented on `buildStatusNodes`): every declared memory groups under every runtime agent, because the CDK L3 injects a `MEMORY_<NAME>_ID` env var for each declared memory into every runtime. A harness's memory ref lives in its own `harness.json`, not in the project spec the report is built from, so harness groups list the harness itself and unclaimed memories fall back to the shared group.
- **Region.** Detail screens read the AWS region off the launch context — the ambient region, not necessarily where a linked resource lives. Links carry `?region=` on the detail route (the project target's region from status; the region parsed from the resource's own ARN from the harness hub, falling back to the region the harness was fetched in), resolved by a shared `useCoreOpts` hook: a truthy region in the query string wins, otherwise the context's region applies as before. The two identity get screens switch from `coreOptsFromCtx` to `useCoreOpts` so the link is honoured there too. History-back restores the previous screen, so escape works at every level and the override is visible in the route itself.
- **Shared ARN helpers.** `serviceIdFromArn` lives in `src/core/arn.ts` (tested) with `resourceNameFromArn`, `regionFromArn` and `credentialProviderTypeFromArn` — credential provider ARNs (`…:token-vault/<vault>/apikeycredentialprovider/<name>`) need the trailing name, and the api-key/oauth2 distinction comes from the ARN alone.
- **Generic slot.** `ResourceDetailScreen` gains an optional `linkedResources` prop rendered through `LinkedResourcesTree` (divider + tree + hint), so the Runtime, Memory and Gateway hubs can adopt it later; only the harness hub is wired up here. The node builders (`buildStatusNodes`, `buildHarnessLinkNodes`) are pure exported functions.
- **Focus hand-off.** On the harness hub the action list and the tree behave as one continuous list: down from the last action moves focus into the tree, up from the tree's first row returns to the last action (new `onUpFromFirst` prop on `TreeView`), enter acts on the focused zone, escape still goes back, and the `❯` marker only ever shows in one zone. Footer hints follow the zone (`select` vs `open`, `←→ collapse/expand` only when the tree has nested rows).
- **Row style.** `TreeView` gains `focusMarker` (the `❯` selection style the rest of the TUI uses instead of inverse video) and per-node muted annotations, with icons off. Type labels are lowercase service names; the shared type-column padding accounts for the guide characters a nested row is pushed right by, and takes a minimum width so the harness tree's names line up with the action descriptions above them.

## Checks

Rebased onto `refactor` at 3fcf4063 (conflicts resolved by hand); a follow-up commit routes the tree's focus marker through the `glyphs` table and spells the quit hint `ctrl+c`, matching the conhost and help-text changes that landed there.

- `bun test src` — 3033 pass. The 11 failures are all in `src/io/exec.test.ts`, which spawns `node`, not installed in the verification environment (same 11 fail on the base commit).
- `bun run typecheck`, `bun run lint:check`, `bun run format:check` — clean.
- Tests: `src/handlers/project/status/` (screen and handler dispatch), `get.screen.test.tsx` (rendering, disabled-memory case, focus hand-off, single marker, Runtime/Memory/Gateway/OAuth2/API Key navigation with the ARN's region, Browser hint, footer hints, node-builder unit tests) and `src/core/arn.test.ts`.

## Live verification

**Project status (live E2E).** Scaffolded a project with runtime `myFirstAgent` + `myFirstAgentMemory` + an added harness, deployed to us-west-2 with ambient region us-east-1 (the mismatch case), and drove the real TUI in a PTY: the tree grouped the memory under the agent, enter landed on live Runtime (`READY`), Memory (`ACTIVE`), and Harness (`READY`) detail pages fetched in us-west-2, and escape walked back cleanly. Headless `--json` verified unchanged; stack torn down afterwards (`DELETE_COMPLETE`, no `StatusE2E` resources remain).

**Harness hub — inventory (live).** `harness list --json` in every region plus `harness get --id … --json` on each result: 19 harnesses — 13 in us-east-1, `MyPDXHarness-rhkXkAE1IS` in us-west-2, `harness_demo-Rrs0v4OyAO` in us-east-2, and `MyFirstHarness-Ya6Rf9E905` / `vpc-xV0snhWxb9` / `vpc_test_2-owfavpaf0x` in ap-southeast-2. Across them the linked resources are:

| Row type | Present on |
| --- | --- |
| runtime | all 19 |
| memory (managed) | `KnicksHarness-MFZ7GXmTYQ`, `inlineCliDemo-2poyWgSG0m`, `myCliHarness-up15WydSrZ` |
| browser, ARN unset | `FunTimes-T2MFxkuezh`, `KnicksHarness-MFZ7GXmTYQ`, `asdf-diSdqKDM2s`, `myCliHarness-up15WydSrZ`, `myFunDemoHarness-uwjQ1a7oM7`, `testAgain-2B1451OLO2`, `wizardDemo-igTsHbt17M` |
| browser, `aws.browser.v1` ARN | `harness_stnea-VVc5FvKgtr`, `harness_ummrg-NC9CEPEP0A`, `harness_demo-Rrs0v4OyAO` (us-east-2) |
| remote MCP tool (must not appear) | `harness_demo-Rrs0v4OyAO` |
| memory (attached), gateway, oauth2 provider, code interpreter, api key | **none** — no deployed harness carries them, and none was created |

**Harness hub — TUI walkthrough.** The temporary session credentials expired partway through and the instance role has no AgentCore permissions, so this walkthrough ran in a real pseudo-terminal (`bun run start harness get --endpoint-url …`) against a local stub that replays the live-captured `GetHarness` responses verbatim, synthesises minimal `GetAgentRuntime` / `GetMemory` / `GetGateway` / credential-provider responses for the link targets, and logs the SigV4 signing region of every request. A `synthetic-linked` harness (the `KnicksHarness` capture plus a gateway with OAuth outbound auth, a code interpreter, an OpenAI API key and a remote MCP tool) covered the row types no deployed harness has. Verified:

- `KnicksHarness-MFZ7GXmTYQ`: divider, `runtime harness_KnicksHarness-QDSgiYAteM`, `memory … managed`, `browser default aws default`; down from `update` focuses the runtime row, further down moves within the tree, up twice returns to `update`, exactly one `❯` at every step; enter on runtime opens `agentcore → runtime → get → harness_KnicksHarness-QDSgiYAteM` (stub saw `GET /runtimes/… region=us-east-1`, the ARN's region), escape returns to the hub with the tree; enter on memory opens the Memory hub (`region=us-east-1`); enter on browser prints the hint and does not navigate.
- `harness_stnea-VVc5FvKgtr` and `harness_demo-Rrs0v4OyAO` (opened with `--region us-east-2`): `browser aws.browser.v1 aws default`; the remote MCP tool does not appear.
- `MyPDXHarness-rhkXkAE1IS` opened with `--region us-west-2`: runtime row present; enter opens the runtime hub with the stub signing for `us-west-2`; escape returns.
- `synthetic-linked`: all seven rows with the type column aligned and `oauth2 provider github-oauth outbound auth` nested under the gateway; `←`/`→` collapse and expand it; enter on gateway, oauth2 provider and api key open the right hubs (`tools-Gw1234567`, `github-oauth`, `openai-key`) with every fetch signed for `us-west-2` from the ARN while the harness sat in `us-east-1`; enter on code interpreter prints the hint. Re-rendered after the row-style pass and again after the rebase to confirm the labels align with the action descriptions and the Memory link still signs for the ARN's region.

**Not verified live.** Forward navigation from the harness hub to the real Runtime and Memory services (only the route and signing region were observed through the stub), and every gateway / oauth2 provider / api key / code interpreter / attached-memory row (synthetic only). With fresh credentials: `bun run start harness get`, pick `KnicksHarness-MFZ7GXmTYQ`, then the same steps as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMPY8yuo2z5Vhrmyte1Lk2
https://claude.ai/code/session_016KnHdxcPYTnQiDY7Y1PY6s
