### PR TITLE
ci(release): placeholder release-prepare workflow so refactor's can be dispatched

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,0 +1,19 @@
+# Placeholder. The real release-prepare workflow lives on the refactor branch.
+#
+# GitHub only lists a workflow in the Actions UI and the dispatch API if a file with its name exists on
+# the default branch. Selecting "refactor" in the branch picker runs refactor's release-prepare.yml with
+# refactor's inputs. Selecting "main" runs this file, which refuses so nothing happens to main.
+#
+# Delete this file when refactor lands on main and brings the real workflow with it.
+name: release-prepare
+
+on:
+  workflow_dispatch:
+
+jobs:
+  refuse:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "::error::release-prepare only exists on the refactor branch. Re-run with 'refactor' selected in the branch picker."
+          exit 1


### PR DESCRIPTION
## Why this PR exists

The refactor branch has its own release process, merged in #2206: `release-prepare.yml` is dispatched by hand to open a release PR, and `release-publish.yml` publishes when that PR merges.

GitHub only lists a workflow in the Actions UI and the dispatch API if a file with that name exists on the **default branch**. `release-prepare.yml` exists only on refactor, so today it cannot be dispatched at all:

```
$ gh workflow run release-prepare.yml --ref refactor -f bump=major -f channel=rc
HTTP 404: workflow release-prepare.yml not found on the default branch
```

Main and refactor will stay separate for a while, and we need to cut `1.0.0-rc.1` from refactor now. This PR adds a placeholder `release-prepare.yml` to main so GitHub knows the name.

## What it does

Nothing to main. When you dispatch `release-prepare`:

- with **refactor** selected in the branch picker, GitHub runs refactor's real `release-prepare.yml` with refactor's inputs (`bump`, `channel`). This is standard GitHub behavior: the selected branch's copy of the file runs.
- with **main** selected, this placeholder runs and fails with an error telling you to pick refactor. Main's package.json is never touched.

Main's own release process (`release.yml`, `release-main-and-preview.yml`) is unchanged.

## When to remove it

When refactor lands on main, the real `release-prepare.yml` overwrites this file. Nothing else to clean up.

`release-publish.yml` needs no placeholder. It runs on `pull_request: closed`, which reads the workflow from the PR's own branch.