### PR TITLE
fix: truncate default harness name for long project names

### DIFF
--- a/src/handlers/project/create/index.ts
+++ b/src/handlers/project/create/index.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import z from "zod";
 import { createHandler, flag, PlatformKey } from "../../../router";
 import { assertProjectPathFits } from "./pathLimit";
@@ -154,10 +155,11 @@ export function resolveScaffoldHarnessInput(flags: HarnessPathFlagValues): Scaff
   const provider = resolveHarnessModelProvider(flags["model-provider"]);
 
   const input: ScaffoldHarnessInput = {
-    // A project name always satisfies the harness name grammar (letters and
-    // digits only), so the harness is named after the project like the
-    // original CLI does.
-    name: flags["name"],
+    // CFN's HarnessName is `${projectName}_${harnessName}` capped at 40 chars.
+    // Defaulting the harness to the project name doubles the string, so when
+    // the doubled form would exceed the CFN cap we truncate the harness half
+    // and append a 5-char hash to keep the derived name short and unique.
+    name: defaultHarnessNameFor(flags["name"]),
     model: {
       provider,
       modelId: flags["model-id"] ?? HARNESS_DEFAULT_MODEL_IDS[provider],
@@ -170,6 +172,19 @@ export function resolveScaffoldHarnessInput(flags: HarnessPathFlagValues): Scaff
   if (!result.success)
     throw new InputValidationError(z.prettifyError(result.error), { cause: result.error });
   return input;
+}
+
+// CloudFormation limits HarnessName to 40 characters. The synth step joins the
+// project name and the harness name with an underscore. The default harness
+// name is the project name. If the project name is 19 characters or less, the
+// joined name fits. If the project name is longer, this function shortens the
+// harness name so that the joined name is 40 characters. The shortened name
+// ends with a 5-character hash of the project name.
+function defaultHarnessNameFor(projectName: string): string {
+  if (projectName.length <= 19) return projectName;
+  const hash = createHash("sha256").update(projectName).digest("hex").slice(0, 5);
+  const prefixLen = 40 - projectName.length - 1 - 6;
+  return `${projectName.slice(0, prefixLen)}_${hash}`;
 }
 
 // Runtimes and harnesses support different model sets and record them under


### PR DESCRIPTION
## Summary
- `agentcore project create --name <name>` (no `--template`) defaulted the harness name to the project name. CFN builds the physical `HarnessName` as `${projectName}_${harnessName}`, capped at 40 chars, so any project name > 19 chars produced a name that failed synth with no recovery other than hand-editing `agentcore.json` and `app/<name>/harness.json`.
- When the doubled form would exceed the 40-char CFN cap, derive the harness name as `<truncated-projectName>_<sha256[:5]>` so `${projectName}_${harnessName}` stays ≤ 40 chars and distinct project names never collide. Short project names keep the historical `harness.name == projectName` behavior.

## Repro (before this change)
```sh
agentcore project create --name HealthCareProfessional
cd HealthCareProfessional
agentcore project deploy
# ✕ Synthesizing CloudFormation templates
#   AgentCore CDK synthesis failed: Harness name
#   "HealthCareProfessional_HealthCareProfessional" is 45 characters;
#   the maximum is 40 (CloudFormation HarnessName limit).
```

## After
| projectName (len) | harness.name written to `harness.json` | CFN physical (len) |
|---|---|---|
| `shortproj` (9) | `shortproj` (unchanged) | `shortproj_shortproj` (19) |
| `HealthCareProfessional` (22) | `HealthCareP_59ceb` (17) | `HealthCareProfessional_HealthCareP_59ceb` (40) |

Existing short-name projects: byte-identical output, no behavior change.

## Test plan
- [x] `bun run typecheck`
- [x] `bun test src/handlers/project/create/` (24/24 pass)
- [x] Scaffold `HealthCareProfessional` locally; confirm `harness.json` receives `HealthCareP_59ceb` and derived CFN name is exactly 40 chars
- [x] Scaffold `shortproj` locally; confirm harness name is unchanged
- [ ] Full `agentcore project deploy` against real AWS (skipped — no fixture account handy; reviewers may want to spot-check)

## Notes
- Not addressed here: **`project add harness`** (separate handler; users passing a name explicitly are still expected to pick something short) and **projects with name > ~34 chars**, where no harness name can fit and a create-time validation error would be the right guardrail. Happy to add in a follow-up if reviewers want.
- The underlying constraint lives in `@aws/agentcore-l3-cdk-constructs` — fixing it there (turn the synth-time throw into a deterministic truncation + `Annotations.addWarning`) would eliminate the trap at the root and cover every scaffolder, not just `project create`. This CLI fix stops the bleed today.