### PR TITLE
fix(templates): bump otel version on two templates

### DIFF
--- a/src/assets/templates/a2a-python-strands/pyproject.toml
+++ b/src/assets/templates/a2a-python-strands/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "a2a-sdk[all] ~= 0.3.0",
-    "aws-opentelemetry-distro ~= 0.17.0",
+    "aws-opentelemetry-distro ~= 0.18.0",
     "bedrock-agentcore[a2a] ~= 1.9.1",
     "botocore[crt] ~= 1.43.0",
     "strands-agents ~= 1.15.0",

--- a/src/assets/templates/agui-python-strands/pyproject.toml
+++ b/src/assets/templates/agui-python-strands/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.12"
 dependencies = [
     "ag-ui-strands >= 0.3.0, < 0.4.0",
     "ag-ui-protocol >= 0.1.19, < 0.2.0",
-    "aws-opentelemetry-distro ~= 0.17.0",
+    "aws-opentelemetry-distro ~= 0.18.0",
     "bedrock-agentcore ~= 1.9.1",
     "botocore[crt] ~= 1.43.0",
     "strands-agents ~= 1.15.0",


### PR DESCRIPTION
### Problem 
There is an old otel version pin in two templates that causes spans to be delivered to the aws/spans group instead of the runtimes own log group. 

### Solution 
bump them to 0.18.0 (which changes this behavior). 

### Verification 
- deployed an A2A and AGUI agent, and invoked each once. 
- previously verified this spans now end up in the correct log group when working with other templates. 