### PR TITLE
fix(tui): list project first in the root menu; rename 'scaffolded agent code' to 'agent code'

### DIFF
--- a/src/components/CliOnlyScreen.test.tsx
+++ b/src/components/CliOnlyScreen.test.tsx
@@ -48,7 +48,7 @@ describe("menus list command-line-only subcommands below a divider", () => {
 
     await waitForText(r.lastFrame, "command line only");
     expect(menuEntries(r.lastFrame()!)).toEqual({
-      screens: ["harness", "identity", "runtime", "memory", "gateway", "eval", "project"],
+      screens: ["project", "harness", "identity", "runtime", "memory", "gateway", "eval"],
       cliOnly: ["feedback", "config", "update"],
     });
     r.unmount();

--- a/src/components/RouterScreen.test.tsx
+++ b/src/components/RouterScreen.test.tsx
@@ -46,8 +46,8 @@ describe("menu rendering", () => {
   test("highlights the first option by default", async () => {
     const r = renderScreen("/agentcore");
     await waitForText(r.lastFrame, "harness");
-    // The focus caret marks the highlighted row; the first option is harness.
-    expect(r.lastFrame()).toContain("❯ harness");
+    // The focus caret marks the highlighted row; the first option is project.
+    expect(r.lastFrame()).toContain("❯ project");
     r.unmount();
   });
 });
@@ -89,31 +89,33 @@ describe("filtering", () => {
 describe("navigation", () => {
   test("down arrow moves the highlight to the next option", async () => {
     const r = renderScreen("/agentcore");
+    await waitForText(r.lastFrame, "❯ project");
+
+    await r.press("down");
     await waitForText(r.lastFrame, "❯ harness");
 
     await r.press("down");
     await waitForText(r.lastFrame, "❯ identity");
-
-    await r.press("down");
-    await waitForText(r.lastFrame, "❯ runtime");
     r.unmount();
   });
 
   test("up arrow does not move past the first option", async () => {
     const r = renderScreen("/agentcore");
-    await waitForText(r.lastFrame, "❯ harness");
+    await waitForText(r.lastFrame, "❯ project");
 
     await r.press("up");
     await tick(20);
     // Still on the first option.
-    expect(r.lastFrame()).toContain("❯ harness");
+    expect(r.lastFrame()).toContain("❯ project");
     r.unmount();
   });
 
   test("enter navigates into the highlighted subcommand's screen", async () => {
     const r = renderScreen("/agentcore");
-    await waitForText(r.lastFrame, "❯ harness");
+    await waitForText(r.lastFrame, "❯ project");
 
+    await r.press("down");
+    await waitForText(r.lastFrame, "❯ harness");
     await r.press("return");
     // The harness screen is itself a RouterScreen showing harness subcommands.
     await waitForText(r.lastFrame, "agentcore → harness");
@@ -128,17 +130,17 @@ describe("navigation", () => {
     await r.press("escape");
     // Back at the root menu (breadcrumb no longer includes harness).
     await waitForText(r.lastFrame, "the platform for production AI agents");
-    expect(r.lastFrame()).toContain("❯ harness");
+    expect(r.lastFrame()).toContain("❯ project");
     r.unmount();
   });
 
   test("esc at the root menu is a no-op (no parent to go to)", async () => {
     const r = renderScreen("/agentcore");
-    await waitForText(r.lastFrame, "❯ harness");
+    await waitForText(r.lastFrame, "❯ project");
 
     await r.press("escape");
     await tick(20);
-    expect(r.lastFrame()).toContain("❯ harness");
+    expect(r.lastFrame()).toContain("❯ project");
     r.unmount();
   });
 });

--- a/src/handlers/index.tsx
+++ b/src/handlers/index.tsx
@@ -31,7 +31,7 @@ export function createRootHandler(core: Core, config: RootHandlerConfig): Router
   const root = new Router(
     "agentcore",
     "the platform for production AI agents",
-  ).supportedTuiCommands("harness", "identity", "runtime", "memory", "gateway", "eval", "project");
+  ).supportedTuiCommands("project", "harness", "identity", "runtime", "memory", "gateway", "eval");
 
   // `agentcore --version` prints the build-time package version.
   root.version(PACKAGE_VERSION);
@@ -53,7 +53,9 @@ export function createRootHandler(core: Core, config: RootHandlerConfig): Router
   // Pin the global config accessor on the context for any handler that needs it.
   root.use(withGlobalConfigAccessor(config.globalConfigAccessor));
 
-  // Install sub handlers
+  // Install sub handlers. Registration order is menu/help order; project is
+  // the primary workflow, so it goes first.
+  root.handler(createProjectHandler({ core, io }));
   root.handler(createHarnessHandler(core, io));
   root.handler(createIdentityHandler(core, io));
   root.handler(createRuntimeHandler(core, io));
@@ -62,7 +64,6 @@ export function createRootHandler(core: Core, config: RootHandlerConfig): Router
   root.handler(createEvalHandler(core, io));
   root.handler(createFeedbackHandler(core, io));
   root.handler(createConfigHandler());
-  root.handler(createProjectHandler({ core, io }));
   root.handler(createUpdateHandler(io));
 
   // Invoking with no subcommand launches the interactive TUI.

--- a/src/handlers/project/create/create.screen.test.tsx
+++ b/src/handlers/project/create/create.screen.test.tsx
@@ -278,8 +278,8 @@ describe("project create wizard", () => {
     await r.press("return");
 
     await waitForText(r.lastFrame, "what should the project be built around?");
-    await r.press("down"); // scaffolded agent code
-    await waitForText(r.lastFrame, "● scaffolded agent code");
+    await r.press("down"); // agent code
+    await waitForText(r.lastFrame, "● agent code");
     await r.press("return");
 
     // Template step: the supported templates are offered, including the

--- a/src/handlers/project/create/screen.tsx
+++ b/src/handlers/project/create/screen.tsx
@@ -107,7 +107,7 @@ const PROJECT_KIND_OPTIONS: { kind: ProjectKind; label: string; description: str
   },
   {
     kind: "agent",
-    label: "scaffolded agent code",
+    label: "agent code",
     description: "generate runnable agent code from a template",
   },
 ];

--- a/src/handlers/root.test.tsx
+++ b/src/handlers/root.test.tsx
@@ -11,6 +11,7 @@ describe("createRootHandler", () => {
     });
     expect(root.name()).toBe("agentcore");
     expect(root.children().map((c) => c.name())).toEqual([
+      "project",
       "harness",
       "identity",
       "runtime",
@@ -19,7 +20,6 @@ describe("createRootHandler", () => {
       "eval",
       "feedback",
       "config",
-      "project",
       "update",
     ]);
   });


### PR DESCRIPTION
## Summary

Two small UX tweaks to the interactive TUI:

- **Root menu**: `project` is now the first entry (it was last among the screen-backed commands). Menu and `--help` order follow handler registration order, so `createProjectHandler` is registered first in `src/handlers/index.tsx`.
- **`project create` → type step**: the second option now reads `agent code` instead of `scaffolded agent code`.

Tests that pinned the old ordering/label are updated accordingly. No behavioral changes beyond ordering and the label.

## Before / after

Root menu:

```text
❯ harness     manage AgentCore harnesses          ❯ project     manage an AgentCore project
  identity    ...                                   harness     manage AgentCore harnesses
  ...                                               identity    ...
  project     manage an AgentCore project           ...
```

`project create` type step:

```text
○ harness (recommended)          ○ harness (recommended)
● scaffolded agent code    →     ● agent code
```

## Verification

- `bun test` — 2900 pass, 0 fail
- `bun run typecheck`, `bun run lint:check`, `bun run format:check` — clean