### PR TITLE
chore(templates): bump aws-opentelemetry-distro to ~= 0.18.0 in Python templates

### DIFF
--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -1948,7 +1948,7 @@ dependencies = [
     {{/if}}{{#if (eq modelProvider "Gemini")}}"langchain-google-genai >= 2.0.0",
     "google-genai >= 1.0.0, < 2.0.0",
     {{/if}}{{#if (eq modelProvider "OpenAI")}}"langchain-openai >= 0.2.0",
-    {{/if}}"aws-opentelemetry-distro",
+    {{/if}}"aws-opentelemetry-distro ~= 0.18.0",
     "opentelemetry-instrumentation-langchain >= 0.59.0",
     "bedrock-agentcore[a2a-v1] >= 1.19.0",
     "botocore[crt] >= 1.35.0",
@@ -2294,7 +2294,7 @@ requires-python = ">=3.10"
 dependencies = [
     {{#if (eq modelProvider "Anthropic")}}"anthropic >= 0.30.0",
     {{/if}}"a2a-sdk[all] >= 0.3.0, < 0.4.0",
-    "aws-opentelemetry-distro",
+    "aws-opentelemetry-distro ~= 0.18.0",
     "bedrock-agentcore[a2a] >= 1.9.1",
     "botocore[crt] >= 1.35.0",
     {{#if (eq modelProvider "Gemini")}}"google-genai >= 1.0.0",
@@ -2971,7 +2971,7 @@ dependencies = [
     {{/if}}{{#if (eq modelProvider "Gemini")}}"langchain-google-genai >= 2.0.0",
     "google-genai >= 1.0.0, < 2.0.0",
     {{/if}}{{#if (eq modelProvider "OpenAI")}}"langchain-openai >= 0.2.0",
-    {{/if}}"aws-opentelemetry-distro",
+    {{/if}}"aws-opentelemetry-distro ~= 0.18.0",
     "opentelemetry-instrumentation-langchain >= 0.59.0",
     "bedrock-agentcore >= 1.8.0",
     "botocore[crt] >= 1.35.0",
@@ -3314,7 +3314,7 @@ dependencies = [
     {{#if (eq modelProvider "Anthropic")}}"anthropic >= 0.30.0",
     {{/if}}"ag-ui-strands >= 0.1.7",
     "ag-ui-protocol >= 0.1.10",
-    "aws-opentelemetry-distro",
+    "aws-opentelemetry-distro ~= 0.18.0",
     "bedrock-agentcore >= 1.9.1",
     "botocore[crt] >= 1.35.0",
     "fastapi >= 0.115.12",
@@ -4872,7 +4872,7 @@ description = "AgentCore Runtime Application using LangChain/LangGraph"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "aws-opentelemetry-distro",
+    "aws-opentelemetry-distro ~= 0.18.0",
     "opentelemetry-instrumentation-langchain >= 0.59.0",
     "langgraph >= 1.0.2",
     "mcp ~= 1.24.0",
@@ -5341,7 +5341,7 @@ description = "AgentCore Runtime Application using OpenAI Agents SDK"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "aws-opentelemetry-distro",
+    "aws-opentelemetry-distro ~= 0.18.0",
     "openai-agents >= 0.16.0",
     "bedrock-agentcore >= 1.8.0",
     "botocore[crt] >= 1.35.0",
@@ -6577,7 +6577,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     {{#if (eq modelProvider "Anthropic")}}"anthropic >= 0.30.0",
-    {{/if}}"aws-opentelemetry-distro",
+    {{/if}}"aws-opentelemetry-distro ~= 0.18.0",
     "bedrock-agentcore >= 1.9.1",
     "botocore[crt] >= 1.35.0",
     {{#if (eq modelProvider "Gemini")}}"google-genai >= 1.0.0",

--- a/src/assets/python/a2a/langchain_langgraph/base/pyproject.toml
+++ b/src/assets/python/a2a/langchain_langgraph/base/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     {{/if}}{{#if (eq modelProvider "Gemini")}}"langchain-google-genai >= 2.0.0",
     "google-genai >= 1.0.0, < 2.0.0",
     {{/if}}{{#if (eq modelProvider "OpenAI")}}"langchain-openai >= 0.2.0",
-    {{/if}}"aws-opentelemetry-distro",
+    {{/if}}"aws-opentelemetry-distro ~= 0.18.0",
     "opentelemetry-instrumentation-langchain >= 0.59.0",
     "bedrock-agentcore[a2a-v1] >= 1.19.0",
     "botocore[crt] >= 1.35.0",

--- a/src/assets/python/a2a/strands/base/pyproject.toml
+++ b/src/assets/python/a2a/strands/base/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 dependencies = [
     {{#if (eq modelProvider "Anthropic")}}"anthropic >= 0.30.0",
     {{/if}}"a2a-sdk[all] >= 0.3.0, < 0.4.0",
-    "aws-opentelemetry-distro",
+    "aws-opentelemetry-distro ~= 0.18.0",
     "bedrock-agentcore[a2a] >= 1.9.1",
     "botocore[crt] >= 1.35.0",
     {{#if (eq modelProvider "Gemini")}}"google-genai >= 1.0.0",

--- a/src/assets/python/agui/langchain_langgraph/base/pyproject.toml
+++ b/src/assets/python/agui/langchain_langgraph/base/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     {{/if}}{{#if (eq modelProvider "Gemini")}}"langchain-google-genai >= 2.0.0",
     "google-genai >= 1.0.0, < 2.0.0",
     {{/if}}{{#if (eq modelProvider "OpenAI")}}"langchain-openai >= 0.2.0",
-    {{/if}}"aws-opentelemetry-distro",
+    {{/if}}"aws-opentelemetry-distro ~= 0.18.0",
     "opentelemetry-instrumentation-langchain >= 0.59.0",
     "bedrock-agentcore >= 1.8.0",
     "botocore[crt] >= 1.35.0",

--- a/src/assets/python/agui/strands/base/pyproject.toml
+++ b/src/assets/python/agui/strands/base/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     {{#if (eq modelProvider "Anthropic")}}"anthropic >= 0.30.0",
     {{/if}}"ag-ui-strands >= 0.1.7",
     "ag-ui-protocol >= 0.1.10",
-    "aws-opentelemetry-distro",
+    "aws-opentelemetry-distro ~= 0.18.0",
     "bedrock-agentcore >= 1.9.1",
     "botocore[crt] >= 1.35.0",
     "fastapi >= 0.115.12",

--- a/src/assets/python/http/langchain_langgraph/base/pyproject.toml
+++ b/src/assets/python/http/langchain_langgraph/base/pyproject.toml
@@ -9,7 +9,7 @@ description = "AgentCore Runtime Application using LangChain/LangGraph"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "aws-opentelemetry-distro",
+    "aws-opentelemetry-distro ~= 0.18.0",
     "opentelemetry-instrumentation-langchain >= 0.59.0",
     "langgraph >= 1.0.2",
     "mcp ~= 1.24.0",

--- a/src/assets/python/http/openaiagents/base/pyproject.toml
+++ b/src/assets/python/http/openaiagents/base/pyproject.toml
@@ -9,7 +9,7 @@ description = "AgentCore Runtime Application using OpenAI Agents SDK"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "aws-opentelemetry-distro",
+    "aws-opentelemetry-distro ~= 0.18.0",
     "openai-agents >= 0.16.0",
     "bedrock-agentcore >= 1.8.0",
     "botocore[crt] >= 1.35.0",

--- a/src/assets/python/http/strands/base/pyproject.toml
+++ b/src/assets/python/http/strands/base/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     {{#if (eq modelProvider "Anthropic")}}"anthropic >= 0.30.0",
-    {{/if}}"aws-opentelemetry-distro",
+    {{/if}}"aws-opentelemetry-distro ~= 0.18.0",
     "bedrock-agentcore >= 1.9.1",
     "botocore[crt] >= 1.35.0",
     {{#if (eq modelProvider "Gemini")}}"google-genai >= 1.0.0",


### PR DESCRIPTION
## What

Pins `aws-opentelemetry-distro` to the 0.18.x line for the Python agent templates that use ADOT, across the `http`, `a2a`, and `agui` protocols:

- **Strands** (http, a2a, agui)
- **LangChain / LangGraph** (http, a2a, agui)
- **OpenAIAgents** (http)

The AgentCore Runtime reports `telemetry.auto.version: 0.18.0-aws`, so this aligns the vended templates with the runtime's ADOT version.

## Why GoogleADK is intentionally excluded

GoogleADK templates are **left on their existing ADOT pin**. `aws-opentelemetry-distro 0.18.0` requires `opentelemetry-api == 1.42.1`, but `google-adk < 2.0.0` caps `opentelemetry-api` at `<= 1.41.1` — the two constraints are unsatisfiable together, and deploy fails at dependency resolution (before any runtime is created).

Moving GoogleADK to 0.18.0 would require bumping `google-adk` from 1.x to 2.x (a major version with breaking changes to template code), which is out of scope for this dependency bump. (The a2a GoogleADK template already tracks `google-adk[a2a] >= 2.5.0` and is unaffected either way.)

## Verification

Each changed template was deployed to AgentCore Runtime and invoked; telemetry was confirmed landing in the agent's **own** log group:

- `telemetry.auto.version: 0.18.0-aws` present on emitted spans/records
- non-zero sampled traceId in the `spans` stream

All 8 verified templates passed. (OpenAIAgents http required an OpenAI key to complete a functional invoke, but ADOT telemetry was confirmed regardless.)

## Tests

- `npm run test:update-snapshots` — asset snapshots regenerated
- `npm test` — 6275 passed