### PR TITLE
fix(tui): show the full Runtime ID 

### DIFF
--- a/src/components/PaginatedTablePicker.test.tsx
+++ b/src/components/PaginatedTablePicker.test.tsx
@@ -356,8 +356,8 @@ describe("paginated table picker contract", () => {
     core.runtime.setListResponse({
       agentRuntimes: [
         runtime({
-          agentRuntimeId: "page-one",
-          agentRuntimeName: "matching-page-one",
+          agentRuntimeId: "matching-page-one",
+          agentRuntimeName: "page-one",
         }),
       ],
       nextToken: "t2",
@@ -366,8 +366,8 @@ describe("paginated table picker contract", () => {
       {
         agentRuntimes: [
           runtime({
-            agentRuntimeId: "page-two",
-            agentRuntimeName: "matching-page-two",
+            agentRuntimeId: "matching-page-two",
+            agentRuntimeName: "page-two",
           }),
         ],
       },
@@ -465,15 +465,20 @@ describe("paginated table picker contract", () => {
     for (const width of [100, 80, 60]) {
       if (width !== 100) await r.resize(width);
       const lines = (r.lastFrame() ?? "").split("\n");
-      const headerIndex = lines.findIndex((line) => line.includes("ID suffix"));
-      const rowLines = suffixes.map((suffix) => lines.find((line) => line.includes(suffix)));
+      const headerIndex = lines.findIndex((line) => line.includes("version"));
+      const rowLines = suffixes.map((_, index) =>
+        lines.find((line) => line.includes(`runtime_${index}`)),
+      );
 
       expect(headerIndex).toBeGreaterThanOrEqual(0);
       expect(stringWidth(lines[headerIndex + 1]!)).toBe(width);
       expect(rowLines.every((line) => line !== undefined)).toBe(true);
       expect(new Set(rowLines.map((line) => lines.indexOf(line!))).size).toBe(suffixes.length);
       expect(rowLines.every((line) => stringWidth(line!) <= width)).toBe(true);
-      expect(rowLines.every((line) => /[A-Za-z0-9]{10}\s+\d/.test(line!))).toBe(true);
+      expect(rowLines.every((line) => /runtime_\d-[A-Za-z0-9…]+\s+\d/.test(line!))).toBe(true);
+      if (width >= 80) {
+        expect(rowLines.every((line, index) => line!.includes(suffixes[index]!))).toBe(true);
+      }
     }
   });
 

--- a/src/components/RuntimePicker.tsx
+++ b/src/components/RuntimePicker.tsx
@@ -8,25 +8,15 @@ import type { DataTableColumn } from "./ui/data-table";
 
 interface RuntimeRow extends Record<string, unknown> {
   runtimeId: string;
-  runtimeName: string;
   runtimeVersion: string;
   status: string;
   lastUpdatedAt: string;
 }
 
-function runtimeIdSuffix(value: unknown): string {
-  const id = String(value ?? "");
-  return id.slice(id.lastIndexOf("-") + 1);
-}
-
+// Runtime IDs include their names, so separate name and suffix columns repeat
+// the same identity.
 export const runtimeColumns = [
-  { key: "runtimeName", header: "name", flex: true },
-  {
-    key: "runtimeId",
-    header: "ID suffix",
-    width: 10,
-    render: runtimeIdSuffix,
-  },
+  { key: "runtimeId", header: "ID", flex: true },
   { key: "runtimeVersion", header: "version", width: 7 },
   { key: "status", header: "status", width: 13 },
   {
@@ -38,10 +28,9 @@ export const runtimeColumns = [
 ] satisfies DataTableColumn<RuntimeRow>[];
 
 function toRow(runtime: AgentRuntime): RuntimeRow {
-  const runtimeId = runtime.agentRuntimeId ?? "";
+  const runtimeId = runtime.agentRuntimeId ?? runtime.agentRuntimeName ?? "";
   return {
     runtimeId,
-    runtimeName: runtime.agentRuntimeName ?? runtimeId,
     runtimeVersion: runtime.agentRuntimeVersion ?? "-",
     status: runtime.status ?? "-",
     lastUpdatedAt: runtime.lastUpdatedAt?.toISOString() ?? "-",

--- a/src/components/ui/data-table/columnWidths.test.ts
+++ b/src/components/ui/data-table/columnWidths.test.ts
@@ -50,15 +50,15 @@ describe("computeColumnWidths", () => {
 
   test("drops fixed columns from right to left without truncating headers", () => {
     expect(computeColumnWidths(runtimeColumns, 40, { selectable: true, borderWidth: 0 })).toEqual({
-      widths: [19, 10, 7, undefined, undefined],
+      widths: [16, 7, 13, undefined],
       totalWidth: 40,
     });
     expect(computeColumnWidths(runtimeColumns, 60, { selectable: true, borderWidth: 0 })).toEqual({
-      widths: [25, 10, 7, 13, undefined],
+      widths: [19, 7, 13, 16],
       totalWidth: 60,
     });
     expect(computeColumnWidths(runtimeColumns, 80, { selectable: true, borderWidth: 0 })).toEqual({
-      widths: [28, 10, 7, 13, 16],
+      widths: [39, 7, 13, 16],
       totalWidth: 80,
     });
   });
@@ -106,7 +106,7 @@ describe("computeColumnWidths", () => {
       borderWidth: 0,
     });
 
-    expect(runtime.widths[2]).toBe(7);
+    expect(runtime.widths[1]).toBe(7);
     expect(harness.widths[1]).toBe(7);
     expect(endpoint.widths[1]).toBe(6);
     expect(endpoint.widths[2]).toBe(6);

--- a/src/handlers/runtime/endpoint/endpoint.screen.test.tsx
+++ b/src/handlers/runtime/endpoint/endpoint.screen.test.tsx
@@ -91,7 +91,7 @@ async function waitForRuntimePicker(lastFrame: () => string | undefined): Promis
     return (
       frame.includes("agentcore → runtime → endpoint → list") &&
       !frame.includes("agentcore → runtime → endpoint → list → runtime-123") &&
-      frame.includes("checkout")
+      frame.includes("runtime-123")
     );
   });
 }
@@ -108,7 +108,7 @@ describe("Runtime endpoint flow", () => {
     });
     const r = renderScreen("/agentcore/runtime/endpoint/list", { core });
 
-    await waitForText(r.lastFrame, "pick-runtime");
+    await waitForText(r.lastFrame, runtimeId);
     await r.press("return");
     await waitForText(r.lastFrame, "agentcore → runtime → endpoint → list → runtime/blue one");
     await waitForText(r.lastFrame, "prod");
@@ -324,7 +324,7 @@ describe("Runtime endpoint flow", () => {
     const parent = renderScreen("/agentcore/runtime/endpoint/list", {
       core: parentCore,
     });
-    await waitForText(parent.lastFrame, "checkout");
+    await waitForText(parent.lastFrame, "runtime-123");
     await parent.press("escape");
     await waitForText(
       parent.lastFrame,
@@ -341,7 +341,7 @@ describe("Runtime endpoint flow", () => {
     });
     listCore.runtime.setGetEndpointResponse(getEndpointResponse());
     const list = renderScreen("/agentcore/runtime/endpoint/list", { core: listCore });
-    await waitForText(list.lastFrame, "checkout");
+    await waitForText(list.lastFrame, "runtime-123");
     await list.press("return");
     await waitForText(list.lastFrame, "prod");
     await list.press("escape");
@@ -358,7 +358,7 @@ describe("Runtime endpoint flow", () => {
   test("bare endpoint get redirects to parent selection", async () => {
     const core = new TestCoreClient();
     core.runtime.setListResponse({
-      agentRuntimes: [runtime({ agentRuntimeName: "redirect-parent" })],
+      agentRuntimes: [runtime({ agentRuntimeId: "redirect-parent" })],
     });
     const r = renderScreen("/agentcore/runtime/endpoint/get", { core });
 

--- a/src/handlers/runtime/invoke/invoke.screen.test.tsx
+++ b/src/handlers/runtime/invoke/invoke.screen.test.tsx
@@ -92,7 +92,7 @@ describe("Runtime invoke routing", () => {
       } as GetAgentRuntimeResponse);
     const screen = renderScreen("/agentcore/runtime/invoke", { core });
 
-    await waitForText(screen.lastFrame, "pick-runtime");
+    await waitForText(screen.lastFrame, runtimeId);
     await screen.press("return");
     await waitForText(screen.lastFrame, qualifier);
     await screen.press("return");
@@ -107,7 +107,7 @@ describe("Runtime invoke routing", () => {
   test("esc from an initial endpoint picker returns to the Runtime picker", async () => {
     const core = new TestCoreClient();
     core.runtime.setListEndpointsResponse({ runtimeEndpoints: [endpoint()] }).setListResponse({
-      agentRuntimes: [runtime({ agentRuntimeName: "back-to-runtime-picker" })],
+      agentRuntimes: [runtime({ agentRuntimeId: "back-to-runtime-picker" })],
     });
     const screen = renderScreen(`/agentcore/runtime/invoke/${RUNTIME_ID}`, { core });
 
@@ -794,7 +794,7 @@ describe("Runtime invoke JSON console", () => {
     await waitForText(screen.lastFrame, "Context user/JWT/1h");
     core.runtime.setGetResponse({ agentRuntimeArn: nextArn } as GetAgentRuntimeResponse);
     await screen.write("\x14");
-    await waitForText(screen.lastFrame, "next-runtime");
+    await waitForText(screen.lastFrame, nextRuntimeId);
     await screen.press("down");
     await screen.press("return");
     await waitForText(screen.lastFrame, nextQualifier);

--- a/src/handlers/runtime/runtime.screen.test.tsx
+++ b/src/handlers/runtime/runtime.screen.test.tsx
@@ -20,7 +20,7 @@ const runtimeEndpointUrl = "https://runtime.test";
 function runtime(overrides: Partial<AgentRuntime> = {}): AgentRuntime {
   return {
     agentRuntimeArn: "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/runtime-1",
-    agentRuntimeId: "runtime-1",
+    agentRuntimeId: "checkout-Ab12Cd34Ef",
     agentRuntimeVersion: "7",
     agentRuntimeName: "checkout",
     description: "Checkout Runtime",
@@ -84,14 +84,13 @@ describe("runtime picker", () => {
 
     await waitForText(r.lastFrame, "orders");
     const frame = r.lastFrame()!;
-    expect(frame).toContain("name");
     expect(frame).toContain("ID");
-    expect(frame).toContain("ID suffix");
     expect(frame).toContain("version");
     expect(frame).toContain("status");
     expect(frame).toContain("updated UTC");
-    expect(frame).toContain("AbCdEf1234");
-    expect(frame).not.toContain("orders-AbCdEf1234");
+    expect(frame).toContain("orders-AbCdEf1234");
+    expect(frame).not.toContain("name");
+    expect(frame).not.toContain("ID suffix");
     expect(frame).toContain("99999");
     expect(frame).toContain("CREATE_FAILED");
     expect(frame).toContain("2026-07-19 01:02");
@@ -149,7 +148,9 @@ describe("runtime picker", () => {
   });
 
   test("bare Runtime get redirects to the picker", async () => {
-    const core = coreWithRuntimes([runtime({ agentRuntimeName: "redirected" })]);
+    const core = coreWithRuntimes([
+      runtime({ agentRuntimeId: "redirected-Ab12Cd34Ef", agentRuntimeName: "redirected" }),
+    ]);
     const r = renderScreen("/agentcore/runtime/get", { core });
 
     await waitForText(r.lastFrame, "redirected");
@@ -237,7 +238,7 @@ describe("runtime hub", () => {
     );
     const r = renderScreen("/agentcore/runtime/list", { core });
 
-    await waitForText(r.lastFrame, "encoded-runtime");
+    await waitForText(r.lastFrame, runtimeId);
     await r.press("return");
     await waitForText(r.lastFrame, `agentcore → runtime → get → ${runtimeId}`);
     await waitFor(() =>
@@ -390,7 +391,7 @@ describe("runtime hub", () => {
     core.runtime.setGetResponse(getRuntimeResponse());
     const r = renderScreen("/agentcore/runtime/list", { core });
 
-    await waitForText(r.lastFrame, "checkout");
+    await waitForText(r.lastFrame, "runtime-123");
     await r.press("return");
     await waitForText(r.lastFrame, "show the full JSON definition");
     await r.press("escape");
@@ -402,7 +403,7 @@ describe("runtime hub", () => {
     core.runtime.setGetResponse(getRuntimeResponse());
     const r = renderScreen("/agentcore/runtime/list", { core });
 
-    await waitForText(r.lastFrame, "checkout");
+    await waitForText(r.lastFrame, "runtime-123");
     await r.press("return");
     await waitForText(r.lastFrame, "show the full JSON definition");
     for (let index = 0; index < 4; index += 1) await r.press("down");
@@ -435,7 +436,7 @@ describe("runtime hub", () => {
     });
     const r = renderScreen("/agentcore/runtime/list", { core });
 
-    await waitForText(r.lastFrame, "checkout");
+    await waitForText(r.lastFrame, "runtime-123");
     await r.press("return");
     await waitForText(r.lastFrame, "invoke this Runtime");
     const listCallsBeforeInvoke = core.runtime.calls.filter(
@@ -461,7 +462,7 @@ describe("runtime hub", () => {
     hubCore.runtime.getRuntime = async () => hubPending.promise;
     const hub = renderScreen("/agentcore/runtime/list", { core: hubCore });
 
-    await waitForText(hub.lastFrame, "checkout");
+    await waitForText(hub.lastFrame, "runtime-123");
     await hub.press("return");
     await waitForText(hub.lastFrame, "loading Runtime…");
     await hub.press("escape");
@@ -475,7 +476,7 @@ describe("runtime hub", () => {
     };
     const hub = renderScreen("/agentcore/runtime/list", { core: hubCore });
 
-    await waitForText(hub.lastFrame, "checkout");
+    await waitForText(hub.lastFrame, "runtime-123");
     await hub.press("return");
     await waitForText(hub.lastFrame, "hub failed");
     await hub.press("escape");
@@ -486,7 +487,7 @@ describe("runtime hub", () => {
     jsonCore.runtime.setGetResponse(getRuntimeResponse());
     const json = renderScreen("/agentcore/runtime/list", { core: jsonCore });
 
-    await waitForText(json.lastFrame, "checkout");
+    await waitForText(json.lastFrame, "runtime-123");
     await json.press("return");
     await waitForText(json.lastFrame, "show the full JSON definition");
     jsonCore.runtime.setError(new Error("json failed"));

--- a/src/handlers/runtime/version/version.screen.test.tsx
+++ b/src/handlers/runtime/version/version.screen.test.tsx
@@ -57,7 +57,7 @@ async function waitForRuntimePicker(lastFrame: () => string | undefined): Promis
     return (
       frame.includes("agentcore → runtime → version → list") &&
       !frame.includes("agentcore → runtime → version → list → runtime-123") &&
-      frame.includes("checkout")
+      frame.includes("runtime-123")
     );
   });
 }
@@ -74,7 +74,7 @@ describe("Runtime version flow", () => {
     });
     const r = renderScreen("/agentcore/runtime/version/list", { core });
 
-    await waitForText(r.lastFrame, "pick-runtime");
+    await waitForText(r.lastFrame, runtimeId);
     await r.press("return");
     await waitForText(r.lastFrame, "agentcore → runtime → version → list → runtime/blue one");
     await waitForText(r.lastFrame, "9");
@@ -220,7 +220,7 @@ describe("Runtime version flow", () => {
     const parent = renderScreen("/agentcore/runtime/version/list", {
       core: parentCore,
     });
-    await waitForText(parent.lastFrame, "checkout");
+    await waitForText(parent.lastFrame, "runtime-123");
     await parent.press("escape");
     await waitForText(
       parent.lastFrame,
@@ -237,7 +237,7 @@ describe("Runtime version flow", () => {
     });
     listCore.runtime.setGetVersionResponse(getVersionResponse());
     const list = renderScreen("/agentcore/runtime/version/list", { core: listCore });
-    await waitForText(list.lastFrame, "checkout");
+    await waitForText(list.lastFrame, "runtime-123");
     await list.press("return");
     await waitForText(list.lastFrame, "agentcore → runtime → version → list → runtime-123");
     await waitForText(list.lastFrame, "3");
@@ -258,7 +258,7 @@ describe("Runtime version flow", () => {
   test("bare version get redirects to parent selection", async () => {
     const core = new TestCoreClient();
     core.runtime.setListResponse({
-      agentRuntimes: [runtime({ agentRuntimeName: "redirect-parent" })],
+      agentRuntimes: [runtime({ agentRuntimeId: "redirect-parent" })],
     });
     const r = renderScreen("/agentcore/runtime/version/get", { core });
 


### PR DESCRIPTION
## Summary

- replace the Runtime picker name and `ID suffix` columns with one full `ID` column
- keep the existing version, status, and timestamp sizing unchanged
- update Runtime picker flows and narrow-width coverage for the new identity column

The table audit found one other `ID suffix` column on Gateway Rules. It remains because Rules have no name or full-ID column, so that suffix is their only visible identifier rather than duplicate data.

This is the focused replacement for the Runtime identity portion of #2217.

## Verification

- `bun test` (2,994 tests)
- `bun run typecheck`
- `bun run lint:check`
- Prettier check on changed files