### PR TITLE
fix: mark logs and traces as cli only

### DIFF
--- a/src/components/CliOnlyScreen.test.tsx
+++ b/src/components/CliOnlyScreen.test.tsx
@@ -61,10 +61,31 @@ describe("menus list command-line-only subcommands below a divider", () => {
     r.unmount();
   });
 
-  test("the divider is omitted when nothing is command line only", async () => {
+  test("the harness menu", async () => {
     const r = renderScreen("/agentcore/harness");
 
-    await waitForText(r.lastFrame, "manage AgentCore harnesses");
+    await waitForText(r.lastFrame, "command line only");
+    expect(menuEntries(r.lastFrame()!)).toEqual({
+      screens: [
+        "create",
+        "get",
+        "list",
+        "update",
+        "delete",
+        "invoke",
+        "exec",
+        "endpoint",
+        "version",
+      ],
+      cliOnly: ["logs", "traces"],
+    });
+    r.unmount();
+  });
+
+  test("the divider is omitted when nothing is command line only", async () => {
+    const r = renderScreen("/agentcore/harness/endpoint");
+
+    await waitForText(r.lastFrame, "manage harness endpoints");
     expect(r.lastFrame()).not.toContain("command line only");
     r.unmount();
   });

--- a/src/handlers/harness/index.tsx
+++ b/src/handlers/harness/index.tsx
@@ -22,6 +22,17 @@ export function createHarnessHandler(core: Core, io: AppIO): Router {
   harness.use(withTuiOnEmptyFlagsAndArgs(core, io));
   // Open the TUI at this root, i.e., `agentcore harness`
   harness.default(renderTui(core, io));
+  harness.supportedTuiCommands(
+    "create",
+    "get",
+    "list",
+    "update",
+    "delete",
+    "invoke",
+    "exec",
+    "endpoint",
+    "version",
+  );
 
   // Register handlers
   harness.handler(createCreateHarnessHandler(core));


### PR DESCRIPTION
## Description

In our TUI, `logs` and `traces` are both appearing under harness as standard TUI items, though both are CLI-only commands. 

This PR updates the harness handler to exclude the above operations as TUI supported, adding the CLI-only line and styling for unsupported commands. 

## Example
`agentcore` -> running RC project installed via npm
`acr-dev` -> running project from my dev environment


https://github.com/user-attachments/assets/774e1cbb-3c03-49e0-bbb7-b7f8739f309c



## Type of Change

<!-- Check all that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] `bun run test` (3179 pass, 0 fail)
- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [x] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
