### PR TITLE
fix: address last list table column cut off in TUI

### DIFF
--- a/src/components/PaginatedTablePicker.test.tsx
+++ b/src/components/PaginatedTablePicker.test.tsx
@@ -471,11 +471,12 @@ describe("paginated table picker contract", () => {
       );
 
       expect(headerIndex).toBeGreaterThanOrEqual(0);
-      expect(stringWidth(lines[headerIndex + 1]!)).toBe(width);
+      expect(stringWidth(lines[headerIndex + 1]!)).toBe(width - 1);
       expect(rowLines.every((line) => line !== undefined)).toBe(true);
       expect(new Set(rowLines.map((line) => lines.indexOf(line!))).size).toBe(suffixes.length);
-      expect(rowLines.every((line) => stringWidth(line!) <= width)).toBe(true);
+      expect(rowLines.every((line) => stringWidth(line!) <= width - 1)).toBe(true);
       expect(rowLines.every((line) => /runtime_\d-[A-Za-z0-9…]+\s+\d/.test(line!))).toBe(true);
+      expect(rowLines.every((line) => line!.includes("2026-07-19 01:02"))).toBe(true);
       if (width >= 80) {
         expect(rowLines.every((line, index) => line!.includes(suffixes[index]!))).toBe(true);
       }

--- a/src/components/ui/data-table/DataTable.test.tsx
+++ b/src/components/ui/data-table/DataTable.test.tsx
@@ -3,6 +3,7 @@ import { Box } from "ink";
 import { cleanup, render } from "ink-testing-library";
 import stringWidth from "string-width";
 import { DataTable, type DataTableColumn } from "./DataTable";
+import { TERMINAL_RIGHT_GUTTER_WIDTH } from "./columnWidths";
 
 afterEach(cleanup);
 
@@ -40,6 +41,16 @@ function renderTableAt(columnsWide: number) {
 }
 
 describe("DataTable layout", () => {
+  test("reserves a one-column gutter at the terminal's right edge", () => {
+    const terminalWidth = 60;
+    const divider = renderTableAt(terminalWidth)
+      .split("\n")
+      .find((line) => /^─+$/.test(line));
+
+    expect(divider).toBeDefined();
+    expect(stringWidth(divider!)).toBe(terminalWidth - TERMINAL_RIGHT_GUTTER_WIDTH);
+  });
+
   test("keeps the selection marker and each logical row on one line at 12 columns", () => {
     const lines = renderTableAt(12).split("\n");
     const rowLines = lines.filter(

--- a/src/components/ui/data-table/DataTable.tsx
+++ b/src/components/ui/data-table/DataTable.tsx
@@ -9,6 +9,7 @@ import {
   computeColumnWidths,
   resolveBorderWidth,
   SELECTION_MARKER_WIDTH,
+  TERMINAL_RIGHT_GUTTER_WIDTH,
 } from "./columnWidths.js";
 import type { ColumnSizing } from "./columnWidths.js";
 
@@ -200,7 +201,8 @@ export function DataTable<T extends Record<string, unknown>>({
     left: borderLeft,
     right: borderRight,
   });
-  const computedWidths = computeColumnWidths(columns, terminalWidth, {
+  const tableWidth = Math.max(0, terminalWidth - TERMINAL_RIGHT_GUTTER_WIDTH);
+  const computedWidths = computeColumnWidths(columns, tableWidth, {
     selectable,
     borderWidth,
   });

--- a/src/components/ui/data-table/columnWidths.ts
+++ b/src/components/ui/data-table/columnWidths.ts
@@ -1,6 +1,7 @@
 export const COLUMN_GAP = 1;
 export const FLEX_MIN_WIDTH = 16;
 export const SELECTION_MARKER_WIDTH = 1;
+export const TERMINAL_RIGHT_GUTTER_WIDTH = 1;
 
 export type ColumnSizing =
   | { flex: true; width?: never; minWidth?: never }


### PR DESCRIPTION
## Description

Currently, the last column of our TUI is cut off across all our list tables. This commonly is UTC timestamp, resulting in `15:4` showing as the last updated time instead of `15:45`, for example. This is caused by our table items using 100% of the width available, meaning the final column will always be just out of view.

The solution introduced in this PR reserves the last column as an empty gutter, meaning that our rendered content will end at `width - 1`. This guarantees our final column of content will always render on a visible column.

## Example
* `agentcore` -> latest RC release installed via npm
* `ac-dev` -> local dev env built off this PR

https://github.com/user-attachments/assets/ce3a0b05-8f09-4460-991b-6afc0f2e198f




## Type of Change

<!-- Check all that apply -->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Testing

How have you tested the change?

- [x] `bun run test` (3199 pass, 0 fail)
- [x] I ran `npm run test:unit` and `npm run test:integ`
- [x] I ran `npm run typecheck`
- [x] I ran `npm run lint`
- [x] If I modified `src/assets/`, I ran `npm run test:update-snapshots` and committed the updated snapshots

## Checklist

- [x] I have read the CONTRIBUTING document
- [x] I have added any necessary tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] I have added an appropriate example to the documentation to outline the feature, or no new docs are needed
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
