### PR TITLE
fix(handlers): standardize mutual flag parsing behavior

### DIFF
--- a/src/handlers/eval/batch-insights/batch-insights.test.tsx
+++ b/src/handlers/eval/batch-insights/batch-insights.test.tsx
@@ -56,7 +56,7 @@ describe("eval batch-insights run", () => {
       /--name/,
     );
     await expect(run(["eval", "batch-insights", "run", "--name", "insights_run"])).rejects.toThrow(
-      /exactly one source/,
+      /specify exactly one of --agent, --online-eval, --data-source-config/,
     );
     await expect(
       run([
@@ -70,7 +70,7 @@ describe("eval batch-insights run", () => {
         "--online-eval",
         "online-1",
       ]),
-    ).rejects.toThrow(/exactly one source/);
+    ).rejects.toThrow(/specify exactly one of --agent, --online-eval, --data-source-config/);
   });
 
   test("uses failure analysis by default and passes the resolved agent source", async () => {

--- a/src/handlers/eval/online-eval/create/index.tsx
+++ b/src/handlers/eval/online-eval/create/index.tsx
@@ -5,7 +5,7 @@ import { InputValidationError } from "../../../../errors";
 import { JsonRendererKey } from "../../../../tui";
 import { SourceResolver, type AppIO } from "../../../../io";
 import type { Core } from "../../../types";
-import { coreOptsFromCtx, parseJsonFlag } from "../../../utils";
+import { assertMutuallyExclusiveFlags, coreOptsFromCtx, parseJsonFlag } from "../../../utils";
 
 export const createCreateOnlineEvalHandler = (core: Core, io: AppIO) =>
   createHandler({
@@ -70,13 +70,9 @@ export const createCreateOnlineEvalHandler = (core: Core, io: AppIO) =>
         );
       }
 
+      assertMutuallyExclusiveFlags(flags, ["agent", "data-source-config"], { exactlyOne: true });
       const hasAgent = flags["agent"] !== undefined;
       const hasDataSource = flags["data-source-config"] !== undefined;
-      if (hasAgent === hasDataSource) {
-        throw new InputValidationError(
-          "specify exactly one of '--agent' or '--data-source-config'",
-        );
-      }
       if (hasDataSource && flags["endpoint"]) {
         throw new InputValidationError("'--endpoint' can only be used with '--agent'");
       }

--- a/src/handlers/eval/online-eval/online-eval.test.tsx
+++ b/src/handlers/eval/online-eval/online-eval.test.tsx
@@ -259,7 +259,7 @@ describe("flag validation", () => {
         "--role-arn",
         FIXTURE_ROLE_ARN,
       ]),
-    ).rejects.toThrow(/exactly one of '--agent' or '--data-source-config'/);
+    ).rejects.toThrow(/exactly one of --agent, --data-source-config/);
   });
 
   test("create rejects both --agent and --data-source-config", async () => {
@@ -281,7 +281,7 @@ describe("flag validation", () => {
         "--role-arn",
         FIXTURE_ROLE_ARN,
       ]),
-    ).rejects.toThrow(/exactly one of '--agent' or '--data-source-config'/);
+    ).rejects.toThrow(/exactly one of --agent, --data-source-config/);
   });
 
   test("create rejects --endpoint without --agent", async () => {
@@ -355,7 +355,7 @@ describe("flag validation", () => {
         "--data-source-config",
         '{"cloudWatchLogs":{"logGroupNames":["/custom"],"serviceNames":["svc"]}}',
       ]),
-    ).rejects.toThrow(/'--agent' and '--data-source-config' are mutually exclusive/);
+    ).rejects.toThrow(/--agent, --data-source-config are mutually exclusive/);
   });
 
   test("update rejects --endpoint together with --data-source-config", async () => {

--- a/src/handlers/eval/online-eval/update/index.tsx
+++ b/src/handlers/eval/online-eval/update/index.tsx
@@ -6,7 +6,7 @@ import { JsonKey } from "../../../keys";
 import { JsonRendererKey } from "../../../../tui";
 import { SourceResolver, type AppIO } from "../../../../io";
 import type { Core } from "../../../types";
-import { coreOptsFromCtx, parseJsonFlag } from "../../../utils";
+import { assertMutuallyExclusiveFlags, coreOptsFromCtx, parseJsonFlag } from "../../../utils";
 
 export const createUpdateOnlineEvalHandler = (core: Core, io: AppIO) =>
   createHandler({
@@ -64,11 +64,7 @@ export const createUpdateOnlineEvalHandler = (core: Core, io: AppIO) =>
           "'--endpoint' and '--clear-endpoint' are mutually exclusive",
         );
       }
-      if (flags["data-source-config"] && flags["agent"]) {
-        throw new InputValidationError(
-          "'--agent' and '--data-source-config' are mutually exclusive",
-        );
-      }
+      assertMutuallyExclusiveFlags(flags, ["agent", "data-source-config"]);
       if (
         flags["data-source-config"] &&
         (flags["endpoint"] || flags["clear-endpoint"] === "true")

--- a/src/handlers/eval/online-insight/create/index.tsx
+++ b/src/handlers/eval/online-insight/create/index.tsx
@@ -5,7 +5,7 @@ import { InputValidationError } from "../../../../errors";
 import { JsonRendererKey } from "../../../../tui";
 import { SourceResolver, type AppIO } from "../../../../io";
 import type { Core } from "../../../types";
-import { coreOptsFromCtx, parseJsonFlag } from "../../../utils";
+import { assertMutuallyExclusiveFlags, coreOptsFromCtx, parseJsonFlag } from "../../../utils";
 
 const BUILTIN_INSIGHT_PREFIX = "Builtin.Insight.";
 const ARN_PREFIX = "arn:";
@@ -83,12 +83,9 @@ export const createCreateOnlineInsightHandler = (core: Core, io: AppIO) =>
           );
       }
 
+      assertMutuallyExclusiveFlags(flags, ["agent", "data-source-config"], { exactlyOne: true });
       const hasAgent = flags["agent"] !== undefined;
       const hasDataSource = flags["data-source-config"] !== undefined;
-      if (hasAgent === hasDataSource)
-        throw new InputValidationError(
-          "specify exactly one of '--agent' or '--data-source-config'",
-        );
       if (hasDataSource && flags["endpoint"])
         throw new InputValidationError("'--endpoint' can only be used with '--agent'");
 

--- a/src/handlers/eval/online-insight/online-insight.test.tsx
+++ b/src/handlers/eval/online-insight/online-insight.test.tsx
@@ -299,7 +299,7 @@ describe("flag validation", () => {
         "--sampling-rate",
         "10",
       ]),
-    ).rejects.toThrow(/exactly one of '--agent' or '--data-source-config'/);
+    ).rejects.toThrow(/exactly one of --agent, --data-source-config/);
   });
 
   test("create rejects both --agent and --data-source-config", async () => {
@@ -321,7 +321,7 @@ describe("flag validation", () => {
         "--sampling-rate",
         "10",
       ]),
-    ).rejects.toThrow(/exactly one of '--agent' or '--data-source-config'/);
+    ).rejects.toThrow(/exactly one of --agent, --data-source-config/);
   });
 
   test("create rejects --endpoint without --agent", async () => {

--- a/src/handlers/eval/online-insight/update/index.tsx
+++ b/src/handlers/eval/online-insight/update/index.tsx
@@ -5,7 +5,7 @@ import { InputValidationError } from "../../../../errors";
 import { JsonRendererKey } from "../../../../tui";
 import { SourceResolver, type AppIO } from "../../../../io";
 import type { Core } from "../../../types";
-import { coreOptsFromCtx, parseJsonFlag } from "../../../utils";
+import { assertMutuallyExclusiveFlags, coreOptsFromCtx, parseJsonFlag } from "../../../utils";
 
 const BUILTIN_INSIGHT_PREFIX = "Builtin.Insight.";
 const ARN_PREFIX = "arn:";
@@ -65,10 +65,7 @@ export const createUpdateOnlineInsightHandler = (core: Core, io: AppIO) =>
         throw new InputValidationError(
           "'--endpoint' and '--clear-endpoint' are mutually exclusive",
         );
-      if (flags["data-source-config"] && flags["agent"])
-        throw new InputValidationError(
-          "'--agent' and '--data-source-config' are mutually exclusive",
-        );
+      assertMutuallyExclusiveFlags(flags, ["agent", "data-source-config"]);
       if (flags["data-source-config"] && (flags["endpoint"] || flags["clear-endpoint"] === "true"))
         throw new InputValidationError(
           "'--endpoint' cannot be combined with '--data-source-config'",

--- a/src/handlers/eval/sessionSource.tsx
+++ b/src/handlers/eval/sessionSource.tsx
@@ -3,7 +3,7 @@ import z from "zod";
 import { InputValidationError } from "../../errors";
 import { SourceResolver, type AppIO } from "../../io";
 import { flag, type Flag } from "../../router";
-import { parseJsonFlag } from "../utils";
+import { assertMutuallyExclusiveFlags, parseJsonFlag } from "../utils";
 import type { SessionSourceValue, SessionWindow } from "./types";
 
 export class SessionSource {
@@ -54,16 +54,12 @@ export class SessionSource {
     flags: SessionSourceFlags,
     rawDataSourceConfig: DataSourceConfig | undefined,
   ): SessionSourceValue {
-    const hasAgent = flags["agent"] !== undefined;
+    assertMutuallyExclusiveFlags(flags, ["agent", "online-eval", "data-source-config"], {
+      exactlyOne: true,
+    });
+
     const hasOnlineEval = flags["online-eval"] !== undefined;
     const hasRaw = rawDataSourceConfig !== undefined;
-
-    const armCount = [hasAgent, hasOnlineEval, hasRaw].filter(Boolean).length;
-    if (armCount !== 1) {
-      throw new InputValidationError(
-        "specify exactly one source: '--agent', '--online-eval', or '--data-source-config'",
-      );
-    }
 
     const hasIds = !!flags["session-ids"]?.length;
 

--- a/src/handlers/gateway/connector/create/index.tsx
+++ b/src/handlers/gateway/connector/create/index.tsx
@@ -10,7 +10,12 @@ import { type AppIO, SourceResolver } from "../../../../io";
 import { createHandler, flag } from "../../../../router";
 import { JsonRendererKey } from "../../../../tui";
 import type { Core } from "../../../types";
-import { coreOptsFromCtx, parseJsonArrayFlag, parseJsonObjectFlag } from "../../../utils";
+import {
+  assertMutuallyExclusiveFlags,
+  coreOptsFromCtx,
+  parseJsonArrayFlag,
+  parseJsonObjectFlag,
+} from "../../../utils";
 import type { CreateGatewayTargetInput } from "../../types";
 import { GatewayConnectorTarget } from "../gatewayConnectorTarget";
 
@@ -60,11 +65,9 @@ export const createCreateGatewayConnectorHandler = (core: Core, io: AppIO) =>
       if (!flags.name) {
         throw new InputValidationError("required option '--name <name>' not specified");
       }
-      if ((flags.connector === undefined) === (flags["connector-configuration"] === undefined)) {
-        throw new InputValidationError(
-          "specify exactly one of '--connector' or '--connector-configuration'",
-        );
-      }
+      assertMutuallyExclusiveFlags(flags, ["connector", "connector-configuration"], {
+        exactlyOne: true,
+      });
       if (
         flags.connector === "bedrock-knowledge-bases" &&
         flags["knowledge-base-id"] === undefined

--- a/src/handlers/gateway/connector/update/index.tsx
+++ b/src/handlers/gateway/connector/update/index.tsx
@@ -11,7 +11,7 @@ import { createHandler, flag } from "../../../../router";
 import { JsonRendererKey } from "../../../../tui";
 import type { Core } from "../../../types";
 import {
-  assertMutuallyExclusiveInputs,
+  assertMutuallyExclusiveFlags,
   coreOptsFromCtx,
   parseJsonArrayFlag,
   parseJsonObjectFlag,
@@ -70,33 +70,17 @@ export const createUpdateGatewayConnectorHandler = (core: Core, io: AppIO) =>
       if (!flags.id) {
         throw new InputValidationError("required option '--id <id>' not specified");
       }
-      assertMutuallyExclusiveInputs([
-        ["connector", flags.connector, "connector-configuration", flags["connector-configuration"]],
-        [
-          "description",
-          flags.description,
-          "clear-description",
-          flags["clear-description"] || undefined,
-        ],
-        [
-          "credential-provider-configurations",
-          flags["credential-provider-configurations"],
-          "clear-credential-provider-configurations",
-          flags["clear-credential-provider-configurations"] || undefined,
-        ],
-        [
-          "metadata-configuration",
-          flags["metadata-configuration"],
-          "clear-metadata-configuration",
-          flags["clear-metadata-configuration"] || undefined,
-        ],
-        [
-          "private-endpoint",
-          flags["private-endpoint"],
-          "clear-private-endpoint",
-          flags["clear-private-endpoint"] || undefined,
-        ],
+      assertMutuallyExclusiveFlags(flags, ["connector", "connector-configuration"]);
+      assertMutuallyExclusiveFlags(flags, ["description", "clear-description"]);
+      assertMutuallyExclusiveFlags(flags, [
+        "credential-provider-configurations",
+        "clear-credential-provider-configurations",
       ]);
+      assertMutuallyExclusiveFlags(flags, [
+        "metadata-configuration",
+        "clear-metadata-configuration",
+      ]);
+      assertMutuallyExclusiveFlags(flags, ["private-endpoint", "clear-private-endpoint"]);
       if (
         flags.connector === "bedrock-knowledge-bases" &&
         flags["knowledge-base-id"] === undefined

--- a/src/handlers/gateway/rule/update/index.tsx
+++ b/src/handlers/gateway/rule/update/index.tsx
@@ -5,7 +5,7 @@ import { type AppIO, SourceResolver } from "../../../../io";
 import { createHandler, flag } from "../../../../router";
 import { JsonRendererKey } from "../../../../tui";
 import type { Core } from "../../../types";
-import { assertMutuallyExclusiveInputs, coreOptsFromCtx, parseJsonArrayFlag } from "../../../utils";
+import { assertMutuallyExclusiveFlags, coreOptsFromCtx, parseJsonArrayFlag } from "../../../utils";
 import type { GatewayRuleUpdateInput } from "../../types";
 
 export const createUpdateGatewayRuleHandler = (core: Core, io: AppIO) =>
@@ -40,14 +40,7 @@ export const createUpdateGatewayRuleHandler = (core: Core, io: AppIO) =>
       if (!flags["rule-id"]) {
         throw new InputValidationError("required option '--rule-id <rule-id>' not specified");
       }
-      assertMutuallyExclusiveInputs([
-        [
-          "conditions",
-          flags.conditions,
-          "clear-conditions",
-          flags["clear-conditions"] || undefined,
-        ],
-      ]);
+      assertMutuallyExclusiveFlags(flags, ["conditions", "clear-conditions"]);
       if (flags.description === "") {
         throw new InputValidationError("Rule description cannot be empty or cleared");
       }

--- a/src/handlers/gateway/target/create/index.tsx
+++ b/src/handlers/gateway/target/create/index.tsx
@@ -11,7 +11,12 @@ import { type AppIO, SourceResolver } from "../../../../io";
 import { createHandler, flag } from "../../../../router";
 import { JsonRendererKey } from "../../../../tui";
 import type { Core } from "../../../types";
-import { coreOptsFromCtx, parseJsonArrayFlag, parseJsonObjectFlag } from "../../../utils";
+import {
+  assertMutuallyExclusiveFlags,
+  coreOptsFromCtx,
+  parseJsonArrayFlag,
+  parseJsonObjectFlag,
+} from "../../../utils";
 import type { CreateGatewayTargetInput } from "../../types";
 
 export const createCreateGatewayTargetHandler = (core: Core, io: AppIO) =>
@@ -58,11 +63,9 @@ export const createCreateGatewayTargetHandler = (core: Core, io: AppIO) =>
       if (!flags["gateway-id"]) {
         throw new InputValidationError("required option '--gateway-id <gateway-id>' not specified");
       }
-      if ((flags.endpoint === undefined) === (flags["target-configuration"] === undefined)) {
-        throw new InputValidationError(
-          "specify exactly one of '--endpoint' or '--target-configuration'",
-        );
-      }
+      assertMutuallyExclusiveFlags(flags, ["endpoint", "target-configuration"], {
+        exactlyOne: true,
+      });
       if (flags["tool-schema"] !== undefined && flags.endpoint === undefined) {
         throw new InputValidationError("--tool-schema requires --endpoint");
       }

--- a/src/handlers/gateway/target/update/index.tsx
+++ b/src/handlers/gateway/target/update/index.tsx
@@ -11,7 +11,7 @@ import { createHandler, flag } from "../../../../router";
 import { JsonRendererKey } from "../../../../tui";
 import type { Core } from "../../../types";
 import {
-  assertMutuallyExclusiveInputs,
+  assertMutuallyExclusiveFlags,
   coreOptsFromCtx,
   parseJsonArrayFlag,
   parseJsonObjectFlag,
@@ -61,33 +61,17 @@ export const createUpdateGatewayTargetHandler = (core: Core, io: AppIO) =>
         throw new InputValidationError("required option '--target-id <target-id>' not specified");
       }
 
-      assertMutuallyExclusiveInputs([
-        [
-          "description",
-          flags.description,
-          "clear-description",
-          flags["clear-description"] || undefined,
-        ],
-        [
-          "credential-provider-configurations",
-          flags["credential-provider-configurations"],
-          "clear-credential-provider-configurations",
-          flags["clear-credential-provider-configurations"] || undefined,
-        ],
-        [
-          "metadata-configuration",
-          flags["metadata-configuration"],
-          "clear-metadata-configuration",
-          flags["clear-metadata-configuration"] || undefined,
-        ],
-        [
-          "private-endpoint",
-          flags["private-endpoint"],
-          "clear-private-endpoint",
-          flags["clear-private-endpoint"] || undefined,
-        ],
-        ["endpoint", flags.endpoint, "target-configuration", flags["target-configuration"]],
+      assertMutuallyExclusiveFlags(flags, ["description", "clear-description"]);
+      assertMutuallyExclusiveFlags(flags, [
+        "credential-provider-configurations",
+        "clear-credential-provider-configurations",
       ]);
+      assertMutuallyExclusiveFlags(flags, [
+        "metadata-configuration",
+        "clear-metadata-configuration",
+      ]);
+      assertMutuallyExclusiveFlags(flags, ["private-endpoint", "clear-private-endpoint"]);
+      assertMutuallyExclusiveFlags(flags, ["endpoint", "target-configuration"]);
 
       const source = new SourceResolver({ stdin: io.stdin });
       const targetConfiguration = parseJsonObjectFlag<TargetConfiguration>(

--- a/src/handlers/gateway/update/index.tsx
+++ b/src/handlers/gateway/update/index.tsx
@@ -12,7 +12,7 @@ import { createHandler, flag } from "../../../router";
 import { JsonRendererKey } from "../../../tui";
 import type { Core } from "../../types";
 import {
-  assertMutuallyExclusiveInputs,
+  assertMutuallyExclusiveFlags,
   coreOptsFromCtx,
   parseJsonArrayFlag,
   parseJsonObjectFlag,
@@ -77,44 +77,21 @@ export const createUpdateGatewayHandler = (core: Core, io: AppIO) =>
         throw new InputValidationError("required option '--id <id>' not specified");
       }
 
-      assertMutuallyExclusiveInputs([
-        [
-          "description",
-          flags.description,
-          "clear-description",
-          flags["clear-description"] || undefined,
-        ],
-        [
-          "protocol-configuration",
-          flags["protocol-configuration"],
-          "clear-protocol-configuration",
-          flags["clear-protocol-configuration"] || undefined,
-        ],
-        [
-          "custom-transform-configuration",
-          flags["custom-transform-configuration"],
-          "clear-custom-transform-configuration",
-          flags["clear-custom-transform-configuration"] || undefined,
-        ],
-        [
-          "interceptor-configurations",
-          flags["interceptor-configurations"],
-          "clear-interceptor-configurations",
-          flags["clear-interceptor-configurations"] || undefined,
-        ],
-        [
-          "exception-level",
-          flags["exception-level"],
-          "clear-exception-level",
-          flags["clear-exception-level"] || undefined,
-        ],
-        [
-          "waf-configuration",
-          flags["waf-configuration"],
-          "clear-waf-configuration",
-          flags["clear-waf-configuration"] || undefined,
-        ],
+      assertMutuallyExclusiveFlags(flags, ["description", "clear-description"]);
+      assertMutuallyExclusiveFlags(flags, [
+        "protocol-configuration",
+        "clear-protocol-configuration",
       ]);
+      assertMutuallyExclusiveFlags(flags, [
+        "custom-transform-configuration",
+        "clear-custom-transform-configuration",
+      ]);
+      assertMutuallyExclusiveFlags(flags, [
+        "interceptor-configurations",
+        "clear-interceptor-configurations",
+      ]);
+      assertMutuallyExclusiveFlags(flags, ["exception-level", "clear-exception-level"]);
+      assertMutuallyExclusiveFlags(flags, ["waf-configuration", "clear-waf-configuration"]);
       if (
         flags["clear-policy-engine"] &&
         (flags["policy-engine-arn"] !== undefined || flags["policy-engine-mode"] !== undefined)

--- a/src/handlers/identity/api-key-credential-provider/create/index.tsx
+++ b/src/handlers/identity/api-key-credential-provider/create/index.tsx
@@ -4,7 +4,7 @@ import { createHandler, flag } from "../../../../router";
 import { JsonRendererKey } from "../../../../tui";
 import type { Core } from "../../../types";
 import type { AppIO } from "../../../../io";
-import { coreOptsFromCtx, parseTags } from "../../../utils";
+import { assertMutuallyExclusiveFlags, coreOptsFromCtx, parseTags } from "../../../utils";
 import { SourceResolver } from "../../../../io";
 import { parseSecretReference } from "../../parser";
 
@@ -31,20 +31,11 @@ export const createCreateApiKeyCredentialProviderHandler = (core: Core, io: AppI
       if (!flags.name) {
         throw new InputValidationError("required option '--name <name>' not specified");
       }
+      assertMutuallyExclusiveFlags(flags, ["api-key", "api-key-secret-reference"], {
+        exactlyOne: true,
+      });
       const hasApiKey = flags["api-key"] !== undefined;
       const hasSecretRef = flags["api-key-secret-reference"] !== undefined;
-
-      if (hasApiKey && hasSecretRef) {
-        throw new InputValidationError(
-          "--api-key and --api-key-secret-reference are mutually exclusive",
-        );
-      }
-
-      if (!hasApiKey && !hasSecretRef) {
-        throw new InputValidationError(
-          "either --api-key or --api-key-secret-reference is required",
-        );
-      }
 
       const resolver = new SourceResolver({ stdin: io.stdin });
       const apiKey = await resolver.resolveSecret("api-key", flags["api-key"]);

--- a/src/handlers/identity/api-key-credential-provider/update/index.tsx
+++ b/src/handlers/identity/api-key-credential-provider/update/index.tsx
@@ -4,7 +4,7 @@ import { createHandler, flag } from "../../../../router";
 import { JsonRendererKey } from "../../../../tui";
 import type { Core } from "../../../types";
 import type { AppIO } from "../../../../io";
-import { coreOptsFromCtx } from "../../../utils";
+import { assertMutuallyExclusiveFlags, coreOptsFromCtx } from "../../../utils";
 import { SourceResolver } from "../../../../io";
 import { parseSecretReference } from "../../parser";
 
@@ -30,19 +30,11 @@ export const createUpdateApiKeyCredentialProviderHandler = (core: Core, io: AppI
       if (!flags.name) {
         throw new InputValidationError("required option '--name <name>' not specified");
       }
+      assertMutuallyExclusiveFlags(flags, ["api-key", "api-key-secret-reference"], {
+        exactlyOne: true,
+      });
       const hasApiKey = flags["api-key"] !== undefined;
       const hasSecretRef = flags["api-key-secret-reference"] !== undefined;
-
-      if (hasApiKey && hasSecretRef) {
-        throw new InputValidationError(
-          "--api-key and --api-key-secret-reference are mutually exclusive",
-        );
-      }
-      if (!hasApiKey && !hasSecretRef) {
-        throw new InputValidationError(
-          "either --api-key or --api-key-secret-reference is required",
-        );
-      }
 
       const opts = coreOptsFromCtx(ctx);
       const existing = await core.identity.getApiKeyCredentialProvider(flags.name, opts);

--- a/src/handlers/identity/identity.test.tsx
+++ b/src/handlers/identity/identity.test.tsx
@@ -267,7 +267,7 @@ describe("api-key-credential-provider CRUDL", () => {
         "--api-key-secret-reference",
         '{"secretId":"arn:aws:secretsmanager:us-west-2:123:secret:s","jsonKey":"apiKey"}',
       ],
-      /mutually exclusive/,
+      /specify exactly one of --api-key, --api-key-secret-reference/,
     ],
     [
       "create: --api-key-secret-reference missing secretId",
@@ -308,7 +308,7 @@ describe("api-key-credential-provider CRUDL", () => {
         "--api-key-secret-reference",
         '{"secretId":"arn:aws:secretsmanager:us-west-2:123:secret:s","jsonKey":"apiKey"}',
       ],
-      /mutually exclusive/,
+      /specify exactly one of --api-key, --api-key-secret-reference/,
     ],
     [
       "create: --api-key with an inline value",

--- a/src/handlers/identity/oauth2-credential-provider/create/index.tsx
+++ b/src/handlers/identity/oauth2-credential-provider/create/index.tsx
@@ -5,7 +5,7 @@ import { createHandler, flag } from "../../../../router";
 import { JsonRendererKey } from "../../../../tui";
 import type { Core } from "../../../types";
 import type { AppIO } from "../../../../io";
-import { coreOptsFromCtx, parseTags } from "../../../utils";
+import { assertMutuallyExclusiveFlags, coreOptsFromCtx, parseTags } from "../../../utils";
 import { SourceResolver } from "../../../../io";
 import { parseSecretReference } from "../../parser";
 import {
@@ -56,19 +56,11 @@ export const createCreateOauth2CredentialProviderHandler = (core: Core, io: AppI
       }
 
       const vendor = flags.vendor as CredentialProviderVendorType;
+      assertMutuallyExclusiveFlags(flags, ["client-secret", "client-secret-reference"], {
+        exactlyOne: true,
+      });
       const hasClientSecret = flags["client-secret"] !== undefined;
       const hasSecretRef = flags["client-secret-reference"] !== undefined;
-
-      if (hasClientSecret && hasSecretRef) {
-        throw new InputValidationError(
-          "--client-secret and --client-secret-reference are mutually exclusive",
-        );
-      }
-      if (!hasClientSecret && !hasSecretRef) {
-        throw new InputValidationError(
-          "either --client-secret or --client-secret-reference is required",
-        );
-      }
 
       const providerConfigMode = parseProviderConfigFlags({
         clientId: flags["client-id"],

--- a/src/handlers/identity/oauth2-credential-provider/oauth2.test.tsx
+++ b/src/handlers/identity/oauth2-credential-provider/oauth2.test.tsx
@@ -177,7 +177,7 @@ describe("oauth2-credential-provider flag validation", () => {
         "--client-secret-reference",
         '{"secretId":"arn:aws:secretsmanager:us-west-2:123:secret:s","jsonKey":"k"}',
       ],
-      /mutually exclusive/,
+      /specify exactly one of --client-secret, --client-secret-reference/,
     ],
     [
       "create: --provider-configuration with guided flags",

--- a/src/handlers/identity/oauth2-credential-provider/update/index.tsx
+++ b/src/handlers/identity/oauth2-credential-provider/update/index.tsx
@@ -5,7 +5,7 @@ import { createHandler, flag } from "../../../../router";
 import { JsonRendererKey } from "../../../../tui";
 import type { Core } from "../../../types";
 import type { AppIO } from "../../../../io";
-import { coreOptsFromCtx } from "../../../utils";
+import { assertMutuallyExclusiveFlags, coreOptsFromCtx } from "../../../utils";
 import { SourceResolver } from "../../../../io";
 import { parseSecretReference } from "../../parser";
 import {
@@ -73,19 +73,11 @@ export const createUpdateOauth2CredentialProviderHandler = (core: Core, io: AppI
         throw new InputValidationError("required option '--name <name>' not specified");
       }
 
+      assertMutuallyExclusiveFlags(flags, ["client-secret", "client-secret-reference"], {
+        exactlyOne: true,
+      });
       const hasClientSecret = flags["client-secret"] !== undefined;
       const hasSecretRef = flags["client-secret-reference"] !== undefined;
-
-      if (hasClientSecret && hasSecretRef) {
-        throw new InputValidationError(
-          "--client-secret and --client-secret-reference are mutually exclusive",
-        );
-      }
-      if (!hasClientSecret && !hasSecretRef) {
-        throw new InputValidationError(
-          "either --client-secret or --client-secret-reference is required",
-        );
-      }
 
       const providerConfigMode = parseProviderConfigFlags({
         clientId: flags["client-id"],

--- a/src/handlers/memory/memory.test.tsx
+++ b/src/handlers/memory/memory.test.tsx
@@ -749,7 +749,7 @@ describe("memory record commands", () => {
 
     await expect(
       command.route(["memory", "record", "list", "--id", EVENT_MEMORY_ID, ...selectors]),
-    ).rejects.toThrow("exactly one of '--namespace' or '--namespace-path' must be specified");
+    ).rejects.toThrow("specify exactly one of --namespace, --namespace-path");
     expect(command.core.memory.calls).toEqual([]);
   });
 

--- a/src/handlers/memory/record/list/index.tsx
+++ b/src/handlers/memory/record/list/index.tsx
@@ -3,7 +3,7 @@ import { InputValidationError } from "../../../../errors";
 import { createHandler, flag } from "../../../../router";
 import { JsonRendererKey } from "../../../../tui";
 import type { Core } from "../../../types";
-import { coreOptsFromCtx } from "../../../utils";
+import { assertMutuallyExclusiveFlags, coreOptsFromCtx } from "../../../utils";
 import { parseMemoryMetadataFilters } from "../../metadataFilters";
 
 export const createListMemoryRecordsHandler = (core: Core) =>
@@ -24,13 +24,7 @@ export const createListMemoryRecordsHandler = (core: Core) =>
         throw new InputValidationError("required option '--id <id>' not specified");
       }
 
-      const hasNamespace = flags.namespace !== undefined;
-      const hasNamespacePath = flags["namespace-path"] !== undefined;
-      if (hasNamespace === hasNamespacePath) {
-        throw new InputValidationError(
-          "exactly one of '--namespace' or '--namespace-path' must be specified",
-        );
-      }
+      assertMutuallyExclusiveFlags(flags, ["namespace", "namespace-path"], { exactlyOne: true });
 
       const metadataFilters = parseMemoryMetadataFilters(flags["metadata-filters"]);
       const response = await core.memory.listMemoryRecords(

--- a/src/handlers/project/add/gateway-connector/index.ts
+++ b/src/handlers/project/add/gateway-connector/index.ts
@@ -7,7 +7,7 @@ import {
   type ConnectorId,
 } from "../../../../projectSchemas/gateway";
 import { createHandler, flag, ProjectKey } from "../../../../router";
-import { parseJsonFlagWithSchema } from "../../../utils";
+import { assertMutuallyExclusiveFlags, parseJsonFlagWithSchema } from "../../../utils";
 import type { AddProjectResourceConfig } from "../types";
 import { addProjectResource } from "../shared";
 
@@ -38,11 +38,9 @@ export const createAddGatewayConnectorHandler = (config: AddProjectResourceConfi
       if (!flags.gateway) {
         throw new InputValidationError("required option '--gateway <gateway>' not specified");
       }
-      if ((flags.connector === undefined) === (flags["connector-configuration"] === undefined)) {
-        throw new InputValidationError(
-          "specify exactly one of '--connector' or '--connector-configuration'",
-        );
-      }
+      assertMutuallyExclusiveFlags(flags, ["connector", "connector-configuration"], {
+        exactlyOne: true,
+      });
 
       const usesConfiguration = flags["connector-configuration"] !== undefined;
       if (usesConfiguration && flags.name !== undefined) {

--- a/src/handlers/project/add/gateway-target/index.ts
+++ b/src/handlers/project/add/gateway-target/index.ts
@@ -8,7 +8,7 @@ import {
   type OutboundAuth,
 } from "../../../../projectSchemas/gateway";
 import { createHandler, flag, ProjectKey } from "../../../../router";
-import { parseJsonFlagWithSchema } from "../../../utils";
+import { assertMutuallyExclusiveFlags, parseJsonFlagWithSchema } from "../../../utils";
 import type { Project } from "../../types";
 import type { AddProjectResourceConfig } from "../types";
 import { addProjectResource } from "../shared";
@@ -52,16 +52,9 @@ Use project add gateway-connector for curated Connector shortcuts.`,
       if (!flags.gateway) {
         throw new InputValidationError("required option '--gateway <gateway>' not specified");
       }
-      const modes = [
-        ["--endpoint", flags.endpoint],
-        ["--runtime", flags.runtime],
-        ["--target-configuration", flags["target-configuration"]],
-      ].filter(([, value]) => value !== undefined);
-      if (modes.length !== 1) {
-        throw new InputValidationError(
-          "specify exactly one of '--endpoint', '--runtime', or '--target-configuration'",
-        );
-      }
+      assertMutuallyExclusiveFlags(flags, ["endpoint", "runtime", "target-configuration"], {
+        exactlyOne: true,
+      });
       if (flags["runtime-endpoint"] !== undefined && flags.runtime === undefined) {
         throw new InputValidationError("--runtime-endpoint requires --runtime");
       }

--- a/src/handlers/project/add/payment-connector/index.ts
+++ b/src/handlers/project/add/payment-connector/index.ts
@@ -3,6 +3,7 @@ import { InputValidationError } from "../../../../errors";
 import { createHandler, flag, ProjectKey } from "../../../../router";
 import type { AddProjectResourceConfig } from "../types";
 import { addProjectResource } from "../shared";
+import { assertMutuallyExclusiveFlags } from "../../../utils";
 
 export const createAddPaymentConnectorHandler = (config: AddProjectResourceConfig) =>
   createHandler({
@@ -22,10 +23,7 @@ export const createAddPaymentConnectorHandler = (config: AddProjectResourceConfi
         throw new InputValidationError("required option '--name <name>' not specified");
       }
 
-      const modes = [flags.credential !== undefined, flags["quick-create"]].filter(Boolean);
-      if (modes.length !== 1) {
-        throw new InputValidationError("specify exactly one of '--credential' or '--quick-create'");
-      }
+      assertMutuallyExclusiveFlags(flags, ["credential", "quick-create"], { exactlyOne: true });
 
       const project = ctx.require(ProjectKey);
       let provider: "CoinbaseCDP" | "StripePrivy";

--- a/src/handlers/project/export/harness.test.ts
+++ b/src/handlers/project/export/harness.test.ts
@@ -89,9 +89,9 @@ describe("project export harness handler", () => {
     const subject = testExportCommand();
     await inProjectWithHarness(subject);
 
-    await expect(subject.run([])).rejects.toThrow(/exactly one of --name .* or --arn/);
+    await expect(subject.run([])).rejects.toThrow(/specify exactly one of --name, --arn/);
     await expect(subject.run(["--name", "exportme", "--arn", HARNESS_ARN])).rejects.toThrow(
-      /exactly one of --name .* or --arn/,
+      /specify exactly one of --name, --arn/,
     );
   });
 

--- a/src/handlers/project/export/harness.ts
+++ b/src/handlers/project/export/harness.ts
@@ -5,7 +5,7 @@ import { JsonRendererKey } from "../../../tui";
 import { JsonKey } from "../../keys";
 import { AgentNameSchema } from "../../../projectSchemas/runtime";
 import { formatExportNotes } from "../../../core/project/templates/export";
-import { coreOptsFromCtx } from "../../utils";
+import { assertMutuallyExclusiveFlags, coreOptsFromCtx } from "../../utils";
 import type { ExportHarnessInput } from "../types";
 import type { ExportProjectResourceConfig } from "./types";
 import { harnessIdFromArn, mapServiceHarnessToSpec, regionFromHarnessArn } from "./serviceHarness";
@@ -28,11 +28,7 @@ export const createExportHarnessHandler = (config: ExportProjectResourceConfig) 
       ),
     ],
     handle: async (ctx, flags) => {
-      if (!!flags.name === !!flags.arn) {
-        throw new InputValidationError(
-          "specify exactly one of --name (in-project harness) or --arn (deployed harness)",
-        );
-      }
+      assertMutuallyExclusiveFlags(flags, ["name", "arn"], { exactlyOne: true });
 
       // withProject has already resolved and validated the enclosing project —
       // before any service fetch, so a broken project fails fast.

--- a/src/handlers/utils.test.tsx
+++ b/src/handlers/utils.test.tsx
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { parseJsonArrayFlag, parseJsonObjectFlag, parseTags } from "./utils";
+import {
+  assertMutuallyExclusiveFlags,
+  parseJsonArrayFlag,
+  parseJsonObjectFlag,
+  parseTags,
+} from "./utils";
 
 describe("structured JSON flags", () => {
   test("parses object and array values", () => {
@@ -63,5 +68,50 @@ describe("parseTags", () => {
 
   test("rejects bare value without equals", () => {
     expect(() => parseTags(["noequals"])).toThrow("expected key=value");
+  });
+});
+
+describe("assertMutuallyExclusiveFlags", () => {
+  test.each([
+    ["nothing set", ["a", "b"], {}, {}],
+    ["a single flag set", ["a", "b"], { a: "x" }, {}],
+    ["a false boolean flag alongside one set", ["a", "c"], { a: "x", c: false }, {}],
+    ["a single flag set with exactlyOne", ["a", "b"], { a: "x" }, { exactlyOne: true }],
+  ] as const)("permits %s", (_label, names, flags, options) => {
+    expect(() => assertMutuallyExclusiveFlags(flags, names, options)).not.toThrow();
+  });
+
+  test.each([
+    ["two flags set", ["a", "b"], { a: "x", b: "y" }, {}, "--a, --b are mutually exclusive"],
+    [
+      "a true boolean flag alongside one set",
+      ["a", "c"],
+      { a: "x", c: true },
+      {},
+      "--a, --c are mutually exclusive",
+    ],
+    [
+      "only the set flags listed",
+      ["a", "b", "c"],
+      { a: "x", c: "z" },
+      {},
+      "--a, --c are mutually exclusive",
+    ],
+    [
+      "nothing set with exactlyOne",
+      ["a", "b"],
+      {},
+      { exactlyOne: true },
+      "specify exactly one of --a, --b",
+    ],
+    [
+      "many set with exactlyOne",
+      ["a", "b", "c"],
+      { a: "x", b: "y" },
+      { exactlyOne: true },
+      "specify exactly one of --a, --b, --c",
+    ],
+  ] as const)("rejects %s", (_label, names, flags, options, message) => {
+    expect(() => assertMutuallyExclusiveFlags(flags, names, options)).toThrow(message);
   });
 });

--- a/src/handlers/utils.tsx
+++ b/src/handlers/utils.tsx
@@ -88,18 +88,26 @@ export function parseJsonArrayFlag<T>(name: string, raw: string | undefined): T[
   return parsed as T[];
 }
 
-export function assertMutuallyExclusiveInputs(
-  pairs: readonly (readonly [
-    leftName: string,
-    leftValue: unknown,
-    rightName: string,
-    rightValue: unknown,
-  ])[],
+/**
+ * Given flag names and the flags object, asserts that at most one flag is
+ * defined (or exactly one with the `exactlyOne` option). A flag counts as
+ * defined when its value is neither `undefined` nor `false`.
+ */
+export function assertMutuallyExclusiveFlags(
+  flags: Record<string, unknown>,
+  names: readonly string[],
+  options: { exactlyOne?: boolean } = {},
 ): void {
-  for (const [leftName, leftValue, rightName, rightValue] of pairs) {
-    if (leftValue !== undefined && rightValue !== undefined) {
-      throw new InputValidationError(`--${leftName} and --${rightName} are mutually exclusive`);
-    }
+  const definedFlags = names.filter((name) => flags[name] !== undefined && flags[name] !== false);
+  if (options.exactlyOne && definedFlags.length !== 1) {
+    throw new InputValidationError(
+      `specify exactly one of ${names.map((name) => `--${name}`).join(", ")}`,
+    );
+  }
+  if (definedFlags.length > 1) {
+    throw new InputValidationError(
+      `${definedFlags.map((name) => `--${name}`).join(", ")} are mutually exclusive`,
+    );
   }
 }
 


### PR DESCRIPTION
### Problem
CLI handlers hand-roll "mutually exclusive" and "specify exactly one of" flag checks with at least three message formats, so identical failures read differently across commands.  

### Solution
- Replace `assertMutuallyExclusiveInputs` with `assertMutuallyExclusiveFlags` that is general enough to handle all of the mutually exclusive checks we make today. 
- Migrate handlers with mutually-exclusive checks onto the shared utility.

### Verification
- All handler tests green; changed lines have explicit coverage.

manually tested a migrated case:
```
$ agentcore  identity api-key-credential-provider create --name x --region us-west-2
Error: specify exactly one of --api-key, --api-key-secret-reference
```