### PR TITLE
fix(telemetry): disable telemetry in tests for local runs. 

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -11,9 +11,6 @@ on:
       CODECOV_TOKEN:
         required: false
 
-env:
-  AGENTCORE_TELEMETRY_DISABLED: "1"
-
 jobs:
   verify:
     name: ${{ matrix.name }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -11,6 +11,9 @@ on:
       CODECOV_TOKEN:
         required: false
 
+env:
+  AGENTCORE_TELEMETRY_DISABLED: "1"
+
 jobs:
   verify:
     name: ${{ matrix.name }}

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,7 +1,4 @@
 [test]
-# Preload runs before any test module loads. setup.ts pins FORCE_COLOR=0 so Ink
-# frames are plain text (no ANSI color codes) regardless of whether stdout is a
-# TTY, keeping frame assertions deterministic across `bun test` and piped runs.
 preload = ["./src/testing/setup.ts"]
 pathIgnorePatterns = ["src/assets/**", "out/**", "dist/**"]
 coveragePathIgnorePatterns = ["src/testing/**", "src/assets/**"]

--- a/src/testing/setup.ts
+++ b/src/testing/setup.ts
@@ -17,3 +17,5 @@ process.env.FORCE_COLOR = "0";
 // terminal env at import time. Pin the Windows Terminal marker so frame
 // assertions on ❯ ✗ ↵ hold on a plain conhost dev box as well.
 process.env.WT_SESSION ??= "bun-test";
+
+process.env.AGENTCORE_TELEMETRY_DISABLED = "1";


### PR DESCRIPTION
### Problem 
We are seeing test data show up in our metrics:

```
{
  "OTelLib": "agentcore-cli",
  "Version": "1",
  "_aws": {
    "CloudWatchMetrics": [
      {
        "Namespace": "agentcore-cli",
        "Dimensions": [
          [],
          [
            "exit_reason"
          ],
          [
            "service.version"
          ]
        ],
        "Metrics": [
          {
            "Name": "cli.command_run",
            "Unit": "",
            "StorageResolution": 60
          }
        ]
      }
    ],
    "Timestamp": 1788963541491
  },
  "agentcore-cli.installation_id": "9f6e8e7f-9bfc-4231-a15f-0354b97ca689",
  "agentcore-cli.session_id": "ffffffff-1111-2222-3333-444444444444",
  "cli.command_run": {
    "Max": 123,
    "Min": 123,
    "Count": 1,
    "Sum": 123
  },
  "command_path": "/agentcore",
  "exit_reason": "failure",
  "host.arch": "x64",
  "is_tui": "false",
  "node.version": "v26.3.0",
  "os.type": "Linux",
  "os.version": "6.12.103-127.188.amzn2023.x86_64",
  "service.name": "agentcore-cli",
  "service.version": "1.0.0-rc.1"
}
```

This is likely coming from https://github.com/aws/agentcore-cli/blob/refactor/src/telemetry/client.test.tsx#L109, on local runs of the tests where telemetry is not disabled. 

### Solution 
- Add a pre-test hook in `testing/setup.ts` the sets `AGENTCORE_TELEMETRY_DISABLED` to 1. 
- Removed `AGENTCORE_TELEMETRY_DISABLED` from the CI workflow since its not baked into the tests. 

### Verification
Setup a basic local collector:
```
const outFile = process.env.COLLECTOR_OUT!;
const port = Number(process.env.COLLECTOR_PORT ?? 4318);
await Bun.write(outFile, "");
Bun.serve({
  port,
  async fetch(req) {
    const body = await req.text();
    await Bun.write(outFile, (await Bun.file(outFile).text()) + body + "\n");
    return new Response("", { status: 200 });
  },
});
console.log(`collector listening on ${port}`);
```

Run the collector via `COLLECTOR_OUT=collector-out.txt COLLECTOR_PORT=4318 bun collector.ts &`

update the default endpoint used in the tests at https://github.com/aws/agentcore-cli/blob/0caec7fe932a0d4f8f8ce2d4821fee0664ab77cf/src/globalConfig/config.tsx#L10 to point to localhost:4318. 

Run the tests with and without the env var injection to verify that it limits what is emitted. 