### PR TITLE
fix(tui): default project creation to agent code

### DIFF
--- a/src/components/HarnessWizard.tsx
+++ b/src/components/HarnessWizard.tsx
@@ -566,7 +566,7 @@ const MODEL_PROVIDERS: {
   {
     kind: "default",
     label: "service default",
-    description: "let the service choose the model (recommended)",
+    description: "let the service choose the model",
     fields: [],
   },
   {
@@ -794,7 +794,7 @@ const MEMORY_OPTIONS: { kind: MemoryKind; label: string; description: string }[]
   {
     kind: "managed",
     label: "managed",
-    description: "AgentCore creates and manages memory for you (recommended)",
+    description: "AgentCore creates and manages memory for you",
   },
   {
     kind: "byo",

--- a/src/handlers/harness/create/create.screen.test.tsx
+++ b/src/handlers/harness/create/create.screen.test.tsx
@@ -49,6 +49,7 @@ describe("harness create wizard", () => {
     // enter a model id.
     await waitForText(r.lastFrame, "choose a model");
     expect(r.lastFrame()).toContain("● service default");
+    expect(r.lastFrame()).not.toContain("(recommended)");
     await r.press("down"); // bedrock
     await waitForText(r.lastFrame, "● bedrock");
     await r.press("return"); // focus the model id field
@@ -58,6 +59,7 @@ describe("harness create wizard", () => {
     // Step: memory — managed is preselected; keep it.
     await waitForText(r.lastFrame, "how should the harness remember conversations?");
     expect(r.lastFrame()).toContain("● managed");
+    expect(r.lastFrame()).not.toContain("(recommended)");
     await r.press("return");
 
     // Step: tools — browser is enabled by default; add a Gateway ARN.

--- a/src/handlers/harness/update/update.screen.test.tsx
+++ b/src/handlers/harness/update/update.screen.test.tsx
@@ -88,6 +88,7 @@ describe("harness update wizard", () => {
 
     // Managed memory is the current config and is preselected.
     await waitForText(r.lastFrame, "● managed");
+    expect(r.lastFrame()).not.toContain("(recommended)");
     await r.press("return");
 
     // Tools reflect the current config: browser on.

--- a/src/handlers/project/create/create.screen.test.tsx
+++ b/src/handlers/project/create/create.screen.test.tsx
@@ -61,7 +61,7 @@ function spyOnCreate(core: TestCoreClient): CreateProjectInput[] {
 const DEFAULT_MODEL_ID = "global.anthropic.claude-sonnet-4-6";
 
 describe("project create wizard", () => {
-  test("harness default flow: name → type → model → review → created", async () => {
+  test("harness flow: name → type → model → review → created", async () => {
     const directory = await inTempDirectory();
     const core = new TestCoreClient();
     const inputs = spyOnCreate(core);
@@ -71,18 +71,20 @@ describe("project create wizard", () => {
     await r.write("DemoApp");
     await r.press("return");
 
-    // Type step: harness is the preselected default.
+    // Type step: agent code is the preselected default.
     await waitForText(r.lastFrame, "what should the project be built around?");
     const typeStep = r.lastFrame()!;
-    expect(typeStep).toContain("○ agent code");
-    expect(typeStep).toContain("● harness");
+    expect(typeStep).toContain("● agent code");
+    expect(typeStep).toContain("○ harness");
     expect(typeStep).not.toContain("harness (recommended)");
-    expect(typeStep.indexOf("○ agent code")).toBeLessThan(typeStep.indexOf("● harness"));
+    expect(typeStep.indexOf("● agent code")).toBeLessThan(typeStep.indexOf("○ harness"));
+    await r.press("down"); // harness
     await r.press("return");
 
     // Model step: providers and the selected provider's fields share one page.
     await waitForText(r.lastFrame, "choose a model");
-    expect(r.lastFrame()).toContain("● bedrock (recommended)");
+    expect(r.lastFrame()).toContain("● bedrock");
+    expect(r.lastFrame()).not.toContain("bedrock (recommended)");
     expect(r.lastFrame()).toContain("○ openai");
     expect(r.lastFrame()).toContain("○ gemini");
     expect(r.lastFrame()).toContain("○ litellm");
@@ -135,6 +137,7 @@ describe("project create wizard", () => {
     await r.write("TunedApp");
     await r.press("return");
     await waitForText(r.lastFrame, "what should the project be built around?");
+    await r.press("down"); // harness
     await r.press("return");
 
     // Enter focuses the selected provider's model field. The cursor starts at
@@ -171,6 +174,7 @@ describe("project create wizard", () => {
     await r.write("OpenAIApp");
     await r.press("return");
     await waitForText(r.lastFrame, "what should the project be built around?");
+    await r.press("down"); // harness
     await r.press("return");
 
     await waitForText(r.lastFrame, "choose a model");
@@ -227,6 +231,7 @@ describe("project create wizard", () => {
     await waitForText(r.lastFrame, "name your project");
     await r.write("ProviderApp");
     await r.press("return");
+    await r.press("down"); // harness
     await r.press("return");
     await waitForText(r.lastFrame, "choose a model");
 
@@ -249,6 +254,7 @@ describe("project create wizard", () => {
     await waitForText(r.lastFrame, "name your project");
     await r.write("CompactApp");
     await r.press("return");
+    await r.press("down"); // harness
     await r.press("return");
     await waitForText(r.lastFrame, "choose a model");
 
@@ -257,7 +263,8 @@ describe("project create wizard", () => {
     expect(lines[0]).toContain("agentcore → project → create");
     expect(lines[1]).toBe("─".repeat(80));
     expect(lines[2]).toContain("✓ name");
-    expect(frame).toContain("● bedrock (recommended)");
+    expect(frame).toContain("● bedrock");
+    expect(frame).not.toContain("bedrock (recommended)");
     expect(frame).toContain("○ openai");
     expect(frame).toContain("○ gemini");
     expect(frame).toContain("○ litellm");
@@ -279,14 +286,14 @@ describe("project create wizard", () => {
     await r.press("return");
 
     await waitForText(r.lastFrame, "what should the project be built around?");
-    await r.press("up"); // agent code
     await waitForText(r.lastFrame, "● agent code");
     await r.press("return");
 
     // Template step: the supported templates are offered, including the
     // -container variants and the empty project.
     await waitForText(r.lastFrame, "choose a template");
-    expect(r.lastFrame()).toContain("● agent-python-strands (recommended)");
+    expect(r.lastFrame()).toContain("● agent-python-strands");
+    expect(r.lastFrame()).not.toContain("agent-python-strands (recommended)");
     expect(r.lastFrame()).toContain("agent-python-strands-container");
     await r.press("return");
 
@@ -328,7 +335,6 @@ describe("project create wizard", () => {
     await r.write("HelloApp");
     await r.press("return");
     await waitForText(r.lastFrame, "what should the project be built around?");
-    await r.press("up");
     await r.press("return");
     await waitForText(r.lastFrame, "choose a template");
     await r.press("down"); // agent-python-strands-container
@@ -363,7 +369,6 @@ describe("project create wizard", () => {
     await r.write("EmptyApp");
     await r.press("return");
     await waitForText(r.lastFrame, "what should the project be built around?");
-    await r.press("up");
     await r.press("return");
     await waitForText(r.lastFrame, "choose a template");
     // empty is the last option in the list.
@@ -479,6 +484,7 @@ describe("project create wizard", () => {
     await r.write("DemoApp");
     await r.press("return");
     await waitForText(r.lastFrame, "what should the project be built around?");
+    await r.press("down"); // harness
     await r.press("return");
     await waitForText(r.lastFrame, "choose a model");
     await r.press("return");
@@ -521,6 +527,7 @@ describe("project create wizard", () => {
     await r.write("DemoApp");
     await r.press("return");
     await waitForText(r.lastFrame, "what should the project be built around?");
+    await r.press("down"); // harness
     await r.press("return");
     await waitForText(r.lastFrame, "choose a model");
     await r.press("return"); // focus model id
@@ -560,6 +567,7 @@ describe("project create wizard", () => {
     await r.write("DemoApp");
     await r.press("return");
     await waitForText(r.lastFrame, "what should the project be built around?");
+    await r.press("down"); // harness
     await r.press("return");
     await waitForText(r.lastFrame, "choose a model");
     await r.press("return");

--- a/src/handlers/project/create/screen.tsx
+++ b/src/handlers/project/create/screen.tsx
@@ -61,7 +61,7 @@ const MODEL_PROVIDERS: {
 }[] = [
   {
     provider: "bedrock",
-    label: "bedrock (recommended)",
+    label: "bedrock",
     description: "an Amazon Bedrock model or inference profile",
   },
   {
@@ -96,7 +96,7 @@ function emptyProjectModel(): ProjectModelValues {
 function emptyCreateProjectForm(): CreateProjectFormValues {
   return {
     name: "",
-    kind: "harness",
+    kind: "agent",
     model: emptyProjectModel(),
     template: "agent-python-strands",
   };
@@ -122,7 +122,7 @@ const TEMPLATE_OPTIONS: {
 }[] = [
   {
     template: "agent-python-strands",
-    label: "agent-python-strands (recommended)",
+    label: "agent-python-strands",
     description: "Strands agent on Bedrock with memory (CodeZip build)",
   },
   {
@@ -220,10 +220,7 @@ function summaryOf(values: CreateProjectFormValues): Record<string, string> {
 }
 
 function providerLabel(provider: HarnessModelProvider): string {
-  return MODEL_PROVIDERS.find((candidate) => candidate.provider === provider)!.label.replace(
-    " (recommended)",
-    "",
-  );
+  return MODEL_PROVIDERS.find((candidate) => candidate.provider === provider)!.label;
 }
 
 // ─── wizard shell ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- make `agent code` the initially focused project type
- remove `(recommended)` from the Project Create Harness model picker (`bedrock`)
- remove `(recommended)` from the Project Create Agent Code template picker (`agent-python-strands`)
- remove the remaining recommendation copy from Harness Create/Update model and memory pickers
- update wizard navigation and assertions for the new default and labels

## TUI recommendation audit

No live `recommended` or `(recommended)` labels remain under `src`. The `project add` subcommands contain none; they render command-line help rather than custom wizard screens in the TUI.

## Verification

- `bun test` — 2,994 pass, 0 fail
- `bun run typecheck`
- `bun run lint:check`
- `bun run format:check`