### PR TITLE
ci(release): use dedicated runners for release publishing

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -46,18 +46,18 @@ compose freely.
 Dispatch `release-prepare` with a bump and a channel, review the release PR it opens, merge it.
 `release-publish` then publishes the merged package.json version.
 
-Publishing listens for pushes to `refactor` (switch to `main` when the refactor lands), not PR
-events. It looks up the pushed commit's associated PRs and proceeds only when that exact commit
+Publishing listens for pushes to `refactor`, not PR events. It looks up the pushed commit's
+associated PRs and proceeds only when that exact commit
 is the merge of a `release/v*` PR opened by `agentcore-devx-automation[bot]` (account ID
 `282717993`) from this repository into the target branch. Manually opened release PRs,
 ordinary merges, fork PRs, and pushes without a matching release PR skip verification and
 publishing. Every job uses the pushed SHA, so later commits cannot change what is released.
 
-The prepare job uses `aws-release-4-core`. The check-release and publish jobs stay on
-`ubuntu-latest` until `release-publish.yml` is allowlisted for the dedicated runner group.
-The allowlist is scoped to workflow paths and branches; renaming a workflow or changing its
-branch requires a runner-group administrator to update it. Keep PR-triggered workflows
-and the verification matrix off this release-only pool.
+The prepare, check-release, and publish jobs use `aws-release-4-core`. The `release-publish.yml`
+allowlist currently covers `refactor` only. After the workflow lands on `main`, have a
+runner-group administrator add its `main` entry before switching the publish branch filter.
+The allowlist is scoped to workflow paths and branches; renaming a workflow also requires an
+update. Keep PR-triggered workflows and the verification matrix off this release-only pool.
 
 The npm package includes `dist` except `dist/bin`, plus standard package metadata. This keeps
 additional bundle chunks and runtime assets included as the build evolves. Native binaries in

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -3,13 +3,13 @@
 name: release-publish
 on:
   push:
-    # TODO: switch to main once the refactor lands there.
+    # TODO: switch to main once the refactor lands and this workflow is allowlisted there.
     branches: [refactor]
 
 jobs:
   check-release:
     if: "!github.event.deleted"
-    runs-on: ubuntu-latest
+    runs-on: aws-release-4-core
     permissions:
       pull-requests: read
     outputs:
@@ -47,7 +47,7 @@ jobs:
   publish:
     needs: verify
     # npm provenance is only issued from GitHub-hosted runners.
-    runs-on: ubuntu-latest
+    runs-on: aws-release-4-core
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
## Description

Complete the dedicated-runner migration after #2259.

- Change `check-release` and `publish` in `release-publish.yml` from `ubuntu-latest` to `aws-release-4-core`.
- Keep the push trigger, all release-PR guards, SHA pinning, permissions, publishing steps, and verification matrix unchanged. Release preparation already uses this runner.
- Update the README and migration TODO: publishing is allowlisted on `refactor` only. After this file lands on `main`, a runner-group administrator must add its `main` pin before changing the branch filter.

No package contents, application code, or test files are changed.

## Related Issue

Closes #2267

Follow-up to #2259.

## Documentation PR

Not applicable. The release documentation is updated in `.github/workflows/README.md`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Other (please describe): CI runner configuration

## Testing

The `refactor` branch uses Bun rather than the default branch's separate npm unit/integration scripts.

- [x] Parsed-workflow comparison against the base branch: the only semantic changes are the two `runs-on` values.
- [x] 14 local release-gate cases, including the real release PR response, manual authors, incorrect bot IDs, forks, wrong branches/SHAs, unmerged PRs, pagination, and API failures.
- [x] Actionlint validation with the custom runner label declared in a temporary local config.
- [x] Formatting check for both changed files.
- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun run lint:check`
- [x] `bun test`: 3,179 existing tests passed.

Runner-group approval was confirmed separately. No release workflow was dispatched, no npm package was published, and runner allocation was not exercised live during validation. All additional checks stayed outside the repository; no test scripts are included.

## Checklist

- [x] I have read the CONTRIBUTING document
- [ ] I have added any necessary tests that prove my fix is effective or my feature works (no new test files; local checks listed above)
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published (#2259 is merged; runner access is configured on `refactor`)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
