### PR TITLE
fix(project): show the live progress list for project add on a TTY

### DIFF
--- a/src/components/ui/spinner/Spinner.tsx
+++ b/src/components/ui/spinner/Spinner.tsx
@@ -32,7 +32,10 @@ export const Spinner: React.FC<SpinnerProps> = ({
 
   return (
     <Box>
-      <Text color={theme.colors.primary}>{frames[frame]}</Text>
+      {/* Keep the frame column when the label is wider than the row. */}
+      <Box flexShrink={0}>
+        <Text color={theme.colors.primary}>{frames[frame]}</Text>
+      </Box>
       {label ? <Text color={theme.colors.text}> {label}</Text> : null}
     </Box>
   );

--- a/src/components/ui/task-list/TaskList.test.tsx
+++ b/src/components/ui/task-list/TaskList.test.tsx
@@ -75,4 +75,25 @@ describe("TaskList", () => {
     expect(tailLine).toContain("…");
     instance.unmount();
   });
+
+  // A title with no break opportunity (a Windows temp path) is wider than the
+  // row; Ink's default shrink used to give the glyph column to the title.
+  test("keeps the glyph and spinner when an unbreakable title exceeds the width", () => {
+    const title = "Reading 'C:\\Users\\Admin\\AppData\\Local\\Temp\\agentcore-x\\agentcore.json'";
+    const instance = render(<></>);
+    Object.defineProperty(instance.stdout, "columns", { configurable: true, value: 40 });
+    instance.rerender(
+      <TaskList
+        tasks={[
+          { title, state: "done", tail: [] },
+          { title, state: "running", tail: [] },
+        ]}
+      />,
+    );
+
+    const lines = (instance.lastFrame() ?? "").split("\n");
+    expect(lines[0]).toMatch(/^✓ Reading/);
+    expect(lines.some((line) => /^[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏] Reading/.test(line))).toBe(true);
+    instance.unmount();
+  });
 });

--- a/src/components/ui/task-list/TaskList.tsx
+++ b/src/components/ui/task-list/TaskList.tsx
@@ -49,9 +49,12 @@ export const TaskList: React.FC<TaskListProps> = ({
             <Spinner label={task.title} theme={theme} />
           ) : (
             <Box>
-              <Text color={task.state === "done" ? theme.colors.success : theme.colors.error}>
-                {task.state === "done" ? glyphs.done : glyphs.failed}
-              </Text>
+              {/* Keep the glyph column when the title is wider than the row. */}
+              <Box flexShrink={0}>
+                <Text color={task.state === "done" ? theme.colors.success : theme.colors.error}>
+                  {task.state === "done" ? glyphs.done : glyphs.failed}
+                </Text>
+              </Box>
               <Text color={theme.colors.text}> {task.title}</Text>
             </Box>
           )}

--- a/src/handlers/project/add/memory/index.test.ts
+++ b/src/handlers/project/add/memory/index.test.ts
@@ -32,8 +32,17 @@ afterEach(async () => {
   );
 });
 
-async function run(args: string[], opts?: { core?: TestCoreClient }) {
-  const io = testIO();
+// Ink writes cursor/erase sequences around each frame; the TTY assertions
+// below care about frame text, not terminal control. Built without a
+// control-char literal so lint stays quiet.
+const ANSI_SEQUENCE = new RegExp(`${String.fromCharCode(0x1b)}\\[[0-9;?]*[A-Za-z]`, "g");
+
+function stripAnsi(text: string): string {
+  return text.replace(ANSI_SEQUENCE, "");
+}
+
+async function run(args: string[], opts?: { core?: TestCoreClient; isTTY?: boolean }) {
+  const io = testIO({ isTTY: opts?.isTTY });
   const core = opts?.core ?? new TestCoreClient();
   const root = createRootHandler(core, {
     io: io.io,
@@ -64,6 +73,33 @@ describe("project add memory", () => {
       resource: { type: "memory", name: "customer_memory" },
     });
     expect(io.stderr()).not.toContain("added memory");
+  });
+
+  // The same progress driver create, build, and deploy use: a TTY gets the live
+  // step list with every step marked done, and the success line follows it.
+  test("renders a live step list on a TTY", async () => {
+    await inProject();
+    const { io } = await run(["add", "memory", "--name", "customer_memory"], { isTTY: true });
+
+    const frames = stripAnsi(io.stderr());
+    expect(frames).toContain("✓ Reading project spec file");
+    expect(frames).toContain("✓ Updating project spec file");
+    expect(frames).toContain("added memory 'customer_memory' to 'TestProject'");
+    expect(io.stdout()).toBe("");
+  });
+
+  test("--json on a TTY keeps the plain step lines so no ANSI reaches stderr", async () => {
+    await inProject();
+    const { io } = await run(["add", "memory", "--name", "customer_memory", "--json"], {
+      isTTY: true,
+    });
+
+    expect(io.stderr()).not.toContain(String.fromCharCode(0x1b));
+    expect(io.stderr()).toContain("Reading project spec file");
+    expect(JSON.parse(io.stdout())).toMatchObject({
+      operation: "add",
+      resource: { type: "memory", name: "customer_memory" },
+    });
   });
 
   /** Verify the flag -> agentcore.json memories[] entry for each flag. */

--- a/src/handlers/project/add/shared.ts
+++ b/src/handlers/project/add/shared.ts
@@ -1,5 +1,6 @@
 import type { Context } from "../../../router";
 import { runWithProgress } from "../../../tui/progress";
+import { JsonKey } from "../../keys";
 import { renderResult } from "../../utils";
 import {
   projectMutationResource,
@@ -23,11 +24,12 @@ export async function addProjectResource(
   humanSuccessMessage: string,
   options: AddProjectResourceResultOptions = {},
 ): Promise<Project> {
+  // Same driver as create, build, and deploy: a live step list in a TTY, and
+  // plain line-per-step output when stderr is not a TTY or --json wants no ANSI
+  // on it.
   const updatedProject = await runWithProgress(config.projectManager.addResource(project, input), {
     io: config.io,
-    // Project add commands historically print plain progress lines even on a
-    // TTY. Keep that behavior while still collecting the generator result.
-    interactive: false,
+    interactive: ctx.require(JsonKey) ? false : undefined,
   });
 
   renderResult<ProjectMutationResult>(


### PR DESCRIPTION
## Description

`agentcore project add <resource>` now renders the same live progress list as `project create`, `build`, and `deploy` when run in a terminal: a spinner on the running step, a scrolling tail of its output (for example `uv sync` during `add runtime`), and a ✓ on each completed step.


https://github.com/user-attachments/assets/e2c1a679-52ff-458b-9c97-b66c2d7b74ef



Every add sub-command runs its generator through the shared helper in `src/handlers/project/add/shared.ts`. Since #2218 that helper called `runWithProgress` with `interactive: false`, which forces the plain line-per-step path even on a TTY. The comment there preserved the pre-#2218 behavior, where each add handler wrote its own plain lines and never used the progress driver. This change gates the plain path on `--json` only, the value every other project mutation already passes.

Behavior for `project add`:

| Situation | Before | After |
|---|---|---|
| Interactive terminal | plain lines | spinner task list, ✓ per step |
| Piped or CI (no TTY) | plain lines | plain lines, unchanged |
| `--json` | plain lines | plain lines, unchanged |

### TaskList: keep the glyph when a step title is wider than the terminal

The new TTY test surfaced a pre-existing rendering bug on the Windows runner. Ink boxes shrink by default, so when a step title is wider than the row (a long path with no break opportunity, such as a Windows temp path), the one-column ✓/✕ glyph and spinner frame were squeezed to zero width and disappeared:

```
before (80 columns):
 Reading project spec file at 'C:\Users\ContainerAdministrator\AppData\Local\Temp
\agentcore-memory-aX9hjo\TestProject\agentcore\agentcore.json'

after:
✓ Reading project spec file at 'C:\Users\ContainerAdministrator\AppData\Local\Te
 mp\agentcore-memory-aX9hjo\TestProject\agentcore\agentcore.json'
```

`TaskList` and `Spinner` now wrap the glyph in `<Box flexShrink={0}>`. The title still wraps beneath itself. The same glitch showed in `project create` at exactly the terminal width, so this fixes it there too.

## Related Issue

No upstream issue; reported internally as "agentcore project add missing nice spinners".

## Documentation PR

N/A. Output shape for `--json` and non-TTY callers is unchanged.

## Type of Change

<!-- Check all that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

New tests:

- `src/handlers/project/add/memory/index.test.ts`: a TTY run asserts the rendered frames contain `✓ Reading project spec file`, `✓ Updating project spec file`, and the success line, with nothing on stdout. A TTY run with `--json` asserts no escape sequences reach stderr and the mutation result lands on stdout.
- `src/components/ui/task-list/TaskList.test.tsx`: at 40 columns, a title wider than the row keeps the ✓ on a done task and the spinner frame on a running task. Fails without the `flexShrink` change on every platform.

Manual checks against a scaffolded project:

- Pseudo-TTY (`script` with `stty cols 200`): `add memory` shows both steps ✓; `add runtime` shows the spinner with the `uv sync` tail under the running step, then all four steps ✓.
- 60-column terminal via the TUI harness: `add runtime` keeps every ✓ with the long paths wrapping beneath their titles.
- Non-TTY and `--json` output is byte-identical to before.

- [x] `bun test` (3181 pass, 0 fail)
- [x] I ran `bun run typecheck`
- [x] I ran `bun run lint:check` and `bun run format:check`
- [ ] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots (not applicable)

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly (no docs change needed)
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
