### PR TITLE
fix(project): refuse status outside the project's deployed region

### DIFF
--- a/src/handlers/project/status/index.test.ts
+++ b/src/handlers/project/status/index.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -12,6 +12,7 @@ import {
   waitFor,
 } from "../../../testing";
 import type { ProjectBackend } from "../../../core/project";
+import { ProjectStateError } from "../../../errors";
 import type { AwsDeploymentTarget } from "../../../projectSchemas/aws-targets";
 import type { ResolvedProjectResource } from "../types";
 
@@ -72,6 +73,18 @@ afterEach(async () => {
   await Promise.all(
     tempDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })),
   );
+});
+
+// The report is refused when the ambient region is not the target's, so pin
+// the ambient region to the default target's rather than leave it to the
+// developer's shell (see withRegion for the fallback chain).
+const SAVED_AWS_REGION = process.env.AWS_REGION;
+beforeEach(() => {
+  process.env.AWS_REGION = DEFAULT_TARGET.region;
+});
+afterEach(() => {
+  if (SAVED_AWS_REGION === undefined) delete process.env.AWS_REGION;
+  else process.env.AWS_REGION = SAVED_AWS_REGION;
 });
 
 async function inProject(
@@ -223,7 +236,7 @@ describe("project status handler", () => {
     const subject = testStatusCommand([]);
     await inProject(subject);
 
-    await subject.run(["--target", "staging"]);
+    await subject.run(["--region", STAGING_TARGET.region, "--target", "staging"]);
 
     expect(subject.targets).toEqual([STAGING_TARGET]);
     expect(subject.json()).toMatchObject({ target: "staging", region: "eu-west-1" });
@@ -231,6 +244,21 @@ describe("project status handler", () => {
     await expect(subject.run(["--target", "typo"])).rejects.toThrow(
       /has no deployment target named 'typo'/,
     );
+  });
+
+  test("refuses a target deployed outside the ambient region", async () => {
+    const subject = testStatusCommand([HARNESS_ROW]);
+    await inProject(subject);
+
+    // The ambient region is the default target's (pinned above); staging's is not.
+    const outcome = subject.run(["--target", "staging"]);
+    await expect(outcome).rejects.toBeInstanceOf(ProjectStateError);
+    await expect(outcome).rejects.toThrow("This project is deployed to eu-west-1, not us-east-1");
+    // An explicit --region takes part in the same comparison.
+    await expect(subject.run(["--region", "us-west-2"])).rejects.toThrow(
+      "This project is deployed to us-east-1, not us-west-2",
+    );
+    expect(subject.io.stdout()).toBe("");
   });
 });
 

--- a/src/handlers/project/status/index.ts
+++ b/src/handlers/project/status/index.ts
@@ -3,6 +3,8 @@ import { DEFAULT_TARGET_NAME } from "../../../projectSchemas/aws-targets";
 import { createHandler, flag, ProjectKey } from "../../../router";
 import { JsonRendererKey } from "../../../tui";
 import type { ProjectManager, ResolvedProjectResource } from "../types";
+import { RegionKey } from "../../keys";
+import { ProjectStateError } from "../../../errors";
 
 type StatusProjectHandlerConfig = {
   projectManager: ProjectManager;
@@ -38,6 +40,15 @@ export const createStatusProjectHandler = (config: StatusProjectHandlerConfig) =
         region: resolved.target.region,
         resources: resolved.resources,
       };
+
+      // Every follow-up command runs in the ambient region, so a report for a
+      // project deployed elsewhere would print ids the user cannot act on as-is.
+      // Refuse it and name the region to rerun with.
+      const region = ctx.require(RegionKey);
+      if (status.region !== region) {
+        throw new ProjectStateError(`This project is deployed to ${status.region}, not ${region}`);
+      }
+
       ctx.require(JsonRendererKey).renderJson(status);
     },
   });

--- a/src/handlers/project/status/screen.tsx
+++ b/src/handlers/project/status/screen.tsx
@@ -15,6 +15,7 @@ import { ProjectKey } from "../../../router";
 import type { ScreenProps } from "../../types";
 import type { DeployableResource, Project, ResolvedProjectResource } from "../types";
 import { LoadingFrame, ProjectGate } from "../ProjectGate";
+import { RegionKey } from "../../keys";
 
 const theme = darkTheme;
 
@@ -168,15 +169,16 @@ export function ProjectStatusScreen({ ctx, core }: ScreenProps) {
       seed={ctx.value(ProjectKey)}
       onBack={() => navigate(PROJECT_MENU)}
     >
-      {(project) => <ProjectStatusView core={core} project={project} />}
+      {(project) => <ProjectStatusView core={core} ctx={ctx} project={project} />}
     </ProjectGate>
   );
 }
 
 function ProjectStatusView({
   core,
+  ctx,
   project,
-}: Pick<ScreenProps, "core"> & {
+}: ScreenProps & {
   project: Project;
 }) {
   const navigate = useNavigate();
@@ -224,6 +226,12 @@ function ProjectStatusView({
     setHint(node.data?.hint);
   };
 
+  // A linked detail page fetches in the target's region, but everything it
+  // opens in turn runs in the ambient one, so a project deployed elsewhere is
+  // reported rather than listed: the user reopens with --region.
+  const region = ctx.require(RegionKey);
+  const isWrongRegion = status.data.target.region !== region;
+
   return (
     <Layout
       breadcrumb={BREADCRUMB}
@@ -237,16 +245,26 @@ function ProjectStatusView({
       ]}
     >
       <Box flexDirection="column" paddingX={1}>
-        <Text bold>resources</Text>
-        <Box flexDirection="column">
-          {nodes.length === 0 ? (
-            <Text color={theme.colors.muted}>
-              No resources are declared in this project. Run `agentcore project add` to declare one.
-            </Text>
-          ) : (
-            <TreeView nodes={nodes} onSelect={select} showIcons={false} focusMarker />
-          )}
-        </Box>
+        {isWrongRegion && (
+          <Text color="red">
+            This project is deployed to {status.data.target.region}, not {region}
+          </Text>
+        )}
+        {!isWrongRegion && (
+          <>
+            <Text bold>resources</Text>
+            <Box flexDirection="column">
+              {nodes.length === 0 ? (
+                <Text color={theme.colors.muted}>
+                  No resources are declared in this project. Run `agentcore project add` to declare
+                  one.
+                </Text>
+              ) : (
+                <TreeView nodes={nodes} onSelect={select} showIcons={false} focusMarker />
+              )}
+            </Box>
+          </>
+        )}
         {hint !== undefined && (
           <Box marginTop={1}>
             <Text color={theme.colors.muted}>{hint}</Text>

--- a/src/handlers/project/status/status.screen.test.tsx
+++ b/src/handlers/project/status/status.screen.test.tsx
@@ -9,6 +9,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { ProjectSpecSchema } from "../../../projectSchemas/project";
 import { ProjectKey } from "../../../router";
+import { RegionKey } from "../../keys";
 import {
   cleanupScreens,
   flatFrame,
@@ -30,9 +31,10 @@ afterEach(async () => {
   );
 });
 
-// The target region differs from the base context's us-east-1 on purpose: the
-// detail screens must fetch where the project deployed, not in the ambient
-// region.
+// The target region differs from the base context's us-east-1 on purpose, so
+// the detail screens are linked with the region the project deployed in.
+// renderStatus pins the ambient region to the target's, since the screen only
+// lists a project deployed there; the mismatch case has a test of its own.
 const TARGET = { name: "default", account: "111122223333", region: "eu-west-1" } as const;
 const ARN = `arn:aws:bedrock-agentcore:${TARGET.region}:${TARGET.account}`;
 const RUNTIME_ID = "checkout-AbCdEf1234";
@@ -100,10 +102,14 @@ function core(resources: ResolvedProjectResource[] = RUNTIME_RESOURCES): TestCor
   return value;
 }
 
-function renderStatus(value: TestCoreClient, seed: Project = RUNTIME_PROJECT) {
+function renderStatus(
+  value: TestCoreClient,
+  seed: Project = RUNTIME_PROJECT,
+  region: string = TARGET.region,
+) {
   return renderScreen("/agentcore/project/status", {
     core: value,
-    withContext: (ctx) => ctx.withValue(ProjectKey, seed),
+    withContext: (ctx) => ctx.withValue(ProjectKey, seed).withValue(RegionKey, region),
   });
 }
 
@@ -275,6 +281,23 @@ describe("project status screen", () => {
     const screen = renderStatus(core([]), project({}));
 
     await waitForText(screen.lastFrame, "No resources are declared in this project.");
+  });
+
+  test("reports a project deployed outside the ambient region instead of listing it", async () => {
+    const screen = renderStatus(core(), RUNTIME_PROJECT, "us-east-1");
+
+    await waitForFlatText(
+      screen.lastFrame,
+      `This project is deployed to ${TARGET.region}, not us-east-1`,
+    );
+    const frame = flatFrame(screen.lastFrame);
+    expect(frame).not.toContain("checkout agent");
+    expect(frame).not.toMatch(/runtime\s+checkout/);
+    // Nothing is focusable, so enter goes nowhere and escape still leaves.
+    await screen.press("return");
+    expect(screen.lastFrame()).toContain("agentcore → project → status");
+    await screen.press("escape");
+    await waitForText(screen.lastFrame, "manage an AgentCore project");
   });
 
   test("reports the CLI's own guidance outside a project", async () => {


### PR DESCRIPTION
## What

`project status` now refuses to describe a project whose target is deployed in a region other than the one the command runs in. The CLI throws a `ProjectStateError` naming both regions; the bare TUI shows the same message in place of the Linked Resources tree and keeps `esc` as the way back. Rerun with `--region <target region>` to see the report.

## Why

A bare `project status` links each deployed row to its detail page with `?region=<target>`, but the actions those pages open in turn (endpoints, events, detail JSON, …) run in the ambient region, so a project deployed anywhere else broke one step past the tree. #2239 tried to carry the region through every flow instead; this is the smaller guard. The headless report has the same problem one step later: the ids it prints only work with the same `--region`.

## How

- `src/handlers/project/status/index.ts`: compare the resolved target's region with the context's `RegionKey` after resolving resources and before rendering.
- `src/handlers/project/status/screen.tsx`: `ProjectStatusView` takes the context, and renders the mismatch message instead of the `resources` heading and tree.

## Tests

- Headless (`index.test.ts`): the suite pins `AWS_REGION` to the default target's region (restored after each test), since `withRegion` would otherwise read the developer's shell. The `--target staging` case now passes a matching `--region`. New case: a mismatched target rejects with a `ProjectStateError` that names both regions, an explicit `--region` takes part in the same comparison, and nothing is written to stdout.
- Screen (`status.screen.test.tsx`): `renderStatus` pins `RegionKey` to the target's region so the existing tree and navigation tests still apply. New case: with the base context's `us-east-1` against a `eu-west-1` target, the message renders, no agent group or runtime row does, `enter` stays put, and `esc` returns to the project menu.
- Both new cases fail against the previous source and pass with the change.

## Checks

- `bun test src` — 3167 pass. The 11 failures are all in `src/io/exec.test.ts`, which spawns `node`, not installed in this environment (same as #2239's run).
- `bun run typecheck`, `bun run lint:check`, `bun run format:check` — clean for the repository's own files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016KnHdxcPYTnQiDY7Y1PY6s
