### PR TITLE
fix(update): assert against the active dist-tag, not hardcoded "latest"

### DIFF
--- a/src/handlers/update/update.test.ts
+++ b/src/handlers/update/update.test.ts
@@ -28,7 +28,7 @@ describe("fetchLatestVersion", () => {
       new Response(JSON.stringify({ version: "9.9.9" }), { status: 200 }),
     );
     expect(await fetchLatestVersion()).toBe("9.9.9");
-    expect(fetchSpy).toHaveBeenCalledWith("https://registry.npmjs.org/@aws/agentcore/latest");
+    expect(fetchSpy).toHaveBeenCalledWith(`https://registry.npmjs.org/@aws/agentcore/${distTag()}`);
   });
 
   test("throws a NetworkingError when the registry responds non-OK", async () => {
@@ -90,7 +90,7 @@ describe("handleUpdate", () => {
     const result = await handleUpdate(false, { runner: okRunner });
     expect(result.status).toBe("updated");
     expect(okRunner).toHaveBeenCalledWith(
-      ["npm", "install", "-g", "@aws/agentcore@latest"],
+      ["npm", "install", "-g", `@aws/agentcore@${distTag()}`],
       expect.objectContaining({ cwd: expect.any(String) }),
     );
   });


### PR DESCRIPTION
## Summary
- CI on `release/v1.0.0-rc.1` fails in `src/handlers/update/update.test.ts` because two assertions hardcode the `latest` dist-tag, while the handler on this branch now resolves the tag from the local prerelease (`rc` for `1.0.0-rc.1`). Route both assertions through `distTag()` so the test follows whichever tag the current version resolves to.
- Failing run for reference: https://github.com/aws/agentcore-cli/actions/runs/33923566119

## Test plan
- [x] `bun test src/handlers/update/update.test.ts` — 11 pass, 0 fail locally on this branch
- [ ] CI green on Linux, Windows, macOS