### PR TITLE
fix: handle ESC properly on policy generate selection screen

### DIFF
--- a/src/handlers/gateway/policy/generate.screen.test.tsx
+++ b/src/handlers/gateway/policy/generate.screen.test.tsx
@@ -47,6 +47,22 @@ describe("gateway policy generate screen", () => {
     expect(frame).toContain("[enter] generate");
   });
 
+  test("escape returns the form through the picker to the Gateway menu", async () => {
+    const screen = renderScreen("/agentcore/gateway/policy/generate", {
+      core: coreWith(ENGINE_ARN),
+    });
+
+    await waitForText(screen.lastFrame, "checkout-gateway");
+    await screen.press("return");
+    await waitForText(screen.lastFrame, PLACEHOLDER);
+
+    await screen.press("escape");
+    await waitForText(screen.lastFrame, "choose a Gateway to generate a policy for");
+    await screen.press("escape");
+    await waitForText(screen.lastFrame, "manage AgentCore Gateways");
+    expect(screen.lastFrame()).toContain("policy");
+  });
+
   test("explains when the gateway has no engine and offers no prompt", async () => {
     const screen = renderScreen(`/agentcore/gateway/policy/generate/${GATEWAY_ID}`, {
       core: coreWith(undefined),

--- a/src/handlers/gateway/policy/screen.tsx
+++ b/src/handlers/gateway/policy/screen.tsx
@@ -38,6 +38,7 @@ export function GatewayPolicyGenerateScreen(props: ScreenProps) {
         breadcrumb={["agentcore", "gateway", "policy", "generate"]}
         description="choose a Gateway to generate a policy for"
         onSelect={(id) => navigate(`${PICKER_PATH}/${encodeURIComponent(id)}`)}
+        onEscape={() => navigate("/agentcore/gateway")}
       />
     );
   }


### PR DESCRIPTION
## Description

Fix an issue in `agentcore -> gateway -> policy -> generate` TUI flow. ESC on the "choose gateway to generate policy for screen" caused an infinite redirection back to the gateway selection table. Solution changes `onEscape` to direct you back to gateway management screen. 

## Before: 

https://github.com/user-attachments/assets/68ee7d1e-baf5-4fc1-9a0f-8e65286dbb3d

## After

https://github.com/user-attachments/assets/48e8a15c-c72a-44e7-8dcf-1aefc9738863



## Type of Change

<!-- Check all that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] `bun run test` (2988 pass, 0 fail)
- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [x] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
