### PR TITLE
Bump agentcore-devx-devtools reusable workflow pin

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -42,7 +42,7 @@ jobs:
       pull-requests: write
       issues: write
       contents: read
-    uses: aws/agentcore-devx-devtools/.github/workflows/reusable-pr-security-review.yml@4b3972e790e4cc312ddf6f1909a0b6ca8a749506
+    uses: aws/agentcore-devx-devtools/.github/workflows/reusable-pr-security-review.yml@51d084b0bf4585725bf370f31cd1e30c4dddfd93
     with:
       runner: codebuild
       pr_number: ${{ inputs.pr_number || format('{0}', github.event.pull_request.number) }}

--- a/.github/workflows/strands-command.yml
+++ b/.github/workflows/strands-command.yml
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   call:
-    uses: aws/agentcore-devx-devtools/.github/workflows/reusable-strands-command.yml@458c0a684af0f9e3a013ec05cd23851def4f9cab
+    uses: aws/agentcore-devx-devtools/.github/workflows/reusable-strands-command.yml@51d084b0bf4585725bf370f31cd1e30c4dddfd93
     with:
       runner: codebuild
       issue_id: ${{ inputs.issue_id || format('{0}', github.event.issue.number || github.event.pull_request.number) }}


### PR DESCRIPTION
Bumps the pinned `agentcore-devx-devtools` reusable-workflow SHA to `51d084b0bf4585725bf370f31cd1e30c4dddfd93` (latest `main`) to pick up the hardened event-context handling (event values passed via `env:` instead of inline shell interpolation). No behavior change.