### PR TITLE
fix(dev): default the command to headless mode

### DIFF
--- a/src/handlers/project/dev/index.ts
+++ b/src/handlers/project/dev/index.ts
@@ -103,8 +103,8 @@ export const createDevProjectHandler = (config: DevProjectHandlerConfig) =>
       flag("traces", "disable local OTEL trace collection", z.boolean().default(true)),
       flag(
         "mode",
-        "how to run: browser (Agent Inspector web UI), headless (agents stream to the terminal), or tui",
-        z.enum(["browser", "headless", "tui"]).default("browser"),
+        "how to run: browser (Agent Inspector web UI) or headless (agents stream to the terminal)",
+        z.enum(["browser", "headless"]).default("headless"),
       ),
       flag(
         "ui-port",
@@ -127,11 +127,6 @@ export const createDevProjectHandler = (config: DevProjectHandlerConfig) =>
       try {
         const project = ctx.require(ProjectKey);
         const region = ctx.require(RegionKey);
-        if (flags.mode === "tui") {
-          throw new InputValidationError(
-            "TUI mode is not available yet. Use --mode browser (default) or --mode headless.",
-          );
-        }
         const runtimes = selectRuntimes(project, flags.agent);
         if (runtimes.length > 1 && flags.port !== undefined) {
           throw new InputValidationError(


### PR DESCRIPTION
### Problem 
- The default for dev is currently opening agent inspector
- the dev help shows tui, but doesn't support it. 

### Solution 
- change default to headless
- update help text. 
- remove tui support. 

### Verification 
```
$ agentcore project create --name DevTest --template agent-python-strands 
$ cd DevTest
$ agentcore project dev & 
[1] 1401410
OTEL collector listening on port 43819; traces persist to [..]
[agent_python_strands] Starting development server
[agent_python_strands] INFO:     Will watch for changes in these directories: [..]
[agent_python_strands] INFO:     Uvicorn running on http://127.0.0.1:8082 (Press CTRL+C to quit)
[agent_python_strands] INFO:     Started reloader process [1401469] using StatReload
[agent_python_strands] INFO:     Started server process [1401497]
[agent_python_strands] INFO:     Waiting for application startup.
[agent_python_strands] INFO:     Application startup complete.
[agent_python_strands] Agent 'agent_python_strands' is running on port 8082.
$ agentcore project invoke runtime --local --port 8082 --payload '{"prompt": "hello world"}'
[agent response]
```

before this would open the browser. 