### PR TITLE
fix(tui): reorder project creation options

### DIFF
--- a/src/handlers/project/create/create.screen.test.tsx
+++ b/src/handlers/project/create/create.screen.test.tsx
@@ -73,7 +73,11 @@ describe("project create wizard", () => {
 
     // Type step: harness is the preselected default.
     await waitForText(r.lastFrame, "what should the project be built around?");
-    expect(r.lastFrame()).toContain("● harness (recommended)");
+    const typeStep = r.lastFrame()!;
+    expect(typeStep).toContain("○ agent code");
+    expect(typeStep).toContain("● harness");
+    expect(typeStep).not.toContain("harness (recommended)");
+    expect(typeStep.indexOf("○ agent code")).toBeLessThan(typeStep.indexOf("● harness"));
     await r.press("return");
 
     // Model step: providers and the selected provider's fields share one page.
@@ -275,7 +279,7 @@ describe("project create wizard", () => {
     await r.press("return");
 
     await waitForText(r.lastFrame, "what should the project be built around?");
-    await r.press("down"); // agent code
+    await r.press("up"); // agent code
     await waitForText(r.lastFrame, "● agent code");
     await r.press("return");
 
@@ -324,7 +328,7 @@ describe("project create wizard", () => {
     await r.write("HelloApp");
     await r.press("return");
     await waitForText(r.lastFrame, "what should the project be built around?");
-    await r.press("down");
+    await r.press("up");
     await r.press("return");
     await waitForText(r.lastFrame, "choose a template");
     await r.press("down"); // agent-python-strands-container
@@ -359,7 +363,7 @@ describe("project create wizard", () => {
     await r.write("EmptyApp");
     await r.press("return");
     await waitForText(r.lastFrame, "what should the project be built around?");
-    await r.press("down");
+    await r.press("up");
     await r.press("return");
     await waitForText(r.lastFrame, "choose a template");
     // empty is the last option in the list.

--- a/src/handlers/project/create/screen.tsx
+++ b/src/handlers/project/create/screen.tsx
@@ -104,14 +104,14 @@ function emptyCreateProjectForm(): CreateProjectFormValues {
 
 const PROJECT_KIND_OPTIONS: { kind: ProjectKind; label: string; description: string }[] = [
   {
-    kind: "harness",
-    label: "harness (recommended)",
-    description: "a managed agent configured by spec — no agent-loop code to maintain",
-  },
-  {
     kind: "agent",
     label: "agent code",
     description: "generate runnable agent code from a template",
+  },
+  {
+    kind: "harness",
+    label: "harness",
+    description: "a managed agent configured by spec — no agent-loop code to maintain",
   },
 ];
 


### PR DESCRIPTION
## Summary

- list `agent code` before `harness` in the project create TUI
- remove the `(recommended)` label from `harness`
- keep harness as the existing default selection
- update wizard tests for the new ordering

## Verification

- `bun test` — 2,987 pass, 0 fail
- `bun run typecheck`
- `bun run lint:check`
- `bun run format:check`