### PR TITLE
Move PR-review Slack notifications to CodeBuild runner

### DIFF
--- a/.github/workflows/slack-pr-review-notification.yml
+++ b/.github/workflows/slack-pr-review-notification.yml
@@ -17,5 +17,5 @@ permissions:
 
 jobs:
   call:
-    uses: aws/agentcore-devx-devtools/.github/workflows/reusable-slack-pr-review-notification.yml@9e85985f68e365774c93ffe0f2d8e992b2a4578f
+    uses: aws/agentcore-devx-devtools/.github/workflows/reusable-slack-pr-review-notification.yml@70f0e5036c431872a63c252e443242c267490dc4
     secrets: inherit

--- a/.github/workflows/slack-pr-review-notification.yml
+++ b/.github/workflows/slack-pr-review-notification.yml
@@ -17,5 +17,5 @@ permissions:
 
 jobs:
   call:
-    uses: aws/agentcore-devx-devtools/.github/workflows/reusable-slack-pr-review-notification.yml@626595f508220b53805c86c1b54d089420add4d3
+    uses: aws/agentcore-devx-devtools/.github/workflows/reusable-slack-pr-review-notification.yml@9e85985f68e365774c93ffe0f2d8e992b2a4578f
     secrets: inherit


### PR DESCRIPTION
## What
Bump the pinned SHA of the `reusable-slack-pr-review-notification.yml` shared workflow: `...@626595f` → `...@9e85985`.

The only diff between those two commits in that file is the `runner` input default flipping `ubuntu` → `codebuild`. No `runner:` argument is added — the caller inherits the new default, so the notify job now runs on `codebuild-agentcore-e2e-…` instead of `ubuntu-latest`.

## ⚠️ Draft — blocked on upstream
- Depends on aws/agentcore-devx-devtools#4. Pin `9e85985` is that PR's **branch** commit; if #4 is squash-merged, re-pin to the resulting `main` SHA before merging.
- Requires the `agentcore-e2e` CodeBuild project (already serves this repo's pr-automation — no infra work).

To force GitHub-hosted again: `with: { runner: ubuntu }` on the `call` job.