### PR TITLE
chore(help): simplify command indexes

### DIFF
--- a/src/router/router.test.ts
+++ b/src/router/router.test.ts
@@ -706,6 +706,35 @@ test("command groups omit Commander's generated help subcommand", async () => {
   expect(out).not.toContain("help [command]");
 });
 
+test("command indexes show names without usage syntax", async () => {
+  const withOptions = createHandler({
+    name: "with-options",
+    description: "command with flags",
+    flags: [flag("format", "output format", z.string().optional())],
+    handle: async () => {},
+  });
+  const withArguments = createHandler({
+    name: "with-arguments",
+    description: "command with arguments",
+    arguments: [
+      argument("required", "required value", z.string()),
+      argument("optional", "optional value", z.string().optional()),
+    ],
+    handle: async () => {},
+  });
+  const nested = new Router("nested", "command group").handler(leaf("deep", () => {}));
+  const root = new Router("app").handler(withOptions).handler(withArguments).handler(nested);
+
+  const out = await helpOutput(root, ["app", "--help"]);
+
+  expect(out).toContain("Usage: app [options] [command]");
+  expect(out).toContain("with-options");
+  expect(out).not.toContain("with-options [options]");
+  expect(out).toContain("with-arguments");
+  expect(out).not.toContain("with-arguments <required> [optional]");
+  expect(out).not.toContain("nested [command]");
+});
+
 test("flags with long-form help render a Parameter details section", async () => {
   const create = createHandler({
     name: "create",

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -166,6 +166,7 @@ export function compile(
   const compiledNode = withEffectiveTuiSupport(node, effectiveTuiSupport);
   const c = new RoutedCommand(compiledNode);
   c.addHelpCommand(false);
+  c.configureHelp({ subcommandTerm: (command) => command.name() });
   c.description(node.description());
 
   const ownFlags = node.flags();


### PR DESCRIPTION
## Summary

- use the documented Commander `subcommandTerm` formatter to show command names only
- remove options, arguments, and subcommand syntax from parent command indexes
- keep the complete invocation grammar in each command-specific `Usage:` line

This makes every command index consistent and easier to scan without changing parsing or command-specific help.

## Example

Before:

```text
Commands:
  create [options]             create a new AgentCore project
  add                          add project resources
  remove [options] [resource]  remove a resource from the project
```

After:

```text
Commands:
  create  create a new AgentCore project
  add     add project resources
  remove  remove a resource from the project
```

`agentcore project remove --help` still shows `Usage: agentcore project remove [options] [resource]`.

## Testing

- `bun test src/router/router.test.ts`
- `bun run typecheck`
- `bun run lint:check`
- `bun run format:check`
- full suite reached 2,901 passing tests; the local Bun 1.3.6 fallback install then stopped on a missing nested CDK fixture dependency because it cannot parse the branch lockfile version