### PR TITLE
fix: clarify gateway-connector help text

### DIFF
--- a/src/handlers/project/add/gateway-connector/index.ts
+++ b/src/handlers/project/add/gateway-connector/index.ts
@@ -19,7 +19,7 @@ export const createAddGatewayConnectorHandler = (config: AddProjectResourceConfi
       flag("name", "the Target name for a connector shortcut", z.string().optional()),
       flag(
         "connector",
-        "curated connector",
+        "curated connector [bedrock-knowledge-bases | web-search]",
         z.enum(["web-search", "bedrock-knowledge-bases"]).optional(),
       ),
       flag(
@@ -29,7 +29,7 @@ export const createAddGatewayConnectorHandler = (config: AddProjectResourceConfi
       ),
       flag(
         "knowledge-base",
-        "project Knowledge Base name or external ten-character ID; only for bedrock-knowledge-bases",
+        "external ten-character Knowledge Base ID; only for bedrock-knowledge-bases",
         z.string().optional(),
       ),
     ],


### PR DESCRIPTION
## Summary
- `agentcore project add gateway-connector --help` didn't list the accepted values for `--connector`. Add \`[bedrock-knowledge-bases | web-search]\` to the description so users can discover them without reading the source.
- `--knowledge-base` claimed to accept a "project Knowledge Base name or external ten-character ID", but project-owned Knowledge Bases are not implemented — the handler passes the string straight through as \`knowledgeBaseId\`. Drop the false claim.

## Before
\`\`\`
--connector <connector>            curated connector
--knowledge-base <knowledge-base>  project Knowledge Base name or external ten-character ID; only for bedrock-knowledge-bases
\`\`\`

## After
\`\`\`
--connector <connector>            curated connector [bedrock-knowledge-bases | web-search]
--knowledge-base <knowledge-base>  external ten-character Knowledge Base ID; only for bedrock-knowledge-bases
\`\`\`

## Test plan
- [x] \`bun run build\`
- [x] \`agentcore project add gateway-connector --help\` shows the updated text
- [x] No behavior change — the enum on \`--connector\` and the pass-through of \`--knowledge-base\` were already what the code did; this only aligns the help text with reality